### PR TITLE
feat(generator): use Rust enumerations

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -212,6 +212,7 @@ extend-ignore-re = [
   "FIELDs",
   # src/generated/cloud/backupdr/v1 uses `BA` in fields and enums.
   "WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA",
+  "WithinOrgButUnrestrictedForBa",
   "ba_proxy_uri",
   "to BA proxy",
   # src/generated/cloud/bigquery/migration/v2 uses product names that look like
@@ -235,6 +236,7 @@ extend-ignore-re = [
   # src/generated/cloud/dialogflow/v2 uses enums that look like typos.
   "GOST R 34",
   "GOST3411",
+  "Gost3411",
   # src/generated/cloud/firestore has a typo, needs to be fixed upstream.
   "`TargetChage\\.",
   # src/generated/cloud/gkemulticloud/v1 uses AKS as an acronym.

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -262,9 +262,10 @@ type enumAnnotation struct {
 }
 
 type enumValueAnnotation struct {
-	Name     string
-	EnumType string
-	DocLines []string
+	Name        string
+	VariantName string
+	EnumType    string
+	DocLines    []string
 }
 
 // annotateModel creates a struct used as input for Mustache templates.
@@ -730,7 +731,7 @@ func (c *codec) annotateEnum(e *api.Enum, state *api.APIState, sourceSpecificati
 	seen := map[string]*api.EnumValue{}
 	var unique []*api.EnumValue
 	for _, ev := range e.Values {
-		name := enumValueName(ev)
+		name := enumValueVariantName(ev)
 		if existing, ok := seen[name]; ok {
 			if existing.Number != ev.Number {
 				slog.Warn("conflicting names for enum values", "enum.ID", e.ID)
@@ -740,6 +741,7 @@ func (c *codec) annotateEnum(e *api.Enum, state *api.APIState, sourceSpecificati
 			seen[name] = ev
 		}
 	}
+
 	qualifiedName := fullyQualifiedEnumName(e, c.modulePath, sourceSpecificationPackageName, c.packageMapping)
 	relativeName := strings.TrimPrefix(qualifiedName, c.modulePath+"::")
 	e.Codec = &enumAnnotation{
@@ -754,9 +756,10 @@ func (c *codec) annotateEnum(e *api.Enum, state *api.APIState, sourceSpecificati
 
 func (c *codec) annotateEnumValue(ev *api.EnumValue, e *api.Enum, state *api.APIState) {
 	ev.Codec = &enumValueAnnotation{
-		DocLines: c.formatDocComments(ev.Documentation, ev.ID, state, ev.Scopes()),
-		Name:     enumValueName(ev),
-		EnumType: enumName(e),
+		DocLines:    c.formatDocComments(ev.Documentation, ev.ID, state, ev.Scopes()),
+		Name:        enumValueName(ev),
+		EnumType:    enumName(e),
+		VariantName: enumValueVariantName(ev),
 	}
 }
 

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -359,11 +359,21 @@ func TestEnumAnnotations(t *testing.T) {
 		Documentation: "VALUE is also documented.",
 		Number:        0,
 	}
+	v3 := &api.EnumValue{
+		Name:   "TEST_ENUM_V3",
+		ID:     ".test.v1.TestEnum.TEST_ENUM_V3",
+		Number: 3,
+	}
+	v4 := &api.EnumValue{
+		Name:   "TEST_ENUM_2025",
+		ID:     ".test.v1.TestEnum.TEST_ENUM_2025",
+		Number: 4,
+	}
 	enum := &api.Enum{
 		Name:          "TestEnum",
 		ID:            ".test.v1.TestEnum",
 		Documentation: "The enum is documented.",
-		Values:        []*api.EnumValue{v0, v1, v2},
+		Values:        []*api.EnumValue{v0, v1, v2, v3, v4},
 	}
 
 	model := api.NewTestAPI(
@@ -380,32 +390,49 @@ func TestEnumAnnotations(t *testing.T) {
 		QualifiedName: "crate::model::TestEnum",
 		RelativeName:  "TestEnum",
 		DocLines:      []string{"/// The enum is documented."},
-		UniqueNames:   []*api.EnumValue{v0, v1, v2},
+		UniqueNames:   []*api.EnumValue{v0, v1, v2, v3, v4},
 	}
 	if diff := cmp.Diff(want, enum.Codec, cmpopts.IgnoreFields(api.EnumValue{}, "Codec", "Parent")); diff != "" {
 		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
 	}
 
 	if diff := cmp.Diff(&enumValueAnnotation{
-		Name:     "WEEK_5",
-		EnumType: "TestEnum",
-		DocLines: []string{"/// week5 is also documented."},
+		Name:        "WEEK_5",
+		VariantName: "Week5",
+		EnumType:    "TestEnum",
+		DocLines:    []string{"/// week5 is also documented."},
 	}, v0.Codec); diff != "" {
 		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
 	}
 
 	if diff := cmp.Diff(&enumValueAnnotation{
-		Name:     "MULTI_WORD_VALUE",
-		EnumType: "TestEnum",
-		DocLines: []string{"/// MULTI_WORD_VALUE is also documented."},
+		Name:        "MULTI_WORD_VALUE",
+		VariantName: "MultiWordValue",
+		EnumType:    "TestEnum",
+		DocLines:    []string{"/// MULTI_WORD_VALUE is also documented."},
 	}, v1.Codec); diff != "" {
 		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
 	}
 	if diff := cmp.Diff(&enumValueAnnotation{
-		Name:     "VALUE",
-		EnumType: "TestEnum",
-		DocLines: []string{"/// VALUE is also documented."},
+		Name:        "VALUE",
+		VariantName: "Value",
+		EnumType:    "TestEnum",
+		DocLines:    []string{"/// VALUE is also documented."},
 	}, v2.Codec); diff != "" {
+		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
+	}
+	if diff := cmp.Diff(&enumValueAnnotation{
+		Name:        "TEST_ENUM_V3",
+		VariantName: "V3",
+		EnumType:    "TestEnum",
+	}, v3.Codec); diff != "" {
+		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
+	}
+	if diff := cmp.Diff(&enumValueAnnotation{
+		Name:        "TEST_ENUM_2025",
+		VariantName: "_2025",
+		EnumType:    "TestEnum",
+	}, v4.Codec); diff != "" {
 		t.Errorf("mismatch in enum annotations (-want, +got)\n:%s", diff)
 	}
 }
@@ -936,7 +963,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 		Attributes:         []string{},
 		FieldType:          "crate::model::TestEnum",
 		PrimitiveFieldType: "crate::model::TestEnum",
-		AddQueryParameter:  `let builder = builder.query(&[("singularField", &req.singular_field.value())]);`,
+		AddQueryParameter:  `let builder = builder.query(&[("singularField", &req.singular_field)]);`,
 	}
 	if diff := cmp.Diff(wantField, singular_field.Codec); diff != "" {
 		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
@@ -952,7 +979,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 		},
 		FieldType:          "std::vec::Vec<crate::model::TestEnum>",
 		PrimitiveFieldType: "crate::model::TestEnum",
-		AddQueryParameter:  `let builder = req.repeated_field.iter().fold(builder, |builder, p| builder.query(&[("repeatedField", p.value())]));`,
+		AddQueryParameter:  `let builder = req.repeated_field.iter().fold(builder, |builder, p| builder.query(&[("repeatedField", p)]));`,
 	}
 	if diff := cmp.Diff(wantField, repeated_field.Codec); diff != "" {
 		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
@@ -968,7 +995,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 		},
 		FieldType:          "std::option::Option<crate::model::TestEnum>",
 		PrimitiveFieldType: "crate::model::TestEnum",
-		AddQueryParameter:  `let builder = req.optional_field.iter().fold(builder, |builder, p| builder.query(&[("optionalField", p.value())]));`,
+		AddQueryParameter:  `let builder = req.optional_field.iter().fold(builder, |builder, p| builder.query(&[("optionalField", p)]));`,
 	}
 	if diff := cmp.Diff(wantField, optional_field.Codec); diff != "" {
 		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
@@ -984,7 +1011,7 @@ func TestEnumFieldAnnotations(t *testing.T) {
 		Attributes:         []string{},
 		FieldType:          "wkt::NullValue",
 		PrimitiveFieldType: "wkt::NullValue",
-		AddQueryParameter:  `let builder = builder.query(&[("nullValueField", &req.null_value_field.value())]);`,
+		AddQueryParameter:  `let builder = builder.query(&[("nullValueField", &req.null_value_field)]);`,
 	}
 	if diff := cmp.Diff(wantField, null_value_field.Codec); diff != "" {
 		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -650,9 +650,9 @@ func addQueryParameter(f *api.Field) string {
 	switch f.Typez {
 	case api.ENUM_TYPE:
 		if f.Optional || f.Repeated {
-			return fmt.Sprintf(`let builder = req.%s.iter().fold(builder, |builder, p| builder.query(&[("%s", p.value())]));`, fieldName, f.JSONName)
+			return fmt.Sprintf(`let builder = req.%s.iter().fold(builder, |builder, p| builder.query(&[("%s", p)]));`, fieldName, f.JSONName)
 		}
-		return fmt.Sprintf(`let builder = builder.query(&[("%s", &req.%s.value())]);`, f.JSONName, fieldName)
+		return fmt.Sprintf(`let builder = builder.query(&[("%s", &req.%s)]);`, f.JSONName, fieldName)
 	case api.MESSAGE_TYPE:
 		if f.TypezID == ".google.protobuf.FieldMask" {
 			// `FieldMask` (and other well-known types) are special. Their JSON
@@ -685,7 +685,7 @@ func addQueryParameterOneOf(f *api.Field) string {
 	fieldName := toSnake(f.Name)
 	switch f.Typez {
 	case api.ENUM_TYPE:
-		return fmt.Sprintf(`let builder = req.%s().iter().fold(builder, |builder, p| builder.query(&[("%s", p.value())]));`, fieldName, f.JSONName)
+		return fmt.Sprintf(`let builder = req.%s().iter().fold(builder, |builder, p| builder.query(&[("%s", p)]));`, fieldName, f.JSONName)
 	case api.MESSAGE_TYPE:
 		// Query parameters in nested messages are first converted to a
 		// `serde_json::Value`` and then recursively merged into the request
@@ -766,8 +766,67 @@ func enumValueName(e *api.EnumValue) string {
 	return escapeKeyword(toScreamingSnake(e.Name))
 }
 
+// enumValueVariantName returns the name of the Rust enumeration variant for a
+// given enumeration.
+//
+// The Protobuf naming convention is to use SCREAMING_SNAKE_CASE, often
+// prefixed with the name of the enum, e.g.:
+//
+// ```proto
+//
+//	enum MyEnum {
+//	    MY_ENUM_UNSPECIFIED = 0;
+//	    MY_ENUM_RED            = 1;
+//	    MY_ENUM_GREEN          = 2;
+//	    MY_ENUM_BLACK_AND_BLUE = 2;
+//	    MY_ENUM_123            = 123;
+//	}
+//
+// ```
+//
+// What we want in this case is something like:
+//
+// ```rust
+// #[non_exhaustive]
+//
+//	pub enum Syntax {
+//	    Unspecified,
+//	    Red,
+//	    Green,
+//	    BlackAndBlue,
+//	    _123,
+//	    UnknownVariant(/* implementation detail */),
+//	}
+//
+// ```
+// sometimes it is not followed.
+func enumValueVariantName(e *api.EnumValue) string {
+	// The most common case is trying to strip the prefix for `FOO_BAR_UNSPECIFIED`.
+	// The naming conventions being what they are, we need to test with with a
+	// couple of different combinations. In particular, names with numbers, such
+	// as `InstancePrivateIpv6GoogleAccess` make life difficult for everyone.
+	parent := toScreamingSnake(e.Parent.Name)
+	if strings.HasPrefix(e.Name, parent+"_") {
+		return enumValueVariantEscape(strings.TrimPrefix(e.Name, parent+"_"))
+	}
+	trimNumbers := regexp.MustCompile(`_([0-9])`)
+	parent = trimNumbers.ReplaceAllString(parent, `$1`)
+	if strings.HasPrefix(e.Name, parent+"_") {
+		return enumValueVariantEscape(strings.TrimPrefix(e.Name, parent+"_"))
+	}
+	return toPascal(e.Name)
+}
+
+func enumValueVariantEscape(trimmed string) string {
+	trimmed = toPascal(trimmed)
+	if strings.IndexFunc(trimmed, unicode.IsLetter) != 0 {
+		return "_" + trimmed
+	}
+	return toPascal(trimmed)
+}
+
 func fullyQualifiedEnumValueName(v *api.EnumValue, modulePath, sourceSpecificationPackageName string, packageMapping map[string]*packagez) string {
-	return fmt.Sprintf("%s::%s::%s", enumScopeName(v.Parent, modulePath, sourceSpecificationPackageName, packageMapping), toSnake(v.Parent.Name), enumValueName(v))
+	return fmt.Sprintf("%s::%s::%s", enumScopeName(v.Parent, modulePath, sourceSpecificationPackageName, packageMapping), enumName(v.Parent), enumValueVariantName(v))
 }
 
 func bodyAccessor(m *api.Method) string {
@@ -816,7 +875,7 @@ func derefFieldSingle(name string, message *api.Message, state *api.APIState) (s
 		}
 		if field.Typez == api.ENUM_TYPE {
 			expr, nextMessage := derefFieldExpr(name, field.Optional, nil)
-			return expr + ".value()", nextMessage
+			return expr, nextMessage
 		}
 		return derefFieldExpr(name, field.Optional, nil)
 	}

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -802,9 +802,9 @@ func enumValueName(e *api.EnumValue) string {
 // sometimes it is not followed.
 func enumValueVariantName(e *api.EnumValue) string {
 	// The most common case is trying to strip the prefix for `FOO_BAR_UNSPECIFIED`.
-	// The naming conventions being what they are, we need to test with with a
-	// couple of different combinations. In particular, names with numbers, such
-	// as `InstancePrivateIpv6GoogleAccess` make life difficult for everyone.
+	// The naming conventions being what they are, we need to test with a couple
+	// of different combinations. In particular, names with numbers, such as
+	// `InstancePrivateIpv6GoogleAccess` make life difficult for everyone.
 	parent := toScreamingSnake(e.Parent.Name)
 	if strings.HasPrefix(e.Name, parent+"_") {
 		return enumValueVariantEscape(strings.TrimPrefix(e.Name, parent+"_"))

--- a/generator/internal/rust/templates/common/enum.mustache
+++ b/generator/internal/rust/templates/common/enum.mustache
@@ -18,60 +18,128 @@ limitations under the License.
 {{{.}}}
 {{/Codec.DocLines}}
 {{> /templates/common/feature_gate}}
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct {{Codec.Name}}(i32);
-
-{{> /templates/common/feature_gate}}
-impl {{Codec.Name}} {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum {{Codec.Name}} {
     {{#Codec.UniqueNames}}
-
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
-    pub const {{Codec.Name}}: {{Codec.EnumType}} = {{Codec.EnumType}}::new({{Number}});
+    {{Codec.VariantName}},
     {{/Codec.UniqueNames}}
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [{{Codec.Name}}::value] or
+    /// [{{Codec.Name}}::name].
+    UnknownValue({{Codec.ModuleName}}::UnknownValue),
+}
 
-    /// Creates a new {{Codec.Name}} instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            {{#UniqueNumberValues}}
-            {{Number}} => std::borrow::Cow::Borrowed("{{Name}}"),
-            {{/UniqueNumberValues}}
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            {{#Values}}
-            "{{Name}}" => std::option::Option::Some(Self::{{Codec.Name}}),
-            {{/Values}}
-            _ => std::option::Option::None,
-        }
-    }
+{{!
+    The `UnknownValue` variant must be public, but we do not want people to
+    build that variant with a known value. We use a struct, with a `pub(crate)`
+    constructor, and a `pub(crate)` enum.
+}}
+#[doc(hidden)]
+{{> /templates/common/feature_gate}}
+pub mod {{Codec.ModuleName}} {
+    {{! Very rarely, this is unused. It is easier to always disable the warning. }}
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 {{> /templates/common/feature_gate}}
-impl std::convert::From<i32> for {{Codec.Name}} {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl {{Codec.Name}} {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            {{#Codec.UniqueNames}}
+            Self::{{Codec.VariantName}} => std::option::Option::Some({{Number}}),
+            {{/Codec.UniqueNames}}
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            {{#Codec.UniqueNames}}
+            Self::{{Codec.VariantName}} => std::option::Option::Some("{{Name}}"),
+            {{/Codec.UniqueNames}}
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 {{> /templates/common/feature_gate}}
 impl std::default::Default for {{Codec.Name}} {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+{{> /templates/common/feature_gate}}
+impl std::fmt::Display for {{Codec.Name}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+{{> /templates/common/feature_gate}}
+impl std::convert::From<i32> for {{Codec.Name}} {
+    fn from(value: i32) -> Self {
+        match value {
+            {{#UniqueNumberValues}}
+            {{Number}} => Self::{{Codec.VariantName}},
+            {{/UniqueNumberValues}}
+            _ => Self::UnknownValue({{Codec.ModuleName}}::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+{{> /templates/common/feature_gate}}
+impl std::convert::From<&str> for {{Codec.Name}} {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            {{#Values}}
+            "{{Name}}" => Self::{{Codec.VariantName}},
+            {{/Values}}
+            _ => Self::UnknownValue({{Codec.ModuleName}}::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+{{> /templates/common/feature_gate}}
+impl serde::ser::Serialize for {{Codec.Name}} {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            {{#Codec.UniqueNames}}
+            Self::{{Codec.VariantName}} => serializer.serialize_i32({{Number}}),
+            {{/Codec.UniqueNames}}
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+{{> /templates/common/feature_gate}}
+impl<'de> serde::de::Deserialize<'de> for {{Codec.Name}} {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<{{Codec.Name}}>::new(
+            "{{ID}}"))
     }
 }

--- a/generator/internal/rust/templates/convert-prost/enum.mustache
+++ b/generator/internal/rust/templates/convert-prost/enum.mustache
@@ -17,6 +17,6 @@ limitations under the License.
 impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("{{Codec.QualifiedName}}"))
     }
 }

--- a/generator/internal/rust/templates/convert-prost/oneof.mustache
+++ b/generator/internal/rust/templates/convert-prost/oneof.mustache
@@ -19,17 +19,12 @@ impl gaxi::prost::ToProto<{{Codec.RelativeName}}> for {{Codec.QualifiedName}} {
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
         match self {
             {{#Fields}}
-            {{#IsEnum}}
-            Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(v.value())),
-            {{/IsEnum}}
-            {{^IsEnum}}
             {{^Codec.IsBoxed}}
             Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}(v.to_proto()?)),
             {{/Codec.IsBoxed}}
             {{#Codec.IsBoxed}}
             Self::{{Codec.BranchName}}(v) => Ok(Self::Output::{{Codec.BranchName}}((*v).to_proto()?)),
             {{/Codec.IsBoxed}}
-            {{/IsEnum}}
             {{/Fields}}
         }
     }

--- a/guide/samples/src/examine_error_details.rs
+++ b/guide/samples/src/examine_error_details.rs
@@ -28,7 +28,7 @@ pub async fn examine_error_details() -> crate::Result<()> {
             lang::model::Document::new()
                 // Missing document contents
                 // .set_content("Hello World!")
-                .set_type(lang::model::document::Type::PLAIN_TEXT),
+                .set_type(lang::model::document::Type::PlainText),
         )
         .send()
         .await;

--- a/guide/samples/src/lro.rs
+++ b/guide/samples/src/lro.rs
@@ -41,7 +41,7 @@ pub async fn start(project_id: &str) -> crate::Result<()> {
         // ANCHOR_END: transcript-output
         // ANCHOR: configuration
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -84,7 +84,7 @@ pub async fn automatic(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -126,7 +126,7 @@ pub async fn polling(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()

--- a/guide/samples/src/polling_policies.rs
+++ b/guide/samples/src/polling_policies.rs
@@ -52,7 +52,7 @@ pub async fn client_backoff(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -110,7 +110,7 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -165,7 +165,7 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()
@@ -223,7 +223,7 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
                 .set_inline_response_config(speech::model::InlineOutputConfig::new()),
         )
         .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DYNAMIC_BATCHING,
+            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
             speech::model::RecognitionConfig::new()

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -42,16 +42,16 @@ bon            = "3"
 gax.workspace = true
 
 [dev-dependencies]
-axum              = "0.8"
-mockall           = "0.13"
-rand              = "0.8"
-regex             = "1"
-rsa               = { version = "0.9", features = ["pem"] }
-scoped-env        = "2"
-serial_test       = "3"
-tempfile          = "3"
-test-case         = "3"
-tokio             = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
-tokio-test        = "0.4"
-url               = "2"
-mutants.workspace = true
+axum                = "0.8"
+mockall             = "0.13"
+rand                = "0.8"
+regex               = "1"
+rsa                 = { version = "0.9", features = ["pem"] }
+scoped-env          = "2"
+serial_test         = "3"
+tempfile            = "3"
+test-case.workspace = true
+tokio               = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+tokio-test          = "0.4"
+url                 = "2"
+mutants.workspace   = true

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -113,7 +113,7 @@ pub async fn api_key() -> Result<()> {
     // Make a request using the API key.
     let d = Document::new()
         .set_content("Hello, world!")
-        .set_type(language::model::document::Type::PLAIN_TEXT);
+        .set_type(language::model::document::Type::PlainText);
     client.analyze_sentiment().set_document(d).send().await?;
 
     Ok(())

--- a/src/firestore/src/convert.rs
+++ b/src/firestore/src/convert.rs
@@ -64,7 +64,7 @@ mod test {
     #[test]
     fn test_enum_field() -> anyhow::Result<()> {
         let sidekick = model::structured_query::FieldFilter::new()
-            .set_op(model::structured_query::field_filter::Operator::EQUAL);
+            .set_op(model::structured_query::field_filter::Operator::Equal);
         let proto = google::firestore::v1::structured_query::FieldFilter {
             op: google::firestore::v1::structured_query::field_filter::Operator::Equal.into(),
             ..Default::default()

--- a/src/firestore/src/generated/convert/firestore/convert.rs
+++ b/src/firestore/src/generated/convert/firestore/convert.rs
@@ -1225,7 +1225,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::Target> for Target {
 impl gaxi::prost::ToProto<target_change::TargetChangeType> for crate::generated::gapic::model::target_change::TargetChangeType {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::target_change::TargetChangeType"))
     }
 }
 
@@ -1427,7 +1427,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Fi
 impl gaxi::prost::ToProto<structured_query::composite_filter::Operator> for crate::generated::gapic::model::structured_query::composite_filter::Operator {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::structured_query::composite_filter::Operator"))
     }
 }
 
@@ -1455,7 +1455,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Co
 impl gaxi::prost::ToProto<structured_query::field_filter::Operator> for crate::generated::gapic::model::structured_query::field_filter::Operator {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::structured_query::field_filter::Operator"))
     }
 }
 
@@ -1482,7 +1482,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Fi
 impl gaxi::prost::ToProto<structured_query::unary_filter::Operator> for crate::generated::gapic::model::structured_query::unary_filter::Operator {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::structured_query::unary_filter::Operator"))
     }
 }
 
@@ -1578,7 +1578,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Pr
 impl gaxi::prost::ToProto<structured_query::find_nearest::DistanceMeasure> for crate::generated::gapic::model::structured_query::find_nearest::DistanceMeasure {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::structured_query::find_nearest::DistanceMeasure"))
     }
 }
 
@@ -1611,7 +1611,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::Fi
 impl gaxi::prost::ToProto<structured_query::Direction> for crate::generated::gapic::model::structured_query::Direction {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::structured_query::Direction"))
     }
 }
 
@@ -1926,7 +1926,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::Write> for Write {
 impl gaxi::prost::ToProto<document_transform::field_transform::ServerValue> for crate::generated::gapic::model::document_transform::field_transform::ServerValue {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::document_transform::field_transform::ServerValue"))
     }
 }
 

--- a/src/firestore/src/generated/convert/rpc/convert.rs
+++ b/src/firestore/src/generated/convert/rpc/convert.rs
@@ -17,7 +17,7 @@
 impl gaxi::prost::ToProto<Code> for rpc::model::Code {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("rpc::model::Code"))
     }
 }
 

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -4866,19 +4866,15 @@ pub mod target_change {
     use super::*;
 
     /// The type of change.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TargetChangeType(i32);
-
-    impl TargetChangeType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TargetChangeType {
         /// No change has occurred. Used only to send an updated `resume_token`.
-        pub const NO_CHANGE: TargetChangeType = TargetChangeType::new(0);
-
+        NoChange,
         /// The targets have been added.
-        pub const ADD: TargetChangeType = TargetChangeType::new(1);
-
+        Add,
         /// The targets have been removed.
-        pub const REMOVE: TargetChangeType = TargetChangeType::new(2);
-
+        Remove,
         /// The targets reflect all changes committed before the targets were added
         /// to the stream.
         ///
@@ -4887,59 +4883,128 @@ pub mod target_change {
         ///
         /// Listeners can wait for this change if read-after-write semantics
         /// are desired.
-        pub const CURRENT: TargetChangeType = TargetChangeType::new(3);
-
+        Current,
         /// The targets have been reset, and a new initial state for the targets
         /// will be returned in subsequent changes.
         ///
         /// After the initial state is complete, `CURRENT` will be returned even
         /// if the target was previously indicated to be `CURRENT`.
-        pub const RESET: TargetChangeType = TargetChangeType::new(4);
+        Reset,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TargetChangeType::value] or
+        /// [TargetChangeType::name].
+        UnknownValue(target_change_type::UnknownValue),
+    }
 
-        /// Creates a new TargetChangeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod target_change_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TargetChangeType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NoChange => std::option::Option::Some(0),
+                Self::Add => std::option::Option::Some(1),
+                Self::Remove => std::option::Option::Some(2),
+                Self::Current => std::option::Option::Some(3),
+                Self::Reset => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NO_CHANGE"),
-                1 => std::borrow::Cow::Borrowed("ADD"),
-                2 => std::borrow::Cow::Borrowed("REMOVE"),
-                3 => std::borrow::Cow::Borrowed("CURRENT"),
-                4 => std::borrow::Cow::Borrowed("RESET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NoChange => std::option::Option::Some("NO_CHANGE"),
+                Self::Add => std::option::Option::Some("ADD"),
+                Self::Remove => std::option::Option::Some("REMOVE"),
+                Self::Current => std::option::Option::Some("CURRENT"),
+                Self::Reset => std::option::Option::Some("RESET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NO_CHANGE" => std::option::Option::Some(Self::NO_CHANGE),
-                "ADD" => std::option::Option::Some(Self::ADD),
-                "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                "CURRENT" => std::option::Option::Some(Self::CURRENT),
-                "RESET" => std::option::Option::Some(Self::RESET),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TargetChangeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TargetChangeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TargetChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TargetChangeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NoChange,
+                1 => Self::Add,
+                2 => Self::Remove,
+                3 => Self::Current,
+                4 => Self::Reset,
+                _ => Self::UnknownValue(target_change_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TargetChangeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NO_CHANGE" => Self::NoChange,
+                "ADD" => Self::Add,
+                "REMOVE" => Self::Remove,
+                "CURRENT" => Self::Current,
+                "RESET" => Self::Reset,
+                _ => Self::UnknownValue(target_change_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TargetChangeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NoChange => serializer.serialize_i32(0),
+                Self::Add => serializer.serialize_i32(1),
+                Self::Remove => serializer.serialize_i32(2),
+                Self::Current => serializer.serialize_i32(3),
+                Self::Reset => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TargetChangeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TargetChangeType>::new(
+                ".google.firestore.v1.TargetChange.TargetChangeType",
+            ))
         }
     }
 }
@@ -5804,59 +5869,123 @@ pub mod structured_query {
         use super::*;
 
         /// A composite filter operator.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
+            /// Unspecified. This value must not be used.
+            Unspecified,
+            /// Documents are required to satisfy all of the combined filters.
+            And,
+            /// Documents are required to satisfy at least one of the combined filters.
+            Or,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Operator {
-            /// Unspecified. This value must not be used.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
-            /// Documents are required to satisfy all of the combined filters.
-            pub const AND: Operator = Operator::new(1);
-
-            /// Documents are required to satisfy at least one of the combined filters.
-            pub const OR: Operator = Operator::new(2);
-
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::And => std::option::Option::Some(1),
+                    Self::Or => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AND"),
-                    2 => std::borrow::Cow::Borrowed("OR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::And => std::option::Option::Some("AND"),
+                    Self::Or => std::option::Option::Some("OR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "AND" => std::option::Option::Some(Self::AND),
-                    "OR" => std::option::Option::Some(Self::OR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::And,
+                    2 => Self::Or,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "AND" => Self::And,
+                    "OR" => Self::Or,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::And => serializer.serialize_i32(1),
+                    Self::Or => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.firestore.v1.StructuredQuery.CompositeFilter.Operator",
+                ))
             }
         }
     }
@@ -5931,55 +6060,46 @@ pub mod structured_query {
         use super::*;
 
         /// A field filter operator.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
-
-        impl Operator {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
             /// Unspecified. This value must not be used.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
+            Unspecified,
             /// The given `field` is less than the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const LESS_THAN: Operator = Operator::new(1);
-
+            LessThan,
             /// The given `field` is less than or equal to the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const LESS_THAN_OR_EQUAL: Operator = Operator::new(2);
-
+            LessThanOrEqual,
             /// The given `field` is greater than the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const GREATER_THAN: Operator = Operator::new(3);
-
+            GreaterThan,
             /// The given `field` is greater than or equal to the given `value`.
             ///
             /// Requires:
             ///
             /// * That `field` come first in `order_by`.
-            pub const GREATER_THAN_OR_EQUAL: Operator = Operator::new(4);
-
+            GreaterThanOrEqual,
             /// The given `field` is equal to the given `value`.
-            pub const EQUAL: Operator = Operator::new(5);
-
+            Equal,
             /// The given `field` is not equal to the given `value`.
             ///
             /// Requires:
             ///
             /// * No other `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const NOT_EQUAL: Operator = Operator::new(6);
-
+            NotEqual,
             /// The given `field` is an array that contains the given `value`.
-            pub const ARRAY_CONTAINS: Operator = Operator::new(7);
-
+            ArrayContains,
             /// The given `field` is equal to at least one value in the given array.
             ///
             /// Requires:
@@ -5987,8 +6107,7 @@ pub mod structured_query {
             /// * That `value` is a non-empty `ArrayValue`, subject to disjunction
             ///   limits.
             /// * No `NOT_IN` filters in the same query.
-            pub const IN: Operator = Operator::new(8);
-
+            In,
             /// The given `field` is an array that contains any of the values in the
             /// given array.
             ///
@@ -5998,8 +6117,7 @@ pub mod structured_query {
             ///   limits.
             /// * No other `ARRAY_CONTAINS_ANY` filters within the same disjunction.
             /// * No `NOT_IN` filters in the same query.
-            pub const ARRAY_CONTAINS_ANY: Operator = Operator::new(9);
-
+            ArrayContainsAny,
             /// The value of the `field` is not in the given array.
             ///
             /// Requires:
@@ -6008,66 +6126,155 @@ pub mod structured_query {
             /// * No other `OR`, `IN`, `ARRAY_CONTAINS_ANY`, `NOT_IN`, `NOT_EQUAL`,
             ///   `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const NOT_IN: Operator = Operator::new(10);
+            NotIn,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
 
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Operator {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::LessThan => std::option::Option::Some(1),
+                    Self::LessThanOrEqual => std::option::Option::Some(2),
+                    Self::GreaterThan => std::option::Option::Some(3),
+                    Self::GreaterThanOrEqual => std::option::Option::Some(4),
+                    Self::Equal => std::option::Option::Some(5),
+                    Self::NotEqual => std::option::Option::Some(6),
+                    Self::ArrayContains => std::option::Option::Some(7),
+                    Self::In => std::option::Option::Some(8),
+                    Self::ArrayContainsAny => std::option::Option::Some(9),
+                    Self::NotIn => std::option::Option::Some(10),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("LESS_THAN"),
-                    2 => std::borrow::Cow::Borrowed("LESS_THAN_OR_EQUAL"),
-                    3 => std::borrow::Cow::Borrowed("GREATER_THAN"),
-                    4 => std::borrow::Cow::Borrowed("GREATER_THAN_OR_EQUAL"),
-                    5 => std::borrow::Cow::Borrowed("EQUAL"),
-                    6 => std::borrow::Cow::Borrowed("NOT_EQUAL"),
-                    7 => std::borrow::Cow::Borrowed("ARRAY_CONTAINS"),
-                    8 => std::borrow::Cow::Borrowed("IN"),
-                    9 => std::borrow::Cow::Borrowed("ARRAY_CONTAINS_ANY"),
-                    10 => std::borrow::Cow::Borrowed("NOT_IN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::LessThan => std::option::Option::Some("LESS_THAN"),
+                    Self::LessThanOrEqual => std::option::Option::Some("LESS_THAN_OR_EQUAL"),
+                    Self::GreaterThan => std::option::Option::Some("GREATER_THAN"),
+                    Self::GreaterThanOrEqual => std::option::Option::Some("GREATER_THAN_OR_EQUAL"),
+                    Self::Equal => std::option::Option::Some("EQUAL"),
+                    Self::NotEqual => std::option::Option::Some("NOT_EQUAL"),
+                    Self::ArrayContains => std::option::Option::Some("ARRAY_CONTAINS"),
+                    Self::In => std::option::Option::Some("IN"),
+                    Self::ArrayContainsAny => std::option::Option::Some("ARRAY_CONTAINS_ANY"),
+                    Self::NotIn => std::option::Option::Some("NOT_IN"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "LESS_THAN" => std::option::Option::Some(Self::LESS_THAN),
-                    "LESS_THAN_OR_EQUAL" => std::option::Option::Some(Self::LESS_THAN_OR_EQUAL),
-                    "GREATER_THAN" => std::option::Option::Some(Self::GREATER_THAN),
-                    "GREATER_THAN_OR_EQUAL" => {
-                        std::option::Option::Some(Self::GREATER_THAN_OR_EQUAL)
-                    }
-                    "EQUAL" => std::option::Option::Some(Self::EQUAL),
-                    "NOT_EQUAL" => std::option::Option::Some(Self::NOT_EQUAL),
-                    "ARRAY_CONTAINS" => std::option::Option::Some(Self::ARRAY_CONTAINS),
-                    "IN" => std::option::Option::Some(Self::IN),
-                    "ARRAY_CONTAINS_ANY" => std::option::Option::Some(Self::ARRAY_CONTAINS_ANY),
-                    "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::LessThan,
+                    2 => Self::LessThanOrEqual,
+                    3 => Self::GreaterThan,
+                    4 => Self::GreaterThanOrEqual,
+                    5 => Self::Equal,
+                    6 => Self::NotEqual,
+                    7 => Self::ArrayContains,
+                    8 => Self::In,
+                    9 => Self::ArrayContainsAny,
+                    10 => Self::NotIn,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "LESS_THAN" => Self::LessThan,
+                    "LESS_THAN_OR_EQUAL" => Self::LessThanOrEqual,
+                    "GREATER_THAN" => Self::GreaterThan,
+                    "GREATER_THAN_OR_EQUAL" => Self::GreaterThanOrEqual,
+                    "EQUAL" => Self::Equal,
+                    "NOT_EQUAL" => Self::NotEqual,
+                    "ARRAY_CONTAINS" => Self::ArrayContains,
+                    "IN" => Self::In,
+                    "ARRAY_CONTAINS_ANY" => Self::ArrayContainsAny,
+                    "NOT_IN" => Self::NotIn,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::LessThan => serializer.serialize_i32(1),
+                    Self::LessThanOrEqual => serializer.serialize_i32(2),
+                    Self::GreaterThan => serializer.serialize_i32(3),
+                    Self::GreaterThanOrEqual => serializer.serialize_i32(4),
+                    Self::Equal => serializer.serialize_i32(5),
+                    Self::NotEqual => serializer.serialize_i32(6),
+                    Self::ArrayContains => serializer.serialize_i32(7),
+                    Self::In => serializer.serialize_i32(8),
+                    Self::ArrayContainsAny => serializer.serialize_i32(9),
+                    Self::NotIn => serializer.serialize_i32(10),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.firestore.v1.StructuredQuery.FieldFilter.Operator",
+                ))
             }
         }
     }
@@ -6168,79 +6375,147 @@ pub mod structured_query {
         use super::*;
 
         /// A unary operator.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
-
-        impl Operator {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
             /// Unspecified. This value must not be used.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
+            Unspecified,
             /// The given `field` is equal to `NaN`.
-            pub const IS_NAN: Operator = Operator::new(2);
-
+            IsNan,
             /// The given `field` is equal to `NULL`.
-            pub const IS_NULL: Operator = Operator::new(3);
-
+            IsNull,
             /// The given `field` is not equal to `NaN`.
             ///
             /// Requires:
             ///
             /// * No other `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const IS_NOT_NAN: Operator = Operator::new(4);
-
+            IsNotNan,
             /// The given `field` is not equal to `NULL`.
             ///
             /// Requires:
             ///
             /// * A single `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
             /// * That `field` comes first in the `order_by`.
-            pub const IS_NOT_NULL: Operator = Operator::new(5);
+            IsNotNull,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
 
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Operator {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::IsNan => std::option::Option::Some(2),
+                    Self::IsNull => std::option::Option::Some(3),
+                    Self::IsNotNan => std::option::Option::Some(4),
+                    Self::IsNotNull => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    2 => std::borrow::Cow::Borrowed("IS_NAN"),
-                    3 => std::borrow::Cow::Borrowed("IS_NULL"),
-                    4 => std::borrow::Cow::Borrowed("IS_NOT_NAN"),
-                    5 => std::borrow::Cow::Borrowed("IS_NOT_NULL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::IsNan => std::option::Option::Some("IS_NAN"),
+                    Self::IsNull => std::option::Option::Some("IS_NULL"),
+                    Self::IsNotNan => std::option::Option::Some("IS_NOT_NAN"),
+                    Self::IsNotNull => std::option::Option::Some("IS_NOT_NULL"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "IS_NAN" => std::option::Option::Some(Self::IS_NAN),
-                    "IS_NULL" => std::option::Option::Some(Self::IS_NULL),
-                    "IS_NOT_NAN" => std::option::Option::Some(Self::IS_NOT_NAN),
-                    "IS_NOT_NULL" => std::option::Option::Some(Self::IS_NOT_NULL),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    2 => Self::IsNan,
+                    3 => Self::IsNull,
+                    4 => Self::IsNotNan,
+                    5 => Self::IsNotNull,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "IS_NAN" => Self::IsNan,
+                    "IS_NULL" => Self::IsNull,
+                    "IS_NOT_NAN" => Self::IsNotNan,
+                    "IS_NOT_NULL" => Self::IsNotNull,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::IsNan => serializer.serialize_i32(2),
+                    Self::IsNull => serializer.serialize_i32(3),
+                    Self::IsNotNan => serializer.serialize_i32(4),
+                    Self::IsNotNull => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.firestore.v1.StructuredQuery.UnaryFilter.Operator",
+                ))
             }
         }
 
@@ -6523,19 +6798,16 @@ pub mod structured_query {
         use super::*;
 
         /// The distance measure to use when comparing vectors.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DistanceMeasure(i32);
-
-        impl DistanceMeasure {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DistanceMeasure {
             /// Should not be set.
-            pub const DISTANCE_MEASURE_UNSPECIFIED: DistanceMeasure = DistanceMeasure::new(0);
-
+            Unspecified,
             /// Measures the EUCLIDEAN distance between the vectors. See
             /// [Euclidean](https://en.wikipedia.org/wiki/Euclidean_distance) to learn
             /// more. The resulting distance decreases the more similar two vectors
             /// are.
-            pub const EUCLIDEAN: DistanceMeasure = DistanceMeasure::new(1);
-
+            Euclidean,
             /// COSINE distance compares vectors based on the angle between them, which
             /// allows you to measure similarity that isn't based on the vectors
             /// magnitude. We recommend using DOT_PRODUCT with unit normalized vectors
@@ -6544,115 +6816,243 @@ pub mod structured_query {
             /// Similarity](https://en.wikipedia.org/wiki/Cosine_similarity) to learn
             /// more about COSINE similarity and COSINE distance. The resulting
             /// COSINE distance decreases the more similar two vectors are.
-            pub const COSINE: DistanceMeasure = DistanceMeasure::new(2);
-
+            Cosine,
             /// Similar to cosine but is affected by the magnitude of the vectors. See
             /// [Dot Product](https://en.wikipedia.org/wiki/Dot_product) to learn more.
             /// The resulting distance increases the more similar two vectors are.
-            pub const DOT_PRODUCT: DistanceMeasure = DistanceMeasure::new(3);
+            DotProduct,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DistanceMeasure::value] or
+            /// [DistanceMeasure::name].
+            UnknownValue(distance_measure::UnknownValue),
+        }
 
-            /// Creates a new DistanceMeasure instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod distance_measure {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl DistanceMeasure {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Euclidean => std::option::Option::Some(1),
+                    Self::Cosine => std::option::Option::Some(2),
+                    Self::DotProduct => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DISTANCE_MEASURE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EUCLIDEAN"),
-                    2 => std::borrow::Cow::Borrowed("COSINE"),
-                    3 => std::borrow::Cow::Borrowed("DOT_PRODUCT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("DISTANCE_MEASURE_UNSPECIFIED"),
+                    Self::Euclidean => std::option::Option::Some("EUCLIDEAN"),
+                    Self::Cosine => std::option::Option::Some("COSINE"),
+                    Self::DotProduct => std::option::Option::Some("DOT_PRODUCT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DISTANCE_MEASURE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DISTANCE_MEASURE_UNSPECIFIED)
-                    }
-                    "EUCLIDEAN" => std::option::Option::Some(Self::EUCLIDEAN),
-                    "COSINE" => std::option::Option::Some(Self::COSINE),
-                    "DOT_PRODUCT" => std::option::Option::Some(Self::DOT_PRODUCT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for DistanceMeasure {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for DistanceMeasure {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for DistanceMeasure {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for DistanceMeasure {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Euclidean,
+                    2 => Self::Cosine,
+                    3 => Self::DotProduct,
+                    _ => Self::UnknownValue(distance_measure::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for DistanceMeasure {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DISTANCE_MEASURE_UNSPECIFIED" => Self::Unspecified,
+                    "EUCLIDEAN" => Self::Euclidean,
+                    "COSINE" => Self::Cosine,
+                    "DOT_PRODUCT" => Self::DotProduct,
+                    _ => Self::UnknownValue(distance_measure::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for DistanceMeasure {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Euclidean => serializer.serialize_i32(1),
+                    Self::Cosine => serializer.serialize_i32(2),
+                    Self::DotProduct => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for DistanceMeasure {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DistanceMeasure>::new(
+                    ".google.firestore.v1.StructuredQuery.FindNearest.DistanceMeasure",
+                ))
             }
         }
     }
 
     /// A sort direction.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Direction {
+        /// Unspecified.
+        Unspecified,
+        /// Ascending.
+        Ascending,
+        /// Descending.
+        Descending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Direction::value] or
+        /// [Direction::name].
+        UnknownValue(direction::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod direction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Direction {
-        /// Unspecified.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
-
-        /// Ascending.
-        pub const ASCENDING: Direction = Direction::new(1);
-
-        /// Descending.
-        pub const DESCENDING: Direction = Direction::new(2);
-
-        /// Creates a new Direction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ascending => std::option::Option::Some(1),
+                Self::Descending => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ASCENDING"),
-                2 => std::borrow::Cow::Borrowed("DESCENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIRECTION_UNSPECIFIED"),
+                Self::Ascending => std::option::Option::Some("ASCENDING"),
+                Self::Descending => std::option::Option::Some("DESCENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
-                "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
-                "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Direction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Direction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ascending,
+                2 => Self::Descending,
+                _ => Self::UnknownValue(direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Direction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIRECTION_UNSPECIFIED" => Self::Unspecified,
+                "ASCENDING" => Self::Ascending,
+                "DESCENDING" => Self::Descending,
+                _ => Self::UnknownValue(direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Direction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ascending => serializer.serialize_i32(1),
+                Self::Descending => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Direction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Direction>::new(
+                ".google.firestore.v1.StructuredQuery.Direction",
+            ))
         }
     }
 }
@@ -7973,58 +8373,118 @@ pub mod document_transform {
         use super::*;
 
         /// A value that is calculated by the server.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ServerValue(i32);
-
-        impl ServerValue {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ServerValue {
             /// Unspecified. This value must not be used.
-            pub const SERVER_VALUE_UNSPECIFIED: ServerValue = ServerValue::new(0);
-
+            Unspecified,
             /// The time at which the server processed the request, with millisecond
             /// precision. If used on multiple fields (same or different documents) in
             /// a transaction, all the fields will get the same server timestamp.
-            pub const REQUEST_TIME: ServerValue = ServerValue::new(1);
+            RequestTime,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ServerValue::value] or
+            /// [ServerValue::name].
+            UnknownValue(server_value::UnknownValue),
+        }
 
-            /// Creates a new ServerValue instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod server_value {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ServerValue {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::RequestTime => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SERVER_VALUE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("REQUEST_TIME"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SERVER_VALUE_UNSPECIFIED"),
+                    Self::RequestTime => std::option::Option::Some("REQUEST_TIME"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SERVER_VALUE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SERVER_VALUE_UNSPECIFIED)
-                    }
-                    "REQUEST_TIME" => std::option::Option::Some(Self::REQUEST_TIME),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ServerValue {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ServerValue {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ServerValue {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ServerValue {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::RequestTime,
+                    _ => Self::UnknownValue(server_value::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ServerValue {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SERVER_VALUE_UNSPECIFIED" => Self::Unspecified,
+                    "REQUEST_TIME" => Self::RequestTime,
+                    _ => Self::UnknownValue(server_value::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ServerValue {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::RequestTime => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ServerValue {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServerValue>::new(
+                    ".google.firestore.v1.DocumentTransform.FieldTransform.ServerValue",
+                ))
             }
         }
 

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -71,15 +71,15 @@ rpc  = { workspace = true, optional = true }
 wkt  = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow.workspace = true
-axum             = "0.8"
-bytes            = "1"
-mockall          = "0.13"
-scoped-env       = "2"
-serde_with       = "3"
-serial_test      = "3"
-test-case        = "3"
-tokio            = { version = "1", features = ["test-util"] }
+anyhow.workspace    = true
+axum                = "0.8"
+bytes               = "1"
+mockall             = "0.13"
+scoped-env          = "2"
+serde_with          = "3"
+serial_test         = "3"
+test-case.workspace = true
+tokio               = { version = "1", features = ["test-util"] }
 # Local crates
 echo-server = { path = "echo-server" }
 grpc-server = { path = "grpc-server" }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -48,14 +48,14 @@ wkt.workspace = true
 [dev-dependencies]
 # This is a workaround to integration test features of this crate. Open issue
 # https://github.com/rust-lang/cargo/issues/2911.
-gax              = { path = ".", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
-anyhow.workspace = true
-mockall          = "0.13"
-serde.workspace  = true
-serial_test      = "3"
-test-case        = "3"
-tokio            = { version = "1", features = ["test-util"] }
-tokio-test       = "0.4"
+gax                 = { path = ".", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
+anyhow.workspace    = true
+mockall             = "0.13"
+serde.workspace     = true
+serial_test         = "3"
+test-case.workspace = true
+tokio               = { version = "1", features = ["test-util"] }
+tokio-test          = "0.4"
 
 [features]
 unstable-sdk-client = []

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -116,164 +116,263 @@ pub mod check_error {
     use super::*;
 
     /// Error codes for Check responses.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// This is never used in `CheckResponse`.
-        pub const ERROR_CODE_UNSPECIFIED: Code = Code::new(0);
-
+        ErrorCodeUnspecified,
         /// The consumer's project id, network container, or resource container was
         /// not found. Same as [google.rpc.Code.NOT_FOUND][google.rpc.Code.NOT_FOUND].
-        pub const NOT_FOUND: Code = Code::new(5);
-
+        NotFound,
         /// The consumer doesn't have access to the specified resource.
         /// Same as [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
-        pub const PERMISSION_DENIED: Code = Code::new(7);
-
+        PermissionDenied,
         /// Quota check failed. Same as [google.rpc.Code.RESOURCE_EXHAUSTED][google.rpc.Code.RESOURCE_EXHAUSTED].
-        pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
-
+        ResourceExhausted,
         /// The consumer hasn't activated the service.
-        pub const SERVICE_NOT_ACTIVATED: Code = Code::new(104);
-
+        ServiceNotActivated,
         /// The consumer cannot access the service because billing is disabled.
-        pub const BILLING_DISABLED: Code = Code::new(107);
-
+        BillingDisabled,
         /// The consumer's project has been marked as deleted (soft deletion).
-        pub const PROJECT_DELETED: Code = Code::new(108);
-
+        ProjectDeleted,
         /// The consumer's project number or id does not represent a valid project.
-        pub const PROJECT_INVALID: Code = Code::new(114);
-
+        ProjectInvalid,
         /// The input consumer info does not represent a valid consumer folder or
         /// organization.
-        pub const CONSUMER_INVALID: Code = Code::new(125);
-
+        ConsumerInvalid,
         /// The IP address of the consumer is invalid for the specific consumer
         /// project.
-        pub const IP_ADDRESS_BLOCKED: Code = Code::new(109);
-
+        IpAddressBlocked,
         /// The referer address of the consumer request is invalid for the specific
         /// consumer project.
-        pub const REFERER_BLOCKED: Code = Code::new(110);
-
+        RefererBlocked,
         /// The client application of the consumer request is invalid for the
         /// specific consumer project.
-        pub const CLIENT_APP_BLOCKED: Code = Code::new(111);
-
+        ClientAppBlocked,
         /// The API targeted by this request is invalid for the specified consumer
         /// project.
-        pub const API_TARGET_BLOCKED: Code = Code::new(122);
-
+        ApiTargetBlocked,
         /// The consumer's API key is invalid.
-        pub const API_KEY_INVALID: Code = Code::new(105);
-
+        ApiKeyInvalid,
         /// The consumer's API Key has expired.
-        pub const API_KEY_EXPIRED: Code = Code::new(112);
-
+        ApiKeyExpired,
         /// The consumer's API Key was not found in config record.
-        pub const API_KEY_NOT_FOUND: Code = Code::new(113);
-
+        ApiKeyNotFound,
         /// The credential in the request can not be verified.
-        pub const INVALID_CREDENTIAL: Code = Code::new(123);
-
+        InvalidCredential,
         /// The backend server for looking up project id/number is unavailable.
-        pub const NAMESPACE_LOOKUP_UNAVAILABLE: Code = Code::new(300);
-
+        NamespaceLookupUnavailable,
         /// The backend server for checking service status is unavailable.
-        pub const SERVICE_STATUS_UNAVAILABLE: Code = Code::new(301);
-
+        ServiceStatusUnavailable,
         /// The backend server for checking billing status is unavailable.
-        pub const BILLING_STATUS_UNAVAILABLE: Code = Code::new(302);
-
+        BillingStatusUnavailable,
         /// Cloud Resource Manager backend server is unavailable.
-        pub const CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE: Code = Code::new(305);
+        CloudResourceManagerBackendUnavailable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::ErrorCodeUnspecified => std::option::Option::Some(0),
+                Self::NotFound => std::option::Option::Some(5),
+                Self::PermissionDenied => std::option::Option::Some(7),
+                Self::ResourceExhausted => std::option::Option::Some(8),
+                Self::ServiceNotActivated => std::option::Option::Some(104),
+                Self::BillingDisabled => std::option::Option::Some(107),
+                Self::ProjectDeleted => std::option::Option::Some(108),
+                Self::ProjectInvalid => std::option::Option::Some(114),
+                Self::ConsumerInvalid => std::option::Option::Some(125),
+                Self::IpAddressBlocked => std::option::Option::Some(109),
+                Self::RefererBlocked => std::option::Option::Some(110),
+                Self::ClientAppBlocked => std::option::Option::Some(111),
+                Self::ApiTargetBlocked => std::option::Option::Some(122),
+                Self::ApiKeyInvalid => std::option::Option::Some(105),
+                Self::ApiKeyExpired => std::option::Option::Some(112),
+                Self::ApiKeyNotFound => std::option::Option::Some(113),
+                Self::InvalidCredential => std::option::Option::Some(123),
+                Self::NamespaceLookupUnavailable => std::option::Option::Some(300),
+                Self::ServiceStatusUnavailable => std::option::Option::Some(301),
+                Self::BillingStatusUnavailable => std::option::Option::Some(302),
+                Self::CloudResourceManagerBackendUnavailable => std::option::Option::Some(305),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
-                5 => std::borrow::Cow::Borrowed("NOT_FOUND"),
-                7 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
-                104 => std::borrow::Cow::Borrowed("SERVICE_NOT_ACTIVATED"),
-                105 => std::borrow::Cow::Borrowed("API_KEY_INVALID"),
-                107 => std::borrow::Cow::Borrowed("BILLING_DISABLED"),
-                108 => std::borrow::Cow::Borrowed("PROJECT_DELETED"),
-                109 => std::borrow::Cow::Borrowed("IP_ADDRESS_BLOCKED"),
-                110 => std::borrow::Cow::Borrowed("REFERER_BLOCKED"),
-                111 => std::borrow::Cow::Borrowed("CLIENT_APP_BLOCKED"),
-                112 => std::borrow::Cow::Borrowed("API_KEY_EXPIRED"),
-                113 => std::borrow::Cow::Borrowed("API_KEY_NOT_FOUND"),
-                114 => std::borrow::Cow::Borrowed("PROJECT_INVALID"),
-                122 => std::borrow::Cow::Borrowed("API_TARGET_BLOCKED"),
-                123 => std::borrow::Cow::Borrowed("INVALID_CREDENTIAL"),
-                125 => std::borrow::Cow::Borrowed("CONSUMER_INVALID"),
-                300 => std::borrow::Cow::Borrowed("NAMESPACE_LOOKUP_UNAVAILABLE"),
-                301 => std::borrow::Cow::Borrowed("SERVICE_STATUS_UNAVAILABLE"),
-                302 => std::borrow::Cow::Borrowed("BILLING_STATUS_UNAVAILABLE"),
-                305 => std::borrow::Cow::Borrowed("CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::ErrorCodeUnspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::NotFound => std::option::Option::Some("NOT_FOUND"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::ResourceExhausted => std::option::Option::Some("RESOURCE_EXHAUSTED"),
+                Self::ServiceNotActivated => std::option::Option::Some("SERVICE_NOT_ACTIVATED"),
+                Self::BillingDisabled => std::option::Option::Some("BILLING_DISABLED"),
+                Self::ProjectDeleted => std::option::Option::Some("PROJECT_DELETED"),
+                Self::ProjectInvalid => std::option::Option::Some("PROJECT_INVALID"),
+                Self::ConsumerInvalid => std::option::Option::Some("CONSUMER_INVALID"),
+                Self::IpAddressBlocked => std::option::Option::Some("IP_ADDRESS_BLOCKED"),
+                Self::RefererBlocked => std::option::Option::Some("REFERER_BLOCKED"),
+                Self::ClientAppBlocked => std::option::Option::Some("CLIENT_APP_BLOCKED"),
+                Self::ApiTargetBlocked => std::option::Option::Some("API_TARGET_BLOCKED"),
+                Self::ApiKeyInvalid => std::option::Option::Some("API_KEY_INVALID"),
+                Self::ApiKeyExpired => std::option::Option::Some("API_KEY_EXPIRED"),
+                Self::ApiKeyNotFound => std::option::Option::Some("API_KEY_NOT_FOUND"),
+                Self::InvalidCredential => std::option::Option::Some("INVALID_CREDENTIAL"),
+                Self::NamespaceLookupUnavailable => {
+                    std::option::Option::Some("NAMESPACE_LOOKUP_UNAVAILABLE")
+                }
+                Self::ServiceStatusUnavailable => {
+                    std::option::Option::Some("SERVICE_STATUS_UNAVAILABLE")
+                }
+                Self::BillingStatusUnavailable => {
+                    std::option::Option::Some("BILLING_STATUS_UNAVAILABLE")
+                }
+                Self::CloudResourceManagerBackendUnavailable => {
+                    std::option::Option::Some("CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
-                "SERVICE_NOT_ACTIVATED" => std::option::Option::Some(Self::SERVICE_NOT_ACTIVATED),
-                "BILLING_DISABLED" => std::option::Option::Some(Self::BILLING_DISABLED),
-                "PROJECT_DELETED" => std::option::Option::Some(Self::PROJECT_DELETED),
-                "PROJECT_INVALID" => std::option::Option::Some(Self::PROJECT_INVALID),
-                "CONSUMER_INVALID" => std::option::Option::Some(Self::CONSUMER_INVALID),
-                "IP_ADDRESS_BLOCKED" => std::option::Option::Some(Self::IP_ADDRESS_BLOCKED),
-                "REFERER_BLOCKED" => std::option::Option::Some(Self::REFERER_BLOCKED),
-                "CLIENT_APP_BLOCKED" => std::option::Option::Some(Self::CLIENT_APP_BLOCKED),
-                "API_TARGET_BLOCKED" => std::option::Option::Some(Self::API_TARGET_BLOCKED),
-                "API_KEY_INVALID" => std::option::Option::Some(Self::API_KEY_INVALID),
-                "API_KEY_EXPIRED" => std::option::Option::Some(Self::API_KEY_EXPIRED),
-                "API_KEY_NOT_FOUND" => std::option::Option::Some(Self::API_KEY_NOT_FOUND),
-                "INVALID_CREDENTIAL" => std::option::Option::Some(Self::INVALID_CREDENTIAL),
-                "NAMESPACE_LOOKUP_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::NAMESPACE_LOOKUP_UNAVAILABLE)
-                }
-                "SERVICE_STATUS_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::SERVICE_STATUS_UNAVAILABLE)
-                }
-                "BILLING_STATUS_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::BILLING_STATUS_UNAVAILABLE)
-                }
-                "CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::ErrorCodeUnspecified,
+                5 => Self::NotFound,
+                7 => Self::PermissionDenied,
+                8 => Self::ResourceExhausted,
+                104 => Self::ServiceNotActivated,
+                105 => Self::ApiKeyInvalid,
+                107 => Self::BillingDisabled,
+                108 => Self::ProjectDeleted,
+                109 => Self::IpAddressBlocked,
+                110 => Self::RefererBlocked,
+                111 => Self::ClientAppBlocked,
+                112 => Self::ApiKeyExpired,
+                113 => Self::ApiKeyNotFound,
+                114 => Self::ProjectInvalid,
+                122 => Self::ApiTargetBlocked,
+                123 => Self::InvalidCredential,
+                125 => Self::ConsumerInvalid,
+                300 => Self::NamespaceLookupUnavailable,
+                301 => Self::ServiceStatusUnavailable,
+                302 => Self::BillingStatusUnavailable,
+                305 => Self::CloudResourceManagerBackendUnavailable,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::ErrorCodeUnspecified,
+                "NOT_FOUND" => Self::NotFound,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                "RESOURCE_EXHAUSTED" => Self::ResourceExhausted,
+                "SERVICE_NOT_ACTIVATED" => Self::ServiceNotActivated,
+                "BILLING_DISABLED" => Self::BillingDisabled,
+                "PROJECT_DELETED" => Self::ProjectDeleted,
+                "PROJECT_INVALID" => Self::ProjectInvalid,
+                "CONSUMER_INVALID" => Self::ConsumerInvalid,
+                "IP_ADDRESS_BLOCKED" => Self::IpAddressBlocked,
+                "REFERER_BLOCKED" => Self::RefererBlocked,
+                "CLIENT_APP_BLOCKED" => Self::ClientAppBlocked,
+                "API_TARGET_BLOCKED" => Self::ApiTargetBlocked,
+                "API_KEY_INVALID" => Self::ApiKeyInvalid,
+                "API_KEY_EXPIRED" => Self::ApiKeyExpired,
+                "API_KEY_NOT_FOUND" => Self::ApiKeyNotFound,
+                "INVALID_CREDENTIAL" => Self::InvalidCredential,
+                "NAMESPACE_LOOKUP_UNAVAILABLE" => Self::NamespaceLookupUnavailable,
+                "SERVICE_STATUS_UNAVAILABLE" => Self::ServiceStatusUnavailable,
+                "BILLING_STATUS_UNAVAILABLE" => Self::BillingStatusUnavailable,
+                "CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE" => {
+                    Self::CloudResourceManagerBackendUnavailable
+                }
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::ErrorCodeUnspecified => serializer.serialize_i32(0),
+                Self::NotFound => serializer.serialize_i32(5),
+                Self::PermissionDenied => serializer.serialize_i32(7),
+                Self::ResourceExhausted => serializer.serialize_i32(8),
+                Self::ServiceNotActivated => serializer.serialize_i32(104),
+                Self::BillingDisabled => serializer.serialize_i32(107),
+                Self::ProjectDeleted => serializer.serialize_i32(108),
+                Self::ProjectInvalid => serializer.serialize_i32(114),
+                Self::ConsumerInvalid => serializer.serialize_i32(125),
+                Self::IpAddressBlocked => serializer.serialize_i32(109),
+                Self::RefererBlocked => serializer.serialize_i32(110),
+                Self::ClientAppBlocked => serializer.serialize_i32(111),
+                Self::ApiTargetBlocked => serializer.serialize_i32(122),
+                Self::ApiKeyInvalid => serializer.serialize_i32(105),
+                Self::ApiKeyExpired => serializer.serialize_i32(112),
+                Self::ApiKeyNotFound => serializer.serialize_i32(113),
+                Self::InvalidCredential => serializer.serialize_i32(123),
+                Self::NamespaceLookupUnavailable => serializer.serialize_i32(300),
+                Self::ServiceStatusUnavailable => serializer.serialize_i32(301),
+                Self::BillingStatusUnavailable => serializer.serialize_i32(302),
+                Self::CloudResourceManagerBackendUnavailable => serializer.serialize_i32(305),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.api.servicecontrol.v1.CheckError.Code",
+            ))
         }
     }
 }
@@ -1835,57 +1934,116 @@ pub mod operation {
     use super::*;
 
     /// Defines the importance of the data contained in the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Importance(i32);
-
-    impl Importance {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Importance {
         /// Allows data caching, batching, and aggregation. It provides
         /// higher performance with higher data loss risk.
-        pub const LOW: Importance = Importance::new(0);
-
+        Low,
         /// Disables data aggregation to minimize data loss. It is for operations
         /// that contains significant monetary value or audit trail. This feature
         /// only applies to the client libraries.
-        pub const HIGH: Importance = Importance::new(1);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Importance::value] or
+        /// [Importance::name].
+        UnknownValue(importance::UnknownValue),
+    }
 
-        /// Creates a new Importance instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod importance {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Importance {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Low => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOW"),
-                1 => std::borrow::Cow::Borrowed("HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Importance {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Importance {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Importance {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Importance {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Low,
+                1 => Self::High,
+                _ => Self::UnknownValue(importance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Importance {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOW" => Self::Low,
+                "HIGH" => Self::High,
+                _ => Self::UnknownValue(importance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Importance {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Low => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Importance {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Importance>::new(
+                ".google.api.servicecontrol.v1.Operation.Importance",
+            ))
         }
     }
 }
@@ -2089,21 +2247,18 @@ pub mod quota_operation {
     use super::*;
 
     /// Supported quota modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QuotaMode(i32);
-
-    impl QuotaMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum QuotaMode {
         /// Guard against implicit default. Must not be used.
-        pub const UNSPECIFIED: QuotaMode = QuotaMode::new(0);
-
+        Unspecified,
         /// For AllocateQuota request, allocates quota for the amount specified in
         /// the service configuration or specified using the quota metrics. If the
         /// amount is higher than the available quota, allocation error will be
         /// returned and no quota will be allocated.
         /// If multiple quotas are part of the request, and one fails, none of the
         /// quotas are allocated or released.
-        pub const NORMAL: QuotaMode = QuotaMode::new(1);
-
+        Normal,
         /// The operation allocates quota for the amount specified in the service
         /// configuration or specified using the quota metrics. If the amount is
         /// higher than the available quota, request does not fail but all available
@@ -2112,73 +2267,143 @@ pub mod quota_operation {
         /// even if one does not have enough quota. For allocation, it will find the
         /// minimum available amount across all groups and deduct that amount from
         /// all the affected groups.
-        pub const BEST_EFFORT: QuotaMode = QuotaMode::new(2);
-
+        BestEffort,
         /// For AllocateQuota request, only checks if there is enough quota
         /// available and does not change the available quota. No lock is placed on
         /// the available quota either.
-        pub const CHECK_ONLY: QuotaMode = QuotaMode::new(3);
-
+        CheckOnly,
         /// Unimplemented. When used in AllocateQuotaRequest, this returns the
         /// effective quota limit(s) in the response, and no quota check will be
         /// performed. Not supported for other requests, and even for
         /// AllocateQuotaRequest, this is currently supported only for allowlisted
         /// services.
-        pub const QUERY_ONLY: QuotaMode = QuotaMode::new(4);
-
+        QueryOnly,
         /// The operation allocates quota for the amount specified in the service
         /// configuration or specified using the quota metrics. If the requested
         /// amount is higher than the available quota, request does not fail and
         /// remaining quota would become negative (going over the limit).
         /// Not supported for Rate Quota.
-        pub const ADJUST_ONLY: QuotaMode = QuotaMode::new(5);
+        AdjustOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [QuotaMode::value] or
+        /// [QuotaMode::name].
+        UnknownValue(quota_mode::UnknownValue),
+    }
 
-        /// Creates a new QuotaMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod quota_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl QuotaMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Normal => std::option::Option::Some(1),
+                Self::BestEffort => std::option::Option::Some(2),
+                Self::CheckOnly => std::option::Option::Some(3),
+                Self::QueryOnly => std::option::Option::Some(4),
+                Self::AdjustOnly => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NORMAL"),
-                2 => std::borrow::Cow::Borrowed("BEST_EFFORT"),
-                3 => std::borrow::Cow::Borrowed("CHECK_ONLY"),
-                4 => std::borrow::Cow::Borrowed("QUERY_ONLY"),
-                5 => std::borrow::Cow::Borrowed("ADJUST_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Normal => std::option::Option::Some("NORMAL"),
+                Self::BestEffort => std::option::Option::Some("BEST_EFFORT"),
+                Self::CheckOnly => std::option::Option::Some("CHECK_ONLY"),
+                Self::QueryOnly => std::option::Option::Some("QUERY_ONLY"),
+                Self::AdjustOnly => std::option::Option::Some("ADJUST_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "NORMAL" => std::option::Option::Some(Self::NORMAL),
-                "BEST_EFFORT" => std::option::Option::Some(Self::BEST_EFFORT),
-                "CHECK_ONLY" => std::option::Option::Some(Self::CHECK_ONLY),
-                "QUERY_ONLY" => std::option::Option::Some(Self::QUERY_ONLY),
-                "ADJUST_ONLY" => std::option::Option::Some(Self::ADJUST_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for QuotaMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for QuotaMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for QuotaMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for QuotaMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Normal,
+                2 => Self::BestEffort,
+                3 => Self::CheckOnly,
+                4 => Self::QueryOnly,
+                5 => Self::AdjustOnly,
+                _ => Self::UnknownValue(quota_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for QuotaMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "NORMAL" => Self::Normal,
+                "BEST_EFFORT" => Self::BestEffort,
+                "CHECK_ONLY" => Self::CheckOnly,
+                "QUERY_ONLY" => Self::QueryOnly,
+                "ADJUST_ONLY" => Self::AdjustOnly,
+                _ => Self::UnknownValue(quota_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for QuotaMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Normal => serializer.serialize_i32(1),
+                Self::BestEffort => serializer.serialize_i32(2),
+                Self::CheckOnly => serializer.serialize_i32(3),
+                Self::QueryOnly => serializer.serialize_i32(4),
+                Self::AdjustOnly => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for QuotaMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<QuotaMode>::new(
+                ".google.api.servicecontrol.v1.QuotaOperation.QuotaMode",
+            ))
         }
     }
 }
@@ -2351,76 +2576,143 @@ pub mod quota_error {
     /// have to call the Check method, without quota_properties field, to perform
     /// these validations before calling the quota controller methods. These
     /// methods check only for project deletion to be wipe out compliant.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// This is never used.
-        pub const UNSPECIFIED: Code = Code::new(0);
-
+        Unspecified,
         /// Quota allocation failed.
         /// Same as [google.rpc.Code.RESOURCE_EXHAUSTED][google.rpc.Code.RESOURCE_EXHAUSTED].
-        pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
-
+        ResourceExhausted,
         /// Consumer cannot access the service because the service requires active
         /// billing.
-        pub const BILLING_NOT_ACTIVE: Code = Code::new(107);
-
+        BillingNotActive,
         /// Consumer's project has been marked as deleted (soft deletion).
-        pub const PROJECT_DELETED: Code = Code::new(108);
-
+        ProjectDeleted,
         /// Specified API key is invalid.
-        pub const API_KEY_INVALID: Code = Code::new(105);
-
+        ApiKeyInvalid,
         /// Specified API Key has expired.
-        pub const API_KEY_EXPIRED: Code = Code::new(112);
+        ApiKeyExpired,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ResourceExhausted => std::option::Option::Some(8),
+                Self::BillingNotActive => std::option::Option::Some(107),
+                Self::ProjectDeleted => std::option::Option::Some(108),
+                Self::ApiKeyInvalid => std::option::Option::Some(105),
+                Self::ApiKeyExpired => std::option::Option::Some(112),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
-                105 => std::borrow::Cow::Borrowed("API_KEY_INVALID"),
-                107 => std::borrow::Cow::Borrowed("BILLING_NOT_ACTIVE"),
-                108 => std::borrow::Cow::Borrowed("PROJECT_DELETED"),
-                112 => std::borrow::Cow::Borrowed("API_KEY_EXPIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::ResourceExhausted => std::option::Option::Some("RESOURCE_EXHAUSTED"),
+                Self::BillingNotActive => std::option::Option::Some("BILLING_NOT_ACTIVE"),
+                Self::ProjectDeleted => std::option::Option::Some("PROJECT_DELETED"),
+                Self::ApiKeyInvalid => std::option::Option::Some("API_KEY_INVALID"),
+                Self::ApiKeyExpired => std::option::Option::Some("API_KEY_EXPIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
-                "BILLING_NOT_ACTIVE" => std::option::Option::Some(Self::BILLING_NOT_ACTIVE),
-                "PROJECT_DELETED" => std::option::Option::Some(Self::PROJECT_DELETED),
-                "API_KEY_INVALID" => std::option::Option::Some(Self::API_KEY_INVALID),
-                "API_KEY_EXPIRED" => std::option::Option::Some(Self::API_KEY_EXPIRED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                8 => Self::ResourceExhausted,
+                105 => Self::ApiKeyInvalid,
+                107 => Self::BillingNotActive,
+                108 => Self::ProjectDeleted,
+                112 => Self::ApiKeyExpired,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "RESOURCE_EXHAUSTED" => Self::ResourceExhausted,
+                "BILLING_NOT_ACTIVE" => Self::BillingNotActive,
+                "PROJECT_DELETED" => Self::ProjectDeleted,
+                "API_KEY_INVALID" => Self::ApiKeyInvalid,
+                "API_KEY_EXPIRED" => Self::ApiKeyExpired,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ResourceExhausted => serializer.serialize_i32(8),
+                Self::BillingNotActive => serializer.serialize_i32(107),
+                Self::ProjectDeleted => serializer.serialize_i32(108),
+                Self::ApiKeyInvalid => serializer.serialize_i32(105),
+                Self::ApiKeyExpired => serializer.serialize_i32(112),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.api.servicecontrol.v1.QuotaError.Code",
+            ))
         }
     }
 }
@@ -2732,73 +3024,139 @@ pub mod check_response {
 
         /// The type of the consumer as defined in
         /// [Google Resource Manager](https://cloud.google.com/resource-manager/).
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ConsumerType(i32);
-
-        impl ConsumerType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ConsumerType {
             /// This is never used.
-            pub const CONSUMER_TYPE_UNSPECIFIED: ConsumerType = ConsumerType::new(0);
-
+            Unspecified,
             /// The consumer is a Google Cloud Project.
-            pub const PROJECT: ConsumerType = ConsumerType::new(1);
-
+            Project,
             /// The consumer is a Google Cloud Folder.
-            pub const FOLDER: ConsumerType = ConsumerType::new(2);
-
+            Folder,
             /// The consumer is a Google Cloud Organization.
-            pub const ORGANIZATION: ConsumerType = ConsumerType::new(3);
-
+            Organization,
             /// Service-specific resource container which is defined by the service
             /// producer to offer their users the ability to manage service control
             /// functionalities at a finer level of granularity than the PROJECT.
-            pub const SERVICE_SPECIFIC: ConsumerType = ConsumerType::new(4);
+            ServiceSpecific,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ConsumerType::value] or
+            /// [ConsumerType::name].
+            UnknownValue(consumer_type::UnknownValue),
+        }
 
-            /// Creates a new ConsumerType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod consumer_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ConsumerType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Project => std::option::Option::Some(1),
+                    Self::Folder => std::option::Option::Some(2),
+                    Self::Organization => std::option::Option::Some(3),
+                    Self::ServiceSpecific => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONSUMER_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PROJECT"),
-                    2 => std::borrow::Cow::Borrowed("FOLDER"),
-                    3 => std::borrow::Cow::Borrowed("ORGANIZATION"),
-                    4 => std::borrow::Cow::Borrowed("SERVICE_SPECIFIC"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CONSUMER_TYPE_UNSPECIFIED"),
+                    Self::Project => std::option::Option::Some("PROJECT"),
+                    Self::Folder => std::option::Option::Some("FOLDER"),
+                    Self::Organization => std::option::Option::Some("ORGANIZATION"),
+                    Self::ServiceSpecific => std::option::Option::Some("SERVICE_SPECIFIC"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONSUMER_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONSUMER_TYPE_UNSPECIFIED)
-                    }
-                    "PROJECT" => std::option::Option::Some(Self::PROJECT),
-                    "FOLDER" => std::option::Option::Some(Self::FOLDER),
-                    "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
-                    "SERVICE_SPECIFIC" => std::option::Option::Some(Self::SERVICE_SPECIFIC),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ConsumerType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ConsumerType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ConsumerType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ConsumerType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Project,
+                    2 => Self::Folder,
+                    3 => Self::Organization,
+                    4 => Self::ServiceSpecific,
+                    _ => Self::UnknownValue(consumer_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ConsumerType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONSUMER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "PROJECT" => Self::Project,
+                    "FOLDER" => Self::Folder,
+                    "ORGANIZATION" => Self::Organization,
+                    "SERVICE_SPECIFIC" => Self::ServiceSpecific,
+                    _ => Self::UnknownValue(consumer_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ConsumerType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Project => serializer.serialize_i32(1),
+                    Self::Folder => serializer.serialize_i32(2),
+                    Self::Organization => serializer.serialize_i32(3),
+                    Self::ServiceSpecific => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ConsumerType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConsumerType>::new(
+                    ".google.api.servicecontrol.v1.CheckResponse.ConsumerInfo.ConsumerType",
+                ))
             }
         }
     }

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -208,75 +208,142 @@ pub mod operation_metadata {
     }
 
     /// Code describes the status of the operation (or one of its steps).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// Unspecifed code.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+        Unspecified,
         /// The operation or step has completed without errors.
-        pub const DONE: Status = Status::new(1);
-
+        Done,
         /// The operation or step has not started yet.
-        pub const NOT_STARTED: Status = Status::new(2);
-
+        NotStarted,
         /// The operation or step is in progress.
-        pub const IN_PROGRESS: Status = Status::new(3);
-
+        InProgress,
         /// The operation or step has completed with errors. If the operation is
         /// rollbackable, the rollback completed with errors too.
-        pub const FAILED: Status = Status::new(4);
-
+        Failed,
         /// The operation or step has completed with cancellation.
-        pub const CANCELLED: Status = Status::new(5);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Done => std::option::Option::Some(1),
+                Self::NotStarted => std::option::Option::Some(2),
+                Self::InProgress => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DONE"),
-                2 => std::borrow::Cow::Borrowed("NOT_STARTED"),
-                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::NotStarted => std::option::Option::Some("NOT_STARTED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Done,
+                2 => Self::NotStarted,
+                3 => Self::InProgress,
+                4 => Self::Failed,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "DONE" => Self::Done,
+                "NOT_STARTED" => Self::NotStarted,
+                "IN_PROGRESS" => Self::InProgress,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Done => serializer.serialize_i32(1),
+                Self::NotStarted => serializer.serialize_i32(2),
+                Self::InProgress => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.api.servicemanagement.v1.OperationMetadata.Status",
+            ))
         }
     }
 }
@@ -338,54 +405,113 @@ pub mod diagnostic {
     use super::*;
 
     /// The kind of diagnostic information possible.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kind {
+        /// Warnings and errors
+        Warning,
+        /// Only errors
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kind::value] or
+        /// [Kind::name].
+        UnknownValue(kind::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Kind {
-        /// Warnings and errors
-        pub const WARNING: Kind = Kind::new(0);
-
-        /// Only errors
-        pub const ERROR: Kind = Kind::new(1);
-
-        /// Creates a new Kind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Warning => std::option::Option::Some(0),
+                Self::Error => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WARNING"),
-                1 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Warning,
+                1 => Self::Error,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Warning => serializer.serialize_i32(0),
+                Self::Error => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                ".google.api.servicemanagement.v1.Diagnostic.Kind",
+            ))
         }
     }
 }
@@ -501,22 +627,17 @@ pub mod config_file {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FileType(i32);
-
-    impl FileType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FileType {
         /// Unknown file type.
-        pub const FILE_TYPE_UNSPECIFIED: FileType = FileType::new(0);
-
+        Unspecified,
         /// YAML-specification of service.
-        pub const SERVICE_CONFIG_YAML: FileType = FileType::new(1);
-
+        ServiceConfigYaml,
         /// OpenAPI specification, serialized in JSON.
-        pub const OPEN_API_JSON: FileType = FileType::new(2);
-
+        OpenApiJson,
         /// OpenAPI specification, serialized in YAML.
-        pub const OPEN_API_YAML: FileType = FileType::new(3);
-
+        OpenApiYaml,
         /// FileDescriptorSet, generated by protoc.
         ///
         /// To generate, use protoc with imports and source info included.
@@ -524,63 +645,135 @@ pub mod config_file {
         /// in a new file named out.pb.
         ///
         /// $protoc --include_imports --include_source_info test.proto -o out.pb
-        pub const FILE_DESCRIPTOR_SET_PROTO: FileType = FileType::new(4);
-
+        FileDescriptorSetProto,
         /// Uncompiled Proto file. Used for storage and display purposes only,
         /// currently server-side compilation is not supported. Should match the
         /// inputs to 'protoc' command used to generated FILE_DESCRIPTOR_SET_PROTO. A
         /// file of this type can only be included if at least one file of type
         /// FILE_DESCRIPTOR_SET_PROTO is included.
-        pub const PROTO_FILE: FileType = FileType::new(6);
+        ProtoFile,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FileType::value] or
+        /// [FileType::name].
+        UnknownValue(file_type::UnknownValue),
+    }
 
-        /// Creates a new FileType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod file_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FileType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ServiceConfigYaml => std::option::Option::Some(1),
+                Self::OpenApiJson => std::option::Option::Some(2),
+                Self::OpenApiYaml => std::option::Option::Some(3),
+                Self::FileDescriptorSetProto => std::option::Option::Some(4),
+                Self::ProtoFile => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FILE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVICE_CONFIG_YAML"),
-                2 => std::borrow::Cow::Borrowed("OPEN_API_JSON"),
-                3 => std::borrow::Cow::Borrowed("OPEN_API_YAML"),
-                4 => std::borrow::Cow::Borrowed("FILE_DESCRIPTOR_SET_PROTO"),
-                6 => std::borrow::Cow::Borrowed("PROTO_FILE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FILE_TYPE_UNSPECIFIED),
-                "SERVICE_CONFIG_YAML" => std::option::Option::Some(Self::SERVICE_CONFIG_YAML),
-                "OPEN_API_JSON" => std::option::Option::Some(Self::OPEN_API_JSON),
-                "OPEN_API_YAML" => std::option::Option::Some(Self::OPEN_API_YAML),
-                "FILE_DESCRIPTOR_SET_PROTO" => {
-                    std::option::Option::Some(Self::FILE_DESCRIPTOR_SET_PROTO)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FILE_TYPE_UNSPECIFIED"),
+                Self::ServiceConfigYaml => std::option::Option::Some("SERVICE_CONFIG_YAML"),
+                Self::OpenApiJson => std::option::Option::Some("OPEN_API_JSON"),
+                Self::OpenApiYaml => std::option::Option::Some("OPEN_API_YAML"),
+                Self::FileDescriptorSetProto => {
+                    std::option::Option::Some("FILE_DESCRIPTOR_SET_PROTO")
                 }
-                "PROTO_FILE" => std::option::Option::Some(Self::PROTO_FILE),
-                _ => std::option::Option::None,
+                Self::ProtoFile => std::option::Option::Some("PROTO_FILE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for FileType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FileType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FileType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FileType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ServiceConfigYaml,
+                2 => Self::OpenApiJson,
+                3 => Self::OpenApiYaml,
+                4 => Self::FileDescriptorSetProto,
+                6 => Self::ProtoFile,
+                _ => Self::UnknownValue(file_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FileType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FILE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SERVICE_CONFIG_YAML" => Self::ServiceConfigYaml,
+                "OPEN_API_JSON" => Self::OpenApiJson,
+                "OPEN_API_YAML" => Self::OpenApiYaml,
+                "FILE_DESCRIPTOR_SET_PROTO" => Self::FileDescriptorSetProto,
+                "PROTO_FILE" => Self::ProtoFile,
+                _ => Self::UnknownValue(file_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FileType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ServiceConfigYaml => serializer.serialize_i32(1),
+                Self::OpenApiJson => serializer.serialize_i32(2),
+                Self::OpenApiYaml => serializer.serialize_i32(3),
+                Self::FileDescriptorSetProto => serializer.serialize_i32(4),
+                Self::ProtoFile => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FileType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileType>::new(
+                ".google.api.servicemanagement.v1.ConfigFile.FileType",
+            ))
         }
     }
 }
@@ -937,83 +1130,150 @@ pub mod rollout {
     }
 
     /// Status of a Rollout.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutStatus(i32);
-
-    impl RolloutStatus {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolloutStatus {
         /// No status specified.
-        pub const ROLLOUT_STATUS_UNSPECIFIED: RolloutStatus = RolloutStatus::new(0);
-
+        Unspecified,
         /// The Rollout is in progress.
-        pub const IN_PROGRESS: RolloutStatus = RolloutStatus::new(1);
-
+        InProgress,
         /// The Rollout has completed successfully.
-        pub const SUCCESS: RolloutStatus = RolloutStatus::new(2);
-
+        Success,
         /// The Rollout has been cancelled. This can happen if you have overlapping
         /// Rollout pushes, and the previous ones will be cancelled.
-        pub const CANCELLED: RolloutStatus = RolloutStatus::new(3);
-
+        Cancelled,
         /// The Rollout has failed and the rollback attempt has failed too.
-        pub const FAILED: RolloutStatus = RolloutStatus::new(4);
-
+        Failed,
         /// The Rollout has not started yet and is pending for execution.
-        pub const PENDING: RolloutStatus = RolloutStatus::new(5);
-
+        Pending,
         /// The Rollout has failed and rolled back to the previous successful
         /// Rollout.
-        pub const FAILED_ROLLED_BACK: RolloutStatus = RolloutStatus::new(6);
+        FailedRolledBack,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolloutStatus::value] or
+        /// [RolloutStatus::name].
+        UnknownValue(rollout_status::UnknownValue),
+    }
 
-        /// Creates a new RolloutStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod rollout_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RolloutStatus {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Success => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Pending => std::option::Option::Some(5),
+                Self::FailedRolledBack => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLLOUT_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("SUCCESS"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("PENDING"),
-                6 => std::borrow::Cow::Borrowed("FAILED_ROLLED_BACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLLOUT_STATUS_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Success => std::option::Option::Some("SUCCESS"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::FailedRolledBack => std::option::Option::Some("FAILED_ROLLED_BACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLLOUT_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLLOUT_STATUS_UNSPECIFIED)
-                }
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "FAILED_ROLLED_BACK" => std::option::Option::Some(Self::FAILED_ROLLED_BACK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolloutStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolloutStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolloutStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Success,
+                3 => Self::Cancelled,
+                4 => Self::Failed,
+                5 => Self::Pending,
+                6 => Self::FailedRolledBack,
+                _ => Self::UnknownValue(rollout_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolloutStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLLOUT_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "SUCCESS" => Self::Success,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                "PENDING" => Self::Pending,
+                "FAILED_ROLLED_BACK" => Self::FailedRolledBack,
+                _ => Self::UnknownValue(rollout_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolloutStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Success => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Pending => serializer.serialize_i32(5),
+                Self::FailedRolledBack => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolloutStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolloutStatus>::new(
+                ".google.api.servicemanagement.v1.Rollout.RolloutStatus",
+            ))
         }
     }
 
@@ -1402,57 +1662,116 @@ pub mod get_service_config_request {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConfigView(i32);
-
-    impl ConfigView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConfigView {
         /// Server response includes all fields except SourceInfo.
-        pub const BASIC: ConfigView = ConfigView::new(0);
-
+        Basic,
         /// Server response includes all fields including SourceInfo.
         /// SourceFiles are of type 'google.api.servicemanagement.v1.ConfigFile'
         /// and are only available for configs created using the
         /// SubmitConfigSource method.
-        pub const FULL: ConfigView = ConfigView::new(1);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConfigView::value] or
+        /// [ConfigView::name].
+        UnknownValue(config_view::UnknownValue),
+    }
 
-        /// Creates a new ConfigView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod config_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConfigView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Basic => std::option::Option::Some(0),
+                Self::Full => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BASIC"),
-                1 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConfigView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConfigView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConfigView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConfigView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Basic,
+                1 => Self::Full,
+                _ => Self::UnknownValue(config_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConfigView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(config_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConfigView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Basic => serializer.serialize_i32(0),
+                Self::Full => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConfigView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConfigView>::new(
+                ".google.api.servicemanagement.v1.GetServiceConfigRequest.ConfigView",
+            ))
         }
     }
 }

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -192,7 +192,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -463,64 +463,124 @@ pub mod disable_service_request {
 
     /// Enum to determine if service usage should be checked when disabling a
     /// service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CheckIfServiceHasUsage(i32);
-
-    impl CheckIfServiceHasUsage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CheckIfServiceHasUsage {
         /// When unset, the default behavior is used, which is SKIP.
-        pub const CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED: CheckIfServiceHasUsage =
-            CheckIfServiceHasUsage::new(0);
-
+        Unspecified,
         /// If set, skip checking service usage when disabling a service.
-        pub const SKIP: CheckIfServiceHasUsage = CheckIfServiceHasUsage::new(1);
-
+        Skip,
         /// If set, service usage is checked when disabling the service. If a
         /// service, or its dependents, has usage in the last 30 days, the request
         /// returns a FAILED_PRECONDITION error.
-        pub const CHECK: CheckIfServiceHasUsage = CheckIfServiceHasUsage::new(2);
+        Check,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CheckIfServiceHasUsage::value] or
+        /// [CheckIfServiceHasUsage::name].
+        UnknownValue(check_if_service_has_usage::UnknownValue),
+    }
 
-        /// Creates a new CheckIfServiceHasUsage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod check_if_service_has_usage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CheckIfServiceHasUsage {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::Check => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SKIP"),
-                2 => std::borrow::Cow::Borrowed("CHECK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED")
                 }
-                "SKIP" => std::option::Option::Some(Self::SKIP),
-                "CHECK" => std::option::Option::Some(Self::CHECK),
-                _ => std::option::Option::None,
+                Self::Skip => std::option::Option::Some("SKIP"),
+                Self::Check => std::option::Option::Some("CHECK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CheckIfServiceHasUsage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CheckIfServiceHasUsage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CheckIfServiceHasUsage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CheckIfServiceHasUsage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::Check,
+                _ => Self::UnknownValue(check_if_service_has_usage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CheckIfServiceHasUsage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED" => Self::Unspecified,
+                "SKIP" => Self::Skip,
+                "CHECK" => Self::Check,
+                _ => Self::UnknownValue(check_if_service_has_usage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CheckIfServiceHasUsage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::Check => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CheckIfServiceHasUsage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CheckIfServiceHasUsage>::new(
+                ".google.api.serviceusage.v1.DisableServiceRequest.CheckIfServiceHasUsage",
+            ))
         }
     }
 }
@@ -991,61 +1051,122 @@ impl wkt::message::Message for BatchGetServicesResponse {
 }
 
 /// Whether or not a service has been enabled for use by a consumer.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(i32);
-
-impl State {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum State {
     /// The default value, which indicates that the enabled state of the service
     /// is unspecified or not meaningful. Currently, all consumers other than
     /// projects (such as folders and organizations) are always in this state.
-    pub const STATE_UNSPECIFIED: State = State::new(0);
-
+    Unspecified,
     /// The service cannot be used by this consumer. It has either been explicitly
     /// disabled, or has never been enabled.
-    pub const DISABLED: State = State::new(1);
-
+    Disabled,
     /// The service has been explicitly enabled for use by this consumer.
-    pub const ENABLED: State = State::new(2);
+    Enabled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [State::value] or
+    /// [State::name].
+    UnknownValue(state::UnknownValue),
+}
 
-    /// Creates a new State instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl State {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Disabled => std::option::Option::Some(1),
+            Self::Enabled => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DISABLED"),
-            2 => std::borrow::Cow::Borrowed("ENABLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+            Self::Disabled => std::option::Option::Some("DISABLED"),
+            Self::Enabled => std::option::Option::Some("ENABLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-            "DISABLED" => std::option::Option::Some(Self::DISABLED),
-            "ENABLED" => std::option::Option::Some(Self::ENABLED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for State {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Disabled,
+            2 => Self::Enabled,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for State {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_UNSPECIFIED" => Self::Unspecified,
+            "DISABLED" => Self::Disabled,
+            "ENABLED" => Self::Enabled,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Disabled => serializer.serialize_i32(1),
+            Self::Enabled => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+            ".google.api.serviceusage.v1.State",
+        ))
     }
 }

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -898,12 +898,10 @@ pub mod backend_rule {
     /// Path Translation is applicable only to HTTP-based backends. Backends which
     /// do not accept requests over HTTP/HTTPS should leave `path_translation`
     /// unspecified.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PathTranslation(i32);
-
-    impl PathTranslation {
-        pub const PATH_TRANSLATION_UNSPECIFIED: PathTranslation = PathTranslation::new(0);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PathTranslation {
+        Unspecified,
         /// Use the backend address as-is, with no modification to the path. If the
         /// URL pattern contains variables, the variable names and values will be
         /// appended to the query string. If a query string parameter and a URL
@@ -931,8 +929,7 @@ pub mod backend_rule {
         /// Translated:
         /// https://example.cloudfunctions.net/getUser?timezone=EST&cid=widgetworks&uid=johndoe
         /// ```
-        pub const CONSTANT_ADDRESS: PathTranslation = PathTranslation::new(1);
-
+        ConstantAddress,
         /// The request path will be appended to the backend address.
         ///
         /// # Examples
@@ -956,50 +953,112 @@ pub mod backend_rule {
         /// Translated:
         /// https://example.appspot.com/api/company/widgetworks/user/johndoe?timezone=EST
         /// ```
-        pub const APPEND_PATH_TO_ADDRESS: PathTranslation = PathTranslation::new(2);
+        AppendPathToAddress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PathTranslation::value] or
+        /// [PathTranslation::name].
+        UnknownValue(path_translation::UnknownValue),
+    }
 
-        /// Creates a new PathTranslation instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod path_translation {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PathTranslation {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConstantAddress => std::option::Option::Some(1),
+                Self::AppendPathToAddress => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PATH_TRANSLATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONSTANT_ADDRESS"),
-                2 => std::borrow::Cow::Borrowed("APPEND_PATH_TO_ADDRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PATH_TRANSLATION_UNSPECIFIED"),
+                Self::ConstantAddress => std::option::Option::Some("CONSTANT_ADDRESS"),
+                Self::AppendPathToAddress => std::option::Option::Some("APPEND_PATH_TO_ADDRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PATH_TRANSLATION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PATH_TRANSLATION_UNSPECIFIED)
-                }
-                "CONSTANT_ADDRESS" => std::option::Option::Some(Self::CONSTANT_ADDRESS),
-                "APPEND_PATH_TO_ADDRESS" => std::option::Option::Some(Self::APPEND_PATH_TO_ADDRESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PathTranslation {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PathTranslation {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PathTranslation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PathTranslation {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConstantAddress,
+                2 => Self::AppendPathToAddress,
+                _ => Self::UnknownValue(path_translation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PathTranslation {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PATH_TRANSLATION_UNSPECIFIED" => Self::Unspecified,
+                "CONSTANT_ADDRESS" => Self::ConstantAddress,
+                "APPEND_PATH_TO_ADDRESS" => Self::AppendPathToAddress,
+                _ => Self::UnknownValue(path_translation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PathTranslation {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConstantAddress => serializer.serialize_i32(1),
+                Self::AppendPathToAddress => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PathTranslation {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PathTranslation>::new(
+                ".google.api.BackendRule.PathTranslation",
+            ))
         }
     }
 
@@ -2620,69 +2679,134 @@ pub mod property {
     use super::*;
 
     /// Supported data type of the property values
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PropertyType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PropertyType {
+        /// The type is unspecified, and will result in an error.
+        Unspecified,
+        /// The type is `int64`.
+        Int64,
+        /// The type is `bool`.
+        Bool,
+        /// The type is `string`.
+        String,
+        /// The type is 'double'.
+        Double,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PropertyType::value] or
+        /// [PropertyType::name].
+        UnknownValue(property_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod property_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PropertyType {
-        /// The type is unspecified, and will result in an error.
-        pub const UNSPECIFIED: PropertyType = PropertyType::new(0);
-
-        /// The type is `int64`.
-        pub const INT64: PropertyType = PropertyType::new(1);
-
-        /// The type is `bool`.
-        pub const BOOL: PropertyType = PropertyType::new(2);
-
-        /// The type is `string`.
-        pub const STRING: PropertyType = PropertyType::new(3);
-
-        /// The type is 'double'.
-        pub const DOUBLE: PropertyType = PropertyType::new(4);
-
-        /// Creates a new PropertyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Int64 => std::option::Option::Some(1),
+                Self::Bool => std::option::Option::Some(2),
+                Self::String => std::option::Option::Some(3),
+                Self::Double => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INT64"),
-                2 => std::borrow::Cow::Borrowed("BOOL"),
-                3 => std::borrow::Cow::Borrowed("STRING"),
-                4 => std::borrow::Cow::Borrowed("DOUBLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PropertyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PropertyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PropertyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PropertyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Int64,
+                2 => Self::Bool,
+                3 => Self::String,
+                4 => Self::Double,
+                _ => Self::UnknownValue(property_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PropertyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "INT64" => Self::Int64,
+                "BOOL" => Self::Bool,
+                "STRING" => Self::String,
+                "DOUBLE" => Self::Double,
+                _ => Self::UnknownValue(property_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PropertyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Int64 => serializer.serialize_i32(1),
+                Self::Bool => serializer.serialize_i32(2),
+                Self::String => serializer.serialize_i32(3),
+                Self::Double => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PropertyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PropertyType>::new(
+                ".google.api.Property.PropertyType",
+            ))
         }
     }
 }
@@ -3990,82 +4114,147 @@ pub mod field_info {
 
     /// The standard format of a field value. The supported formats are all backed
     /// by either an RFC defined by the IETF or a Google-defined AIP.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(i32);
-
-    impl Format {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Format {
         /// Default, unspecified value.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
-
+        Unspecified,
         /// Universally Unique Identifier, version 4, value as defined by
         /// <https://datatracker.ietf.org/doc/html/rfc4122>. The value may be
         /// normalized to entirely lowercase letters. For example, the value
         /// `F47AC10B-58CC-0372-8567-0E02B2C3D479` would be normalized to
         /// `f47ac10b-58cc-0372-8567-0e02b2c3d479`.
-        pub const UUID4: Format = Format::new(1);
-
+        Uuid4,
         /// Internet Protocol v4 value as defined by [RFC
         /// 791](https://datatracker.ietf.org/doc/html/rfc791). The value may be
         /// condensed, with leading zeros in each octet stripped. For example,
         /// `001.022.233.040` would be condensed to `1.22.233.40`.
-        pub const IPV4: Format = Format::new(2);
-
+        Ipv4,
         /// Internet Protocol v6 value as defined by [RFC
         /// 2460](https://datatracker.ietf.org/doc/html/rfc2460). The value may be
         /// normalized to entirely lowercase letters with zeros compressed, following
         /// [RFC 5952](https://datatracker.ietf.org/doc/html/rfc5952). For example,
         /// the value `2001:0DB8:0::0` would be normalized to `2001:db8::`.
-        pub const IPV6: Format = Format::new(3);
-
+        Ipv6,
         /// An IP address in either v4 or v6 format as described by the individual
         /// values defined herein. See the comments on the IPV4 and IPV6 types for
         /// allowed normalizations of each.
-        pub const IPV4_OR_IPV6: Format = Format::new(4);
+        Ipv4OrIpv6,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Format::value] or
+        /// [Format::name].
+        UnknownValue(format::UnknownValue),
+    }
 
-        /// Creates a new Format instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Format {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Uuid4 => std::option::Option::Some(1),
+                Self::Ipv4 => std::option::Option::Some(2),
+                Self::Ipv6 => std::option::Option::Some(3),
+                Self::Ipv4OrIpv6 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UUID4"),
-                2 => std::borrow::Cow::Borrowed("IPV4"),
-                3 => std::borrow::Cow::Borrowed("IPV6"),
-                4 => std::borrow::Cow::Borrowed("IPV4_OR_IPV6"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FORMAT_UNSPECIFIED"),
+                Self::Uuid4 => std::option::Option::Some("UUID4"),
+                Self::Ipv4 => std::option::Option::Some("IPV4"),
+                Self::Ipv6 => std::option::Option::Some("IPV6"),
+                Self::Ipv4OrIpv6 => std::option::Option::Some("IPV4_OR_IPV6"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
-                "UUID4" => std::option::Option::Some(Self::UUID4),
-                "IPV4" => std::option::Option::Some(Self::IPV4),
-                "IPV6" => std::option::Option::Some(Self::IPV6),
-                "IPV4_OR_IPV6" => std::option::Option::Some(Self::IPV4_OR_IPV6),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Format {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Format {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Uuid4,
+                2 => Self::Ipv4,
+                3 => Self::Ipv6,
+                4 => Self::Ipv4OrIpv6,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Format {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "UUID4" => Self::Uuid4,
+                "IPV4" => Self::Ipv4,
+                "IPV6" => Self::Ipv6,
+                "IPV4_OR_IPV6" => Self::Ipv4OrIpv6,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Format {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Uuid4 => serializer.serialize_i32(1),
+                Self::Ipv4 => serializer.serialize_i32(2),
+                Self::Ipv6 => serializer.serialize_i32(3),
+                Self::Ipv4OrIpv6 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Format {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Format>::new(
+                ".google.api.FieldInfo.Format",
+            ))
         }
     }
 }
@@ -4926,59 +5115,120 @@ pub mod label_descriptor {
     use super::*;
 
     /// Value types that can be used as label values.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ValueType {
+        /// A variable-length string. This is the default.
+        String,
+        /// Boolean; true or false.
+        Bool,
+        /// A 64-bit signed integer.
+        Int64,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ValueType::value] or
+        /// [ValueType::name].
+        UnknownValue(value_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod value_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ValueType {
-        /// A variable-length string. This is the default.
-        pub const STRING: ValueType = ValueType::new(0);
-
-        /// Boolean; true or false.
-        pub const BOOL: ValueType = ValueType::new(1);
-
-        /// A 64-bit signed integer.
-        pub const INT64: ValueType = ValueType::new(2);
-
-        /// Creates a new ValueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::String => std::option::Option::Some(0),
+                Self::Bool => std::option::Option::Some(1),
+                Self::Int64 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STRING"),
-                1 => std::borrow::Cow::Borrowed("BOOL"),
-                2 => std::borrow::Cow::Borrowed("INT64"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ValueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ValueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::String,
+                1 => Self::Bool,
+                2 => Self::Int64,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ValueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STRING" => Self::String,
+                "BOOL" => Self::Bool,
+                "INT64" => Self::Int64,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ValueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::String => serializer.serialize_i32(0),
+                Self::Bool => serializer.serialize_i32(1),
+                Self::Int64 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ValueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueType>::new(
+                ".google.api.LabelDescriptor.ValueType",
+            ))
         }
     }
 }
@@ -5622,74 +5872,131 @@ pub mod metric_descriptor {
         use super::*;
 
         /// The resource hierarchy level of the timeseries data of a metric.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TimeSeriesResourceHierarchyLevel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TimeSeriesResourceHierarchyLevel {
+            /// Do not use this default value.
+            Unspecified,
+            /// Scopes a metric to a project.
+            Project,
+            /// Scopes a metric to an organization.
+            Organization,
+            /// Scopes a metric to a folder.
+            Folder,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TimeSeriesResourceHierarchyLevel::value] or
+            /// [TimeSeriesResourceHierarchyLevel::name].
+            UnknownValue(time_series_resource_hierarchy_level::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod time_series_resource_hierarchy_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl TimeSeriesResourceHierarchyLevel {
-            /// Do not use this default value.
-            pub const TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED:
-                TimeSeriesResourceHierarchyLevel = TimeSeriesResourceHierarchyLevel::new(0);
-
-            /// Scopes a metric to a project.
-            pub const PROJECT: TimeSeriesResourceHierarchyLevel =
-                TimeSeriesResourceHierarchyLevel::new(1);
-
-            /// Scopes a metric to an organization.
-            pub const ORGANIZATION: TimeSeriesResourceHierarchyLevel =
-                TimeSeriesResourceHierarchyLevel::new(2);
-
-            /// Scopes a metric to a folder.
-            pub const FOLDER: TimeSeriesResourceHierarchyLevel =
-                TimeSeriesResourceHierarchyLevel::new(3);
-
-            /// Creates a new TimeSeriesResourceHierarchyLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Project => std::option::Option::Some(1),
+                    Self::Organization => std::option::Option::Some(2),
+                    Self::Folder => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed(
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(
                         "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED",
                     ),
-                    1 => std::borrow::Cow::Borrowed("PROJECT"),
-                    2 => std::borrow::Cow::Borrowed("ORGANIZATION"),
-                    3 => std::borrow::Cow::Borrowed("FOLDER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    Self::Project => std::option::Option::Some("PROJECT"),
+                    Self::Organization => std::option::Option::Some("ORGANIZATION"),
+                    Self::Folder => std::option::Option::Some("FOLDER"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(
-                            Self::TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED,
-                        )
-                    }
-                    "PROJECT" => std::option::Option::Some(Self::PROJECT),
-                    "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
-                    "FOLDER" => std::option::Option::Some(Self::FOLDER),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for TimeSeriesResourceHierarchyLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TimeSeriesResourceHierarchyLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TimeSeriesResourceHierarchyLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TimeSeriesResourceHierarchyLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Project,
+                    2 => Self::Organization,
+                    3 => Self::Folder,
+                    _ => Self::UnknownValue(time_series_resource_hierarchy_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TimeSeriesResourceHierarchyLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "PROJECT" => Self::Project,
+                    "ORGANIZATION" => Self::Organization,
+                    "FOLDER" => Self::Folder,
+                    _ => Self::UnknownValue(time_series_resource_hierarchy_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TimeSeriesResourceHierarchyLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Project => serializer.serialize_i32(1),
+                    Self::Organization => serializer.serialize_i32(2),
+                    Self::Folder => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TimeSeriesResourceHierarchyLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimeSeriesResourceHierarchyLevel>::new(
+                    ".google.api.MetricDescriptor.MetricDescriptorMetadata.TimeSeriesResourceHierarchyLevel"))
             }
         }
     }
@@ -5697,151 +6004,281 @@ pub mod metric_descriptor {
     /// The kind of measurement. It describes how the data is reported.
     /// For information on setting the start time and end time based on
     /// the MetricKind, see [TimeInterval][google.monitoring.v3.TimeInterval].
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricKind(i32);
-
-    impl MetricKind {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MetricKind {
         /// Do not use this default value.
-        pub const METRIC_KIND_UNSPECIFIED: MetricKind = MetricKind::new(0);
-
+        Unspecified,
         /// An instantaneous measurement of a value.
-        pub const GAUGE: MetricKind = MetricKind::new(1);
-
+        Gauge,
         /// The change in a value during a time interval.
-        pub const DELTA: MetricKind = MetricKind::new(2);
-
+        Delta,
         /// A value accumulated over a time interval.  Cumulative
         /// measurements in a time series should have the same start time
         /// and increasing end times, until an event resets the cumulative
         /// value to zero and sets a new start time for the following
         /// points.
-        pub const CUMULATIVE: MetricKind = MetricKind::new(3);
+        Cumulative,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MetricKind::value] or
+        /// [MetricKind::name].
+        UnknownValue(metric_kind::UnknownValue),
+    }
 
-        /// Creates a new MetricKind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod metric_kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MetricKind {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gauge => std::option::Option::Some(1),
+                Self::Delta => std::option::Option::Some(2),
+                Self::Cumulative => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METRIC_KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GAUGE"),
-                2 => std::borrow::Cow::Borrowed("DELTA"),
-                3 => std::borrow::Cow::Borrowed("CUMULATIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METRIC_KIND_UNSPECIFIED"),
+                Self::Gauge => std::option::Option::Some("GAUGE"),
+                Self::Delta => std::option::Option::Some("DELTA"),
+                Self::Cumulative => std::option::Option::Some("CUMULATIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METRIC_KIND_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METRIC_KIND_UNSPECIFIED)
-                }
-                "GAUGE" => std::option::Option::Some(Self::GAUGE),
-                "DELTA" => std::option::Option::Some(Self::DELTA),
-                "CUMULATIVE" => std::option::Option::Some(Self::CUMULATIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MetricKind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MetricKind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MetricKind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MetricKind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Gauge,
+                2 => Self::Delta,
+                3 => Self::Cumulative,
+                _ => Self::UnknownValue(metric_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MetricKind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METRIC_KIND_UNSPECIFIED" => Self::Unspecified,
+                "GAUGE" => Self::Gauge,
+                "DELTA" => Self::Delta,
+                "CUMULATIVE" => Self::Cumulative,
+                _ => Self::UnknownValue(metric_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MetricKind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gauge => serializer.serialize_i32(1),
+                Self::Delta => serializer.serialize_i32(2),
+                Self::Cumulative => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MetricKind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetricKind>::new(
+                ".google.api.MetricDescriptor.MetricKind",
+            ))
         }
     }
 
     /// The value type of a metric.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(i32);
-
-    impl ValueType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ValueType {
         /// Do not use this default value.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
-
+        Unspecified,
         /// The value is a boolean.
         /// This value type can be used only if the metric kind is `GAUGE`.
-        pub const BOOL: ValueType = ValueType::new(1);
-
+        Bool,
         /// The value is a signed 64-bit integer.
-        pub const INT64: ValueType = ValueType::new(2);
-
+        Int64,
         /// The value is a double precision floating point number.
-        pub const DOUBLE: ValueType = ValueType::new(3);
-
+        Double,
         /// The value is a text string.
         /// This value type can be used only if the metric kind is `GAUGE`.
-        pub const STRING: ValueType = ValueType::new(4);
-
+        String,
         /// The value is a [`Distribution`][google.api.Distribution].
         ///
         /// [google.api.Distribution]: crate::model::Distribution
-        pub const DISTRIBUTION: ValueType = ValueType::new(5);
-
+        Distribution,
         /// The value is money.
-        pub const MONEY: ValueType = ValueType::new(6);
+        Money,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ValueType::value] or
+        /// [ValueType::name].
+        UnknownValue(value_type::UnknownValue),
+    }
 
-        /// Creates a new ValueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod value_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ValueType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bool => std::option::Option::Some(1),
+                Self::Int64 => std::option::Option::Some(2),
+                Self::Double => std::option::Option::Some(3),
+                Self::String => std::option::Option::Some(4),
+                Self::Distribution => std::option::Option::Some(5),
+                Self::Money => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BOOL"),
-                2 => std::borrow::Cow::Borrowed("INT64"),
-                3 => std::borrow::Cow::Borrowed("DOUBLE"),
-                4 => std::borrow::Cow::Borrowed("STRING"),
-                5 => std::borrow::Cow::Borrowed("DISTRIBUTION"),
-                6 => std::borrow::Cow::Borrowed("MONEY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VALUE_TYPE_UNSPECIFIED"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Distribution => std::option::Option::Some("DISTRIBUTION"),
+                Self::Money => std::option::Option::Some("MONEY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "DISTRIBUTION" => std::option::Option::Some(Self::DISTRIBUTION),
-                "MONEY" => std::option::Option::Some(Self::MONEY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ValueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ValueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bool,
+                2 => Self::Int64,
+                3 => Self::Double,
+                4 => Self::String,
+                5 => Self::Distribution,
+                6 => Self::Money,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ValueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VALUE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BOOL" => Self::Bool,
+                "INT64" => Self::Int64,
+                "DOUBLE" => Self::Double,
+                "STRING" => Self::String,
+                "DISTRIBUTION" => Self::Distribution,
+                "MONEY" => Self::Money,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ValueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bool => serializer.serialize_i32(1),
+                Self::Int64 => serializer.serialize_i32(2),
+                Self::Double => serializer.serialize_i32(3),
+                Self::String => serializer.serialize_i32(4),
+                Self::Distribution => serializer.serialize_i32(5),
+                Self::Money => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ValueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueType>::new(
+                ".google.api.MetricDescriptor.ValueType",
+            ))
         }
     }
 }
@@ -7058,75 +7495,134 @@ pub mod resource_descriptor {
 
     /// A description of the historical or future-looking state of the
     /// resource pattern.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct History(i32);
-
-    impl History {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum History {
         /// The "unset" value.
-        pub const HISTORY_UNSPECIFIED: History = History::new(0);
-
+        Unspecified,
         /// The resource originally had one pattern and launched as such, and
         /// additional patterns were added later.
-        pub const ORIGINALLY_SINGLE_PATTERN: History = History::new(1);
-
+        OriginallySinglePattern,
         /// The resource has one pattern, but the API owner expects to add more
         /// later. (This is the inverse of ORIGINALLY_SINGLE_PATTERN, and prevents
         /// that from being necessary once there are multiple patterns.)
-        pub const FUTURE_MULTI_PATTERN: History = History::new(2);
+        FutureMultiPattern,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [History::value] or
+        /// [History::name].
+        UnknownValue(history::UnknownValue),
+    }
 
-        /// Creates a new History instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod history {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl History {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OriginallySinglePattern => std::option::Option::Some(1),
+                Self::FutureMultiPattern => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HISTORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ORIGINALLY_SINGLE_PATTERN"),
-                2 => std::borrow::Cow::Borrowed("FUTURE_MULTI_PATTERN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HISTORY_UNSPECIFIED" => std::option::Option::Some(Self::HISTORY_UNSPECIFIED),
-                "ORIGINALLY_SINGLE_PATTERN" => {
-                    std::option::Option::Some(Self::ORIGINALLY_SINGLE_PATTERN)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HISTORY_UNSPECIFIED"),
+                Self::OriginallySinglePattern => {
+                    std::option::Option::Some("ORIGINALLY_SINGLE_PATTERN")
                 }
-                "FUTURE_MULTI_PATTERN" => std::option::Option::Some(Self::FUTURE_MULTI_PATTERN),
-                _ => std::option::Option::None,
+                Self::FutureMultiPattern => std::option::Option::Some("FUTURE_MULTI_PATTERN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for History {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for History {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for History {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for History {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OriginallySinglePattern,
+                2 => Self::FutureMultiPattern,
+                _ => Self::UnknownValue(history::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for History {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HISTORY_UNSPECIFIED" => Self::Unspecified,
+                "ORIGINALLY_SINGLE_PATTERN" => Self::OriginallySinglePattern,
+                "FUTURE_MULTI_PATTERN" => Self::FutureMultiPattern,
+                _ => Self::UnknownValue(history::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for History {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OriginallySinglePattern => serializer.serialize_i32(1),
+                Self::FutureMultiPattern => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for History {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<History>::new(
+                ".google.api.ResourceDescriptor.History",
+            ))
         }
     }
 
     /// A flag representing a specific style that a resource claims to conform to.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Style(i32);
-
-    impl Style {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Style {
         /// The unspecified value. Do not use.
-        pub const STYLE_UNSPECIFIED: Style = Style::new(0);
-
+        Unspecified,
         /// This resource is intended to be "declarative-friendly".
         ///
         /// Declarative-friendly resources must be more strictly consistent, and
@@ -7135,46 +7631,107 @@ pub mod resource_descriptor {
         ///
         /// Note: This is used by the API linter (linter.aip.dev) to enable
         /// additional checks.
-        pub const DECLARATIVE_FRIENDLY: Style = Style::new(1);
+        DeclarativeFriendly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Style::value] or
+        /// [Style::name].
+        UnknownValue(style::UnknownValue),
+    }
 
-        /// Creates a new Style instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod style {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Style {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DeclarativeFriendly => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STYLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DECLARATIVE_FRIENDLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STYLE_UNSPECIFIED"),
+                Self::DeclarativeFriendly => std::option::Option::Some("DECLARATIVE_FRIENDLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STYLE_UNSPECIFIED" => std::option::Option::Some(Self::STYLE_UNSPECIFIED),
-                "DECLARATIVE_FRIENDLY" => std::option::Option::Some(Self::DECLARATIVE_FRIENDLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Style {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Style {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Style {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Style {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DeclarativeFriendly,
+                _ => Self::UnknownValue(style::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Style {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STYLE_UNSPECIFIED" => Self::Unspecified,
+                "DECLARATIVE_FRIENDLY" => Self::DeclarativeFriendly,
+                _ => Self::UnknownValue(style::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Style {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DeclarativeFriendly => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Style {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Style>::new(
+                ".google.api.ResourceDescriptor.Style",
+            ))
         }
     }
 }
@@ -8787,215 +9344,410 @@ impl wkt::message::Message for VisibilityRule {
 
 /// The organization for which the client libraries are being published.
 /// Affects the url where generated docs are published, etc.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClientLibraryOrganization(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ClientLibraryOrganization {
+    /// Not useful.
+    Unspecified,
+    /// Google Cloud Platform Org.
+    Cloud,
+    /// Ads (Advertising) Org.
+    Ads,
+    /// Photos Org.
+    Photos,
+    /// Street View Org.
+    StreetView,
+    /// Shopping Org.
+    Shopping,
+    /// Geo Org.
+    Geo,
+    /// Generative AI - <https://developers.generativeai.google>
+    GenerativeAi,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ClientLibraryOrganization::value] or
+    /// [ClientLibraryOrganization::name].
+    UnknownValue(client_library_organization::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod client_library_organization {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ClientLibraryOrganization {
-    /// Not useful.
-    pub const CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED: ClientLibraryOrganization =
-        ClientLibraryOrganization::new(0);
-
-    /// Google Cloud Platform Org.
-    pub const CLOUD: ClientLibraryOrganization = ClientLibraryOrganization::new(1);
-
-    /// Ads (Advertising) Org.
-    pub const ADS: ClientLibraryOrganization = ClientLibraryOrganization::new(2);
-
-    /// Photos Org.
-    pub const PHOTOS: ClientLibraryOrganization = ClientLibraryOrganization::new(3);
-
-    /// Street View Org.
-    pub const STREET_VIEW: ClientLibraryOrganization = ClientLibraryOrganization::new(4);
-
-    /// Shopping Org.
-    pub const SHOPPING: ClientLibraryOrganization = ClientLibraryOrganization::new(5);
-
-    /// Geo Org.
-    pub const GEO: ClientLibraryOrganization = ClientLibraryOrganization::new(6);
-
-    /// Generative AI - <https://developers.generativeai.google>
-    pub const GENERATIVE_AI: ClientLibraryOrganization = ClientLibraryOrganization::new(7);
-
-    /// Creates a new ClientLibraryOrganization instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Cloud => std::option::Option::Some(1),
+            Self::Ads => std::option::Option::Some(2),
+            Self::Photos => std::option::Option::Some(3),
+            Self::StreetView => std::option::Option::Some(4),
+            Self::Shopping => std::option::Option::Some(5),
+            Self::Geo => std::option::Option::Some(6),
+            Self::GenerativeAi => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CLOUD"),
-            2 => std::borrow::Cow::Borrowed("ADS"),
-            3 => std::borrow::Cow::Borrowed("PHOTOS"),
-            4 => std::borrow::Cow::Borrowed("STREET_VIEW"),
-            5 => std::borrow::Cow::Borrowed("SHOPPING"),
-            6 => std::borrow::Cow::Borrowed("GEO"),
-            7 => std::borrow::Cow::Borrowed("GENERATIVE_AI"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED")
             }
-            "CLOUD" => std::option::Option::Some(Self::CLOUD),
-            "ADS" => std::option::Option::Some(Self::ADS),
-            "PHOTOS" => std::option::Option::Some(Self::PHOTOS),
-            "STREET_VIEW" => std::option::Option::Some(Self::STREET_VIEW),
-            "SHOPPING" => std::option::Option::Some(Self::SHOPPING),
-            "GEO" => std::option::Option::Some(Self::GEO),
-            "GENERATIVE_AI" => std::option::Option::Some(Self::GENERATIVE_AI),
-            _ => std::option::Option::None,
+            Self::Cloud => std::option::Option::Some("CLOUD"),
+            Self::Ads => std::option::Option::Some("ADS"),
+            Self::Photos => std::option::Option::Some("PHOTOS"),
+            Self::StreetView => std::option::Option::Some("STREET_VIEW"),
+            Self::Shopping => std::option::Option::Some("SHOPPING"),
+            Self::Geo => std::option::Option::Some("GEO"),
+            Self::GenerativeAi => std::option::Option::Some("GENERATIVE_AI"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ClientLibraryOrganization {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ClientLibraryOrganization {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ClientLibraryOrganization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ClientLibraryOrganization {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Cloud,
+            2 => Self::Ads,
+            3 => Self::Photos,
+            4 => Self::StreetView,
+            5 => Self::Shopping,
+            6 => Self::Geo,
+            7 => Self::GenerativeAi,
+            _ => Self::UnknownValue(client_library_organization::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ClientLibraryOrganization {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED" => Self::Unspecified,
+            "CLOUD" => Self::Cloud,
+            "ADS" => Self::Ads,
+            "PHOTOS" => Self::Photos,
+            "STREET_VIEW" => Self::StreetView,
+            "SHOPPING" => Self::Shopping,
+            "GEO" => Self::Geo,
+            "GENERATIVE_AI" => Self::GenerativeAi,
+            _ => Self::UnknownValue(client_library_organization::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ClientLibraryOrganization {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Cloud => serializer.serialize_i32(1),
+            Self::Ads => serializer.serialize_i32(2),
+            Self::Photos => serializer.serialize_i32(3),
+            Self::StreetView => serializer.serialize_i32(4),
+            Self::Shopping => serializer.serialize_i32(5),
+            Self::Geo => serializer.serialize_i32(6),
+            Self::GenerativeAi => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ClientLibraryOrganization {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<ClientLibraryOrganization>::new(
+                ".google.api.ClientLibraryOrganization",
+            ),
+        )
     }
 }
 
 /// To where should client libraries be published?
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClientLibraryDestination(i32);
-
-impl ClientLibraryDestination {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ClientLibraryDestination {
     /// Client libraries will neither be generated nor published to package
     /// managers.
-    pub const CLIENT_LIBRARY_DESTINATION_UNSPECIFIED: ClientLibraryDestination =
-        ClientLibraryDestination::new(0);
-
+    Unspecified,
     /// Generate the client library in a repo under github.com/googleapis,
     /// but don't publish it to package managers.
-    pub const GITHUB: ClientLibraryDestination = ClientLibraryDestination::new(10);
-
+    Github,
     /// Publish the library to package managers like nuget.org and npmjs.com.
-    pub const PACKAGE_MANAGER: ClientLibraryDestination = ClientLibraryDestination::new(20);
+    PackageManager,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ClientLibraryDestination::value] or
+    /// [ClientLibraryDestination::name].
+    UnknownValue(client_library_destination::UnknownValue),
+}
 
-    /// Creates a new ClientLibraryDestination instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod client_library_destination {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ClientLibraryDestination {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Github => std::option::Option::Some(10),
+            Self::PackageManager => std::option::Option::Some(20),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CLIENT_LIBRARY_DESTINATION_UNSPECIFIED"),
-            10 => std::borrow::Cow::Borrowed("GITHUB"),
-            20 => std::borrow::Cow::Borrowed("PACKAGE_MANAGER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CLIENT_LIBRARY_DESTINATION_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("CLIENT_LIBRARY_DESTINATION_UNSPECIFIED")
             }
-            "GITHUB" => std::option::Option::Some(Self::GITHUB),
-            "PACKAGE_MANAGER" => std::option::Option::Some(Self::PACKAGE_MANAGER),
-            _ => std::option::Option::None,
+            Self::Github => std::option::Option::Some("GITHUB"),
+            Self::PackageManager => std::option::Option::Some("PACKAGE_MANAGER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ClientLibraryDestination {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ClientLibraryDestination {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ClientLibraryDestination {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ClientLibraryDestination {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            10 => Self::Github,
+            20 => Self::PackageManager,
+            _ => Self::UnknownValue(client_library_destination::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ClientLibraryDestination {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED" => Self::Unspecified,
+            "GITHUB" => Self::Github,
+            "PACKAGE_MANAGER" => Self::PackageManager,
+            _ => Self::UnknownValue(client_library_destination::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ClientLibraryDestination {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Github => serializer.serialize_i32(10),
+            Self::PackageManager => serializer.serialize_i32(20),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ClientLibraryDestination {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ClientLibraryDestination>::new(
+            ".google.api.ClientLibraryDestination",
+        ))
     }
 }
 
 /// Classifies set of possible modifications to an object in the service
 /// configuration.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ChangeType(i32);
-
-impl ChangeType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ChangeType {
     /// No value was provided.
-    pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new(0);
-
+    Unspecified,
     /// The changed object exists in the 'new' service configuration, but not
     /// in the 'old' service configuration.
-    pub const ADDED: ChangeType = ChangeType::new(1);
-
+    Added,
     /// The changed object exists in the 'old' service configuration, but not
     /// in the 'new' service configuration.
-    pub const REMOVED: ChangeType = ChangeType::new(2);
-
+    Removed,
     /// The changed object exists in both service configurations, but its value
     /// is different.
-    pub const MODIFIED: ChangeType = ChangeType::new(3);
+    Modified,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ChangeType::value] or
+    /// [ChangeType::name].
+    UnknownValue(change_type::UnknownValue),
+}
 
-    /// Creates a new ChangeType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod change_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ChangeType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Added => std::option::Option::Some(1),
+            Self::Removed => std::option::Option::Some(2),
+            Self::Modified => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CHANGE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ADDED"),
-            2 => std::borrow::Cow::Borrowed("REMOVED"),
-            3 => std::borrow::Cow::Borrowed("MODIFIED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CHANGE_TYPE_UNSPECIFIED"),
+            Self::Added => std::option::Option::Some("ADDED"),
+            Self::Removed => std::option::Option::Some("REMOVED"),
+            Self::Modified => std::option::Option::Some("MODIFIED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CHANGE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::CHANGE_TYPE_UNSPECIFIED),
-            "ADDED" => std::option::Option::Some(Self::ADDED),
-            "REMOVED" => std::option::Option::Some(Self::REMOVED),
-            "MODIFIED" => std::option::Option::Some(Self::MODIFIED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ChangeType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ChangeType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ChangeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ChangeType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Added,
+            2 => Self::Removed,
+            3 => Self::Modified,
+            _ => Self::UnknownValue(change_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ChangeType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CHANGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ADDED" => Self::Added,
+            "REMOVED" => Self::Removed,
+            "MODIFIED" => Self::Modified,
+            _ => Self::UnknownValue(change_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ChangeType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Added => serializer.serialize_i32(1),
+            Self::Removed => serializer.serialize_i32(2),
+            Self::Modified => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ChangeType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ChangeType>::new(
+            ".google.api.ChangeType",
+        ))
     }
 }
 
@@ -9009,13 +9761,11 @@ impl std::default::Default for ChangeType {
 /// such as "projects/123". Other metadata keys are specific to each error
 /// reason. For more information, see the definition of the specific error
 /// reason.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ErrorReason(i32);
-
-impl ErrorReason {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorReason {
     /// Do not use this default value.
-    pub const ERROR_REASON_UNSPECIFIED: ErrorReason = ErrorReason::new(0);
-
+    Unspecified,
     /// The request is calling a disabled service for a consumer.
     ///
     /// Example of an ErrorInfo when the consumer "projects/123" contacting
@@ -9033,8 +9783,7 @@ impl ErrorReason {
     ///
     /// This response indicates the "pubsub.googleapis.com" has been disabled in
     /// "projects/123".
-    pub const SERVICE_DISABLED: ErrorReason = ErrorReason::new(1);
-
+    ServiceDisabled,
     /// The request whose associated billing account is disabled.
     ///
     /// Example of an ErrorInfo when the consumer "projects/123" fails to contact
@@ -9052,8 +9801,7 @@ impl ErrorReason {
     /// ```
     ///
     /// This response indicates the billing account associated has been disabled.
-    pub const BILLING_DISABLED: ErrorReason = ErrorReason::new(2);
-
+    BillingDisabled,
     /// The request is denied because the provided [API
     /// key](https://cloud.google.com/docs/authentication/api-keys) is invalid. It
     /// may be in a bad format, cannot be found, or has been expired).
@@ -9069,8 +9817,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_INVALID: ErrorReason = ErrorReason::new(3);
-
+    ApiKeyInvalid,
     /// The request is denied because it violates [API key API
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_api_restrictions).
     ///
@@ -9087,8 +9834,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_SERVICE_BLOCKED: ErrorReason = ErrorReason::new(4);
-
+    ApiKeyServiceBlocked,
     /// The request is denied because it violates [API key HTTP
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_http_restrictions).
     ///
@@ -9105,8 +9851,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_HTTP_REFERRER_BLOCKED: ErrorReason = ErrorReason::new(7);
-
+    ApiKeyHttpReferrerBlocked,
     /// The request is denied because it violates [API key IP address
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions).
     ///
@@ -9123,8 +9868,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_IP_ADDRESS_BLOCKED: ErrorReason = ErrorReason::new(8);
-
+    ApiKeyIpAddressBlocked,
     /// The request is denied because it violates [API key Android application
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions).
     ///
@@ -9141,8 +9885,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_ANDROID_APP_BLOCKED: ErrorReason = ErrorReason::new(9);
-
+    ApiKeyAndroidAppBlocked,
     /// The request is denied because it violates [API key iOS application
     /// restrictions](https://cloud.google.com/docs/authentication/api-keys#adding_application_restrictions).
     ///
@@ -9159,8 +9902,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const API_KEY_IOS_APP_BLOCKED: ErrorReason = ErrorReason::new(13);
-
+    ApiKeyIosAppBlocked,
     /// The request is denied because there is not enough rate quota for the
     /// consumer.
     ///
@@ -9198,8 +9940,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const RATE_LIMIT_EXCEEDED: ErrorReason = ErrorReason::new(5);
-
+    RateLimitExceeded,
     /// The request is denied because there is not enough resource quota for the
     /// consumer.
     ///
@@ -9236,8 +9977,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const RESOURCE_QUOTA_EXCEEDED: ErrorReason = ErrorReason::new(6);
-
+    ResourceQuotaExceeded,
     /// The request whose associated billing account address is in a tax restricted
     /// location, violates the local tax restrictions when creating resources in
     /// the restricted region.
@@ -9259,8 +9999,7 @@ impl ErrorReason {
     ///
     /// This response indicates creating the Cloud Storage Bucket in
     /// "locations/asia-northeast3" violates the location tax restriction.
-    pub const LOCATION_TAX_POLICY_VIOLATED: ErrorReason = ErrorReason::new(10);
-
+    LocationTaxPolicyViolated,
     /// The request is denied because the caller does not have required permission
     /// on the user project "projects/123" or the user project is invalid. For more
     /// information, check the [userProject System
@@ -9278,8 +10017,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const USER_PROJECT_DENIED: ErrorReason = ErrorReason::new(11);
-
+    UserProjectDenied,
     /// The request is denied because the consumer "projects/123" is suspended due
     /// to Terms of Service(Tos) violations. Check [Project suspension
     /// guidelines](https://cloud.google.com/resource-manager/docs/project-suspension-guidelines)
@@ -9297,8 +10035,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const CONSUMER_SUSPENDED: ErrorReason = ErrorReason::new(12);
-
+    ConsumerSuspended,
     /// The request is denied because the associated consumer is invalid. It may be
     /// in a bad format, cannot be found, or have been deleted.
     ///
@@ -9314,8 +10051,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const CONSUMER_INVALID: ErrorReason = ErrorReason::new(14);
-
+    ConsumerInvalid,
     /// The request is denied because it violates [VPC Service
     /// Controls](https://cloud.google.com/vpc-service-controls/docs/overview).
     /// The 'uid' field is a random generated identifier that customer can use it
@@ -9337,8 +10073,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const SECURITY_POLICY_VIOLATED: ErrorReason = ErrorReason::new(15);
-
+    SecurityPolicyViolated,
     /// The request is denied because the provided access token has expired.
     ///
     /// Example of an ErrorInfo when the request is calling Cloud Storage service
@@ -9353,8 +10088,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const ACCESS_TOKEN_EXPIRED: ErrorReason = ErrorReason::new(16);
-
+    AccessTokenExpired,
     /// The request is denied because the provided access token doesn't have at
     /// least one of the acceptable scopes required for the API. Please check
     /// [OAuth 2.0 Scopes for Google
@@ -9374,8 +10108,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const ACCESS_TOKEN_SCOPE_INSUFFICIENT: ErrorReason = ErrorReason::new(17);
-
+    AccessTokenScopeInsufficient,
     /// The request is denied because the account associated with the provided
     /// access token is in an invalid state, such as disabled or deleted.
     /// For more information, see <https://cloud.google.com/docs/authentication>.
@@ -9398,8 +10131,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const ACCOUNT_STATE_INVALID: ErrorReason = ErrorReason::new(18);
-
+    AccountStateInvalid,
     /// The request is denied because the type of the provided access token is not
     /// supported by the API being called.
     ///
@@ -9415,8 +10147,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const ACCESS_TOKEN_TYPE_UNSUPPORTED: ErrorReason = ErrorReason::new(19);
-
+    AccessTokenTypeUnsupported,
     /// The request is denied because the request doesn't have any authentication
     /// credentials. For more information regarding the supported authentication
     /// strategies for Google Cloud APIs, see
@@ -9434,8 +10165,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const CREDENTIALS_MISSING: ErrorReason = ErrorReason::new(20);
-
+    CredentialsMissing,
     /// The request is denied because the provided project owning the resource
     /// which acts as the [API
     /// consumer](https://cloud.google.com/apis/design/glossary#api_consumer) is
@@ -9455,8 +10185,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const RESOURCE_PROJECT_INVALID: ErrorReason = ErrorReason::new(21);
-
+    ResourceProjectInvalid,
     /// The request is denied because the provided session cookie is missing,
     /// invalid or failed to decode.
     ///
@@ -9473,8 +10202,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const SESSION_COOKIE_INVALID: ErrorReason = ErrorReason::new(23);
-
+    SessionCookieInvalid,
     /// The request is denied because the user is from a Google Workspace customer
     /// that blocks their users from accessing a particular service.
     ///
@@ -9492,8 +10220,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const USER_BLOCKED_BY_ADMIN: ErrorReason = ErrorReason::new(24);
-
+    UserBlockedByAdmin,
     /// The request is denied because the resource service usage is restricted
     /// by administrators according to the organization policy constraint.
     /// For more information see
@@ -9511,8 +10238,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const RESOURCE_USAGE_RESTRICTION_VIOLATED: ErrorReason = ErrorReason::new(25);
-
+    ResourceUsageRestrictionViolated,
     /// Unimplemented. Do not use.
     ///
     /// The request is denied because it contains unsupported system parameters in
@@ -9531,8 +10257,7 @@ impl ErrorReason {
     ///   }
     /// }
     /// ```
-    pub const SYSTEM_PARAMETER_UNSUPPORTED: ErrorReason = ErrorReason::new(26);
-
+    SystemParameterUnsupported,
     /// The request is denied because it violates Org Restriction: the requested
     /// resource does not belong to allowed organizations specified in
     /// "X-Goog-Allowed-Resources" header.
@@ -9548,8 +10273,7 @@ impl ErrorReason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const ORG_RESTRICTION_VIOLATION: ErrorReason = ErrorReason::new(27);
-
+    OrgRestrictionViolation,
     /// The request is denied because "X-Goog-Allowed-Resources" header is in a bad
     /// format.
     ///
@@ -9565,8 +10289,7 @@ impl ErrorReason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const ORG_RESTRICTION_HEADER_INVALID: ErrorReason = ErrorReason::new(28);
-
+    OrgRestrictionHeaderInvalid,
     /// Unimplemented. Do not use.
     ///
     /// The request is calling a service that is not visible to the consumer.
@@ -9586,8 +10309,7 @@ impl ErrorReason {
     ///
     /// This response indicates the "pubsub.googleapis.com" is not visible to
     /// "projects/123" (or it may not exist).
-    pub const SERVICE_NOT_VISIBLE: ErrorReason = ErrorReason::new(29);
-
+    ServiceNotVisible,
     /// The request is related to a project for which GCP access is suspended.
     ///
     /// Example of an ErrorInfo when the consumer "projects/123" fails to contact
@@ -9604,8 +10326,7 @@ impl ErrorReason {
     /// ```
     ///
     /// This response indicates the associated GCP account has been suspended.
-    pub const GCP_SUSPENDED: ErrorReason = ErrorReason::new(30);
-
+    GcpSuspended,
     /// The request violates the location policies when creating resources in
     /// the restricted region.
     ///
@@ -9625,8 +10346,7 @@ impl ErrorReason {
     /// This response indicates creating the Cloud Storage Bucket in
     /// "locations/asia-northeast3" violates at least one location policy.
     /// The troubleshooting guidance is provided in the Help links.
-    pub const LOCATION_POLICY_VIOLATED: ErrorReason = ErrorReason::new(31);
-
+    LocationPolicyViolated,
     /// The request is denied because origin request header is missing.
     ///
     /// Example of an ErrorInfo when
@@ -9641,8 +10361,7 @@ impl ErrorReason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const MISSING_ORIGIN: ErrorReason = ErrorReason::new(33);
-
+    MissingOrigin,
     /// The request is denied because the request contains more than one credential
     /// type that are individually acceptable, but not together. The customer
     /// should retry their request with only one set of credentials.
@@ -9658,128 +10377,278 @@ impl ErrorReason {
     /// "service": "pubsub.googleapis.com"
     /// }
     /// }
-    pub const OVERLOADED_CREDENTIALS: ErrorReason = ErrorReason::new(34);
+    OverloadedCredentials,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ErrorReason::value] or
+    /// [ErrorReason::name].
+    UnknownValue(error_reason::UnknownValue),
+}
 
-    /// Creates a new ErrorReason instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod error_reason {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ErrorReason {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ServiceDisabled => std::option::Option::Some(1),
+            Self::BillingDisabled => std::option::Option::Some(2),
+            Self::ApiKeyInvalid => std::option::Option::Some(3),
+            Self::ApiKeyServiceBlocked => std::option::Option::Some(4),
+            Self::ApiKeyHttpReferrerBlocked => std::option::Option::Some(7),
+            Self::ApiKeyIpAddressBlocked => std::option::Option::Some(8),
+            Self::ApiKeyAndroidAppBlocked => std::option::Option::Some(9),
+            Self::ApiKeyIosAppBlocked => std::option::Option::Some(13),
+            Self::RateLimitExceeded => std::option::Option::Some(5),
+            Self::ResourceQuotaExceeded => std::option::Option::Some(6),
+            Self::LocationTaxPolicyViolated => std::option::Option::Some(10),
+            Self::UserProjectDenied => std::option::Option::Some(11),
+            Self::ConsumerSuspended => std::option::Option::Some(12),
+            Self::ConsumerInvalid => std::option::Option::Some(14),
+            Self::SecurityPolicyViolated => std::option::Option::Some(15),
+            Self::AccessTokenExpired => std::option::Option::Some(16),
+            Self::AccessTokenScopeInsufficient => std::option::Option::Some(17),
+            Self::AccountStateInvalid => std::option::Option::Some(18),
+            Self::AccessTokenTypeUnsupported => std::option::Option::Some(19),
+            Self::CredentialsMissing => std::option::Option::Some(20),
+            Self::ResourceProjectInvalid => std::option::Option::Some(21),
+            Self::SessionCookieInvalid => std::option::Option::Some(23),
+            Self::UserBlockedByAdmin => std::option::Option::Some(24),
+            Self::ResourceUsageRestrictionViolated => std::option::Option::Some(25),
+            Self::SystemParameterUnsupported => std::option::Option::Some(26),
+            Self::OrgRestrictionViolation => std::option::Option::Some(27),
+            Self::OrgRestrictionHeaderInvalid => std::option::Option::Some(28),
+            Self::ServiceNotVisible => std::option::Option::Some(29),
+            Self::GcpSuspended => std::option::Option::Some(30),
+            Self::LocationPolicyViolated => std::option::Option::Some(31),
+            Self::MissingOrigin => std::option::Option::Some(33),
+            Self::OverloadedCredentials => std::option::Option::Some(34),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ERROR_REASON_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SERVICE_DISABLED"),
-            2 => std::borrow::Cow::Borrowed("BILLING_DISABLED"),
-            3 => std::borrow::Cow::Borrowed("API_KEY_INVALID"),
-            4 => std::borrow::Cow::Borrowed("API_KEY_SERVICE_BLOCKED"),
-            5 => std::borrow::Cow::Borrowed("RATE_LIMIT_EXCEEDED"),
-            6 => std::borrow::Cow::Borrowed("RESOURCE_QUOTA_EXCEEDED"),
-            7 => std::borrow::Cow::Borrowed("API_KEY_HTTP_REFERRER_BLOCKED"),
-            8 => std::borrow::Cow::Borrowed("API_KEY_IP_ADDRESS_BLOCKED"),
-            9 => std::borrow::Cow::Borrowed("API_KEY_ANDROID_APP_BLOCKED"),
-            10 => std::borrow::Cow::Borrowed("LOCATION_TAX_POLICY_VIOLATED"),
-            11 => std::borrow::Cow::Borrowed("USER_PROJECT_DENIED"),
-            12 => std::borrow::Cow::Borrowed("CONSUMER_SUSPENDED"),
-            13 => std::borrow::Cow::Borrowed("API_KEY_IOS_APP_BLOCKED"),
-            14 => std::borrow::Cow::Borrowed("CONSUMER_INVALID"),
-            15 => std::borrow::Cow::Borrowed("SECURITY_POLICY_VIOLATED"),
-            16 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_EXPIRED"),
-            17 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_SCOPE_INSUFFICIENT"),
-            18 => std::borrow::Cow::Borrowed("ACCOUNT_STATE_INVALID"),
-            19 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_TYPE_UNSUPPORTED"),
-            20 => std::borrow::Cow::Borrowed("CREDENTIALS_MISSING"),
-            21 => std::borrow::Cow::Borrowed("RESOURCE_PROJECT_INVALID"),
-            23 => std::borrow::Cow::Borrowed("SESSION_COOKIE_INVALID"),
-            24 => std::borrow::Cow::Borrowed("USER_BLOCKED_BY_ADMIN"),
-            25 => std::borrow::Cow::Borrowed("RESOURCE_USAGE_RESTRICTION_VIOLATED"),
-            26 => std::borrow::Cow::Borrowed("SYSTEM_PARAMETER_UNSUPPORTED"),
-            27 => std::borrow::Cow::Borrowed("ORG_RESTRICTION_VIOLATION"),
-            28 => std::borrow::Cow::Borrowed("ORG_RESTRICTION_HEADER_INVALID"),
-            29 => std::borrow::Cow::Borrowed("SERVICE_NOT_VISIBLE"),
-            30 => std::borrow::Cow::Borrowed("GCP_SUSPENDED"),
-            31 => std::borrow::Cow::Borrowed("LOCATION_POLICY_VIOLATED"),
-            33 => std::borrow::Cow::Borrowed("MISSING_ORIGIN"),
-            34 => std::borrow::Cow::Borrowed("OVERLOADED_CREDENTIALS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ERROR_REASON_UNSPECIFIED"),
+            Self::ServiceDisabled => std::option::Option::Some("SERVICE_DISABLED"),
+            Self::BillingDisabled => std::option::Option::Some("BILLING_DISABLED"),
+            Self::ApiKeyInvalid => std::option::Option::Some("API_KEY_INVALID"),
+            Self::ApiKeyServiceBlocked => std::option::Option::Some("API_KEY_SERVICE_BLOCKED"),
+            Self::ApiKeyHttpReferrerBlocked => {
+                std::option::Option::Some("API_KEY_HTTP_REFERRER_BLOCKED")
+            }
+            Self::ApiKeyIpAddressBlocked => std::option::Option::Some("API_KEY_IP_ADDRESS_BLOCKED"),
+            Self::ApiKeyAndroidAppBlocked => {
+                std::option::Option::Some("API_KEY_ANDROID_APP_BLOCKED")
+            }
+            Self::ApiKeyIosAppBlocked => std::option::Option::Some("API_KEY_IOS_APP_BLOCKED"),
+            Self::RateLimitExceeded => std::option::Option::Some("RATE_LIMIT_EXCEEDED"),
+            Self::ResourceQuotaExceeded => std::option::Option::Some("RESOURCE_QUOTA_EXCEEDED"),
+            Self::LocationTaxPolicyViolated => {
+                std::option::Option::Some("LOCATION_TAX_POLICY_VIOLATED")
+            }
+            Self::UserProjectDenied => std::option::Option::Some("USER_PROJECT_DENIED"),
+            Self::ConsumerSuspended => std::option::Option::Some("CONSUMER_SUSPENDED"),
+            Self::ConsumerInvalid => std::option::Option::Some("CONSUMER_INVALID"),
+            Self::SecurityPolicyViolated => std::option::Option::Some("SECURITY_POLICY_VIOLATED"),
+            Self::AccessTokenExpired => std::option::Option::Some("ACCESS_TOKEN_EXPIRED"),
+            Self::AccessTokenScopeInsufficient => {
+                std::option::Option::Some("ACCESS_TOKEN_SCOPE_INSUFFICIENT")
+            }
+            Self::AccountStateInvalid => std::option::Option::Some("ACCOUNT_STATE_INVALID"),
+            Self::AccessTokenTypeUnsupported => {
+                std::option::Option::Some("ACCESS_TOKEN_TYPE_UNSUPPORTED")
+            }
+            Self::CredentialsMissing => std::option::Option::Some("CREDENTIALS_MISSING"),
+            Self::ResourceProjectInvalid => std::option::Option::Some("RESOURCE_PROJECT_INVALID"),
+            Self::SessionCookieInvalid => std::option::Option::Some("SESSION_COOKIE_INVALID"),
+            Self::UserBlockedByAdmin => std::option::Option::Some("USER_BLOCKED_BY_ADMIN"),
+            Self::ResourceUsageRestrictionViolated => {
+                std::option::Option::Some("RESOURCE_USAGE_RESTRICTION_VIOLATED")
+            }
+            Self::SystemParameterUnsupported => {
+                std::option::Option::Some("SYSTEM_PARAMETER_UNSUPPORTED")
+            }
+            Self::OrgRestrictionViolation => std::option::Option::Some("ORG_RESTRICTION_VIOLATION"),
+            Self::OrgRestrictionHeaderInvalid => {
+                std::option::Option::Some("ORG_RESTRICTION_HEADER_INVALID")
+            }
+            Self::ServiceNotVisible => std::option::Option::Some("SERVICE_NOT_VISIBLE"),
+            Self::GcpSuspended => std::option::Option::Some("GCP_SUSPENDED"),
+            Self::LocationPolicyViolated => std::option::Option::Some("LOCATION_POLICY_VIOLATED"),
+            Self::MissingOrigin => std::option::Option::Some("MISSING_ORIGIN"),
+            Self::OverloadedCredentials => std::option::Option::Some("OVERLOADED_CREDENTIALS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ERROR_REASON_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_REASON_UNSPECIFIED),
-            "SERVICE_DISABLED" => std::option::Option::Some(Self::SERVICE_DISABLED),
-            "BILLING_DISABLED" => std::option::Option::Some(Self::BILLING_DISABLED),
-            "API_KEY_INVALID" => std::option::Option::Some(Self::API_KEY_INVALID),
-            "API_KEY_SERVICE_BLOCKED" => std::option::Option::Some(Self::API_KEY_SERVICE_BLOCKED),
-            "API_KEY_HTTP_REFERRER_BLOCKED" => {
-                std::option::Option::Some(Self::API_KEY_HTTP_REFERRER_BLOCKED)
-            }
-            "API_KEY_IP_ADDRESS_BLOCKED" => {
-                std::option::Option::Some(Self::API_KEY_IP_ADDRESS_BLOCKED)
-            }
-            "API_KEY_ANDROID_APP_BLOCKED" => {
-                std::option::Option::Some(Self::API_KEY_ANDROID_APP_BLOCKED)
-            }
-            "API_KEY_IOS_APP_BLOCKED" => std::option::Option::Some(Self::API_KEY_IOS_APP_BLOCKED),
-            "RATE_LIMIT_EXCEEDED" => std::option::Option::Some(Self::RATE_LIMIT_EXCEEDED),
-            "RESOURCE_QUOTA_EXCEEDED" => std::option::Option::Some(Self::RESOURCE_QUOTA_EXCEEDED),
-            "LOCATION_TAX_POLICY_VIOLATED" => {
-                std::option::Option::Some(Self::LOCATION_TAX_POLICY_VIOLATED)
-            }
-            "USER_PROJECT_DENIED" => std::option::Option::Some(Self::USER_PROJECT_DENIED),
-            "CONSUMER_SUSPENDED" => std::option::Option::Some(Self::CONSUMER_SUSPENDED),
-            "CONSUMER_INVALID" => std::option::Option::Some(Self::CONSUMER_INVALID),
-            "SECURITY_POLICY_VIOLATED" => std::option::Option::Some(Self::SECURITY_POLICY_VIOLATED),
-            "ACCESS_TOKEN_EXPIRED" => std::option::Option::Some(Self::ACCESS_TOKEN_EXPIRED),
-            "ACCESS_TOKEN_SCOPE_INSUFFICIENT" => {
-                std::option::Option::Some(Self::ACCESS_TOKEN_SCOPE_INSUFFICIENT)
-            }
-            "ACCOUNT_STATE_INVALID" => std::option::Option::Some(Self::ACCOUNT_STATE_INVALID),
-            "ACCESS_TOKEN_TYPE_UNSUPPORTED" => {
-                std::option::Option::Some(Self::ACCESS_TOKEN_TYPE_UNSUPPORTED)
-            }
-            "CREDENTIALS_MISSING" => std::option::Option::Some(Self::CREDENTIALS_MISSING),
-            "RESOURCE_PROJECT_INVALID" => std::option::Option::Some(Self::RESOURCE_PROJECT_INVALID),
-            "SESSION_COOKIE_INVALID" => std::option::Option::Some(Self::SESSION_COOKIE_INVALID),
-            "USER_BLOCKED_BY_ADMIN" => std::option::Option::Some(Self::USER_BLOCKED_BY_ADMIN),
-            "RESOURCE_USAGE_RESTRICTION_VIOLATED" => {
-                std::option::Option::Some(Self::RESOURCE_USAGE_RESTRICTION_VIOLATED)
-            }
-            "SYSTEM_PARAMETER_UNSUPPORTED" => {
-                std::option::Option::Some(Self::SYSTEM_PARAMETER_UNSUPPORTED)
-            }
-            "ORG_RESTRICTION_VIOLATION" => {
-                std::option::Option::Some(Self::ORG_RESTRICTION_VIOLATION)
-            }
-            "ORG_RESTRICTION_HEADER_INVALID" => {
-                std::option::Option::Some(Self::ORG_RESTRICTION_HEADER_INVALID)
-            }
-            "SERVICE_NOT_VISIBLE" => std::option::Option::Some(Self::SERVICE_NOT_VISIBLE),
-            "GCP_SUSPENDED" => std::option::Option::Some(Self::GCP_SUSPENDED),
-            "LOCATION_POLICY_VIOLATED" => std::option::Option::Some(Self::LOCATION_POLICY_VIOLATED),
-            "MISSING_ORIGIN" => std::option::Option::Some(Self::MISSING_ORIGIN),
-            "OVERLOADED_CREDENTIALS" => std::option::Option::Some(Self::OVERLOADED_CREDENTIALS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ErrorReason {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ErrorReason {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ErrorReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ErrorReason {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ServiceDisabled,
+            2 => Self::BillingDisabled,
+            3 => Self::ApiKeyInvalid,
+            4 => Self::ApiKeyServiceBlocked,
+            5 => Self::RateLimitExceeded,
+            6 => Self::ResourceQuotaExceeded,
+            7 => Self::ApiKeyHttpReferrerBlocked,
+            8 => Self::ApiKeyIpAddressBlocked,
+            9 => Self::ApiKeyAndroidAppBlocked,
+            10 => Self::LocationTaxPolicyViolated,
+            11 => Self::UserProjectDenied,
+            12 => Self::ConsumerSuspended,
+            13 => Self::ApiKeyIosAppBlocked,
+            14 => Self::ConsumerInvalid,
+            15 => Self::SecurityPolicyViolated,
+            16 => Self::AccessTokenExpired,
+            17 => Self::AccessTokenScopeInsufficient,
+            18 => Self::AccountStateInvalid,
+            19 => Self::AccessTokenTypeUnsupported,
+            20 => Self::CredentialsMissing,
+            21 => Self::ResourceProjectInvalid,
+            23 => Self::SessionCookieInvalid,
+            24 => Self::UserBlockedByAdmin,
+            25 => Self::ResourceUsageRestrictionViolated,
+            26 => Self::SystemParameterUnsupported,
+            27 => Self::OrgRestrictionViolation,
+            28 => Self::OrgRestrictionHeaderInvalid,
+            29 => Self::ServiceNotVisible,
+            30 => Self::GcpSuspended,
+            31 => Self::LocationPolicyViolated,
+            33 => Self::MissingOrigin,
+            34 => Self::OverloadedCredentials,
+            _ => Self::UnknownValue(error_reason::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ErrorReason {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ERROR_REASON_UNSPECIFIED" => Self::Unspecified,
+            "SERVICE_DISABLED" => Self::ServiceDisabled,
+            "BILLING_DISABLED" => Self::BillingDisabled,
+            "API_KEY_INVALID" => Self::ApiKeyInvalid,
+            "API_KEY_SERVICE_BLOCKED" => Self::ApiKeyServiceBlocked,
+            "API_KEY_HTTP_REFERRER_BLOCKED" => Self::ApiKeyHttpReferrerBlocked,
+            "API_KEY_IP_ADDRESS_BLOCKED" => Self::ApiKeyIpAddressBlocked,
+            "API_KEY_ANDROID_APP_BLOCKED" => Self::ApiKeyAndroidAppBlocked,
+            "API_KEY_IOS_APP_BLOCKED" => Self::ApiKeyIosAppBlocked,
+            "RATE_LIMIT_EXCEEDED" => Self::RateLimitExceeded,
+            "RESOURCE_QUOTA_EXCEEDED" => Self::ResourceQuotaExceeded,
+            "LOCATION_TAX_POLICY_VIOLATED" => Self::LocationTaxPolicyViolated,
+            "USER_PROJECT_DENIED" => Self::UserProjectDenied,
+            "CONSUMER_SUSPENDED" => Self::ConsumerSuspended,
+            "CONSUMER_INVALID" => Self::ConsumerInvalid,
+            "SECURITY_POLICY_VIOLATED" => Self::SecurityPolicyViolated,
+            "ACCESS_TOKEN_EXPIRED" => Self::AccessTokenExpired,
+            "ACCESS_TOKEN_SCOPE_INSUFFICIENT" => Self::AccessTokenScopeInsufficient,
+            "ACCOUNT_STATE_INVALID" => Self::AccountStateInvalid,
+            "ACCESS_TOKEN_TYPE_UNSUPPORTED" => Self::AccessTokenTypeUnsupported,
+            "CREDENTIALS_MISSING" => Self::CredentialsMissing,
+            "RESOURCE_PROJECT_INVALID" => Self::ResourceProjectInvalid,
+            "SESSION_COOKIE_INVALID" => Self::SessionCookieInvalid,
+            "USER_BLOCKED_BY_ADMIN" => Self::UserBlockedByAdmin,
+            "RESOURCE_USAGE_RESTRICTION_VIOLATED" => Self::ResourceUsageRestrictionViolated,
+            "SYSTEM_PARAMETER_UNSUPPORTED" => Self::SystemParameterUnsupported,
+            "ORG_RESTRICTION_VIOLATION" => Self::OrgRestrictionViolation,
+            "ORG_RESTRICTION_HEADER_INVALID" => Self::OrgRestrictionHeaderInvalid,
+            "SERVICE_NOT_VISIBLE" => Self::ServiceNotVisible,
+            "GCP_SUSPENDED" => Self::GcpSuspended,
+            "LOCATION_POLICY_VIOLATED" => Self::LocationPolicyViolated,
+            "MISSING_ORIGIN" => Self::MissingOrigin,
+            "OVERLOADED_CREDENTIALS" => Self::OverloadedCredentials,
+            _ => Self::UnknownValue(error_reason::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ErrorReason {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ServiceDisabled => serializer.serialize_i32(1),
+            Self::BillingDisabled => serializer.serialize_i32(2),
+            Self::ApiKeyInvalid => serializer.serialize_i32(3),
+            Self::ApiKeyServiceBlocked => serializer.serialize_i32(4),
+            Self::ApiKeyHttpReferrerBlocked => serializer.serialize_i32(7),
+            Self::ApiKeyIpAddressBlocked => serializer.serialize_i32(8),
+            Self::ApiKeyAndroidAppBlocked => serializer.serialize_i32(9),
+            Self::ApiKeyIosAppBlocked => serializer.serialize_i32(13),
+            Self::RateLimitExceeded => serializer.serialize_i32(5),
+            Self::ResourceQuotaExceeded => serializer.serialize_i32(6),
+            Self::LocationTaxPolicyViolated => serializer.serialize_i32(10),
+            Self::UserProjectDenied => serializer.serialize_i32(11),
+            Self::ConsumerSuspended => serializer.serialize_i32(12),
+            Self::ConsumerInvalid => serializer.serialize_i32(14),
+            Self::SecurityPolicyViolated => serializer.serialize_i32(15),
+            Self::AccessTokenExpired => serializer.serialize_i32(16),
+            Self::AccessTokenScopeInsufficient => serializer.serialize_i32(17),
+            Self::AccountStateInvalid => serializer.serialize_i32(18),
+            Self::AccessTokenTypeUnsupported => serializer.serialize_i32(19),
+            Self::CredentialsMissing => serializer.serialize_i32(20),
+            Self::ResourceProjectInvalid => serializer.serialize_i32(21),
+            Self::SessionCookieInvalid => serializer.serialize_i32(23),
+            Self::UserBlockedByAdmin => serializer.serialize_i32(24),
+            Self::ResourceUsageRestrictionViolated => serializer.serialize_i32(25),
+            Self::SystemParameterUnsupported => serializer.serialize_i32(26),
+            Self::OrgRestrictionViolation => serializer.serialize_i32(27),
+            Self::OrgRestrictionHeaderInvalid => serializer.serialize_i32(28),
+            Self::ServiceNotVisible => serializer.serialize_i32(29),
+            Self::GcpSuspended => serializer.serialize_i32(30),
+            Self::LocationPolicyViolated => serializer.serialize_i32(31),
+            Self::MissingOrigin => serializer.serialize_i32(33),
+            Self::OverloadedCredentials => serializer.serialize_i32(34),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ErrorReason {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorReason>::new(
+            ".google.api.ErrorReason",
+        ))
     }
 }
 
@@ -9789,51 +10658,42 @@ impl std::default::Default for ErrorReason {
 /// denotes the behavior and may affect how API tooling handles the field.
 ///
 /// Note: This enum **may** receive new values in the future.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FieldBehavior(i32);
-
-impl FieldBehavior {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FieldBehavior {
     /// Conventional default for enums. Do not use this.
-    pub const FIELD_BEHAVIOR_UNSPECIFIED: FieldBehavior = FieldBehavior::new(0);
-
+    Unspecified,
     /// Specifically denotes a field as optional.
     /// While all fields in protocol buffers are optional, this may be specified
     /// for emphasis if appropriate.
-    pub const OPTIONAL: FieldBehavior = FieldBehavior::new(1);
-
+    Optional,
     /// Denotes a field as required.
     /// This indicates that the field **must** be provided as part of the request,
     /// and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
-    pub const REQUIRED: FieldBehavior = FieldBehavior::new(2);
-
+    Required,
     /// Denotes a field as output only.
     /// This indicates that the field is provided in responses, but including the
     /// field in a request does nothing (the server *must* ignore it and
     /// *must not* throw an error as a result of the field's presence).
-    pub const OUTPUT_ONLY: FieldBehavior = FieldBehavior::new(3);
-
+    OutputOnly,
     /// Denotes a field as input only.
     /// This indicates that the field is provided in requests, and the
     /// corresponding field is not included in output.
-    pub const INPUT_ONLY: FieldBehavior = FieldBehavior::new(4);
-
+    InputOnly,
     /// Denotes a field as immutable.
     /// This indicates that the field may be set once in a request to create a
     /// resource, but may not be changed thereafter.
-    pub const IMMUTABLE: FieldBehavior = FieldBehavior::new(5);
-
+    Immutable,
     /// Denotes that a (repeated) field is an unordered list.
     /// This indicates that the service may provide the elements of the list
     /// in any arbitrary  order, rather than the order the user originally
     /// provided. Additionally, the list's order may or may not be stable.
-    pub const UNORDERED_LIST: FieldBehavior = FieldBehavior::new(6);
-
+    UnorderedList,
     /// Denotes that this field returns a non-empty default value if not set.
     /// This indicates that if the user provides the empty value in a request,
     /// a non-empty value will be returned. The user will not be aware of what
     /// non-empty value to expect.
-    pub const NON_EMPTY_DEFAULT: FieldBehavior = FieldBehavior::new(7);
-
+    NonEmptyDefault,
     /// Denotes that the field in a resource (a message annotated with
     /// google.api.resource) is used in the resource name to uniquely identify the
     /// resource. For AIP-compliant APIs, this should only be applied to the
@@ -9846,87 +10706,162 @@ impl FieldBehavior {
     /// depending on the request it is embedded in (e.g. for Create methods name
     /// is optional and unused, while for Update methods it is required). Instead
     /// of method-specific annotations, only `IDENTIFIER` is required.
-    pub const IDENTIFIER: FieldBehavior = FieldBehavior::new(8);
+    Identifier,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FieldBehavior::value] or
+    /// [FieldBehavior::name].
+    UnknownValue(field_behavior::UnknownValue),
+}
 
-    /// Creates a new FieldBehavior instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod field_behavior {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl FieldBehavior {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Optional => std::option::Option::Some(1),
+            Self::Required => std::option::Option::Some(2),
+            Self::OutputOnly => std::option::Option::Some(3),
+            Self::InputOnly => std::option::Option::Some(4),
+            Self::Immutable => std::option::Option::Some(5),
+            Self::UnorderedList => std::option::Option::Some(6),
+            Self::NonEmptyDefault => std::option::Option::Some(7),
+            Self::Identifier => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FIELD_BEHAVIOR_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OPTIONAL"),
-            2 => std::borrow::Cow::Borrowed("REQUIRED"),
-            3 => std::borrow::Cow::Borrowed("OUTPUT_ONLY"),
-            4 => std::borrow::Cow::Borrowed("INPUT_ONLY"),
-            5 => std::borrow::Cow::Borrowed("IMMUTABLE"),
-            6 => std::borrow::Cow::Borrowed("UNORDERED_LIST"),
-            7 => std::borrow::Cow::Borrowed("NON_EMPTY_DEFAULT"),
-            8 => std::borrow::Cow::Borrowed("IDENTIFIER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FIELD_BEHAVIOR_UNSPECIFIED"),
+            Self::Optional => std::option::Option::Some("OPTIONAL"),
+            Self::Required => std::option::Option::Some("REQUIRED"),
+            Self::OutputOnly => std::option::Option::Some("OUTPUT_ONLY"),
+            Self::InputOnly => std::option::Option::Some("INPUT_ONLY"),
+            Self::Immutable => std::option::Option::Some("IMMUTABLE"),
+            Self::UnorderedList => std::option::Option::Some("UNORDERED_LIST"),
+            Self::NonEmptyDefault => std::option::Option::Some("NON_EMPTY_DEFAULT"),
+            Self::Identifier => std::option::Option::Some("IDENTIFIER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FIELD_BEHAVIOR_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FIELD_BEHAVIOR_UNSPECIFIED)
-            }
-            "OPTIONAL" => std::option::Option::Some(Self::OPTIONAL),
-            "REQUIRED" => std::option::Option::Some(Self::REQUIRED),
-            "OUTPUT_ONLY" => std::option::Option::Some(Self::OUTPUT_ONLY),
-            "INPUT_ONLY" => std::option::Option::Some(Self::INPUT_ONLY),
-            "IMMUTABLE" => std::option::Option::Some(Self::IMMUTABLE),
-            "UNORDERED_LIST" => std::option::Option::Some(Self::UNORDERED_LIST),
-            "NON_EMPTY_DEFAULT" => std::option::Option::Some(Self::NON_EMPTY_DEFAULT),
-            "IDENTIFIER" => std::option::Option::Some(Self::IDENTIFIER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FieldBehavior {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FieldBehavior {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FieldBehavior {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FieldBehavior {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Optional,
+            2 => Self::Required,
+            3 => Self::OutputOnly,
+            4 => Self::InputOnly,
+            5 => Self::Immutable,
+            6 => Self::UnorderedList,
+            7 => Self::NonEmptyDefault,
+            8 => Self::Identifier,
+            _ => Self::UnknownValue(field_behavior::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FieldBehavior {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FIELD_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+            "OPTIONAL" => Self::Optional,
+            "REQUIRED" => Self::Required,
+            "OUTPUT_ONLY" => Self::OutputOnly,
+            "INPUT_ONLY" => Self::InputOnly,
+            "IMMUTABLE" => Self::Immutable,
+            "UNORDERED_LIST" => Self::UnorderedList,
+            "NON_EMPTY_DEFAULT" => Self::NonEmptyDefault,
+            "IDENTIFIER" => Self::Identifier,
+            _ => Self::UnknownValue(field_behavior::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FieldBehavior {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Optional => serializer.serialize_i32(1),
+            Self::Required => serializer.serialize_i32(2),
+            Self::OutputOnly => serializer.serialize_i32(3),
+            Self::InputOnly => serializer.serialize_i32(4),
+            Self::Immutable => serializer.serialize_i32(5),
+            Self::UnorderedList => serializer.serialize_i32(6),
+            Self::NonEmptyDefault => serializer.serialize_i32(7),
+            Self::Identifier => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FieldBehavior {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FieldBehavior>::new(
+            ".google.api.FieldBehavior",
+        ))
     }
 }
 
 /// The launch stage as defined by [Google Cloud Platform
 /// Launch Stages](https://cloud.google.com/terms/launch-stages).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LaunchStage(i32);
-
-impl LaunchStage {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LaunchStage {
     /// Do not use this default value.
-    pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new(0);
-
+    Unspecified,
     /// The feature is not yet implemented. Users can not use it.
-    pub const UNIMPLEMENTED: LaunchStage = LaunchStage::new(6);
-
+    Unimplemented,
     /// Prelaunch features are hidden from users and are only visible internally.
-    pub const PRELAUNCH: LaunchStage = LaunchStage::new(7);
-
+    Prelaunch,
     /// Early Access features are limited to a closed group of testers. To use
     /// these features, you must sign up in advance and sign a Trusted Tester
     /// agreement (which includes confidentiality provisions). These features may
     /// be unstable, changed in backward-incompatible ways, and are not
     /// guaranteed to be released.
-    pub const EARLY_ACCESS: LaunchStage = LaunchStage::new(1);
-
+    EarlyAccess,
     /// Alpha is a limited availability test for releases before they are cleared
     /// for widespread use. By Alpha, all significant design issues are resolved
     /// and we are in the process of verifying functionality. Alpha customers
@@ -9936,75 +10871,151 @@ impl LaunchStage {
     /// they will be far enough along that customers can actually use them in
     /// test environments or for limited-use tests -- just like they would in
     /// normal production cases.
-    pub const ALPHA: LaunchStage = LaunchStage::new(2);
-
+    Alpha,
     /// Beta is the point at which we are ready to open a release for any
     /// customer to use. There are no SLA or technical support obligations in a
     /// Beta release. Products will be complete from a feature perspective, but
     /// may have some open outstanding issues. Beta releases are suitable for
     /// limited production use cases.
-    pub const BETA: LaunchStage = LaunchStage::new(3);
-
+    Beta,
     /// GA features are open to all developers and are considered stable and
     /// fully qualified for production use.
-    pub const GA: LaunchStage = LaunchStage::new(4);
-
+    Ga,
     /// Deprecated features are scheduled to be shut down and removed. For more
     /// information, see the "Deprecation Policy" section of our [Terms of
     /// Service](https://cloud.google.com/terms/)
     /// and the [Google Cloud Platform Subject to the Deprecation
     /// Policy](https://cloud.google.com/terms/deprecation) documentation.
-    pub const DEPRECATED: LaunchStage = LaunchStage::new(5);
+    Deprecated,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LaunchStage::value] or
+    /// [LaunchStage::name].
+    UnknownValue(launch_stage::UnknownValue),
+}
 
-    /// Creates a new LaunchStage instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod launch_stage {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LaunchStage {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Unimplemented => std::option::Option::Some(6),
+            Self::Prelaunch => std::option::Option::Some(7),
+            Self::EarlyAccess => std::option::Option::Some(1),
+            Self::Alpha => std::option::Option::Some(2),
+            Self::Beta => std::option::Option::Some(3),
+            Self::Ga => std::option::Option::Some(4),
+            Self::Deprecated => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LAUNCH_STAGE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EARLY_ACCESS"),
-            2 => std::borrow::Cow::Borrowed("ALPHA"),
-            3 => std::borrow::Cow::Borrowed("BETA"),
-            4 => std::borrow::Cow::Borrowed("GA"),
-            5 => std::borrow::Cow::Borrowed("DEPRECATED"),
-            6 => std::borrow::Cow::Borrowed("UNIMPLEMENTED"),
-            7 => std::borrow::Cow::Borrowed("PRELAUNCH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LAUNCH_STAGE_UNSPECIFIED"),
+            Self::Unimplemented => std::option::Option::Some("UNIMPLEMENTED"),
+            Self::Prelaunch => std::option::Option::Some("PRELAUNCH"),
+            Self::EarlyAccess => std::option::Option::Some("EARLY_ACCESS"),
+            Self::Alpha => std::option::Option::Some("ALPHA"),
+            Self::Beta => std::option::Option::Some("BETA"),
+            Self::Ga => std::option::Option::Some("GA"),
+            Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LAUNCH_STAGE_UNSPECIFIED" => std::option::Option::Some(Self::LAUNCH_STAGE_UNSPECIFIED),
-            "UNIMPLEMENTED" => std::option::Option::Some(Self::UNIMPLEMENTED),
-            "PRELAUNCH" => std::option::Option::Some(Self::PRELAUNCH),
-            "EARLY_ACCESS" => std::option::Option::Some(Self::EARLY_ACCESS),
-            "ALPHA" => std::option::Option::Some(Self::ALPHA),
-            "BETA" => std::option::Option::Some(Self::BETA),
-            "GA" => std::option::Option::Some(Self::GA),
-            "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LaunchStage {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LaunchStage {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LaunchStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LaunchStage {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::EarlyAccess,
+            2 => Self::Alpha,
+            3 => Self::Beta,
+            4 => Self::Ga,
+            5 => Self::Deprecated,
+            6 => Self::Unimplemented,
+            7 => Self::Prelaunch,
+            _ => Self::UnknownValue(launch_stage::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LaunchStage {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LAUNCH_STAGE_UNSPECIFIED" => Self::Unspecified,
+            "UNIMPLEMENTED" => Self::Unimplemented,
+            "PRELAUNCH" => Self::Prelaunch,
+            "EARLY_ACCESS" => Self::EarlyAccess,
+            "ALPHA" => Self::Alpha,
+            "BETA" => Self::Beta,
+            "GA" => Self::Ga,
+            "DEPRECATED" => Self::Deprecated,
+            _ => Self::UnknownValue(launch_stage::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LaunchStage {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Unimplemented => serializer.serialize_i32(6),
+            Self::Prelaunch => serializer.serialize_i32(7),
+            Self::EarlyAccess => serializer.serialize_i32(1),
+            Self::Alpha => serializer.serialize_i32(2),
+            Self::Beta => serializer.serialize_i32(3),
+            Self::Ga => serializer.serialize_i32(4),
+            Self::Deprecated => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LaunchStage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LaunchStage>::new(
+            ".google.api.LaunchStage",
+        ))
     }
 }

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -173,71 +173,134 @@ pub mod error_handler {
     use super::*;
 
     /// Error codes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(i32);
-
-    impl ErrorCode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorCode {
         /// Not specified. ERROR_CODE_DEFAULT is assumed.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
-
+        Unspecified,
         /// All other error types.
-        pub const ERROR_CODE_DEFAULT: ErrorCode = ErrorCode::new(0);
-
+        Default,
         /// Application has exceeded a resource quota.
-        pub const ERROR_CODE_OVER_QUOTA: ErrorCode = ErrorCode::new(1);
-
+        OverQuota,
         /// Client blocked by the application's Denial of Service protection
         /// configuration.
-        pub const ERROR_CODE_DOS_API_DENIAL: ErrorCode = ErrorCode::new(2);
-
+        DosApiDenial,
         /// Deadline reached before the application responds.
-        pub const ERROR_CODE_TIMEOUT: ErrorCode = ErrorCode::new(3);
+        Timeout,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorCode::value] or
+        /// [ErrorCode::name].
+        UnknownValue(error_code::UnknownValue),
+    }
 
-        /// Creates a new ErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ErrorCode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(0),
+                Self::OverQuota => std::option::Option::Some(1),
+                Self::DosApiDenial => std::option::Option::Some(2),
+                Self::Timeout => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_DEFAULT"),
-                1 => std::borrow::Cow::Borrowed("ERROR_CODE_OVER_QUOTA"),
-                2 => std::borrow::Cow::Borrowed("ERROR_CODE_DOS_API_DENIAL"),
-                3 => std::borrow::Cow::Borrowed("ERROR_CODE_TIMEOUT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("ERROR_CODE_DEFAULT"),
+                Self::OverQuota => std::option::Option::Some("ERROR_CODE_OVER_QUOTA"),
+                Self::DosApiDenial => std::option::Option::Some("ERROR_CODE_DOS_API_DENIAL"),
+                Self::Timeout => std::option::Option::Some("ERROR_CODE_TIMEOUT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "ERROR_CODE_DEFAULT" => std::option::Option::Some(Self::ERROR_CODE_DEFAULT),
-                "ERROR_CODE_OVER_QUOTA" => std::option::Option::Some(Self::ERROR_CODE_OVER_QUOTA),
-                "ERROR_CODE_DOS_API_DENIAL" => {
-                    std::option::Option::Some(Self::ERROR_CODE_DOS_API_DENIAL)
-                }
-                "ERROR_CODE_TIMEOUT" => std::option::Option::Some(Self::ERROR_CODE_TIMEOUT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Default,
+                1 => Self::OverQuota,
+                2 => Self::DosApiDenial,
+                3 => Self::Timeout,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "ERROR_CODE_DEFAULT" => Self::Default,
+                "ERROR_CODE_OVER_QUOTA" => Self::OverQuota,
+                "ERROR_CODE_DOS_API_DENIAL" => Self::DosApiDenial,
+                "ERROR_CODE_TIMEOUT" => Self::Timeout,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(0),
+                Self::OverQuota => serializer.serialize_i32(1),
+                Self::DosApiDenial => serializer.serialize_i32(2),
+                Self::Timeout => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                ".google.appengine.v1.ErrorHandler.ErrorCode",
+            ))
         }
     }
 }
@@ -439,84 +502,138 @@ pub mod url_map {
     use super::*;
 
     /// Redirect codes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedirectHttpResponseCode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RedirectHttpResponseCode {
+        /// Not specified. `302` is assumed.
+        Unspecified,
+        /// `301 Moved Permanently` code.
+        _301,
+        /// `302 Moved Temporarily` code.
+        _302,
+        /// `303 See Other` code.
+        _303,
+        /// `307 Temporary Redirect` code.
+        _307,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RedirectHttpResponseCode::value] or
+        /// [RedirectHttpResponseCode::name].
+        UnknownValue(redirect_http_response_code::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod redirect_http_response_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RedirectHttpResponseCode {
-        /// Not specified. `302` is assumed.
-        pub const REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new(0);
-
-        /// `301 Moved Permanently` code.
-        pub const REDIRECT_HTTP_RESPONSE_CODE_301: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new(1);
-
-        /// `302 Moved Temporarily` code.
-        pub const REDIRECT_HTTP_RESPONSE_CODE_302: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new(2);
-
-        /// `303 See Other` code.
-        pub const REDIRECT_HTTP_RESPONSE_CODE_303: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new(3);
-
-        /// `307 Temporary Redirect` code.
-        pub const REDIRECT_HTTP_RESPONSE_CODE_307: RedirectHttpResponseCode =
-            RedirectHttpResponseCode::new(4);
-
-        /// Creates a new RedirectHttpResponseCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::_301 => std::option::Option::Some(1),
+                Self::_302 => std::option::Option::Some(2),
+                Self::_303 => std::option::Option::Some(3),
+                Self::_307 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_301"),
-                2 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_302"),
-                3 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_303"),
-                4 => std::borrow::Cow::Borrowed("REDIRECT_HTTP_RESPONSE_CODE_307"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED")
+                }
+                Self::_301 => std::option::Option::Some("REDIRECT_HTTP_RESPONSE_CODE_301"),
+                Self::_302 => std::option::Option::Some("REDIRECT_HTTP_RESPONSE_CODE_302"),
+                Self::_303 => std::option::Option::Some("REDIRECT_HTTP_RESPONSE_CODE_303"),
+                Self::_307 => std::option::Option::Some("REDIRECT_HTTP_RESPONSE_CODE_307"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED)
-                }
-                "REDIRECT_HTTP_RESPONSE_CODE_301" => {
-                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_301)
-                }
-                "REDIRECT_HTTP_RESPONSE_CODE_302" => {
-                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_302)
-                }
-                "REDIRECT_HTTP_RESPONSE_CODE_303" => {
-                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_303)
-                }
-                "REDIRECT_HTTP_RESPONSE_CODE_307" => {
-                    std::option::Option::Some(Self::REDIRECT_HTTP_RESPONSE_CODE_307)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RedirectHttpResponseCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RedirectHttpResponseCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RedirectHttpResponseCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RedirectHttpResponseCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::_301,
+                2 => Self::_302,
+                3 => Self::_303,
+                4 => Self::_307,
+                _ => Self::UnknownValue(redirect_http_response_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RedirectHttpResponseCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REDIRECT_HTTP_RESPONSE_CODE_UNSPECIFIED" => Self::Unspecified,
+                "REDIRECT_HTTP_RESPONSE_CODE_301" => Self::_301,
+                "REDIRECT_HTTP_RESPONSE_CODE_302" => Self::_302,
+                "REDIRECT_HTTP_RESPONSE_CODE_303" => Self::_303,
+                "REDIRECT_HTTP_RESPONSE_CODE_307" => Self::_307,
+                _ => Self::UnknownValue(redirect_http_response_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RedirectHttpResponseCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::_301 => serializer.serialize_i32(1),
+                Self::_302 => serializer.serialize_i32(2),
+                Self::_303 => serializer.serialize_i32(3),
+                Self::_307 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RedirectHttpResponseCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<RedirectHttpResponseCode>::new(
+                    ".google.appengine.v1.UrlMap.RedirectHttpResponseCode",
+                ),
+            )
         }
     }
 
@@ -3516,129 +3633,253 @@ pub mod application {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServingStatus(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ServingStatus {
+        /// Serving status is unspecified.
+        Unspecified,
+        /// Application is serving.
+        Serving,
+        /// Application has been disabled by the user.
+        UserDisabled,
+        /// Application has been disabled by the system.
+        SystemDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ServingStatus::value] or
+        /// [ServingStatus::name].
+        UnknownValue(serving_status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod serving_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ServingStatus {
-        /// Serving status is unspecified.
-        pub const UNSPECIFIED: ServingStatus = ServingStatus::new(0);
-
-        /// Application is serving.
-        pub const SERVING: ServingStatus = ServingStatus::new(1);
-
-        /// Application has been disabled by the user.
-        pub const USER_DISABLED: ServingStatus = ServingStatus::new(2);
-
-        /// Application has been disabled by the system.
-        pub const SYSTEM_DISABLED: ServingStatus = ServingStatus::new(3);
-
-        /// Creates a new ServingStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Serving => std::option::Option::Some(1),
+                Self::UserDisabled => std::option::Option::Some(2),
+                Self::SystemDisabled => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVING"),
-                2 => std::borrow::Cow::Borrowed("USER_DISABLED"),
-                3 => std::borrow::Cow::Borrowed("SYSTEM_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Serving => std::option::Option::Some("SERVING"),
+                Self::UserDisabled => std::option::Option::Some("USER_DISABLED"),
+                Self::SystemDisabled => std::option::Option::Some("SYSTEM_DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "SERVING" => std::option::Option::Some(Self::SERVING),
-                "USER_DISABLED" => std::option::Option::Some(Self::USER_DISABLED),
-                "SYSTEM_DISABLED" => std::option::Option::Some(Self::SYSTEM_DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ServingStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ServingStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(i32);
+    impl std::fmt::Display for ServingStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ServingStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Serving,
+                2 => Self::UserDisabled,
+                3 => Self::SystemDisabled,
+                _ => Self::UnknownValue(serving_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ServingStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "SERVING" => Self::Serving,
+                "USER_DISABLED" => Self::UserDisabled,
+                "SYSTEM_DISABLED" => Self::SystemDisabled,
+                _ => Self::UnknownValue(serving_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ServingStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Serving => serializer.serialize_i32(1),
+                Self::UserDisabled => serializer.serialize_i32(2),
+                Self::SystemDisabled => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ServingStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServingStatus>::new(
+                ".google.appengine.v1.Application.ServingStatus",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseType {
+        /// Database type is unspecified.
+        Unspecified,
+        /// Cloud Datastore
+        CloudDatastore,
+        /// Cloud Firestore Native
+        CloudFirestore,
+        /// Cloud Firestore in Datastore Mode
+        CloudDatastoreCompatibility,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseType::value] or
+        /// [DatabaseType::name].
+        UnknownValue(database_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseType {
-        /// Database type is unspecified.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
-
-        /// Cloud Datastore
-        pub const CLOUD_DATASTORE: DatabaseType = DatabaseType::new(1);
-
-        /// Cloud Firestore Native
-        pub const CLOUD_FIRESTORE: DatabaseType = DatabaseType::new(2);
-
-        /// Cloud Firestore in Datastore Mode
-        pub const CLOUD_DATASTORE_COMPATIBILITY: DatabaseType = DatabaseType::new(3);
-
-        /// Creates a new DatabaseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudDatastore => std::option::Option::Some(1),
+                Self::CloudFirestore => std::option::Option::Some(2),
+                Self::CloudDatastoreCompatibility => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_DATASTORE"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_FIRESTORE"),
-                3 => std::borrow::Cow::Borrowed("CLOUD_DATASTORE_COMPATIBILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_TYPE_UNSPECIFIED"),
+                Self::CloudDatastore => std::option::Option::Some("CLOUD_DATASTORE"),
+                Self::CloudFirestore => std::option::Option::Some("CLOUD_FIRESTORE"),
+                Self::CloudDatastoreCompatibility => {
+                    std::option::Option::Some("CLOUD_DATASTORE_COMPATIBILITY")
                 }
-                "CLOUD_DATASTORE" => std::option::Option::Some(Self::CLOUD_DATASTORE),
-                "CLOUD_FIRESTORE" => std::option::Option::Some(Self::CLOUD_FIRESTORE),
-                "CLOUD_DATASTORE_COMPATIBILITY" => {
-                    std::option::Option::Some(Self::CLOUD_DATASTORE_COMPATIBILITY)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudDatastore,
+                2 => Self::CloudFirestore,
+                3 => Self::CloudDatastoreCompatibility,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_DATASTORE" => Self::CloudDatastore,
+                "CLOUD_FIRESTORE" => Self::CloudFirestore,
+                "CLOUD_DATASTORE_COMPATIBILITY" => Self::CloudDatastoreCompatibility,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudDatastore => serializer.serialize_i32(1),
+                Self::CloudFirestore => serializer.serialize_i32(2),
+                Self::CloudDatastoreCompatibility => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseType>::new(
+                ".google.appengine.v1.Application.DatabaseType",
+            ))
         }
     }
 }
@@ -4670,64 +4911,123 @@ pub mod ssl_settings {
     use super::*;
 
     /// The SSL management type for this domain.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslManagementType(i32);
-
-    impl SslManagementType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SslManagementType {
         /// Defaults to `AUTOMATIC`.
-        pub const SSL_MANAGEMENT_TYPE_UNSPECIFIED: SslManagementType = SslManagementType::new(0);
-
+        Unspecified,
         /// SSL support for this domain is configured automatically. The mapped SSL
         /// certificate will be automatically renewed.
-        pub const AUTOMATIC: SslManagementType = SslManagementType::new(1);
-
+        Automatic,
         /// SSL support for this domain is configured manually by the user. Either
         /// the domain has no SSL support or a user-obtained SSL certificate has been
         /// explictly mapped to this domain.
-        pub const MANUAL: SslManagementType = SslManagementType::new(2);
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SslManagementType::value] or
+        /// [SslManagementType::name].
+        UnknownValue(ssl_management_type::UnknownValue),
+    }
 
-        /// Creates a new SslManagementType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod ssl_management_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SslManagementType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SSL_MANAGEMENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SSL_MANAGEMENT_TYPE_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SSL_MANAGEMENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SSL_MANAGEMENT_TYPE_UNSPECIFIED)
-                }
-                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SslManagementType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SslManagementType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SslManagementType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SslManagementType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(ssl_management_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SslManagementType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SSL_MANAGEMENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC" => Self::Automatic,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(ssl_management_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SslManagementType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SslManagementType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SslManagementType>::new(
+                ".google.appengine.v1.SslSettings.SslManagementType",
+            ))
         }
     }
 }
@@ -4795,66 +5095,127 @@ pub mod resource_record {
     use super::*;
 
     /// A resource record type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RecordType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RecordType {
+        /// An unknown resource record.
+        Unspecified,
+        /// An A resource record. Data is an IPv4 address.
+        A,
+        /// An AAAA resource record. Data is an IPv6 address.
+        Aaaa,
+        /// A CNAME resource record. Data is a domain name to be aliased.
+        Cname,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RecordType::value] or
+        /// [RecordType::name].
+        UnknownValue(record_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod record_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RecordType {
-        /// An unknown resource record.
-        pub const RECORD_TYPE_UNSPECIFIED: RecordType = RecordType::new(0);
-
-        /// An A resource record. Data is an IPv4 address.
-        pub const A: RecordType = RecordType::new(1);
-
-        /// An AAAA resource record. Data is an IPv6 address.
-        pub const AAAA: RecordType = RecordType::new(2);
-
-        /// A CNAME resource record. Data is a domain name to be aliased.
-        pub const CNAME: RecordType = RecordType::new(3);
-
-        /// Creates a new RecordType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::A => std::option::Option::Some(1),
+                Self::Aaaa => std::option::Option::Some(2),
+                Self::Cname => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RECORD_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("A"),
-                2 => std::borrow::Cow::Borrowed("AAAA"),
-                3 => std::borrow::Cow::Borrowed("CNAME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RECORD_TYPE_UNSPECIFIED"),
+                Self::A => std::option::Option::Some("A"),
+                Self::Aaaa => std::option::Option::Some("AAAA"),
+                Self::Cname => std::option::Option::Some("CNAME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RECORD_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RECORD_TYPE_UNSPECIFIED)
-                }
-                "A" => std::option::Option::Some(Self::A),
-                "AAAA" => std::option::Option::Some(Self::AAAA),
-                "CNAME" => std::option::Option::Some(Self::CNAME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RecordType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RecordType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RecordType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RecordType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::A,
+                2 => Self::Aaaa,
+                3 => Self::Cname,
+                _ => Self::UnknownValue(record_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RecordType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RECORD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "A" => Self::A,
+                "AAAA" => Self::Aaaa,
+                "CNAME" => Self::Cname,
+                _ => Self::UnknownValue(record_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RecordType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::A => serializer.serialize_i32(1),
+                Self::Aaaa => serializer.serialize_i32(2),
+                Self::Cname => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RecordType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RecordType>::new(
+                ".google.appengine.v1.ResourceRecord.RecordType",
+            ))
         }
     }
 }
@@ -4940,58 +5301,119 @@ pub mod firewall_rule {
     use super::*;
 
     /// Available actions to take on matching requests.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        UnspecifiedAction,
+        /// Matching requests are allowed.
+        Allow,
+        /// Matching requests are denied.
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        pub const UNSPECIFIED_ACTION: Action = Action::new(0);
-
-        /// Matching requests are allowed.
-        pub const ALLOW: Action = Action::new(1);
-
-        /// Matching requests are denied.
-        pub const DENY: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::UnspecifiedAction => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED_ACTION"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::UnspecifiedAction => std::option::Option::Some("UNSPECIFIED_ACTION"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED_ACTION" => std::option::Option::Some(Self::UNSPECIFIED_ACTION),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::UnspecifiedAction,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED_ACTION" => Self::UnspecifiedAction,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::UnspecifiedAction => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.appengine.v1.FirewallRule.Action",
+            ))
         }
     }
 }
@@ -5246,139 +5668,268 @@ pub mod instance {
         use super::*;
 
         /// Liveness health check status for Flex instances.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LivenessState(i32);
-
-        impl LivenessState {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum LivenessState {
             /// There is no liveness health check for the instance. Only applicable for
             /// instances in App Engine standard environment.
-            pub const LIVENESS_STATE_UNSPECIFIED: LivenessState = LivenessState::new(0);
-
+            Unspecified,
             /// The health checking system is aware of the instance but its health is
             /// not known at the moment.
-            pub const UNKNOWN: LivenessState = LivenessState::new(1);
-
+            Unknown,
             /// The instance is reachable i.e. a connection to the application health
             /// checking endpoint can be established, and conforms to the requirements
             /// defined by the health check.
-            pub const HEALTHY: LivenessState = LivenessState::new(2);
-
+            Healthy,
             /// The instance is reachable, but does not conform to the requirements
             /// defined by the health check.
-            pub const UNHEALTHY: LivenessState = LivenessState::new(3);
-
+            Unhealthy,
             /// The instance is being drained. The existing connections to the instance
             /// have time to complete, but the new ones are being refused.
-            pub const DRAINING: LivenessState = LivenessState::new(4);
-
+            Draining,
             /// The instance is unreachable i.e. a connection to the application health
             /// checking endpoint cannot be established, or the server does not respond
             /// within the specified timeout.
-            pub const TIMEOUT: LivenessState = LivenessState::new(5);
+            Timeout,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [LivenessState::value] or
+            /// [LivenessState::name].
+            UnknownValue(liveness_state::UnknownValue),
+        }
 
-            /// Creates a new LivenessState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod liveness_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl LivenessState {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Unknown => std::option::Option::Some(1),
+                    Self::Healthy => std::option::Option::Some(2),
+                    Self::Unhealthy => std::option::Option::Some(3),
+                    Self::Draining => std::option::Option::Some(4),
+                    Self::Timeout => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("LIVENESS_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                    2 => std::borrow::Cow::Borrowed("HEALTHY"),
-                    3 => std::borrow::Cow::Borrowed("UNHEALTHY"),
-                    4 => std::borrow::Cow::Borrowed("DRAINING"),
-                    5 => std::borrow::Cow::Borrowed("TIMEOUT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("LIVENESS_STATE_UNSPECIFIED"),
+                    Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                    Self::Healthy => std::option::Option::Some("HEALTHY"),
+                    Self::Unhealthy => std::option::Option::Some("UNHEALTHY"),
+                    Self::Draining => std::option::Option::Some("DRAINING"),
+                    Self::Timeout => std::option::Option::Some("TIMEOUT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "LIVENESS_STATE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::LIVENESS_STATE_UNSPECIFIED)
-                    }
-                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                    "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
-                    "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
-                    "DRAINING" => std::option::Option::Some(Self::DRAINING),
-                    "TIMEOUT" => std::option::Option::Some(Self::TIMEOUT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for LivenessState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for LivenessState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for LivenessState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for LivenessState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Unknown,
+                    2 => Self::Healthy,
+                    3 => Self::Unhealthy,
+                    4 => Self::Draining,
+                    5 => Self::Timeout,
+                    _ => Self::UnknownValue(liveness_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for LivenessState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "LIVENESS_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "UNKNOWN" => Self::Unknown,
+                    "HEALTHY" => Self::Healthy,
+                    "UNHEALTHY" => Self::Unhealthy,
+                    "DRAINING" => Self::Draining,
+                    "TIMEOUT" => Self::Timeout,
+                    _ => Self::UnknownValue(liveness_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for LivenessState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Unknown => serializer.serialize_i32(1),
+                    Self::Healthy => serializer.serialize_i32(2),
+                    Self::Unhealthy => serializer.serialize_i32(3),
+                    Self::Draining => serializer.serialize_i32(4),
+                    Self::Timeout => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for LivenessState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<LivenessState>::new(
+                    ".google.appengine.v1.Instance.Liveness.LivenessState",
+                ))
             }
         }
     }
 
     /// Availability of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Availability(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Availability {
+        Unspecified,
+        Resident,
+        Dynamic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Availability::value] or
+        /// [Availability::name].
+        UnknownValue(availability::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod availability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Availability {
-        pub const UNSPECIFIED: Availability = Availability::new(0);
-
-        pub const RESIDENT: Availability = Availability::new(1);
-
-        pub const DYNAMIC: Availability = Availability::new(2);
-
-        /// Creates a new Availability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Resident => std::option::Option::Some(1),
+                Self::Dynamic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESIDENT"),
-                2 => std::borrow::Cow::Borrowed("DYNAMIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Resident => std::option::Option::Some("RESIDENT"),
+                Self::Dynamic => std::option::Option::Some("DYNAMIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "RESIDENT" => std::option::Option::Some(Self::RESIDENT),
-                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Availability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Availability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Availability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Availability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Resident,
+                2 => Self::Dynamic,
+                _ => Self::UnknownValue(availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Availability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "RESIDENT" => Self::Resident,
+                "DYNAMIC" => Self::Dynamic,
+                _ => Self::UnknownValue(availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Availability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Resident => serializer.serialize_i32(1),
+                Self::Dynamic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Availability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Availability>::new(
+                ".google.appengine.v1.Instance.Availability",
+            ))
         }
     }
 }
@@ -5483,76 +6034,133 @@ pub mod network_settings {
     use super::*;
 
     /// If unspecified, INGRESS_TRAFFIC_ALLOWED_ALL will be used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IngressTrafficAllowed(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IngressTrafficAllowed {
+        /// Unspecified
+        Unspecified,
+        /// Allow HTTP traffic from public and private sources.
+        All,
+        /// Allow HTTP traffic from only private VPC sources.
+        InternalOnly,
+        /// Allow HTTP traffic from private VPC sources and through load balancers.
+        InternalAndLb,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IngressTrafficAllowed::value] or
+        /// [IngressTrafficAllowed::name].
+        UnknownValue(ingress_traffic_allowed::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ingress_traffic_allowed {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IngressTrafficAllowed {
-        /// Unspecified
-        pub const INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED: IngressTrafficAllowed =
-            IngressTrafficAllowed::new(0);
-
-        /// Allow HTTP traffic from public and private sources.
-        pub const INGRESS_TRAFFIC_ALLOWED_ALL: IngressTrafficAllowed =
-            IngressTrafficAllowed::new(1);
-
-        /// Allow HTTP traffic from only private VPC sources.
-        pub const INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY: IngressTrafficAllowed =
-            IngressTrafficAllowed::new(2);
-
-        /// Allow HTTP traffic from private VPC sources and through load balancers.
-        pub const INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB: IngressTrafficAllowed =
-            IngressTrafficAllowed::new(3);
-
-        /// Creates a new IngressTrafficAllowed instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::All => std::option::Option::Some(1),
+                Self::InternalOnly => std::option::Option::Some(2),
+                Self::InternalAndLb => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_ALL"),
-                2 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY"),
-                3 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED")
+                }
+                Self::All => std::option::Option::Some("INGRESS_TRAFFIC_ALLOWED_ALL"),
+                Self::InternalOnly => {
+                    std::option::Option::Some("INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY")
+                }
+                Self::InternalAndLb => {
+                    std::option::Option::Some("INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED)
-                }
-                "INGRESS_TRAFFIC_ALLOWED_ALL" => {
-                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_ALL)
-                }
-                "INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY" => {
-                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY)
-                }
-                "INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB" => {
-                    std::option::Option::Some(Self::INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IngressTrafficAllowed {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IngressTrafficAllowed {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IngressTrafficAllowed {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IngressTrafficAllowed {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::All,
+                2 => Self::InternalOnly,
+                3 => Self::InternalAndLb,
+                _ => Self::UnknownValue(ingress_traffic_allowed::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IngressTrafficAllowed {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INGRESS_TRAFFIC_ALLOWED_UNSPECIFIED" => Self::Unspecified,
+                "INGRESS_TRAFFIC_ALLOWED_ALL" => Self::All,
+                "INGRESS_TRAFFIC_ALLOWED_INTERNAL_ONLY" => Self::InternalOnly,
+                "INGRESS_TRAFFIC_ALLOWED_INTERNAL_AND_LB" => Self::InternalAndLb,
+                _ => Self::UnknownValue(ingress_traffic_allowed::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IngressTrafficAllowed {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::All => serializer.serialize_i32(1),
+                Self::InternalOnly => serializer.serialize_i32(2),
+                Self::InternalAndLb => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IngressTrafficAllowed {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IngressTrafficAllowed>::new(
+                ".google.appengine.v1.NetworkSettings.IngressTrafficAllowed",
+            ))
         }
     }
 }
@@ -5954,68 +6562,131 @@ pub mod traffic_split {
     use super::*;
 
     /// Available sharding mechanisms.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ShardBy(i32);
-
-    impl ShardBy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ShardBy {
         /// Diversion method unspecified.
-        pub const UNSPECIFIED: ShardBy = ShardBy::new(0);
-
+        Unspecified,
         /// Diversion based on a specially named cookie, "GOOGAPPUID." The cookie
         /// must be set by the application itself or no diversion will occur.
-        pub const COOKIE: ShardBy = ShardBy::new(1);
-
+        Cookie,
         /// Diversion based on applying the modulus operation to a fingerprint
         /// of the IP address.
-        pub const IP: ShardBy = ShardBy::new(2);
-
+        Ip,
         /// Diversion based on weighted random assignment. An incoming request is
         /// randomly routed to a version in the traffic split, with probability
         /// proportional to the version's traffic share.
-        pub const RANDOM: ShardBy = ShardBy::new(3);
+        Random,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ShardBy::value] or
+        /// [ShardBy::name].
+        UnknownValue(shard_by::UnknownValue),
+    }
 
-        /// Creates a new ShardBy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod shard_by {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ShardBy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Cookie => std::option::Option::Some(1),
+                Self::Ip => std::option::Option::Some(2),
+                Self::Random => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COOKIE"),
-                2 => std::borrow::Cow::Borrowed("IP"),
-                3 => std::borrow::Cow::Borrowed("RANDOM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Cookie => std::option::Option::Some("COOKIE"),
+                Self::Ip => std::option::Option::Some("IP"),
+                Self::Random => std::option::Option::Some("RANDOM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "COOKIE" => std::option::Option::Some(Self::COOKIE),
-                "IP" => std::option::Option::Some(Self::IP),
-                "RANDOM" => std::option::Option::Some(Self::RANDOM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ShardBy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ShardBy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ShardBy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ShardBy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Cookie,
+                2 => Self::Ip,
+                3 => Self::Random,
+                _ => Self::UnknownValue(shard_by::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ShardBy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "COOKIE" => Self::Cookie,
+                "IP" => Self::Ip,
+                "RANDOM" => Self::Random,
+                _ => Self::UnknownValue(shard_by::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ShardBy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Cookie => serializer.serialize_i32(1),
+                Self::Ip => serializer.serialize_i32(2),
+                Self::Random => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ShardBy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ShardBy>::new(
+                ".google.appengine.v1.TrafficSplit.ShardBy",
+            ))
         }
     }
 }
@@ -6817,62 +7488,123 @@ pub mod endpoints_api_service {
     use super::*;
 
     /// Available rollout strategies.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutStrategy(i32);
-
-    impl RolloutStrategy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolloutStrategy {
         /// Not specified. Defaults to `FIXED`.
-        pub const UNSPECIFIED_ROLLOUT_STRATEGY: RolloutStrategy = RolloutStrategy::new(0);
-
+        UnspecifiedRolloutStrategy,
         /// Endpoints service configuration ID will be fixed to the configuration ID
         /// specified by `config_id`.
-        pub const FIXED: RolloutStrategy = RolloutStrategy::new(1);
-
+        Fixed,
         /// Endpoints service configuration ID will be updated with each rollout.
-        pub const MANAGED: RolloutStrategy = RolloutStrategy::new(2);
+        Managed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolloutStrategy::value] or
+        /// [RolloutStrategy::name].
+        UnknownValue(rollout_strategy::UnknownValue),
+    }
 
-        /// Creates a new RolloutStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod rollout_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RolloutStrategy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::UnspecifiedRolloutStrategy => std::option::Option::Some(0),
+                Self::Fixed => std::option::Option::Some(1),
+                Self::Managed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED_ROLLOUT_STRATEGY"),
-                1 => std::borrow::Cow::Borrowed("FIXED"),
-                2 => std::borrow::Cow::Borrowed("MANAGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED_ROLLOUT_STRATEGY" => {
-                    std::option::Option::Some(Self::UNSPECIFIED_ROLLOUT_STRATEGY)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::UnspecifiedRolloutStrategy => {
+                    std::option::Option::Some("UNSPECIFIED_ROLLOUT_STRATEGY")
                 }
-                "FIXED" => std::option::Option::Some(Self::FIXED),
-                "MANAGED" => std::option::Option::Some(Self::MANAGED),
-                _ => std::option::Option::None,
+                Self::Fixed => std::option::Option::Some("FIXED"),
+                Self::Managed => std::option::Option::Some("MANAGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for RolloutStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolloutStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolloutStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::UnspecifiedRolloutStrategy,
+                1 => Self::Fixed,
+                2 => Self::Managed,
+                _ => Self::UnknownValue(rollout_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolloutStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED_ROLLOUT_STRATEGY" => Self::UnspecifiedRolloutStrategy,
+                "FIXED" => Self::Fixed,
+                "MANAGED" => Self::Managed,
+                _ => Self::UnknownValue(rollout_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolloutStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::UnspecifiedRolloutStrategy => serializer.serialize_i32(0),
+                Self::Fixed => serializer.serialize_i32(1),
+                Self::Managed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolloutStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolloutStrategy>::new(
+                ".google.appengine.v1.EndpointsApiService.RolloutStrategy",
+            ))
         }
     }
 }
@@ -7743,60 +8475,119 @@ pub mod vpc_access_connector {
     ///
     /// This controls what traffic is diverted through the VPC Access Connector
     /// resource. By default PRIVATE_IP_RANGES will be used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EgressSetting(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EgressSetting {
+        Unspecified,
+        /// Force the use of VPC Access for all egress traffic from the function.
+        AllTraffic,
+        /// Use the VPC Access Connector for private IP space from RFC1918.
+        PrivateIpRanges,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EgressSetting::value] or
+        /// [EgressSetting::name].
+        UnknownValue(egress_setting::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod egress_setting {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EgressSetting {
-        pub const EGRESS_SETTING_UNSPECIFIED: EgressSetting = EgressSetting::new(0);
-
-        /// Force the use of VPC Access for all egress traffic from the function.
-        pub const ALL_TRAFFIC: EgressSetting = EgressSetting::new(1);
-
-        /// Use the VPC Access Connector for private IP space from RFC1918.
-        pub const PRIVATE_IP_RANGES: EgressSetting = EgressSetting::new(2);
-
-        /// Creates a new EgressSetting instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllTraffic => std::option::Option::Some(1),
+                Self::PrivateIpRanges => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EGRESS_SETTING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_TRAFFIC"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE_IP_RANGES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EGRESS_SETTING_UNSPECIFIED"),
+                Self::AllTraffic => std::option::Option::Some("ALL_TRAFFIC"),
+                Self::PrivateIpRanges => std::option::Option::Some("PRIVATE_IP_RANGES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EGRESS_SETTING_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EGRESS_SETTING_UNSPECIFIED)
-                }
-                "ALL_TRAFFIC" => std::option::Option::Some(Self::ALL_TRAFFIC),
-                "PRIVATE_IP_RANGES" => std::option::Option::Some(Self::PRIVATE_IP_RANGES),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EgressSetting {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EgressSetting {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EgressSetting {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EgressSetting {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllTraffic,
+                2 => Self::PrivateIpRanges,
+                _ => Self::UnknownValue(egress_setting::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EgressSetting {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EGRESS_SETTING_UNSPECIFIED" => Self::Unspecified,
+                "ALL_TRAFFIC" => Self::AllTraffic,
+                "PRIVATE_IP_RANGES" => Self::PrivateIpRanges,
+                _ => Self::UnknownValue(egress_setting::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EgressSetting {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllTraffic => serializer.serialize_i32(1),
+                Self::PrivateIpRanges => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EgressSetting {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EgressSetting>::new(
+                ".google.appengine.v1.VpcAccessConnector.EgressSetting",
+            ))
         }
     }
 }
@@ -7879,207 +8670,390 @@ pub mod entrypoint {
 }
 
 /// Actions to take when the user is not logged in.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthFailAction(i32);
-
-impl AuthFailAction {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AuthFailAction {
     /// Not specified. `AUTH_FAIL_ACTION_REDIRECT` is assumed.
-    pub const AUTH_FAIL_ACTION_UNSPECIFIED: AuthFailAction = AuthFailAction::new(0);
-
+    Unspecified,
     /// Redirects user to "accounts.google.com". The user is redirected back to the
     /// application URL after signing in or creating an account.
-    pub const AUTH_FAIL_ACTION_REDIRECT: AuthFailAction = AuthFailAction::new(1);
-
+    Redirect,
     /// Rejects request with a `401` HTTP status code and an error
     /// message.
-    pub const AUTH_FAIL_ACTION_UNAUTHORIZED: AuthFailAction = AuthFailAction::new(2);
+    Unauthorized,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AuthFailAction::value] or
+    /// [AuthFailAction::name].
+    UnknownValue(auth_fail_action::UnknownValue),
+}
 
-    /// Creates a new AuthFailAction instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod auth_fail_action {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AuthFailAction {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Redirect => std::option::Option::Some(1),
+            Self::Unauthorized => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUTH_FAIL_ACTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AUTH_FAIL_ACTION_REDIRECT"),
-            2 => std::borrow::Cow::Borrowed("AUTH_FAIL_ACTION_UNAUTHORIZED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AUTH_FAIL_ACTION_UNSPECIFIED"),
+            Self::Redirect => std::option::Option::Some("AUTH_FAIL_ACTION_REDIRECT"),
+            Self::Unauthorized => std::option::Option::Some("AUTH_FAIL_ACTION_UNAUTHORIZED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUTH_FAIL_ACTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::AUTH_FAIL_ACTION_UNSPECIFIED)
-            }
-            "AUTH_FAIL_ACTION_REDIRECT" => {
-                std::option::Option::Some(Self::AUTH_FAIL_ACTION_REDIRECT)
-            }
-            "AUTH_FAIL_ACTION_UNAUTHORIZED" => {
-                std::option::Option::Some(Self::AUTH_FAIL_ACTION_UNAUTHORIZED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AuthFailAction {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthFailAction {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AuthFailAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AuthFailAction {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Redirect,
+            2 => Self::Unauthorized,
+            _ => Self::UnknownValue(auth_fail_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AuthFailAction {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUTH_FAIL_ACTION_UNSPECIFIED" => Self::Unspecified,
+            "AUTH_FAIL_ACTION_REDIRECT" => Self::Redirect,
+            "AUTH_FAIL_ACTION_UNAUTHORIZED" => Self::Unauthorized,
+            _ => Self::UnknownValue(auth_fail_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AuthFailAction {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Redirect => serializer.serialize_i32(1),
+            Self::Unauthorized => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AuthFailAction {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthFailAction>::new(
+            ".google.appengine.v1.AuthFailAction",
+        ))
     }
 }
 
 /// Methods to restrict access to a URL based on login status.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LoginRequirement(i32);
-
-impl LoginRequirement {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LoginRequirement {
     /// Not specified. `LOGIN_OPTIONAL` is assumed.
-    pub const LOGIN_UNSPECIFIED: LoginRequirement = LoginRequirement::new(0);
-
+    LoginUnspecified,
     /// Does not require that the user is signed in.
-    pub const LOGIN_OPTIONAL: LoginRequirement = LoginRequirement::new(1);
-
+    LoginOptional,
     /// If the user is not signed in, the `auth_fail_action` is taken.
     /// In addition, if the user is not an administrator for the
     /// application, they are given an error message regardless of
     /// `auth_fail_action`. If the user is an administrator, the handler
     /// proceeds.
-    pub const LOGIN_ADMIN: LoginRequirement = LoginRequirement::new(2);
-
+    LoginAdmin,
     /// If the user has signed in, the handler proceeds normally. Otherwise, the
     /// auth_fail_action is taken.
-    pub const LOGIN_REQUIRED: LoginRequirement = LoginRequirement::new(3);
+    LoginRequired,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LoginRequirement::value] or
+    /// [LoginRequirement::name].
+    UnknownValue(login_requirement::UnknownValue),
+}
 
-    /// Creates a new LoginRequirement instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod login_requirement {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LoginRequirement {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::LoginUnspecified => std::option::Option::Some(0),
+            Self::LoginOptional => std::option::Option::Some(1),
+            Self::LoginAdmin => std::option::Option::Some(2),
+            Self::LoginRequired => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LOGIN_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LOGIN_OPTIONAL"),
-            2 => std::borrow::Cow::Borrowed("LOGIN_ADMIN"),
-            3 => std::borrow::Cow::Borrowed("LOGIN_REQUIRED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::LoginUnspecified => std::option::Option::Some("LOGIN_UNSPECIFIED"),
+            Self::LoginOptional => std::option::Option::Some("LOGIN_OPTIONAL"),
+            Self::LoginAdmin => std::option::Option::Some("LOGIN_ADMIN"),
+            Self::LoginRequired => std::option::Option::Some("LOGIN_REQUIRED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LOGIN_UNSPECIFIED" => std::option::Option::Some(Self::LOGIN_UNSPECIFIED),
-            "LOGIN_OPTIONAL" => std::option::Option::Some(Self::LOGIN_OPTIONAL),
-            "LOGIN_ADMIN" => std::option::Option::Some(Self::LOGIN_ADMIN),
-            "LOGIN_REQUIRED" => std::option::Option::Some(Self::LOGIN_REQUIRED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LoginRequirement {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LoginRequirement {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LoginRequirement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LoginRequirement {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::LoginUnspecified,
+            1 => Self::LoginOptional,
+            2 => Self::LoginAdmin,
+            3 => Self::LoginRequired,
+            _ => Self::UnknownValue(login_requirement::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LoginRequirement {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LOGIN_UNSPECIFIED" => Self::LoginUnspecified,
+            "LOGIN_OPTIONAL" => Self::LoginOptional,
+            "LOGIN_ADMIN" => Self::LoginAdmin,
+            "LOGIN_REQUIRED" => Self::LoginRequired,
+            _ => Self::UnknownValue(login_requirement::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LoginRequirement {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::LoginUnspecified => serializer.serialize_i32(0),
+            Self::LoginOptional => serializer.serialize_i32(1),
+            Self::LoginAdmin => serializer.serialize_i32(2),
+            Self::LoginRequired => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LoginRequirement {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoginRequirement>::new(
+            ".google.appengine.v1.LoginRequirement",
+        ))
     }
 }
 
 /// Methods to enforce security (HTTPS) on a URL.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SecurityLevel(i32);
-
-impl SecurityLevel {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SecurityLevel {
     /// Not specified.
-    pub const SECURE_UNSPECIFIED: SecurityLevel = SecurityLevel::new(0);
-
+    SecureUnspecified,
     /// Both HTTP and HTTPS requests with URLs that match the handler succeed
     /// without redirects. The application can examine the request to determine
     /// which protocol was used, and respond accordingly.
-    pub const SECURE_DEFAULT: SecurityLevel = SecurityLevel::new(0);
-
+    SecureDefault,
     /// Requests for a URL that match this handler that use HTTPS are automatically
     /// redirected to the HTTP equivalent URL.
-    pub const SECURE_NEVER: SecurityLevel = SecurityLevel::new(1);
-
+    SecureNever,
     /// Both HTTP and HTTPS requests with URLs that match the handler succeed
     /// without redirects. The application can examine the request to determine
     /// which protocol was used and respond accordingly.
-    pub const SECURE_OPTIONAL: SecurityLevel = SecurityLevel::new(2);
-
+    SecureOptional,
     /// Requests for a URL that match this handler that do not use HTTPS are
     /// automatically redirected to the HTTPS URL with the same path. Query
     /// parameters are reserved for the redirect.
-    pub const SECURE_ALWAYS: SecurityLevel = SecurityLevel::new(3);
+    SecureAlways,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SecurityLevel::value] or
+    /// [SecurityLevel::name].
+    UnknownValue(security_level::UnknownValue),
+}
 
-    /// Creates a new SecurityLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod security_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SecurityLevel {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::SecureUnspecified => std::option::Option::Some(0),
+            Self::SecureDefault => std::option::Option::Some(0),
+            Self::SecureNever => std::option::Option::Some(1),
+            Self::SecureOptional => std::option::Option::Some(2),
+            Self::SecureAlways => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SECURE_DEFAULT"),
-            1 => std::borrow::Cow::Borrowed("SECURE_NEVER"),
-            2 => std::borrow::Cow::Borrowed("SECURE_OPTIONAL"),
-            3 => std::borrow::Cow::Borrowed("SECURE_ALWAYS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::SecureUnspecified => std::option::Option::Some("SECURE_UNSPECIFIED"),
+            Self::SecureDefault => std::option::Option::Some("SECURE_DEFAULT"),
+            Self::SecureNever => std::option::Option::Some("SECURE_NEVER"),
+            Self::SecureOptional => std::option::Option::Some("SECURE_OPTIONAL"),
+            Self::SecureAlways => std::option::Option::Some("SECURE_ALWAYS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SECURE_UNSPECIFIED" => std::option::Option::Some(Self::SECURE_UNSPECIFIED),
-            "SECURE_DEFAULT" => std::option::Option::Some(Self::SECURE_DEFAULT),
-            "SECURE_NEVER" => std::option::Option::Some(Self::SECURE_NEVER),
-            "SECURE_OPTIONAL" => std::option::Option::Some(Self::SECURE_OPTIONAL),
-            "SECURE_ALWAYS" => std::option::Option::Some(Self::SECURE_ALWAYS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SecurityLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SecurityLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SecurityLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SecurityLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::SecureDefault,
+            1 => Self::SecureNever,
+            2 => Self::SecureOptional,
+            3 => Self::SecureAlways,
+            _ => Self::UnknownValue(security_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SecurityLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SECURE_UNSPECIFIED" => Self::SecureUnspecified,
+            "SECURE_DEFAULT" => Self::SecureDefault,
+            "SECURE_NEVER" => Self::SecureNever,
+            "SECURE_OPTIONAL" => Self::SecureOptional,
+            "SECURE_ALWAYS" => Self::SecureAlways,
+            _ => Self::UnknownValue(security_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SecurityLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::SecureUnspecified => serializer.serialize_i32(0),
+            Self::SecureDefault => serializer.serialize_i32(0),
+            Self::SecureNever => serializer.serialize_i32(1),
+            Self::SecureOptional => serializer.serialize_i32(2),
+            Self::SecureAlways => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SecurityLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SecurityLevel>::new(
+            ".google.appengine.v1.SecurityLevel",
+        ))
     }
 }
 
@@ -8087,438 +9061,817 @@ impl std::default::Default for SecurityLevel {
 /// are retrieved.
 ///
 /// [google.appengine.v1.Version]: crate::model::Version
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct VersionView(i32);
-
-impl VersionView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum VersionView {
     /// Basic version information including scaling and inbound services,
     /// but not detailed deployment information.
-    pub const BASIC: VersionView = VersionView::new(0);
-
+    Basic,
     /// The information from `BASIC`, plus detailed information about the
     /// deployment. This format is required when creating resources, but
     /// is not returned in `Get` or `List` by default.
-    pub const FULL: VersionView = VersionView::new(1);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [VersionView::value] or
+    /// [VersionView::name].
+    UnknownValue(version_view::UnknownValue),
+}
 
-    /// Creates a new VersionView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod version_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl VersionView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Basic => std::option::Option::Some(0),
+            Self::Full => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BASIC"),
-            1 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for VersionView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for VersionView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for VersionView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for VersionView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Basic,
+            1 => Self::Full,
+            _ => Self::UnknownValue(version_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for VersionView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(version_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for VersionView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Basic => serializer.serialize_i32(0),
+            Self::Full => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for VersionView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionView>::new(
+            ".google.appengine.v1.VersionView",
+        ))
     }
 }
 
 /// Fields that should be returned when an AuthorizedCertificate resource is
 /// retrieved.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthorizedCertificateView(i32);
-
-impl AuthorizedCertificateView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AuthorizedCertificateView {
     /// Basic certificate information, including applicable domains and expiration
     /// date.
-    pub const BASIC_CERTIFICATE: AuthorizedCertificateView = AuthorizedCertificateView::new(0);
-
+    BasicCertificate,
     /// The information from `BASIC_CERTIFICATE`, plus detailed information on the
     /// domain mappings that have this certificate mapped.
-    pub const FULL_CERTIFICATE: AuthorizedCertificateView = AuthorizedCertificateView::new(1);
+    FullCertificate,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AuthorizedCertificateView::value] or
+    /// [AuthorizedCertificateView::name].
+    UnknownValue(authorized_certificate_view::UnknownValue),
+}
 
-    /// Creates a new AuthorizedCertificateView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod authorized_certificate_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AuthorizedCertificateView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::BasicCertificate => std::option::Option::Some(0),
+            Self::FullCertificate => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BASIC_CERTIFICATE"),
-            1 => std::borrow::Cow::Borrowed("FULL_CERTIFICATE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::BasicCertificate => std::option::Option::Some("BASIC_CERTIFICATE"),
+            Self::FullCertificate => std::option::Option::Some("FULL_CERTIFICATE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BASIC_CERTIFICATE" => std::option::Option::Some(Self::BASIC_CERTIFICATE),
-            "FULL_CERTIFICATE" => std::option::Option::Some(Self::FULL_CERTIFICATE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AuthorizedCertificateView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthorizedCertificateView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AuthorizedCertificateView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AuthorizedCertificateView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::BasicCertificate,
+            1 => Self::FullCertificate,
+            _ => Self::UnknownValue(authorized_certificate_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AuthorizedCertificateView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BASIC_CERTIFICATE" => Self::BasicCertificate,
+            "FULL_CERTIFICATE" => Self::FullCertificate,
+            _ => Self::UnknownValue(authorized_certificate_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AuthorizedCertificateView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::BasicCertificate => serializer.serialize_i32(0),
+            Self::FullCertificate => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AuthorizedCertificateView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<AuthorizedCertificateView>::new(
+                ".google.appengine.v1.AuthorizedCertificateView",
+            ),
+        )
     }
 }
 
 /// Override strategy for mutating an existing mapping.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DomainOverrideStrategy(i32);
-
-impl DomainOverrideStrategy {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DomainOverrideStrategy {
     /// Strategy unspecified. Defaults to `STRICT`.
-    pub const UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY: DomainOverrideStrategy =
-        DomainOverrideStrategy::new(0);
-
+    UnspecifiedDomainOverrideStrategy,
     /// Overrides not allowed. If a mapping already exists for the
     /// specified domain, the request will return an ALREADY_EXISTS (409).
-    pub const STRICT: DomainOverrideStrategy = DomainOverrideStrategy::new(1);
-
+    Strict,
     /// Overrides allowed. If a mapping already exists for the specified domain,
     /// the request will overwrite it. Note that this might stop another
     /// Google product from serving. For example, if the domain is
     /// mapped to another App Engine application, that app will no
     /// longer serve from that domain.
-    pub const OVERRIDE: DomainOverrideStrategy = DomainOverrideStrategy::new(2);
+    Override,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DomainOverrideStrategy::value] or
+    /// [DomainOverrideStrategy::name].
+    UnknownValue(domain_override_strategy::UnknownValue),
+}
 
-    /// Creates a new DomainOverrideStrategy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod domain_override_strategy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DomainOverrideStrategy {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::UnspecifiedDomainOverrideStrategy => std::option::Option::Some(0),
+            Self::Strict => std::option::Option::Some(1),
+            Self::Override => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY"),
-            1 => std::borrow::Cow::Borrowed("STRICT"),
-            2 => std::borrow::Cow::Borrowed("OVERRIDE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY" => {
-                std::option::Option::Some(Self::UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::UnspecifiedDomainOverrideStrategy => {
+                std::option::Option::Some("UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY")
             }
-            "STRICT" => std::option::Option::Some(Self::STRICT),
-            "OVERRIDE" => std::option::Option::Some(Self::OVERRIDE),
-            _ => std::option::Option::None,
+            Self::Strict => std::option::Option::Some("STRICT"),
+            Self::Override => std::option::Option::Some("OVERRIDE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for DomainOverrideStrategy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DomainOverrideStrategy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DomainOverrideStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DomainOverrideStrategy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::UnspecifiedDomainOverrideStrategy,
+            1 => Self::Strict,
+            2 => Self::Override,
+            _ => Self::UnknownValue(domain_override_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DomainOverrideStrategy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UNSPECIFIED_DOMAIN_OVERRIDE_STRATEGY" => Self::UnspecifiedDomainOverrideStrategy,
+            "STRICT" => Self::Strict,
+            "OVERRIDE" => Self::Override,
+            _ => Self::UnknownValue(domain_override_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DomainOverrideStrategy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::UnspecifiedDomainOverrideStrategy => serializer.serialize_i32(0),
+            Self::Strict => serializer.serialize_i32(1),
+            Self::Override => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DomainOverrideStrategy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DomainOverrideStrategy>::new(
+            ".google.appengine.v1.DomainOverrideStrategy",
+        ))
     }
 }
 
 /// State of certificate management. Refers to the most recent certificate
 /// acquisition or renewal attempt.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ManagementStatus(i32);
-
-impl ManagementStatus {
-    pub const MANAGEMENT_STATUS_UNSPECIFIED: ManagementStatus = ManagementStatus::new(0);
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ManagementStatus {
+    Unspecified,
     /// Certificate was successfully obtained and inserted into the serving
     /// system.
-    pub const OK: ManagementStatus = ManagementStatus::new(1);
-
+    Ok,
     /// Certificate is under active attempts to acquire or renew.
-    pub const PENDING: ManagementStatus = ManagementStatus::new(2);
-
+    Pending,
     /// Most recent renewal failed due to an invalid DNS setup and will be
     /// retried. Renewal attempts will continue to fail until the certificate
     /// domain's DNS configuration is fixed. The last successfully provisioned
     /// certificate may still be serving.
-    pub const FAILED_RETRYING_NOT_VISIBLE: ManagementStatus = ManagementStatus::new(4);
-
+    FailedRetryingNotVisible,
     /// All renewal attempts have been exhausted, likely due to an invalid DNS
     /// setup.
-    pub const FAILED_PERMANENT: ManagementStatus = ManagementStatus::new(6);
-
+    FailedPermanent,
     /// Most recent renewal failed due to an explicit CAA record that does not
     /// include one of the in-use CAs (Google CA and Let's Encrypt). Renewals will
     /// continue to fail until the CAA is reconfigured. The last successfully
     /// provisioned certificate may still be serving.
-    pub const FAILED_RETRYING_CAA_FORBIDDEN: ManagementStatus = ManagementStatus::new(7);
-
+    FailedRetryingCaaForbidden,
     /// Most recent renewal failed due to a CAA retrieval failure. This means that
     /// the domain's DNS provider does not properly handle CAA records, failing
     /// requests for CAA records when no CAA records are defined. Renewals will
     /// continue to fail until the DNS provider is changed or a CAA record is
     /// added for the given domain. The last successfully provisioned certificate
     /// may still be serving.
-    pub const FAILED_RETRYING_CAA_CHECKING: ManagementStatus = ManagementStatus::new(8);
+    FailedRetryingCaaChecking,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ManagementStatus::value] or
+    /// [ManagementStatus::name].
+    UnknownValue(management_status::UnknownValue),
+}
 
-    /// Creates a new ManagementStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod management_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ManagementStatus {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Ok => std::option::Option::Some(1),
+            Self::Pending => std::option::Option::Some(2),
+            Self::FailedRetryingNotVisible => std::option::Option::Some(4),
+            Self::FailedPermanent => std::option::Option::Some(6),
+            Self::FailedRetryingCaaForbidden => std::option::Option::Some(7),
+            Self::FailedRetryingCaaChecking => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MANAGEMENT_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OK"),
-            2 => std::borrow::Cow::Borrowed("PENDING"),
-            4 => std::borrow::Cow::Borrowed("FAILED_RETRYING_NOT_VISIBLE"),
-            6 => std::borrow::Cow::Borrowed("FAILED_PERMANENT"),
-            7 => std::borrow::Cow::Borrowed("FAILED_RETRYING_CAA_FORBIDDEN"),
-            8 => std::borrow::Cow::Borrowed("FAILED_RETRYING_CAA_CHECKING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MANAGEMENT_STATUS_UNSPECIFIED"),
+            Self::Ok => std::option::Option::Some("OK"),
+            Self::Pending => std::option::Option::Some("PENDING"),
+            Self::FailedRetryingNotVisible => {
+                std::option::Option::Some("FAILED_RETRYING_NOT_VISIBLE")
+            }
+            Self::FailedPermanent => std::option::Option::Some("FAILED_PERMANENT"),
+            Self::FailedRetryingCaaForbidden => {
+                std::option::Option::Some("FAILED_RETRYING_CAA_FORBIDDEN")
+            }
+            Self::FailedRetryingCaaChecking => {
+                std::option::Option::Some("FAILED_RETRYING_CAA_CHECKING")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MANAGEMENT_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MANAGEMENT_STATUS_UNSPECIFIED)
-            }
-            "OK" => std::option::Option::Some(Self::OK),
-            "PENDING" => std::option::Option::Some(Self::PENDING),
-            "FAILED_RETRYING_NOT_VISIBLE" => {
-                std::option::Option::Some(Self::FAILED_RETRYING_NOT_VISIBLE)
-            }
-            "FAILED_PERMANENT" => std::option::Option::Some(Self::FAILED_PERMANENT),
-            "FAILED_RETRYING_CAA_FORBIDDEN" => {
-                std::option::Option::Some(Self::FAILED_RETRYING_CAA_FORBIDDEN)
-            }
-            "FAILED_RETRYING_CAA_CHECKING" => {
-                std::option::Option::Some(Self::FAILED_RETRYING_CAA_CHECKING)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ManagementStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ManagementStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ManagementStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ManagementStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Ok,
+            2 => Self::Pending,
+            4 => Self::FailedRetryingNotVisible,
+            6 => Self::FailedPermanent,
+            7 => Self::FailedRetryingCaaForbidden,
+            8 => Self::FailedRetryingCaaChecking,
+            _ => Self::UnknownValue(management_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ManagementStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MANAGEMENT_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "OK" => Self::Ok,
+            "PENDING" => Self::Pending,
+            "FAILED_RETRYING_NOT_VISIBLE" => Self::FailedRetryingNotVisible,
+            "FAILED_PERMANENT" => Self::FailedPermanent,
+            "FAILED_RETRYING_CAA_FORBIDDEN" => Self::FailedRetryingCaaForbidden,
+            "FAILED_RETRYING_CAA_CHECKING" => Self::FailedRetryingCaaChecking,
+            _ => Self::UnknownValue(management_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ManagementStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Ok => serializer.serialize_i32(1),
+            Self::Pending => serializer.serialize_i32(2),
+            Self::FailedRetryingNotVisible => serializer.serialize_i32(4),
+            Self::FailedPermanent => serializer.serialize_i32(6),
+            Self::FailedRetryingCaaForbidden => serializer.serialize_i32(7),
+            Self::FailedRetryingCaaChecking => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ManagementStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ManagementStatus>::new(
+            ".google.appengine.v1.ManagementStatus",
+        ))
     }
 }
 
 /// Available inbound services.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InboundServiceType(i32);
-
-impl InboundServiceType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum InboundServiceType {
     /// Not specified.
-    pub const INBOUND_SERVICE_UNSPECIFIED: InboundServiceType = InboundServiceType::new(0);
-
+    InboundServiceUnspecified,
     /// Allows an application to receive mail.
-    pub const INBOUND_SERVICE_MAIL: InboundServiceType = InboundServiceType::new(1);
-
+    InboundServiceMail,
     /// Allows an application to receive email-bound notifications.
-    pub const INBOUND_SERVICE_MAIL_BOUNCE: InboundServiceType = InboundServiceType::new(2);
-
+    InboundServiceMailBounce,
     /// Allows an application to receive error stanzas.
-    pub const INBOUND_SERVICE_XMPP_ERROR: InboundServiceType = InboundServiceType::new(3);
-
+    InboundServiceXmppError,
     /// Allows an application to receive instant messages.
-    pub const INBOUND_SERVICE_XMPP_MESSAGE: InboundServiceType = InboundServiceType::new(4);
-
+    InboundServiceXmppMessage,
     /// Allows an application to receive user subscription POSTs.
-    pub const INBOUND_SERVICE_XMPP_SUBSCRIBE: InboundServiceType = InboundServiceType::new(5);
-
+    InboundServiceXmppSubscribe,
     /// Allows an application to receive a user's chat presence.
-    pub const INBOUND_SERVICE_XMPP_PRESENCE: InboundServiceType = InboundServiceType::new(6);
-
+    InboundServiceXmppPresence,
     /// Registers an application for notifications when a client connects or
     /// disconnects from a channel.
-    pub const INBOUND_SERVICE_CHANNEL_PRESENCE: InboundServiceType = InboundServiceType::new(7);
-
+    InboundServiceChannelPresence,
     /// Enables warmup requests.
-    pub const INBOUND_SERVICE_WARMUP: InboundServiceType = InboundServiceType::new(9);
+    InboundServiceWarmup,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [InboundServiceType::value] or
+    /// [InboundServiceType::name].
+    UnknownValue(inbound_service_type::UnknownValue),
+}
 
-    /// Creates a new InboundServiceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod inbound_service_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl InboundServiceType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::InboundServiceUnspecified => std::option::Option::Some(0),
+            Self::InboundServiceMail => std::option::Option::Some(1),
+            Self::InboundServiceMailBounce => std::option::Option::Some(2),
+            Self::InboundServiceXmppError => std::option::Option::Some(3),
+            Self::InboundServiceXmppMessage => std::option::Option::Some(4),
+            Self::InboundServiceXmppSubscribe => std::option::Option::Some(5),
+            Self::InboundServiceXmppPresence => std::option::Option::Some(6),
+            Self::InboundServiceChannelPresence => std::option::Option::Some(7),
+            Self::InboundServiceWarmup => std::option::Option::Some(9),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_MAIL"),
-            2 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_MAIL_BOUNCE"),
-            3 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_ERROR"),
-            4 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_MESSAGE"),
-            5 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_SUBSCRIBE"),
-            6 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_XMPP_PRESENCE"),
-            7 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_CHANNEL_PRESENCE"),
-            9 => std::borrow::Cow::Borrowed("INBOUND_SERVICE_WARMUP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::InboundServiceUnspecified => {
+                std::option::Option::Some("INBOUND_SERVICE_UNSPECIFIED")
+            }
+            Self::InboundServiceMail => std::option::Option::Some("INBOUND_SERVICE_MAIL"),
+            Self::InboundServiceMailBounce => {
+                std::option::Option::Some("INBOUND_SERVICE_MAIL_BOUNCE")
+            }
+            Self::InboundServiceXmppError => {
+                std::option::Option::Some("INBOUND_SERVICE_XMPP_ERROR")
+            }
+            Self::InboundServiceXmppMessage => {
+                std::option::Option::Some("INBOUND_SERVICE_XMPP_MESSAGE")
+            }
+            Self::InboundServiceXmppSubscribe => {
+                std::option::Option::Some("INBOUND_SERVICE_XMPP_SUBSCRIBE")
+            }
+            Self::InboundServiceXmppPresence => {
+                std::option::Option::Some("INBOUND_SERVICE_XMPP_PRESENCE")
+            }
+            Self::InboundServiceChannelPresence => {
+                std::option::Option::Some("INBOUND_SERVICE_CHANNEL_PRESENCE")
+            }
+            Self::InboundServiceWarmup => std::option::Option::Some("INBOUND_SERVICE_WARMUP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INBOUND_SERVICE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_UNSPECIFIED)
-            }
-            "INBOUND_SERVICE_MAIL" => std::option::Option::Some(Self::INBOUND_SERVICE_MAIL),
-            "INBOUND_SERVICE_MAIL_BOUNCE" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_MAIL_BOUNCE)
-            }
-            "INBOUND_SERVICE_XMPP_ERROR" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_ERROR)
-            }
-            "INBOUND_SERVICE_XMPP_MESSAGE" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_MESSAGE)
-            }
-            "INBOUND_SERVICE_XMPP_SUBSCRIBE" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_SUBSCRIBE)
-            }
-            "INBOUND_SERVICE_XMPP_PRESENCE" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_XMPP_PRESENCE)
-            }
-            "INBOUND_SERVICE_CHANNEL_PRESENCE" => {
-                std::option::Option::Some(Self::INBOUND_SERVICE_CHANNEL_PRESENCE)
-            }
-            "INBOUND_SERVICE_WARMUP" => std::option::Option::Some(Self::INBOUND_SERVICE_WARMUP),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for InboundServiceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for InboundServiceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for InboundServiceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for InboundServiceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::InboundServiceUnspecified,
+            1 => Self::InboundServiceMail,
+            2 => Self::InboundServiceMailBounce,
+            3 => Self::InboundServiceXmppError,
+            4 => Self::InboundServiceXmppMessage,
+            5 => Self::InboundServiceXmppSubscribe,
+            6 => Self::InboundServiceXmppPresence,
+            7 => Self::InboundServiceChannelPresence,
+            9 => Self::InboundServiceWarmup,
+            _ => Self::UnknownValue(inbound_service_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for InboundServiceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INBOUND_SERVICE_UNSPECIFIED" => Self::InboundServiceUnspecified,
+            "INBOUND_SERVICE_MAIL" => Self::InboundServiceMail,
+            "INBOUND_SERVICE_MAIL_BOUNCE" => Self::InboundServiceMailBounce,
+            "INBOUND_SERVICE_XMPP_ERROR" => Self::InboundServiceXmppError,
+            "INBOUND_SERVICE_XMPP_MESSAGE" => Self::InboundServiceXmppMessage,
+            "INBOUND_SERVICE_XMPP_SUBSCRIBE" => Self::InboundServiceXmppSubscribe,
+            "INBOUND_SERVICE_XMPP_PRESENCE" => Self::InboundServiceXmppPresence,
+            "INBOUND_SERVICE_CHANNEL_PRESENCE" => Self::InboundServiceChannelPresence,
+            "INBOUND_SERVICE_WARMUP" => Self::InboundServiceWarmup,
+            _ => Self::UnknownValue(inbound_service_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for InboundServiceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::InboundServiceUnspecified => serializer.serialize_i32(0),
+            Self::InboundServiceMail => serializer.serialize_i32(1),
+            Self::InboundServiceMailBounce => serializer.serialize_i32(2),
+            Self::InboundServiceXmppError => serializer.serialize_i32(3),
+            Self::InboundServiceXmppMessage => serializer.serialize_i32(4),
+            Self::InboundServiceXmppSubscribe => serializer.serialize_i32(5),
+            Self::InboundServiceXmppPresence => serializer.serialize_i32(6),
+            Self::InboundServiceChannelPresence => serializer.serialize_i32(7),
+            Self::InboundServiceWarmup => serializer.serialize_i32(9),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for InboundServiceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<InboundServiceType>::new(
+            ".google.appengine.v1.InboundServiceType",
+        ))
     }
 }
 
 /// Run states of a version.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServingStatus(i32);
-
-impl ServingStatus {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServingStatus {
     /// Not specified.
-    pub const SERVING_STATUS_UNSPECIFIED: ServingStatus = ServingStatus::new(0);
-
+    Unspecified,
     /// Currently serving. Instances are created according to the
     /// scaling settings of the version.
-    pub const SERVING: ServingStatus = ServingStatus::new(1);
-
+    Serving,
     /// Disabled. No instances will be created and the scaling
     /// settings are ignored until the state of the version changes
     /// to `SERVING`.
-    pub const STOPPED: ServingStatus = ServingStatus::new(2);
+    Stopped,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServingStatus::value] or
+    /// [ServingStatus::name].
+    UnknownValue(serving_status::UnknownValue),
+}
 
-    /// Creates a new ServingStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod serving_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ServingStatus {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Serving => std::option::Option::Some(1),
+            Self::Stopped => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SERVING_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SERVING"),
-            2 => std::borrow::Cow::Borrowed("STOPPED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SERVING_STATUS_UNSPECIFIED"),
+            Self::Serving => std::option::Option::Some("SERVING"),
+            Self::Stopped => std::option::Option::Some("STOPPED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SERVING_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SERVING_STATUS_UNSPECIFIED)
-            }
-            "SERVING" => std::option::Option::Some(Self::SERVING),
-            "STOPPED" => std::option::Option::Some(Self::STOPPED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServingStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServingStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServingStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServingStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Serving,
+            2 => Self::Stopped,
+            _ => Self::UnknownValue(serving_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServingStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SERVING_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "SERVING" => Self::Serving,
+            "STOPPED" => Self::Stopped,
+            _ => Self::UnknownValue(serving_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServingStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Serving => serializer.serialize_i32(1),
+            Self::Stopped => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServingStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServingStatus>::new(
+            ".google.appengine.v1.ServingStatus",
+        ))
     }
 }

--- a/src/generated/appengine/v1/src/transport.rs
+++ b/src/generated/appengine/v1/src/transport.rs
@@ -375,7 +375,7 @@ impl super::stub::Versions for Versions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -397,7 +397,7 @@ impl super::stub::Versions for Versions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1003,7 +1003,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -1025,7 +1025,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1225,7 +1225,7 @@ impl super::stub::DomainMappings for DomainMappings {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("overrideStrategy", &req.override_strategy.value())]);
+        let builder = builder.query(&[("overrideStrategy", &req.override_strategy)]);
         self.inner
             .execute(builder, Some(req.domain_mapping), options)
             .await

--- a/src/generated/apps/script/calendar/src/model.rs
+++ b/src/generated/apps/script/calendar/src/model.rs
@@ -146,75 +146,140 @@ pub mod calendar_add_on_manifest {
     use super::*;
 
     /// An enum defining the level of data access event triggers require.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventAccess(i32);
-
-    impl EventAccess {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventAccess {
         /// Default value when nothing is set for EventAccess.
-        pub const UNSPECIFIED: EventAccess = EventAccess::new(0);
-
+        Unspecified,
         /// METADATA gives event triggers the permission to access the metadata of
         /// events such as event id and calendar id.
-        pub const METADATA: EventAccess = EventAccess::new(1);
-
+        Metadata,
         /// READ gives event triggers access to all provided event fields including
         /// the metadata, attendees, and conference data.
-        pub const READ: EventAccess = EventAccess::new(3);
-
+        Read,
         /// WRITE gives event triggers access to the metadata of events and the
         /// ability to perform all actions, including adding attendees and setting
         /// conference data.
-        pub const WRITE: EventAccess = EventAccess::new(4);
-
+        Write,
         /// READ_WRITE gives event triggers access to all provided event fields
         /// including the metadata, attendees, and conference data and the ability to
         /// perform all actions.
-        pub const READ_WRITE: EventAccess = EventAccess::new(5);
+        ReadWrite,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventAccess::value] or
+        /// [EventAccess::name].
+        UnknownValue(event_access::UnknownValue),
+    }
 
-        /// Creates a new EventAccess instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod event_access {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EventAccess {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Metadata => std::option::Option::Some(1),
+                Self::Read => std::option::Option::Some(3),
+                Self::Write => std::option::Option::Some(4),
+                Self::ReadWrite => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("METADATA"),
-                3 => std::borrow::Cow::Borrowed("READ"),
-                4 => std::borrow::Cow::Borrowed("WRITE"),
-                5 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Metadata => std::option::Option::Some("METADATA"),
+                Self::Read => std::option::Option::Some("READ"),
+                Self::Write => std::option::Option::Some("WRITE"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "METADATA" => std::option::Option::Some(Self::METADATA),
-                "READ" => std::option::Option::Some(Self::READ),
-                "WRITE" => std::option::Option::Some(Self::WRITE),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventAccess {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventAccess {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventAccess {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventAccess {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Metadata,
+                3 => Self::Read,
+                4 => Self::Write,
+                5 => Self::ReadWrite,
+                _ => Self::UnknownValue(event_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventAccess {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "METADATA" => Self::Metadata,
+                "READ" => Self::Read,
+                "WRITE" => Self::Write,
+                "READ_WRITE" => Self::ReadWrite,
+                _ => Self::UnknownValue(event_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventAccess {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Metadata => serializer.serialize_i32(1),
+                Self::Read => serializer.serialize_i32(3),
+                Self::Write => serializer.serialize_i32(4),
+                Self::ReadWrite => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventAccess {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventAccess>::new(
+                ".google.apps.script.type.calendar.CalendarAddOnManifest.EventAccess",
+            ))
         }
     }
 }

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -314,62 +314,123 @@ pub mod compose_trigger {
     use super::*;
 
     /// An enum defining the level of data access this compose trigger requires.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DraftAccess(i32);
-
-    impl DraftAccess {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DraftAccess {
         /// Default value when nothing is set for DraftAccess.
-        pub const UNSPECIFIED: DraftAccess = DraftAccess::new(0);
-
+        Unspecified,
         /// NONE means compose trigger won't be able to access any data of the draft
         /// when a compose addon is triggered.
-        pub const NONE: DraftAccess = DraftAccess::new(1);
-
+        None,
         /// METADATA gives compose trigger the permission to access the metadata of
         /// the draft when a compose addon is triggered. This includes the audience
         /// list (To/cc list) of a draft message.
-        pub const METADATA: DraftAccess = DraftAccess::new(2);
+        Metadata,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DraftAccess::value] or
+        /// [DraftAccess::name].
+        UnknownValue(draft_access::UnknownValue),
+    }
 
-        /// Creates a new DraftAccess instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod draft_access {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DraftAccess {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Metadata => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("METADATA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Metadata => std::option::Option::Some("METADATA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "METADATA" => std::option::Option::Some(Self::METADATA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DraftAccess {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DraftAccess {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DraftAccess {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DraftAccess {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Metadata,
+                _ => Self::UnknownValue(draft_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DraftAccess {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "METADATA" => Self::Metadata,
+                _ => Self::UnknownValue(draft_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DraftAccess {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Metadata => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DraftAccess {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DraftAccess>::new(
+                ".google.apps.script.type.gmail.ComposeTrigger.DraftAccess",
+            ))
         }
     }
 }

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -67,90 +67,157 @@ pub mod add_on_widget_set {
     use super::*;
 
     /// The Widget type. DEFAULT is the basic widget set.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WidgetType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WidgetType {
+        /// The default widget set.
+        Unspecified,
+        /// The date picker.
+        DatePicker,
+        /// Styled buttons include filled buttons and disabled buttons.
+        StyledButtons,
+        /// Persistent forms allow persisting form values during actions.
+        PersistentForms,
+        /// Fixed footer in card.
+        FixedFooter,
+        /// Update the subject and recipients of a draft.
+        UpdateSubjectAndRecipients,
+        /// The grid widget.
+        GridWidget,
+        /// A Gmail add-on action that applies to the addon compose UI.
+        AddonComposeUiAction,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WidgetType::value] or
+        /// [WidgetType::name].
+        UnknownValue(widget_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod widget_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WidgetType {
-        /// The default widget set.
-        pub const WIDGET_TYPE_UNSPECIFIED: WidgetType = WidgetType::new(0);
-
-        /// The date picker.
-        pub const DATE_PICKER: WidgetType = WidgetType::new(1);
-
-        /// Styled buttons include filled buttons and disabled buttons.
-        pub const STYLED_BUTTONS: WidgetType = WidgetType::new(2);
-
-        /// Persistent forms allow persisting form values during actions.
-        pub const PERSISTENT_FORMS: WidgetType = WidgetType::new(3);
-
-        /// Fixed footer in card.
-        pub const FIXED_FOOTER: WidgetType = WidgetType::new(4);
-
-        /// Update the subject and recipients of a draft.
-        pub const UPDATE_SUBJECT_AND_RECIPIENTS: WidgetType = WidgetType::new(5);
-
-        /// The grid widget.
-        pub const GRID_WIDGET: WidgetType = WidgetType::new(6);
-
-        /// A Gmail add-on action that applies to the addon compose UI.
-        pub const ADDON_COMPOSE_UI_ACTION: WidgetType = WidgetType::new(7);
-
-        /// Creates a new WidgetType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DatePicker => std::option::Option::Some(1),
+                Self::StyledButtons => std::option::Option::Some(2),
+                Self::PersistentForms => std::option::Option::Some(3),
+                Self::FixedFooter => std::option::Option::Some(4),
+                Self::UpdateSubjectAndRecipients => std::option::Option::Some(5),
+                Self::GridWidget => std::option::Option::Some(6),
+                Self::AddonComposeUiAction => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WIDGET_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATE_PICKER"),
-                2 => std::borrow::Cow::Borrowed("STYLED_BUTTONS"),
-                3 => std::borrow::Cow::Borrowed("PERSISTENT_FORMS"),
-                4 => std::borrow::Cow::Borrowed("FIXED_FOOTER"),
-                5 => std::borrow::Cow::Borrowed("UPDATE_SUBJECT_AND_RECIPIENTS"),
-                6 => std::borrow::Cow::Borrowed("GRID_WIDGET"),
-                7 => std::borrow::Cow::Borrowed("ADDON_COMPOSE_UI_ACTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WIDGET_TYPE_UNSPECIFIED"),
+                Self::DatePicker => std::option::Option::Some("DATE_PICKER"),
+                Self::StyledButtons => std::option::Option::Some("STYLED_BUTTONS"),
+                Self::PersistentForms => std::option::Option::Some("PERSISTENT_FORMS"),
+                Self::FixedFooter => std::option::Option::Some("FIXED_FOOTER"),
+                Self::UpdateSubjectAndRecipients => {
+                    std::option::Option::Some("UPDATE_SUBJECT_AND_RECIPIENTS")
+                }
+                Self::GridWidget => std::option::Option::Some("GRID_WIDGET"),
+                Self::AddonComposeUiAction => std::option::Option::Some("ADDON_COMPOSE_UI_ACTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WIDGET_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WIDGET_TYPE_UNSPECIFIED)
-                }
-                "DATE_PICKER" => std::option::Option::Some(Self::DATE_PICKER),
-                "STYLED_BUTTONS" => std::option::Option::Some(Self::STYLED_BUTTONS),
-                "PERSISTENT_FORMS" => std::option::Option::Some(Self::PERSISTENT_FORMS),
-                "FIXED_FOOTER" => std::option::Option::Some(Self::FIXED_FOOTER),
-                "UPDATE_SUBJECT_AND_RECIPIENTS" => {
-                    std::option::Option::Some(Self::UPDATE_SUBJECT_AND_RECIPIENTS)
-                }
-                "GRID_WIDGET" => std::option::Option::Some(Self::GRID_WIDGET),
-                "ADDON_COMPOSE_UI_ACTION" => {
-                    std::option::Option::Some(Self::ADDON_COMPOSE_UI_ACTION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WidgetType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WidgetType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WidgetType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WidgetType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DatePicker,
+                2 => Self::StyledButtons,
+                3 => Self::PersistentForms,
+                4 => Self::FixedFooter,
+                5 => Self::UpdateSubjectAndRecipients,
+                6 => Self::GridWidget,
+                7 => Self::AddonComposeUiAction,
+                _ => Self::UnknownValue(widget_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WidgetType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WIDGET_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DATE_PICKER" => Self::DatePicker,
+                "STYLED_BUTTONS" => Self::StyledButtons,
+                "PERSISTENT_FORMS" => Self::PersistentForms,
+                "FIXED_FOOTER" => Self::FixedFooter,
+                "UPDATE_SUBJECT_AND_RECIPIENTS" => Self::UpdateSubjectAndRecipients,
+                "GRID_WIDGET" => Self::GridWidget,
+                "ADDON_COMPOSE_UI_ACTION" => Self::AddonComposeUiAction,
+                _ => Self::UnknownValue(widget_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WidgetType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DatePicker => serializer.serialize_i32(1),
+                Self::StyledButtons => serializer.serialize_i32(2),
+                Self::PersistentForms => serializer.serialize_i32(3),
+                Self::FixedFooter => serializer.serialize_i32(4),
+                Self::UpdateSubjectAndRecipients => serializer.serialize_i32(5),
+                Self::GridWidget => serializer.serialize_i32(6),
+                Self::AddonComposeUiAction => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WidgetType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WidgetType>::new(
+                ".google.apps.script.type.AddOnWidgetSet.WidgetType",
+            ))
         }
     }
 }
@@ -611,67 +678,127 @@ impl wkt::message::Message for HttpOptions {
 }
 
 /// Authorization header sent in add-on HTTP requests
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HttpAuthorizationHeader(i32);
-
-impl HttpAuthorizationHeader {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HttpAuthorizationHeader {
     /// Default value, equivalent to `SYSTEM_ID_TOKEN`
-    pub const HTTP_AUTHORIZATION_HEADER_UNSPECIFIED: HttpAuthorizationHeader =
-        HttpAuthorizationHeader::new(0);
-
+    Unspecified,
     /// Send an ID token for the project-specific Google Workspace add-ons system
     /// service account (default)
-    pub const SYSTEM_ID_TOKEN: HttpAuthorizationHeader = HttpAuthorizationHeader::new(1);
-
+    SystemIdToken,
     /// Send an ID token for the end user
-    pub const USER_ID_TOKEN: HttpAuthorizationHeader = HttpAuthorizationHeader::new(2);
-
+    UserIdToken,
     /// Do not send an Authentication header
-    pub const NONE: HttpAuthorizationHeader = HttpAuthorizationHeader::new(3);
+    None,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HttpAuthorizationHeader::value] or
+    /// [HttpAuthorizationHeader::name].
+    UnknownValue(http_authorization_header::UnknownValue),
+}
 
-    /// Creates a new HttpAuthorizationHeader instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod http_authorization_header {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl HttpAuthorizationHeader {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SystemIdToken => std::option::Option::Some(1),
+            Self::UserIdToken => std::option::Option::Some(2),
+            Self::None => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HTTP_AUTHORIZATION_HEADER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SYSTEM_ID_TOKEN"),
-            2 => std::borrow::Cow::Borrowed("USER_ID_TOKEN"),
-            3 => std::borrow::Cow::Borrowed("NONE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HTTP_AUTHORIZATION_HEADER_UNSPECIFIED"),
+            Self::SystemIdToken => std::option::Option::Some("SYSTEM_ID_TOKEN"),
+            Self::UserIdToken => std::option::Option::Some("USER_ID_TOKEN"),
+            Self::None => std::option::Option::Some("NONE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HTTP_AUTHORIZATION_HEADER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HTTP_AUTHORIZATION_HEADER_UNSPECIFIED)
-            }
-            "SYSTEM_ID_TOKEN" => std::option::Option::Some(Self::SYSTEM_ID_TOKEN),
-            "USER_ID_TOKEN" => std::option::Option::Some(Self::USER_ID_TOKEN),
-            "NONE" => std::option::Option::Some(Self::NONE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HttpAuthorizationHeader {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HttpAuthorizationHeader {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HttpAuthorizationHeader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HttpAuthorizationHeader {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::SystemIdToken,
+            2 => Self::UserIdToken,
+            3 => Self::None,
+            _ => Self::UnknownValue(http_authorization_header::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HttpAuthorizationHeader {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HTTP_AUTHORIZATION_HEADER_UNSPECIFIED" => Self::Unspecified,
+            "SYSTEM_ID_TOKEN" => Self::SystemIdToken,
+            "USER_ID_TOKEN" => Self::UserIdToken,
+            "NONE" => Self::None,
+            _ => Self::UnknownValue(http_authorization_header::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HttpAuthorizationHeader {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SystemIdToken => serializer.serialize_i32(1),
+            Self::UserIdToken => serializer.serialize_i32(2),
+            Self::None => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HttpAuthorizationHeader {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HttpAuthorizationHeader>::new(
+            ".google.apps.script.type.HttpAuthorizationHeader",
+        ))
     }
 }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -858,70 +858,138 @@ pub mod create_cluster_metadata {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            Unspecified,
             /// The table has not yet begun copying to the new cluster.
-            pub const PENDING: State = State::new(1);
-
+            Pending,
             /// The table is actively being copied to the new cluster.
-            pub const COPYING: State = State::new(2);
-
+            Copying,
             /// The table has been fully copied to the new cluster.
-            pub const COMPLETED: State = State::new(3);
-
+            Completed,
             /// The table was deleted before it finished copying to the new cluster.
             /// Note that tables deleted after completion will stay marked as
             /// COMPLETED, not CANCELLED.
-            pub const CANCELLED: State = State::new(4);
+            Cancelled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Pending => std::option::Option::Some(1),
+                    Self::Copying => std::option::Option::Some(2),
+                    Self::Completed => std::option::Option::Some(3),
+                    Self::Cancelled => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PENDING"),
-                    2 => std::borrow::Cow::Borrowed("COPYING"),
-                    3 => std::borrow::Cow::Borrowed("COMPLETED"),
-                    4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Pending => std::option::Option::Some("PENDING"),
+                    Self::Copying => std::option::Option::Some("COPYING"),
+                    Self::Completed => std::option::Option::Some("COMPLETED"),
+                    Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "PENDING" => std::option::Option::Some(Self::PENDING),
-                    "COPYING" => std::option::Option::Some(Self::COPYING),
-                    "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                    "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Pending,
+                    2 => Self::Copying,
+                    3 => Self::Completed,
+                    4 => Self::Cancelled,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "PENDING" => Self::Pending,
+                    "COPYING" => Self::Copying,
+                    "COMPLETED" => Self::Completed,
+                    "CANCELLED" => Self::Cancelled,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Pending => serializer.serialize_i32(1),
+                    Self::Copying => serializer.serialize_i32(2),
+                    Self::Completed => serializer.serialize_i32(3),
+                    Self::Cancelled => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.bigtable.admin.v2.CreateClusterMetadata.TableProgress.State",
+                ))
             }
         }
     }
@@ -5969,122 +6037,244 @@ pub mod instance {
     use super::*;
 
     /// Possible states of an instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the instance could not be determined.
-        pub const STATE_NOT_KNOWN: State = State::new(0);
-
+        NotKnown,
         /// The instance has been successfully created and can serve requests
         /// to its tables.
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// The instance is currently being created, and may be destroyed
         /// if the creation process encounters an error.
-        pub const CREATING: State = State::new(2);
+        Creating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NotKnown => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NotKnown => std::option::Option::Some("STATE_NOT_KNOWN"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NotKnown,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_NOT_KNOWN" => Self::NotKnown,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NotKnown => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.bigtable.admin.v2.Instance.State",
+            ))
         }
     }
 
     /// The type of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// The type of the instance is unspecified. If set when creating an
         /// instance, a `PRODUCTION` instance will be created. If set when updating
         /// an instance, the type will be left unchanged.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// An instance meant for production use. `serve_nodes` must be set
         /// on the cluster.
-        pub const PRODUCTION: Type = Type::new(1);
-
+        Production,
         /// DEPRECATED: Prefer PRODUCTION for all use cases, as it no longer enforces
         /// a higher minimum node count than DEVELOPMENT.
-        pub const DEVELOPMENT: Type = Type::new(2);
+        Development,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Production => std::option::Option::Some(1),
+                Self::Development => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRODUCTION"),
-                2 => std::borrow::Cow::Borrowed("DEVELOPMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Production => std::option::Option::Some("PRODUCTION"),
+                Self::Development => std::option::Option::Some("DEVELOPMENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PRODUCTION" => std::option::Option::Some(Self::PRODUCTION),
-                "DEVELOPMENT" => std::option::Option::Some(Self::DEVELOPMENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Production,
+                2 => Self::Development,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PRODUCTION" => Self::Production,
+                "DEVELOPMENT" => Self::Development,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Production => serializer.serialize_i32(1),
+                Self::Development => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.bigtable.admin.v2.Instance.Type",
+            ))
         }
     }
 }
@@ -6485,138 +6675,262 @@ pub mod cluster {
     }
 
     /// Possible states of a cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the cluster could not be determined.
-        pub const STATE_NOT_KNOWN: State = State::new(0);
-
+        NotKnown,
         /// The cluster has been successfully created and is ready to serve requests.
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// The cluster is currently being created, and may be destroyed
         /// if the creation process encounters an error.
         /// A cluster may not be able to serve requests while being created.
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// The cluster is currently being resized, and may revert to its previous
         /// node count if the process encounters an error.
         /// A cluster is still capable of serving requests while being resized,
         /// but may exhibit performance as if its number of allocated nodes is
         /// between the starting and requested states.
-        pub const RESIZING: State = State::new(3);
-
+        Resizing,
         /// The cluster has no backing nodes. The data (tables) still
         /// exist, but no operations can be performed on the cluster.
-        pub const DISABLED: State = State::new(4);
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NotKnown => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Resizing => std::option::Option::Some(3),
+                Self::Disabled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("RESIZING"),
-                4 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NotKnown => std::option::Option::Some("STATE_NOT_KNOWN"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Resizing => std::option::Option::Some("RESIZING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "RESIZING" => std::option::Option::Some(Self::RESIZING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NotKnown,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Resizing,
+                4 => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_NOT_KNOWN" => Self::NotKnown,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "RESIZING" => Self::Resizing,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NotKnown => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Resizing => serializer.serialize_i32(3),
+                Self::Disabled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.bigtable.admin.v2.Cluster.State",
+            ))
         }
     }
 
     /// Possible node scaling factors of the clusters. Node scaling delivers better
     /// latency and more throughput by removing node boundaries.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeScalingFactor(i32);
-
-    impl NodeScalingFactor {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NodeScalingFactor {
         /// No node scaling specified. Defaults to NODE_SCALING_FACTOR_1X.
-        pub const NODE_SCALING_FACTOR_UNSPECIFIED: NodeScalingFactor = NodeScalingFactor::new(0);
-
+        Unspecified,
         /// The cluster is running with a scaling factor of 1.
-        pub const NODE_SCALING_FACTOR_1X: NodeScalingFactor = NodeScalingFactor::new(1);
-
+        _1X,
         /// The cluster is running with a scaling factor of 2.
         /// All node count values must be in increments of 2 with this scaling factor
         /// enabled, otherwise an INVALID_ARGUMENT error will be returned.
-        pub const NODE_SCALING_FACTOR_2X: NodeScalingFactor = NodeScalingFactor::new(2);
+        _2X,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NodeScalingFactor::value] or
+        /// [NodeScalingFactor::name].
+        UnknownValue(node_scaling_factor::UnknownValue),
+    }
 
-        /// Creates a new NodeScalingFactor instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod node_scaling_factor {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NodeScalingFactor {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::_1X => std::option::Option::Some(1),
+                Self::_2X => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NODE_SCALING_FACTOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NODE_SCALING_FACTOR_1X"),
-                2 => std::borrow::Cow::Borrowed("NODE_SCALING_FACTOR_2X"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NODE_SCALING_FACTOR_UNSPECIFIED"),
+                Self::_1X => std::option::Option::Some("NODE_SCALING_FACTOR_1X"),
+                Self::_2X => std::option::Option::Some("NODE_SCALING_FACTOR_2X"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NODE_SCALING_FACTOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NODE_SCALING_FACTOR_UNSPECIFIED)
-                }
-                "NODE_SCALING_FACTOR_1X" => std::option::Option::Some(Self::NODE_SCALING_FACTOR_1X),
-                "NODE_SCALING_FACTOR_2X" => std::option::Option::Some(Self::NODE_SCALING_FACTOR_2X),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NodeScalingFactor {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeScalingFactor {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NodeScalingFactor {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NodeScalingFactor {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::_1X,
+                2 => Self::_2X,
+                _ => Self::UnknownValue(node_scaling_factor::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NodeScalingFactor {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NODE_SCALING_FACTOR_UNSPECIFIED" => Self::Unspecified,
+                "NODE_SCALING_FACTOR_1X" => Self::_1X,
+                "NODE_SCALING_FACTOR_2X" => Self::_2X,
+                _ => Self::UnknownValue(node_scaling_factor::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NodeScalingFactor {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::_1X => serializer.serialize_i32(1),
+                Self::_2X => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NodeScalingFactor {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodeScalingFactor>::new(
+                ".google.bigtable.admin.v2.Cluster.NodeScalingFactor",
+            ))
         }
     }
 
@@ -7184,58 +7498,118 @@ pub mod app_profile {
         /// Compute Billing Owner specifies how usage should be accounted when using
         /// Data Boost. Compute Billing Owner also configures which Cloud Project is
         /// charged for relevant quota.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ComputeBillingOwner(i32);
-
-        impl ComputeBillingOwner {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ComputeBillingOwner {
             /// Unspecified value.
-            pub const COMPUTE_BILLING_OWNER_UNSPECIFIED: ComputeBillingOwner =
-                ComputeBillingOwner::new(0);
-
+            Unspecified,
             /// The host Cloud Project containing the targeted Bigtable Instance /
             /// Table pays for compute.
-            pub const HOST_PAYS: ComputeBillingOwner = ComputeBillingOwner::new(1);
+            HostPays,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ComputeBillingOwner::value] or
+            /// [ComputeBillingOwner::name].
+            UnknownValue(compute_billing_owner::UnknownValue),
+        }
 
-            /// Creates a new ComputeBillingOwner instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod compute_billing_owner {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ComputeBillingOwner {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::HostPays => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("COMPUTE_BILLING_OWNER_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("HOST_PAYS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "COMPUTE_BILLING_OWNER_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::COMPUTE_BILLING_OWNER_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("COMPUTE_BILLING_OWNER_UNSPECIFIED")
                     }
-                    "HOST_PAYS" => std::option::Option::Some(Self::HOST_PAYS),
-                    _ => std::option::Option::None,
+                    Self::HostPays => std::option::Option::Some("HOST_PAYS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ComputeBillingOwner {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ComputeBillingOwner {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ComputeBillingOwner {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ComputeBillingOwner {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::HostPays,
+                    _ => Self::UnknownValue(compute_billing_owner::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ComputeBillingOwner {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "COMPUTE_BILLING_OWNER_UNSPECIFIED" => Self::Unspecified,
+                    "HOST_PAYS" => Self::HostPays,
+                    _ => Self::UnknownValue(compute_billing_owner::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ComputeBillingOwner {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::HostPays => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ComputeBillingOwner {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComputeBillingOwner>::new(
+                    ".google.bigtable.admin.v2.AppProfile.DataBoostIsolationReadOnly.ComputeBillingOwner"))
             }
         }
     }
@@ -7243,61 +7617,124 @@ pub mod app_profile {
     /// Possible priorities for an app profile. Note that higher priority writes
     /// can sometimes queue behind lower priority writes to the same tablet, as
     /// writes must be strictly sequenced in the durability log.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Priority {
+        /// Default value. Mapped to PRIORITY_HIGH (the legacy behavior) on creation.
+        Unspecified,
+        Low,
+        Medium,
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Priority::value] or
+        /// [Priority::name].
+        UnknownValue(priority::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod priority {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Priority {
-        /// Default value. Mapped to PRIORITY_HIGH (the legacy behavior) on creation.
-        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
-
-        pub const PRIORITY_LOW: Priority = Priority::new(1);
-
-        pub const PRIORITY_MEDIUM: Priority = Priority::new(2);
-
-        pub const PRIORITY_HIGH: Priority = Priority::new(3);
-
-        /// Creates a new Priority instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::Medium => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIORITY_LOW"),
-                2 => std::borrow::Cow::Borrowed("PRIORITY_MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("PRIORITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIORITY_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("PRIORITY_LOW"),
+                Self::Medium => std::option::Option::Some("PRIORITY_MEDIUM"),
+                Self::High => std::option::Option::Some("PRIORITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
-                "PRIORITY_LOW" => std::option::Option::Some(Self::PRIORITY_LOW),
-                "PRIORITY_MEDIUM" => std::option::Option::Some(Self::PRIORITY_MEDIUM),
-                "PRIORITY_HIGH" => std::option::Option::Some(Self::PRIORITY_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Priority {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Priority {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::Medium,
+                3 => Self::High,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Priority {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIORITY_UNSPECIFIED" => Self::Unspecified,
+                "PRIORITY_LOW" => Self::Low,
+                "PRIORITY_MEDIUM" => Self::Medium,
+                "PRIORITY_HIGH" => Self::High,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Priority {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::Medium => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Priority {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Priority>::new(
+                ".google.bigtable.admin.v2.AppProfile.Priority",
+            ))
         }
     }
 
@@ -8023,84 +8460,154 @@ pub mod table {
         use super::*;
 
         /// Table replication states.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ReplicationState(i32);
-
-        impl ReplicationState {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ReplicationState {
             /// The replication state of the table is unknown in this cluster.
-            pub const STATE_NOT_KNOWN: ReplicationState = ReplicationState::new(0);
-
+            StateNotKnown,
             /// The cluster was recently created, and the table must finish copying
             /// over pre-existing data from other clusters before it can begin
             /// receiving live replication updates and serving Data API requests.
-            pub const INITIALIZING: ReplicationState = ReplicationState::new(1);
-
+            Initializing,
             /// The table is temporarily unable to serve Data API requests from this
             /// cluster due to planned internal maintenance.
-            pub const PLANNED_MAINTENANCE: ReplicationState = ReplicationState::new(2);
-
+            PlannedMaintenance,
             /// The table is temporarily unable to serve Data API requests from this
             /// cluster due to unplanned or emergency maintenance.
-            pub const UNPLANNED_MAINTENANCE: ReplicationState = ReplicationState::new(3);
-
+            UnplannedMaintenance,
             /// The table can serve Data API requests from this cluster. Depending on
             /// replication delay, reads may not immediately reflect the state of the
             /// table in other clusters.
-            pub const READY: ReplicationState = ReplicationState::new(4);
-
+            Ready,
             /// The table is fully created and ready for use after a restore, and is
             /// being optimized for performance. When optimizations are complete, the
             /// table will transition to `READY` state.
-            pub const READY_OPTIMIZING: ReplicationState = ReplicationState::new(5);
+            ReadyOptimizing,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ReplicationState::value] or
+            /// [ReplicationState::name].
+            UnknownValue(replication_state::UnknownValue),
+        }
 
-            /// Creates a new ReplicationState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod replication_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ReplicationState {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::StateNotKnown => std::option::Option::Some(0),
+                    Self::Initializing => std::option::Option::Some(1),
+                    Self::PlannedMaintenance => std::option::Option::Some(2),
+                    Self::UnplannedMaintenance => std::option::Option::Some(3),
+                    Self::Ready => std::option::Option::Some(4),
+                    Self::ReadyOptimizing => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
-                    1 => std::borrow::Cow::Borrowed("INITIALIZING"),
-                    2 => std::borrow::Cow::Borrowed("PLANNED_MAINTENANCE"),
-                    3 => std::borrow::Cow::Borrowed("UNPLANNED_MAINTENANCE"),
-                    4 => std::borrow::Cow::Borrowed("READY"),
-                    5 => std::borrow::Cow::Borrowed("READY_OPTIMIZING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
-                    "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
-                    "PLANNED_MAINTENANCE" => std::option::Option::Some(Self::PLANNED_MAINTENANCE),
-                    "UNPLANNED_MAINTENANCE" => {
-                        std::option::Option::Some(Self::UNPLANNED_MAINTENANCE)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::StateNotKnown => std::option::Option::Some("STATE_NOT_KNOWN"),
+                    Self::Initializing => std::option::Option::Some("INITIALIZING"),
+                    Self::PlannedMaintenance => std::option::Option::Some("PLANNED_MAINTENANCE"),
+                    Self::UnplannedMaintenance => {
+                        std::option::Option::Some("UNPLANNED_MAINTENANCE")
                     }
-                    "READY" => std::option::Option::Some(Self::READY),
-                    "READY_OPTIMIZING" => std::option::Option::Some(Self::READY_OPTIMIZING),
-                    _ => std::option::Option::None,
+                    Self::Ready => std::option::Option::Some("READY"),
+                    Self::ReadyOptimizing => std::option::Option::Some("READY_OPTIMIZING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ReplicationState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ReplicationState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ReplicationState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ReplicationState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::StateNotKnown,
+                    1 => Self::Initializing,
+                    2 => Self::PlannedMaintenance,
+                    3 => Self::UnplannedMaintenance,
+                    4 => Self::Ready,
+                    5 => Self::ReadyOptimizing,
+                    _ => Self::UnknownValue(replication_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ReplicationState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_NOT_KNOWN" => Self::StateNotKnown,
+                    "INITIALIZING" => Self::Initializing,
+                    "PLANNED_MAINTENANCE" => Self::PlannedMaintenance,
+                    "UNPLANNED_MAINTENANCE" => Self::UnplannedMaintenance,
+                    "READY" => Self::Ready,
+                    "READY_OPTIMIZING" => Self::ReadyOptimizing,
+                    _ => Self::UnknownValue(replication_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ReplicationState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::StateNotKnown => serializer.serialize_i32(0),
+                    Self::Initializing => serializer.serialize_i32(1),
+                    Self::PlannedMaintenance => serializer.serialize_i32(2),
+                    Self::UnplannedMaintenance => serializer.serialize_i32(3),
+                    Self::Ready => serializer.serialize_i32(4),
+                    Self::ReadyOptimizing => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ReplicationState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReplicationState>::new(
+                    ".google.bigtable.admin.v2.Table.ClusterState.ReplicationState",
+                ))
             }
         }
     }
@@ -8157,131 +8664,254 @@ pub mod table {
 
     /// Possible timestamp granularities to use when keeping multiple versions
     /// of data in a table.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimestampGranularity(i32);
-
-    impl TimestampGranularity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimestampGranularity {
         /// The user did not specify a granularity. Should not be returned.
         /// When specified during table creation, MILLIS will be used.
-        pub const TIMESTAMP_GRANULARITY_UNSPECIFIED: TimestampGranularity =
-            TimestampGranularity::new(0);
-
+        Unspecified,
         /// The table keeps data versioned at a granularity of 1ms.
-        pub const MILLIS: TimestampGranularity = TimestampGranularity::new(1);
+        Millis,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimestampGranularity::value] or
+        /// [TimestampGranularity::name].
+        UnknownValue(timestamp_granularity::UnknownValue),
+    }
 
-        /// Creates a new TimestampGranularity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod timestamp_granularity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TimestampGranularity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Millis => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIMESTAMP_GRANULARITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MILLIS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIMESTAMP_GRANULARITY_UNSPECIFIED"),
+                Self::Millis => std::option::Option::Some("MILLIS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIMESTAMP_GRANULARITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TIMESTAMP_GRANULARITY_UNSPECIFIED)
-                }
-                "MILLIS" => std::option::Option::Some(Self::MILLIS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TimestampGranularity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimestampGranularity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimestampGranularity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimestampGranularity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Millis,
+                _ => Self::UnknownValue(timestamp_granularity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimestampGranularity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIMESTAMP_GRANULARITY_UNSPECIFIED" => Self::Unspecified,
+                "MILLIS" => Self::Millis,
+                _ => Self::UnknownValue(timestamp_granularity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimestampGranularity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Millis => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimestampGranularity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimestampGranularity>::new(
+                ".google.bigtable.admin.v2.Table.TimestampGranularity",
+            ))
         }
     }
 
     /// Defines a view over a table's fields.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct View(i32);
-
-    impl View {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum View {
         /// Uses the default view for each method as documented in its request.
-        pub const VIEW_UNSPECIFIED: View = View::new(0);
-
+        Unspecified,
         /// Only populates `name`.
-        pub const NAME_ONLY: View = View::new(1);
-
+        NameOnly,
         /// Only populates `name` and fields related to the table's schema.
-        pub const SCHEMA_VIEW: View = View::new(2);
-
+        SchemaView,
         /// Only populates `name` and fields related to the table's replication
         /// state.
-        pub const REPLICATION_VIEW: View = View::new(3);
-
+        ReplicationView,
         /// Only populates `name` and fields related to the table's encryption state.
-        pub const ENCRYPTION_VIEW: View = View::new(5);
-
+        EncryptionView,
         /// Populates all fields.
-        pub const FULL: View = View::new(4);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [View::value] or
+        /// [View::name].
+        UnknownValue(view::UnknownValue),
+    }
 
-        /// Creates a new View instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl View {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NameOnly => std::option::Option::Some(1),
+                Self::SchemaView => std::option::Option::Some(2),
+                Self::ReplicationView => std::option::Option::Some(3),
+                Self::EncryptionView => std::option::Option::Some(5),
+                Self::Full => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NAME_ONLY"),
-                2 => std::borrow::Cow::Borrowed("SCHEMA_VIEW"),
-                3 => std::borrow::Cow::Borrowed("REPLICATION_VIEW"),
-                4 => std::borrow::Cow::Borrowed("FULL"),
-                5 => std::borrow::Cow::Borrowed("ENCRYPTION_VIEW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VIEW_UNSPECIFIED"),
+                Self::NameOnly => std::option::Option::Some("NAME_ONLY"),
+                Self::SchemaView => std::option::Option::Some("SCHEMA_VIEW"),
+                Self::ReplicationView => std::option::Option::Some("REPLICATION_VIEW"),
+                Self::EncryptionView => std::option::Option::Some("ENCRYPTION_VIEW"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
-                "NAME_ONLY" => std::option::Option::Some(Self::NAME_ONLY),
-                "SCHEMA_VIEW" => std::option::Option::Some(Self::SCHEMA_VIEW),
-                "REPLICATION_VIEW" => std::option::Option::Some(Self::REPLICATION_VIEW),
-                "ENCRYPTION_VIEW" => std::option::Option::Some(Self::ENCRYPTION_VIEW),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for View {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for View {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for View {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for View {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NameOnly,
+                2 => Self::SchemaView,
+                3 => Self::ReplicationView,
+                4 => Self::Full,
+                5 => Self::EncryptionView,
+                _ => Self::UnknownValue(view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for View {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VIEW_UNSPECIFIED" => Self::Unspecified,
+                "NAME_ONLY" => Self::NameOnly,
+                "SCHEMA_VIEW" => Self::SchemaView,
+                "REPLICATION_VIEW" => Self::ReplicationView,
+                "ENCRYPTION_VIEW" => Self::EncryptionView,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for View {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NameOnly => serializer.serialize_i32(1),
+                Self::SchemaView => serializer.serialize_i32(2),
+                Self::ReplicationView => serializer.serialize_i32(3),
+                Self::EncryptionView => serializer.serialize_i32(5),
+                Self::Full => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for View {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<View>::new(
+                ".google.bigtable.admin.v2.Table.View",
+            ))
         }
     }
 
@@ -8528,67 +9158,128 @@ pub mod authorized_view {
     }
 
     /// Defines a subset of an AuthorizedView's fields.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseView(i32);
-
-    impl ResponseView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResponseView {
         /// Uses the default view for each method as documented in the request.
-        pub const RESPONSE_VIEW_UNSPECIFIED: ResponseView = ResponseView::new(0);
-
+        Unspecified,
         /// Only populates `name`.
-        pub const NAME_ONLY: ResponseView = ResponseView::new(1);
-
+        NameOnly,
         /// Only populates the AuthorizedView's basic metadata. This includes:
         /// name, deletion_protection, etag.
-        pub const BASIC: ResponseView = ResponseView::new(2);
-
+        Basic,
         /// Populates every fields.
-        pub const FULL: ResponseView = ResponseView::new(3);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResponseView::value] or
+        /// [ResponseView::name].
+        UnknownValue(response_view::UnknownValue),
+    }
 
-        /// Creates a new ResponseView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod response_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ResponseView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NameOnly => std::option::Option::Some(1),
+                Self::Basic => std::option::Option::Some(2),
+                Self::Full => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESPONSE_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NAME_ONLY"),
-                2 => std::borrow::Cow::Borrowed("BASIC"),
-                3 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESPONSE_VIEW_UNSPECIFIED"),
+                Self::NameOnly => std::option::Option::Some("NAME_ONLY"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESPONSE_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESPONSE_VIEW_UNSPECIFIED)
-                }
-                "NAME_ONLY" => std::option::Option::Some(Self::NAME_ONLY),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResponseView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResponseView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResponseView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NameOnly,
+                2 => Self::Basic,
+                3 => Self::Full,
+                _ => Self::UnknownValue(response_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResponseView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESPONSE_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "NAME_ONLY" => Self::NameOnly,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(response_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResponseView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NameOnly => serializer.serialize_i32(1),
+                Self::Basic => serializer.serialize_i32(2),
+                Self::Full => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResponseView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseView>::new(
+                ".google.bigtable.admin.v2.AuthorizedView.ResponseView",
+            ))
         }
     }
 
@@ -8968,18 +9659,15 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types for a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(i32);
-
-    impl EncryptionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EncryptionType {
         /// Encryption type was not specified, though data at rest remains encrypted.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
-
+        Unspecified,
         /// The data backing this resource is encrypted at rest with a key that is
         /// fully managed by Google. No key version or status will be populated.
         /// This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(1);
-
+        GoogleDefaultEncryption,
         /// The data backing this resource is encrypted at rest with a key that is
         /// managed by the customer.
         /// The in-use version of the key and its status are populated for
@@ -8987,54 +9675,116 @@ pub mod encryption_info {
         /// CMEK-protected backups are pinned to the key version that was in use at
         /// the time the backup was taken. This key version is populated but its
         /// status is not tracked and is reported as `UNKNOWN`.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(2);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EncryptionType::value] or
+        /// [EncryptionType::name].
+        UnknownValue(encryption_type::UnknownValue),
+    }
 
-        /// Creates a new EncryptionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod encryption_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EncryptionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(1),
+                Self::CustomerManagedEncryption => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENCRYPTION_TYPE_UNSPECIFIED"),
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
+                }
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENCRYPTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
-                }
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
-                }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EncryptionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EncryptionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleDefaultEncryption,
+                2 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EncryptionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EncryptionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(1),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EncryptionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionType>::new(
+                ".google.bigtable.admin.v2.EncryptionInfo.EncryptionType",
+            ))
         }
     }
 }
@@ -9159,61 +9909,122 @@ pub mod snapshot {
     use super::*;
 
     /// Possible states of a snapshot.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the snapshot could not be determined.
-        pub const STATE_NOT_KNOWN: State = State::new(0);
-
+        NotKnown,
         /// The snapshot has been successfully created and can serve all requests.
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// The snapshot is currently being created, and may be destroyed if the
         /// creation process encounters an error. A snapshot may not be restored to a
         /// table while it is being created.
-        pub const CREATING: State = State::new(2);
+        Creating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NotKnown => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_NOT_KNOWN"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NotKnown => std::option::Option::Some("STATE_NOT_KNOWN"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_NOT_KNOWN" => std::option::Option::Some(Self::STATE_NOT_KNOWN),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NotKnown,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_NOT_KNOWN" => Self::NotKnown,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NotKnown => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.bigtable.admin.v2.Snapshot.State",
+            ))
         }
     }
 }
@@ -9411,124 +10222,244 @@ pub mod backup {
     use super::*;
 
     /// Indicates the current state of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The pending backup is still being created. Operations on the
         /// backup may fail with `FAILED_PRECONDITION` in this state.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The backup is complete and ready for use.
-        pub const READY: State = State::new(2);
+        Ready,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.bigtable.admin.v2.Backup.State",
+            ))
         }
     }
 
     /// The type of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(i32);
-
-    impl BackupType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BackupType {
         /// Not specified.
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
-
+        Unspecified,
         /// The default type for Cloud Bigtable managed backups. Supported for
         /// backups created in both HDD and SSD instances. Requires optimization when
         /// restored to a table in an SSD instance.
-        pub const STANDARD: BackupType = BackupType::new(1);
-
+        Standard,
         /// A backup type with faster restore to SSD performance. Only supported for
         /// backups created in SSD instances. A new SSD table restored from a hot
         /// backup reaches production performance more quickly than a standard
         /// backup.
-        pub const HOT: BackupType = BackupType::new(2);
+        Hot,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BackupType::value] or
+        /// [BackupType::name].
+        UnknownValue(backup_type::UnknownValue),
+    }
 
-        /// Creates a new BackupType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod backup_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl BackupType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Hot => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("HOT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BACKUP_TYPE_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Hot => std::option::Option::Some("HOT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BACKUP_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED)
-                }
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "HOT" => std::option::Option::Some(Self::HOT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BackupType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BackupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Hot,
+                _ => Self::UnknownValue(backup_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BackupType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BACKUP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "HOT" => Self::Hot,
+                _ => Self::UnknownValue(backup_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BackupType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Hot => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BackupType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupType>::new(
+                ".google.bigtable.admin.v2.Backup.BackupType",
+            ))
         }
     }
 }
@@ -11745,112 +12676,230 @@ pub mod r#type {
 }
 
 /// Storage media types for persisting Bigtable data.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StorageType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum StorageType {
+    /// The user did not specify a storage type.
+    Unspecified,
+    /// Flash (SSD) storage should be used.
+    Ssd,
+    /// Magnetic drive (HDD) storage should be used.
+    Hdd,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [StorageType::value] or
+    /// [StorageType::name].
+    UnknownValue(storage_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod storage_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl StorageType {
-    /// The user did not specify a storage type.
-    pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
-
-    /// Flash (SSD) storage should be used.
-    pub const SSD: StorageType = StorageType::new(1);
-
-    /// Magnetic drive (HDD) storage should be used.
-    pub const HDD: StorageType = StorageType::new(2);
-
-    /// Creates a new StorageType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Ssd => std::option::Option::Some(1),
+            Self::Hdd => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SSD"),
-            2 => std::borrow::Cow::Borrowed("HDD"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STORAGE_TYPE_UNSPECIFIED"),
+            Self::Ssd => std::option::Option::Some("SSD"),
+            Self::Hdd => std::option::Option::Some("HDD"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STORAGE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED),
-            "SSD" => std::option::Option::Some(Self::SSD),
-            "HDD" => std::option::Option::Some(Self::HDD),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for StorageType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for StorageType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for StorageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for StorageType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Ssd,
+            2 => Self::Hdd,
+            _ => Self::UnknownValue(storage_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for StorageType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STORAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SSD" => Self::Ssd,
+            "HDD" => Self::Hdd,
+            _ => Self::UnknownValue(storage_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for StorageType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Ssd => serializer.serialize_i32(1),
+            Self::Hdd => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for StorageType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageType>::new(
+            ".google.bigtable.admin.v2.StorageType",
+        ))
     }
 }
 
 /// Indicates the type of the restore source.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RestoreSourceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RestoreSourceType {
+    /// No restore associated.
+    Unspecified,
+    /// A backup was used as the source of the restore.
+    Backup,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RestoreSourceType::value] or
+    /// [RestoreSourceType::name].
+    UnknownValue(restore_source_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod restore_source_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RestoreSourceType {
-    /// No restore associated.
-    pub const RESTORE_SOURCE_TYPE_UNSPECIFIED: RestoreSourceType = RestoreSourceType::new(0);
-
-    /// A backup was used as the source of the restore.
-    pub const BACKUP: RestoreSourceType = RestoreSourceType::new(1);
-
-    /// Creates a new RestoreSourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Backup => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESTORE_SOURCE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BACKUP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RESTORE_SOURCE_TYPE_UNSPECIFIED"),
+            Self::Backup => std::option::Option::Some("BACKUP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESTORE_SOURCE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESTORE_SOURCE_TYPE_UNSPECIFIED)
-            }
-            "BACKUP" => std::option::Option::Some(Self::BACKUP),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RestoreSourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RestoreSourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RestoreSourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RestoreSourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Backup,
+            _ => Self::UnknownValue(restore_source_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RestoreSourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESTORE_SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BACKUP" => Self::Backup,
+            _ => Self::UnknownValue(restore_source_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RestoreSourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Backup => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RestoreSourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestoreSourceType>::new(
+            ".google.bigtable.admin.v2.RestoreSourceType",
+        ))
     }
 }

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -965,7 +965,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -987,7 +987,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1108,7 +1108,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1128,7 +1128,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -154,13 +154,11 @@ pub mod access_reason {
     use super::*;
 
     /// Type of access justification.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Default value for proto, shouldn't be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Customer made a request or raised an issue that required the principal to
         /// access customer data. `detail` is of the form ("#####" is the issue ID):
         ///
@@ -170,83 +168,150 @@ pub mod access_reason {
         /// * "E-PIN Reference: #####"
         /// * "Google-#####"
         /// * "T-#####"
-        pub const CUSTOMER_INITIATED_SUPPORT: Type = Type::new(1);
-
+        CustomerInitiatedSupport,
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services. Often this access is used to confirm that
         /// customers are not affected by a suspected service issue or to remediate a
         /// reversible system issue.
-        pub const GOOGLE_INITIATED_SERVICE: Type = Type::new(2);
-
+        GoogleInitiatedService,
         /// Google initiated service for security, fraud, abuse, or compliance
         /// purposes.
-        pub const GOOGLE_INITIATED_REVIEW: Type = Type::new(3);
-
+        GoogleInitiatedReview,
         /// The principal was compelled to access customer data in order to respond
         /// to a legal third party data request or process, including legal processes
         /// from customers themselves.
-        pub const THIRD_PARTY_DATA_REQUEST: Type = Type::new(4);
-
+        ThirdPartyDataRequest,
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services or a known outage.
-        pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: Type = Type::new(5);
+        GoogleResponseToProductionAlert,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CustomerInitiatedSupport => std::option::Option::Some(1),
+                Self::GoogleInitiatedService => std::option::Option::Some(2),
+                Self::GoogleInitiatedReview => std::option::Option::Some(3),
+                Self::ThirdPartyDataRequest => std::option::Option::Some(4),
+                Self::GoogleResponseToProductionAlert => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_SUPPORT"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SERVICE"),
-                3 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_REVIEW"),
-                4 => std::borrow::Cow::Borrowed("THIRD_PARTY_DATA_REQUEST"),
-                5 => std::borrow::Cow::Borrowed("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::CustomerInitiatedSupport => {
+                    std::option::Option::Some("CUSTOMER_INITIATED_SUPPORT")
+                }
+                Self::GoogleInitiatedService => {
+                    std::option::Option::Some("GOOGLE_INITIATED_SERVICE")
+                }
+                Self::GoogleInitiatedReview => std::option::Option::Some("GOOGLE_INITIATED_REVIEW"),
+                Self::ThirdPartyDataRequest => {
+                    std::option::Option::Some("THIRD_PARTY_DATA_REQUEST")
+                }
+                Self::GoogleResponseToProductionAlert => {
+                    std::option::Option::Some("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CUSTOMER_INITIATED_SUPPORT" => {
-                    std::option::Option::Some(Self::CUSTOMER_INITIATED_SUPPORT)
-                }
-                "GOOGLE_INITIATED_SERVICE" => {
-                    std::option::Option::Some(Self::GOOGLE_INITIATED_SERVICE)
-                }
-                "GOOGLE_INITIATED_REVIEW" => {
-                    std::option::Option::Some(Self::GOOGLE_INITIATED_REVIEW)
-                }
-                "THIRD_PARTY_DATA_REQUEST" => {
-                    std::option::Option::Some(Self::THIRD_PARTY_DATA_REQUEST)
-                }
-                "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => {
-                    std::option::Option::Some(Self::GOOGLE_RESPONSE_TO_PRODUCTION_ALERT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CustomerInitiatedSupport,
+                2 => Self::GoogleInitiatedService,
+                3 => Self::GoogleInitiatedReview,
+                4 => Self::ThirdPartyDataRequest,
+                5 => Self::GoogleResponseToProductionAlert,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CUSTOMER_INITIATED_SUPPORT" => Self::CustomerInitiatedSupport,
+                "GOOGLE_INITIATED_SERVICE" => Self::GoogleInitiatedService,
+                "GOOGLE_INITIATED_REVIEW" => Self::GoogleInitiatedReview,
+                "THIRD_PARTY_DATA_REQUEST" => Self::ThirdPartyDataRequest,
+                "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => Self::GoogleResponseToProductionAlert,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CustomerInitiatedSupport => serializer.serialize_i32(1),
+                Self::GoogleInitiatedService => serializer.serialize_i32(2),
+                Self::GoogleInitiatedReview => serializer.serialize_i32(3),
+                Self::ThirdPartyDataRequest => serializer.serialize_i32(4),
+                Self::GoogleResponseToProductionAlert => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.accessapproval.v1.AccessReason.Type",
+            ))
         }
     }
 }
@@ -1479,55 +1544,112 @@ impl wkt::message::Message for GetAccessApprovalServiceAccountMessage {
 }
 
 /// Represents the type of enrollment for a given service to Access Approval.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EnrollmentLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EnrollmentLevel {
+    /// Default value for proto, shouldn't be used.
+    Unspecified,
+    /// Service is enrolled in Access Approval for all requests
+    BlockAll,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EnrollmentLevel::value] or
+    /// [EnrollmentLevel::name].
+    UnknownValue(enrollment_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod enrollment_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl EnrollmentLevel {
-    /// Default value for proto, shouldn't be used.
-    pub const ENROLLMENT_LEVEL_UNSPECIFIED: EnrollmentLevel = EnrollmentLevel::new(0);
-
-    /// Service is enrolled in Access Approval for all requests
-    pub const BLOCK_ALL: EnrollmentLevel = EnrollmentLevel::new(1);
-
-    /// Creates a new EnrollmentLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::BlockAll => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENROLLMENT_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BLOCK_ALL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENROLLMENT_LEVEL_UNSPECIFIED"),
+            Self::BlockAll => std::option::Option::Some("BLOCK_ALL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENROLLMENT_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ENROLLMENT_LEVEL_UNSPECIFIED)
-            }
-            "BLOCK_ALL" => std::option::Option::Some(Self::BLOCK_ALL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EnrollmentLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EnrollmentLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EnrollmentLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EnrollmentLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::BlockAll,
+            _ => Self::UnknownValue(enrollment_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EnrollmentLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENROLLMENT_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "BLOCK_ALL" => Self::BlockAll,
+            _ => Self::UnknownValue(enrollment_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EnrollmentLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::BlockAll => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EnrollmentLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnrollmentLevel>::new(
+            ".google.cloud.accessapproval.v1.EnrollmentLevel",
+        ))
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -884,74 +884,131 @@ impl wkt::message::Message for UpdateSettingsRequest {
 }
 
 /// Notification view.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotificationView(i32);
-
-impl NotificationView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NotificationView {
     /// Not specified, equivalent to BASIC.
-    pub const NOTIFICATION_VIEW_UNSPECIFIED: NotificationView = NotificationView::new(0);
-
+    Unspecified,
     /// Server responses only include title, creation time and Notification ID.
     /// Note: for internal use responses also include the last update time,
     /// the latest message text and whether notification has attachments.
-    pub const BASIC: NotificationView = NotificationView::new(1);
-
+    Basic,
     /// Include everything.
-    pub const FULL: NotificationView = NotificationView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NotificationView::value] or
+    /// [NotificationView::name].
+    UnknownValue(notification_view::UnknownValue),
+}
 
-    /// Creates a new NotificationView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod notification_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl NotificationView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NOTIFICATION_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NOTIFICATION_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NOTIFICATION_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NOTIFICATION_VIEW_UNSPECIFIED)
-            }
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NotificationView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NotificationView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NotificationView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NotificationView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(notification_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NotificationView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NOTIFICATION_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(notification_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NotificationView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NotificationView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NotificationView>::new(
+            ".google.cloud.advisorynotifications.v1.NotificationView",
+        ))
     }
 }
 
 /// Status of localized text.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LocalizationState(i32);
-
-impl LocalizationState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LocalizationState {
     /// Not used.
-    pub const LOCALIZATION_STATE_UNSPECIFIED: LocalizationState = LocalizationState::new(0);
-
+    Unspecified,
     /// Localization is not applicable for requested language. This can happen
     /// when:
     ///
@@ -959,141 +1016,256 @@ impl LocalizationState {
     ///   time of localization (including notifications created before the
     ///   localization feature was launched).
     /// - The requested language is English, so only the English text is returned.
-    pub const LOCALIZATION_STATE_NOT_APPLICABLE: LocalizationState = LocalizationState::new(1);
-
+    NotApplicable,
     /// Localization for requested language is in progress, and not ready yet.
-    pub const LOCALIZATION_STATE_PENDING: LocalizationState = LocalizationState::new(2);
-
+    Pending,
     /// Localization for requested language is completed.
-    pub const LOCALIZATION_STATE_COMPLETED: LocalizationState = LocalizationState::new(3);
+    Completed,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LocalizationState::value] or
+    /// [LocalizationState::name].
+    UnknownValue(localization_state::UnknownValue),
+}
 
-    /// Creates a new LocalizationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod localization_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LocalizationState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NotApplicable => std::option::Option::Some(1),
+            Self::Pending => std::option::Option::Some(2),
+            Self::Completed => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_NOT_APPLICABLE"),
-            2 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_PENDING"),
-            3 => std::borrow::Cow::Borrowed("LOCALIZATION_STATE_COMPLETED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LOCALIZATION_STATE_UNSPECIFIED"),
+            Self::NotApplicable => std::option::Option::Some("LOCALIZATION_STATE_NOT_APPLICABLE"),
+            Self::Pending => std::option::Option::Some("LOCALIZATION_STATE_PENDING"),
+            Self::Completed => std::option::Option::Some("LOCALIZATION_STATE_COMPLETED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LOCALIZATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LOCALIZATION_STATE_UNSPECIFIED)
-            }
-            "LOCALIZATION_STATE_NOT_APPLICABLE" => {
-                std::option::Option::Some(Self::LOCALIZATION_STATE_NOT_APPLICABLE)
-            }
-            "LOCALIZATION_STATE_PENDING" => {
-                std::option::Option::Some(Self::LOCALIZATION_STATE_PENDING)
-            }
-            "LOCALIZATION_STATE_COMPLETED" => {
-                std::option::Option::Some(Self::LOCALIZATION_STATE_COMPLETED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LocalizationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LocalizationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LocalizationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LocalizationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NotApplicable,
+            2 => Self::Pending,
+            3 => Self::Completed,
+            _ => Self::UnknownValue(localization_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LocalizationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LOCALIZATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "LOCALIZATION_STATE_NOT_APPLICABLE" => Self::NotApplicable,
+            "LOCALIZATION_STATE_PENDING" => Self::Pending,
+            "LOCALIZATION_STATE_COMPLETED" => Self::Completed,
+            _ => Self::UnknownValue(localization_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LocalizationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NotApplicable => serializer.serialize_i32(1),
+            Self::Pending => serializer.serialize_i32(2),
+            Self::Completed => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LocalizationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocalizationState>::new(
+            ".google.cloud.advisorynotifications.v1.LocalizationState",
+        ))
     }
 }
 
 /// Type of notification
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotificationType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NotificationType {
+    /// Default type
+    Unspecified,
+    /// Security and privacy advisory notifications
+    SecurityPrivacyAdvisory,
+    /// Sensitive action notifications
+    SensitiveActions,
+    /// General security MSA
+    SecurityMsa,
+    /// Threat horizons MSA
+    ThreatHorizons,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NotificationType::value] or
+    /// [NotificationType::name].
+    UnknownValue(notification_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod notification_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl NotificationType {
-    /// Default type
-    pub const NOTIFICATION_TYPE_UNSPECIFIED: NotificationType = NotificationType::new(0);
-
-    /// Security and privacy advisory notifications
-    pub const NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY: NotificationType =
-        NotificationType::new(1);
-
-    /// Sensitive action notifications
-    pub const NOTIFICATION_TYPE_SENSITIVE_ACTIONS: NotificationType = NotificationType::new(2);
-
-    /// General security MSA
-    pub const NOTIFICATION_TYPE_SECURITY_MSA: NotificationType = NotificationType::new(3);
-
-    /// Threat horizons MSA
-    pub const NOTIFICATION_TYPE_THREAT_HORIZONS: NotificationType = NotificationType::new(4);
-
-    /// Creates a new NotificationType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SecurityPrivacyAdvisory => std::option::Option::Some(1),
+            Self::SensitiveActions => std::option::Option::Some(2),
+            Self::SecurityMsa => std::option::Option::Some(3),
+            Self::ThreatHorizons => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY"),
-            2 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_SENSITIVE_ACTIONS"),
-            3 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_SECURITY_MSA"),
-            4 => std::borrow::Cow::Borrowed("NOTIFICATION_TYPE_THREAT_HORIZONS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NOTIFICATION_TYPE_UNSPECIFIED"),
+            Self::SecurityPrivacyAdvisory => {
+                std::option::Option::Some("NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY")
+            }
+            Self::SensitiveActions => {
+                std::option::Option::Some("NOTIFICATION_TYPE_SENSITIVE_ACTIONS")
+            }
+            Self::SecurityMsa => std::option::Option::Some("NOTIFICATION_TYPE_SECURITY_MSA"),
+            Self::ThreatHorizons => std::option::Option::Some("NOTIFICATION_TYPE_THREAT_HORIZONS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NOTIFICATION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NOTIFICATION_TYPE_UNSPECIFIED)
-            }
-            "NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY" => {
-                std::option::Option::Some(Self::NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY)
-            }
-            "NOTIFICATION_TYPE_SENSITIVE_ACTIONS" => {
-                std::option::Option::Some(Self::NOTIFICATION_TYPE_SENSITIVE_ACTIONS)
-            }
-            "NOTIFICATION_TYPE_SECURITY_MSA" => {
-                std::option::Option::Some(Self::NOTIFICATION_TYPE_SECURITY_MSA)
-            }
-            "NOTIFICATION_TYPE_THREAT_HORIZONS" => {
-                std::option::Option::Some(Self::NOTIFICATION_TYPE_THREAT_HORIZONS)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NotificationType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NotificationType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NotificationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NotificationType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::SecurityPrivacyAdvisory,
+            2 => Self::SensitiveActions,
+            3 => Self::SecurityMsa,
+            4 => Self::ThreatHorizons,
+            _ => Self::UnknownValue(notification_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NotificationType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NOTIFICATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "NOTIFICATION_TYPE_SECURITY_PRIVACY_ADVISORY" => Self::SecurityPrivacyAdvisory,
+            "NOTIFICATION_TYPE_SENSITIVE_ACTIONS" => Self::SensitiveActions,
+            "NOTIFICATION_TYPE_SECURITY_MSA" => Self::SecurityMsa,
+            "NOTIFICATION_TYPE_THREAT_HORIZONS" => Self::ThreatHorizons,
+            _ => Self::UnknownValue(notification_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NotificationType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SecurityPrivacyAdvisory => serializer.serialize_i32(1),
+            Self::SensitiveActions => serializer.serialize_i32(2),
+            Self::SecurityMsa => serializer.serialize_i32(3),
+            Self::ThreatHorizons => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NotificationType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NotificationType>::new(
+            ".google.cloud.advisorynotifications.v1.NotificationType",
+        ))
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/transport.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/transport.rs
@@ -59,7 +59,7 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("languageCode", &req.language_code)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -625,55 +625,35 @@ pub mod artifact {
         feature = "pipeline_service",
         feature = "schedule_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state for the Artifact.
+        Unspecified,
+        /// A state used by systems like Vertex AI Pipelines to indicate that the
+        /// underlying data item represented by this Artifact is being created.
+        Pending,
+        /// A state indicating that the Artifact should exist, unless something
+        /// external to the system deletes it.
+        Live,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "metadata_service",
         feature = "pipeline_service",
         feature = "schedule_service",
     ))]
-    impl State {
-        /// Unspecified state for the Artifact.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// A state used by systems like Vertex AI Pipelines to indicate that the
-        /// underlying data item represented by this Artifact is being created.
-        pub const PENDING: State = State::new(1);
-
-        /// A state indicating that the Artifact should exist, unless something
-        /// external to the system deletes it.
-        pub const LIVE: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("LIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "LIVE" => std::option::Option::Some(Self::LIVE),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -681,9 +661,31 @@ pub mod artifact {
         feature = "pipeline_service",
         feature = "schedule_service",
     ))]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Live => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Live => std::option::Option::Some("LIVE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -694,7 +696,91 @@ pub mod artifact {
     ))]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Live,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "LIVE" => Self::Live,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Live => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.Artifact.State",
+            ))
         }
     }
 }
@@ -3354,68 +3440,137 @@ pub mod generation_config {
 
             /// The model routing preference.
             #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ModelRoutingPreference(i32);
-
-            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
-            impl ModelRoutingPreference {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ModelRoutingPreference {
                 /// Unspecified model routing preference.
-                pub const UNKNOWN: ModelRoutingPreference = ModelRoutingPreference::new(0);
-
+                Unknown,
                 /// Prefer higher quality over low cost.
-                pub const PRIORITIZE_QUALITY: ModelRoutingPreference =
-                    ModelRoutingPreference::new(1);
-
+                PrioritizeQuality,
                 /// Balanced model routing preference.
-                pub const BALANCED: ModelRoutingPreference = ModelRoutingPreference::new(2);
-
+                Balanced,
                 /// Prefer lower cost over higher quality.
-                pub const PRIORITIZE_COST: ModelRoutingPreference = ModelRoutingPreference::new(3);
+                PrioritizeCost,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ModelRoutingPreference::value] or
+                /// [ModelRoutingPreference::name].
+                UnknownValue(model_routing_preference::UnknownValue),
+            }
 
-                /// Creates a new ModelRoutingPreference instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                        1 => std::borrow::Cow::Borrowed("PRIORITIZE_QUALITY"),
-                        2 => std::borrow::Cow::Borrowed("BALANCED"),
-                        3 => std::borrow::Cow::Borrowed("PRIORITIZE_COST"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                        "PRIORITIZE_QUALITY" => std::option::Option::Some(Self::PRIORITIZE_QUALITY),
-                        "BALANCED" => std::option::Option::Some(Self::BALANCED),
-                        "PRIORITIZE_COST" => std::option::Option::Some(Self::PRIORITIZE_COST),
-                        _ => std::option::Option::None,
-                    }
-                }
+            #[doc(hidden)]
+            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+            pub mod model_routing_preference {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
-            impl std::convert::From<i32> for ModelRoutingPreference {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl ModelRoutingPreference {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unknown => std::option::Option::Some(0),
+                        Self::PrioritizeQuality => std::option::Option::Some(1),
+                        Self::Balanced => std::option::Option::Some(2),
+                        Self::PrioritizeCost => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                        Self::PrioritizeQuality => std::option::Option::Some("PRIORITIZE_QUALITY"),
+                        Self::Balanced => std::option::Option::Some("BALANCED"),
+                        Self::PrioritizeCost => std::option::Option::Some("PRIORITIZE_COST"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
             #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
             impl std::default::Default for ModelRoutingPreference {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+            impl std::fmt::Display for ModelRoutingPreference {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+            impl std::convert::From<i32> for ModelRoutingPreference {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unknown,
+                        1 => Self::PrioritizeQuality,
+                        2 => Self::Balanced,
+                        3 => Self::PrioritizeCost,
+                        _ => Self::UnknownValue(model_routing_preference::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+            impl std::convert::From<&str> for ModelRoutingPreference {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "UNKNOWN" => Self::Unknown,
+                        "PRIORITIZE_QUALITY" => Self::PrioritizeQuality,
+                        "BALANCED" => Self::Balanced,
+                        "PRIORITIZE_COST" => Self::PrioritizeCost,
+                        _ => Self::UnknownValue(model_routing_preference::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+            impl serde::ser::Serialize for ModelRoutingPreference {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unknown => serializer.serialize_i32(0),
+                        Self::PrioritizeQuality => serializer.serialize_i32(1),
+                        Self::Balanced => serializer.serialize_i32(2),
+                        Self::PrioritizeCost => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+            impl<'de> serde::de::Deserialize<'de> for ModelRoutingPreference {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelRoutingPreference>::new(
+                        ".google.cloud.aiplatform.v1.GenerationConfig.RoutingConfig.AutoRoutingMode.ModelRoutingPreference"))
                 }
             }
         }
@@ -3548,142 +3703,276 @@ pub mod safety_setting {
 
     /// Probability based thresholds levels for blocking.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmBlockThreshold(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl HarmBlockThreshold {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HarmBlockThreshold {
         /// Unspecified harm block threshold.
-        pub const HARM_BLOCK_THRESHOLD_UNSPECIFIED: HarmBlockThreshold = HarmBlockThreshold::new(0);
-
+        Unspecified,
         /// Block low threshold and above (i.e. block more).
-        pub const BLOCK_LOW_AND_ABOVE: HarmBlockThreshold = HarmBlockThreshold::new(1);
-
+        BlockLowAndAbove,
         /// Block medium threshold and above.
-        pub const BLOCK_MEDIUM_AND_ABOVE: HarmBlockThreshold = HarmBlockThreshold::new(2);
-
+        BlockMediumAndAbove,
         /// Block only high threshold (i.e. block less).
-        pub const BLOCK_ONLY_HIGH: HarmBlockThreshold = HarmBlockThreshold::new(3);
-
+        BlockOnlyHigh,
         /// Block none.
-        pub const BLOCK_NONE: HarmBlockThreshold = HarmBlockThreshold::new(4);
-
+        BlockNone,
         /// Turn off the safety filter.
-        pub const OFF: HarmBlockThreshold = HarmBlockThreshold::new(5);
+        Off,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HarmBlockThreshold::value] or
+        /// [HarmBlockThreshold::name].
+        UnknownValue(harm_block_threshold::UnknownValue),
+    }
 
-        /// Creates a new HarmBlockThreshold instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HARM_BLOCK_THRESHOLD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BLOCK_LOW_AND_ABOVE"),
-                2 => std::borrow::Cow::Borrowed("BLOCK_MEDIUM_AND_ABOVE"),
-                3 => std::borrow::Cow::Borrowed("BLOCK_ONLY_HIGH"),
-                4 => std::borrow::Cow::Borrowed("BLOCK_NONE"),
-                5 => std::borrow::Cow::Borrowed("OFF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HARM_BLOCK_THRESHOLD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HARM_BLOCK_THRESHOLD_UNSPECIFIED)
-                }
-                "BLOCK_LOW_AND_ABOVE" => std::option::Option::Some(Self::BLOCK_LOW_AND_ABOVE),
-                "BLOCK_MEDIUM_AND_ABOVE" => std::option::Option::Some(Self::BLOCK_MEDIUM_AND_ABOVE),
-                "BLOCK_ONLY_HIGH" => std::option::Option::Some(Self::BLOCK_ONLY_HIGH),
-                "BLOCK_NONE" => std::option::Option::Some(Self::BLOCK_NONE),
-                "OFF" => std::option::Option::Some(Self::OFF),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod harm_block_threshold {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for HarmBlockThreshold {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl HarmBlockThreshold {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BlockLowAndAbove => std::option::Option::Some(1),
+                Self::BlockMediumAndAbove => std::option::Option::Some(2),
+                Self::BlockOnlyHigh => std::option::Option::Some(3),
+                Self::BlockNone => std::option::Option::Some(4),
+                Self::Off => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HARM_BLOCK_THRESHOLD_UNSPECIFIED"),
+                Self::BlockLowAndAbove => std::option::Option::Some("BLOCK_LOW_AND_ABOVE"),
+                Self::BlockMediumAndAbove => std::option::Option::Some("BLOCK_MEDIUM_AND_ABOVE"),
+                Self::BlockOnlyHigh => std::option::Option::Some("BLOCK_ONLY_HIGH"),
+                Self::BlockNone => std::option::Option::Some("BLOCK_NONE"),
+                Self::Off => std::option::Option::Some("OFF"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for HarmBlockThreshold {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for HarmBlockThreshold {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for HarmBlockThreshold {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BlockLowAndAbove,
+                2 => Self::BlockMediumAndAbove,
+                3 => Self::BlockOnlyHigh,
+                4 => Self::BlockNone,
+                5 => Self::Off,
+                _ => Self::UnknownValue(harm_block_threshold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for HarmBlockThreshold {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HARM_BLOCK_THRESHOLD_UNSPECIFIED" => Self::Unspecified,
+                "BLOCK_LOW_AND_ABOVE" => Self::BlockLowAndAbove,
+                "BLOCK_MEDIUM_AND_ABOVE" => Self::BlockMediumAndAbove,
+                "BLOCK_ONLY_HIGH" => Self::BlockOnlyHigh,
+                "BLOCK_NONE" => Self::BlockNone,
+                "OFF" => Self::Off,
+                _ => Self::UnknownValue(harm_block_threshold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for HarmBlockThreshold {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BlockLowAndAbove => serializer.serialize_i32(1),
+                Self::BlockMediumAndAbove => serializer.serialize_i32(2),
+                Self::BlockOnlyHigh => serializer.serialize_i32(3),
+                Self::BlockNone => serializer.serialize_i32(4),
+                Self::Off => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for HarmBlockThreshold {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmBlockThreshold>::new(
+                ".google.cloud.aiplatform.v1.SafetySetting.HarmBlockThreshold",
+            ))
         }
     }
 
     /// Probability vs severity.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmBlockMethod(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl HarmBlockMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HarmBlockMethod {
         /// The harm block method is unspecified.
-        pub const HARM_BLOCK_METHOD_UNSPECIFIED: HarmBlockMethod = HarmBlockMethod::new(0);
-
+        Unspecified,
         /// The harm block method uses both probability and severity scores.
-        pub const SEVERITY: HarmBlockMethod = HarmBlockMethod::new(1);
-
+        Severity,
         /// The harm block method uses the probability score.
-        pub const PROBABILITY: HarmBlockMethod = HarmBlockMethod::new(2);
+        Probability,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HarmBlockMethod::value] or
+        /// [HarmBlockMethod::name].
+        UnknownValue(harm_block_method::UnknownValue),
+    }
 
-        /// Creates a new HarmBlockMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HARM_BLOCK_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SEVERITY"),
-                2 => std::borrow::Cow::Borrowed("PROBABILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HARM_BLOCK_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HARM_BLOCK_METHOD_UNSPECIFIED)
-                }
-                "SEVERITY" => std::option::Option::Some(Self::SEVERITY),
-                "PROBABILITY" => std::option::Option::Some(Self::PROBABILITY),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod harm_block_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for HarmBlockMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl HarmBlockMethod {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Severity => std::option::Option::Some(1),
+                Self::Probability => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HARM_BLOCK_METHOD_UNSPECIFIED"),
+                Self::Severity => std::option::Option::Some("SEVERITY"),
+                Self::Probability => std::option::Option::Some("PROBABILITY"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for HarmBlockMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for HarmBlockMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for HarmBlockMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Severity,
+                2 => Self::Probability,
+                _ => Self::UnknownValue(harm_block_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for HarmBlockMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HARM_BLOCK_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "SEVERITY" => Self::Severity,
+                "PROBABILITY" => Self::Probability,
+                _ => Self::UnknownValue(harm_block_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for HarmBlockMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Severity => serializer.serialize_i32(1),
+                Self::Probability => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for HarmBlockMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmBlockMethod>::new(
+                ".google.cloud.aiplatform.v1.SafetySetting.HarmBlockMethod",
+            ))
         }
     }
 }
@@ -3785,149 +4074,283 @@ pub mod safety_rating {
 
     /// Harm probability levels in the content.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmProbability(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl HarmProbability {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HarmProbability {
         /// Harm probability unspecified.
-        pub const HARM_PROBABILITY_UNSPECIFIED: HarmProbability = HarmProbability::new(0);
-
+        Unspecified,
         /// Negligible level of harm.
-        pub const NEGLIGIBLE: HarmProbability = HarmProbability::new(1);
-
+        Negligible,
         /// Low level of harm.
-        pub const LOW: HarmProbability = HarmProbability::new(2);
-
+        Low,
         /// Medium level of harm.
-        pub const MEDIUM: HarmProbability = HarmProbability::new(3);
-
+        Medium,
         /// High level of harm.
-        pub const HIGH: HarmProbability = HarmProbability::new(4);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HarmProbability::value] or
+        /// [HarmProbability::name].
+        UnknownValue(harm_probability::UnknownValue),
+    }
 
-        /// Creates a new HarmProbability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HARM_PROBABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEGLIGIBLE"),
-                2 => std::borrow::Cow::Borrowed("LOW"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HARM_PROBABILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HARM_PROBABILITY_UNSPECIFIED)
-                }
-                "NEGLIGIBLE" => std::option::Option::Some(Self::NEGLIGIBLE),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod harm_probability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for HarmProbability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl HarmProbability {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Negligible => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HARM_PROBABILITY_UNSPECIFIED"),
+                Self::Negligible => std::option::Option::Some("NEGLIGIBLE"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for HarmProbability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for HarmProbability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for HarmProbability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Negligible,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                _ => Self::UnknownValue(harm_probability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for HarmProbability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HARM_PROBABILITY_UNSPECIFIED" => Self::Unspecified,
+                "NEGLIGIBLE" => Self::Negligible,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                _ => Self::UnknownValue(harm_probability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for HarmProbability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Negligible => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for HarmProbability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmProbability>::new(
+                ".google.cloud.aiplatform.v1.SafetyRating.HarmProbability",
+            ))
         }
     }
 
     /// Harm severity levels.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmSeverity(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl HarmSeverity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HarmSeverity {
         /// Harm severity unspecified.
-        pub const HARM_SEVERITY_UNSPECIFIED: HarmSeverity = HarmSeverity::new(0);
-
+        Unspecified,
         /// Negligible level of harm severity.
-        pub const HARM_SEVERITY_NEGLIGIBLE: HarmSeverity = HarmSeverity::new(1);
-
+        Negligible,
         /// Low level of harm severity.
-        pub const HARM_SEVERITY_LOW: HarmSeverity = HarmSeverity::new(2);
-
+        Low,
         /// Medium level of harm severity.
-        pub const HARM_SEVERITY_MEDIUM: HarmSeverity = HarmSeverity::new(3);
-
+        Medium,
         /// High level of harm severity.
-        pub const HARM_SEVERITY_HIGH: HarmSeverity = HarmSeverity::new(4);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HarmSeverity::value] or
+        /// [HarmSeverity::name].
+        UnknownValue(harm_severity::UnknownValue),
+    }
 
-        /// Creates a new HarmSeverity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HARM_SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HARM_SEVERITY_NEGLIGIBLE"),
-                2 => std::borrow::Cow::Borrowed("HARM_SEVERITY_LOW"),
-                3 => std::borrow::Cow::Borrowed("HARM_SEVERITY_MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HARM_SEVERITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HARM_SEVERITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HARM_SEVERITY_UNSPECIFIED)
-                }
-                "HARM_SEVERITY_NEGLIGIBLE" => {
-                    std::option::Option::Some(Self::HARM_SEVERITY_NEGLIGIBLE)
-                }
-                "HARM_SEVERITY_LOW" => std::option::Option::Some(Self::HARM_SEVERITY_LOW),
-                "HARM_SEVERITY_MEDIUM" => std::option::Option::Some(Self::HARM_SEVERITY_MEDIUM),
-                "HARM_SEVERITY_HIGH" => std::option::Option::Some(Self::HARM_SEVERITY_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod harm_severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for HarmSeverity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl HarmSeverity {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Negligible => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HARM_SEVERITY_UNSPECIFIED"),
+                Self::Negligible => std::option::Option::Some("HARM_SEVERITY_NEGLIGIBLE"),
+                Self::Low => std::option::Option::Some("HARM_SEVERITY_LOW"),
+                Self::Medium => std::option::Option::Some("HARM_SEVERITY_MEDIUM"),
+                Self::High => std::option::Option::Some("HARM_SEVERITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for HarmSeverity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for HarmSeverity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for HarmSeverity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Negligible,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                _ => Self::UnknownValue(harm_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for HarmSeverity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HARM_SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "HARM_SEVERITY_NEGLIGIBLE" => Self::Negligible,
+                "HARM_SEVERITY_LOW" => Self::Low,
+                "HARM_SEVERITY_MEDIUM" => Self::Medium,
+                "HARM_SEVERITY_HIGH" => Self::High,
+                _ => Self::UnknownValue(harm_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for HarmSeverity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Negligible => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for HarmSeverity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmSeverity>::new(
+                ".google.cloud.aiplatform.v1.SafetyRating.HarmSeverity",
+            ))
         }
     }
 }
@@ -4226,109 +4649,185 @@ pub mod candidate {
     /// The reason why the model stopped generating tokens.
     /// If empty, the model has not stopped generating the tokens.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FinishReason(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl FinishReason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FinishReason {
         /// The finish reason is unspecified.
-        pub const FINISH_REASON_UNSPECIFIED: FinishReason = FinishReason::new(0);
-
+        Unspecified,
         /// Token generation reached a natural stopping point or a configured stop
         /// sequence.
-        pub const STOP: FinishReason = FinishReason::new(1);
-
+        Stop,
         /// Token generation reached the configured maximum output tokens.
-        pub const MAX_TOKENS: FinishReason = FinishReason::new(2);
-
+        MaxTokens,
         /// Token generation stopped because the content potentially contains safety
         /// violations. NOTE: When streaming,
         /// [content][google.cloud.aiplatform.v1.Candidate.content] is empty if
         /// content filters blocks the output.
         ///
         /// [google.cloud.aiplatform.v1.Candidate.content]: crate::model::Candidate::content
-        pub const SAFETY: FinishReason = FinishReason::new(3);
-
+        Safety,
         /// Token generation stopped because the content potentially contains
         /// copyright violations.
-        pub const RECITATION: FinishReason = FinishReason::new(4);
-
+        Recitation,
         /// All other reasons that stopped the token generation.
-        pub const OTHER: FinishReason = FinishReason::new(5);
-
+        Other,
         /// Token generation stopped because the content contains forbidden terms.
-        pub const BLOCKLIST: FinishReason = FinishReason::new(6);
-
+        Blocklist,
         /// Token generation stopped for potentially containing prohibited content.
-        pub const PROHIBITED_CONTENT: FinishReason = FinishReason::new(7);
-
+        ProhibitedContent,
         /// Token generation stopped because the content potentially contains
         /// Sensitive Personally Identifiable Information (SPII).
-        pub const SPII: FinishReason = FinishReason::new(8);
-
+        Spii,
         /// The function call generated by the model is invalid.
-        pub const MALFORMED_FUNCTION_CALL: FinishReason = FinishReason::new(9);
+        MalformedFunctionCall,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FinishReason::value] or
+        /// [FinishReason::name].
+        UnknownValue(finish_reason::UnknownValue),
+    }
 
-        /// Creates a new FinishReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FINISH_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STOP"),
-                2 => std::borrow::Cow::Borrowed("MAX_TOKENS"),
-                3 => std::borrow::Cow::Borrowed("SAFETY"),
-                4 => std::borrow::Cow::Borrowed("RECITATION"),
-                5 => std::borrow::Cow::Borrowed("OTHER"),
-                6 => std::borrow::Cow::Borrowed("BLOCKLIST"),
-                7 => std::borrow::Cow::Borrowed("PROHIBITED_CONTENT"),
-                8 => std::borrow::Cow::Borrowed("SPII"),
-                9 => std::borrow::Cow::Borrowed("MALFORMED_FUNCTION_CALL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FINISH_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FINISH_REASON_UNSPECIFIED)
-                }
-                "STOP" => std::option::Option::Some(Self::STOP),
-                "MAX_TOKENS" => std::option::Option::Some(Self::MAX_TOKENS),
-                "SAFETY" => std::option::Option::Some(Self::SAFETY),
-                "RECITATION" => std::option::Option::Some(Self::RECITATION),
-                "OTHER" => std::option::Option::Some(Self::OTHER),
-                "BLOCKLIST" => std::option::Option::Some(Self::BLOCKLIST),
-                "PROHIBITED_CONTENT" => std::option::Option::Some(Self::PROHIBITED_CONTENT),
-                "SPII" => std::option::Option::Some(Self::SPII),
-                "MALFORMED_FUNCTION_CALL" => {
-                    std::option::Option::Some(Self::MALFORMED_FUNCTION_CALL)
-                }
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod finish_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for FinishReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl FinishReason {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Stop => std::option::Option::Some(1),
+                Self::MaxTokens => std::option::Option::Some(2),
+                Self::Safety => std::option::Option::Some(3),
+                Self::Recitation => std::option::Option::Some(4),
+                Self::Other => std::option::Option::Some(5),
+                Self::Blocklist => std::option::Option::Some(6),
+                Self::ProhibitedContent => std::option::Option::Some(7),
+                Self::Spii => std::option::Option::Some(8),
+                Self::MalformedFunctionCall => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FINISH_REASON_UNSPECIFIED"),
+                Self::Stop => std::option::Option::Some("STOP"),
+                Self::MaxTokens => std::option::Option::Some("MAX_TOKENS"),
+                Self::Safety => std::option::Option::Some("SAFETY"),
+                Self::Recitation => std::option::Option::Some("RECITATION"),
+                Self::Other => std::option::Option::Some("OTHER"),
+                Self::Blocklist => std::option::Option::Some("BLOCKLIST"),
+                Self::ProhibitedContent => std::option::Option::Some("PROHIBITED_CONTENT"),
+                Self::Spii => std::option::Option::Some("SPII"),
+                Self::MalformedFunctionCall => std::option::Option::Some("MALFORMED_FUNCTION_CALL"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for FinishReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for FinishReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for FinishReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Stop,
+                2 => Self::MaxTokens,
+                3 => Self::Safety,
+                4 => Self::Recitation,
+                5 => Self::Other,
+                6 => Self::Blocklist,
+                7 => Self::ProhibitedContent,
+                8 => Self::Spii,
+                9 => Self::MalformedFunctionCall,
+                _ => Self::UnknownValue(finish_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for FinishReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FINISH_REASON_UNSPECIFIED" => Self::Unspecified,
+                "STOP" => Self::Stop,
+                "MAX_TOKENS" => Self::MaxTokens,
+                "SAFETY" => Self::Safety,
+                "RECITATION" => Self::Recitation,
+                "OTHER" => Self::Other,
+                "BLOCKLIST" => Self::Blocklist,
+                "PROHIBITED_CONTENT" => Self::ProhibitedContent,
+                "SPII" => Self::Spii,
+                "MALFORMED_FUNCTION_CALL" => Self::MalformedFunctionCall,
+                _ => Self::UnknownValue(finish_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for FinishReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Stop => serializer.serialize_i32(1),
+                Self::MaxTokens => serializer.serialize_i32(2),
+                Self::Safety => serializer.serialize_i32(3),
+                Self::Recitation => serializer.serialize_i32(4),
+                Self::Other => serializer.serialize_i32(5),
+                Self::Blocklist => serializer.serialize_i32(6),
+                Self::ProhibitedContent => serializer.serialize_i32(7),
+                Self::Spii => serializer.serialize_i32(8),
+                Self::MalformedFunctionCall => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for FinishReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FinishReason>::new(
+                ".google.cloud.aiplatform.v1.Candidate.FinishReason",
+            ))
         }
     }
 }
@@ -6359,77 +6858,149 @@ pub mod scheduling {
     /// leverage spot resources alongwith regular resources to schedule
     /// the job.
     #[cfg(feature = "job_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Strategy(i32);
-
-    #[cfg(feature = "job_service")]
-    impl Strategy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Strategy {
         /// Strategy will default to STANDARD.
-        pub const STRATEGY_UNSPECIFIED: Strategy = Strategy::new(0);
-
+        Unspecified,
         /// Deprecated. Regular on-demand provisioning strategy.
-        pub const ON_DEMAND: Strategy = Strategy::new(1);
-
+        OnDemand,
         /// Deprecated. Low cost by making potential use of spot resources.
-        pub const LOW_COST: Strategy = Strategy::new(2);
-
+        LowCost,
         /// Standard provisioning strategy uses regular on-demand resources.
-        pub const STANDARD: Strategy = Strategy::new(3);
-
+        Standard,
         /// Spot provisioning strategy uses spot resources.
-        pub const SPOT: Strategy = Strategy::new(4);
-
+        Spot,
         /// Flex Start strategy uses DWS to queue for resources.
-        pub const FLEX_START: Strategy = Strategy::new(6);
+        FlexStart,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Strategy::value] or
+        /// [Strategy::name].
+        UnknownValue(strategy::UnknownValue),
+    }
 
-        /// Creates a new Strategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                2 => std::borrow::Cow::Borrowed("LOW_COST"),
-                3 => std::borrow::Cow::Borrowed("STANDARD"),
-                4 => std::borrow::Cow::Borrowed("SPOT"),
-                6 => std::borrow::Cow::Borrowed("FLEX_START"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STRATEGY_UNSPECIFIED" => std::option::Option::Some(Self::STRATEGY_UNSPECIFIED),
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                "LOW_COST" => std::option::Option::Some(Self::LOW_COST),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "SPOT" => std::option::Option::Some(Self::SPOT),
-                "FLEX_START" => std::option::Option::Some(Self::FLEX_START),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "job_service")]
+    pub mod strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "job_service")]
-    impl std::convert::From<i32> for Strategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Strategy {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OnDemand => std::option::Option::Some(1),
+                Self::LowCost => std::option::Option::Some(2),
+                Self::Standard => std::option::Option::Some(3),
+                Self::Spot => std::option::Option::Some(4),
+                Self::FlexStart => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STRATEGY_UNSPECIFIED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::LowCost => std::option::Option::Some("LOW_COST"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Spot => std::option::Option::Some("SPOT"),
+                Self::FlexStart => std::option::Option::Some("FLEX_START"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "job_service")]
     impl std::default::Default for Strategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::fmt::Display for Strategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<i32> for Strategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OnDemand,
+                2 => Self::LowCost,
+                3 => Self::Standard,
+                4 => Self::Spot,
+                6 => Self::FlexStart,
+                _ => Self::UnknownValue(strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<&str> for Strategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "ON_DEMAND" => Self::OnDemand,
+                "LOW_COST" => Self::LowCost,
+                "STANDARD" => Self::Standard,
+                "SPOT" => Self::Spot,
+                "FLEX_START" => Self::FlexStart,
+                _ => Self::UnknownValue(strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl serde::ser::Serialize for Strategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OnDemand => serializer.serialize_i32(1),
+                Self::LowCost => serializer.serialize_i32(2),
+                Self::Standard => serializer.serialize_i32(3),
+                Self::Spot => serializer.serialize_i32(4),
+                Self::FlexStart => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl<'de> serde::de::Deserialize<'de> for Strategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Strategy>::new(
+                ".google.cloud.aiplatform.v1.Scheduling.Strategy",
+            ))
         }
     }
 }
@@ -7168,59 +7739,121 @@ pub mod sample_config {
     /// Sample strategy decides which subset of DataItems should be selected for
     /// human labeling in every batch.
     #[cfg(feature = "job_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SampleStrategy(i32);
-
-    #[cfg(feature = "job_service")]
-    impl SampleStrategy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SampleStrategy {
         /// Default will be treated as UNCERTAINTY.
-        pub const SAMPLE_STRATEGY_UNSPECIFIED: SampleStrategy = SampleStrategy::new(0);
-
+        Unspecified,
         /// Sample the most uncertain data to label.
-        pub const UNCERTAINTY: SampleStrategy = SampleStrategy::new(1);
+        Uncertainty,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SampleStrategy::value] or
+        /// [SampleStrategy::name].
+        UnknownValue(sample_strategy::UnknownValue),
+    }
 
-        /// Creates a new SampleStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SAMPLE_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNCERTAINTY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SAMPLE_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SAMPLE_STRATEGY_UNSPECIFIED)
-                }
-                "UNCERTAINTY" => std::option::Option::Some(Self::UNCERTAINTY),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "job_service")]
+    pub mod sample_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "job_service")]
-    impl std::convert::From<i32> for SampleStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl SampleStrategy {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Uncertainty => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SAMPLE_STRATEGY_UNSPECIFIED"),
+                Self::Uncertainty => std::option::Option::Some("UNCERTAINTY"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "job_service")]
     impl std::default::Default for SampleStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::fmt::Display for SampleStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<i32> for SampleStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Uncertainty,
+                _ => Self::UnknownValue(sample_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<&str> for SampleStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SAMPLE_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "UNCERTAINTY" => Self::Uncertainty,
+                _ => Self::UnknownValue(sample_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl serde::ser::Serialize for SampleStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Uncertainty => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl<'de> serde::de::Deserialize<'de> for SampleStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SampleStrategy>::new(
+                ".google.cloud.aiplatform.v1.SampleConfig.SampleStrategy",
+            ))
         }
     }
 
@@ -7976,57 +8609,121 @@ pub mod export_data_config {
     /// unannotated data to be exported and whether to clone files to temp Cloud
     /// Storage bucket.
     #[cfg(feature = "dataset_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExportUse(i32);
-
-    #[cfg(feature = "dataset_service")]
-    impl ExportUse {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExportUse {
         /// Regular user export.
-        pub const EXPORT_USE_UNSPECIFIED: ExportUse = ExportUse::new(0);
-
+        Unspecified,
         /// Export for custom code training.
-        pub const CUSTOM_CODE_TRAINING: ExportUse = ExportUse::new(6);
+        CustomCodeTraining,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExportUse::value] or
+        /// [ExportUse::name].
+        UnknownValue(export_use::UnknownValue),
+    }
 
-        /// Creates a new ExportUse instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXPORT_USE_UNSPECIFIED"),
-                6 => std::borrow::Cow::Borrowed("CUSTOM_CODE_TRAINING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXPORT_USE_UNSPECIFIED" => std::option::Option::Some(Self::EXPORT_USE_UNSPECIFIED),
-                "CUSTOM_CODE_TRAINING" => std::option::Option::Some(Self::CUSTOM_CODE_TRAINING),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "dataset_service")]
+    pub mod export_use {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "dataset_service")]
-    impl std::convert::From<i32> for ExportUse {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl ExportUse {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CustomCodeTraining => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXPORT_USE_UNSPECIFIED"),
+                Self::CustomCodeTraining => std::option::Option::Some("CUSTOM_CODE_TRAINING"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "dataset_service")]
     impl std::default::Default for ExportUse {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "dataset_service")]
+    impl std::fmt::Display for ExportUse {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "dataset_service")]
+    impl std::convert::From<i32> for ExportUse {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                6 => Self::CustomCodeTraining,
+                _ => Self::UnknownValue(export_use::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "dataset_service")]
+    impl std::convert::From<&str> for ExportUse {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXPORT_USE_UNSPECIFIED" => Self::Unspecified,
+                "CUSTOM_CODE_TRAINING" => Self::CustomCodeTraining,
+                _ => Self::UnknownValue(export_use::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "dataset_service")]
+    impl serde::ser::Serialize for ExportUse {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CustomCodeTraining => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "dataset_service")]
+    impl<'de> serde::de::Deserialize<'de> for ExportUse {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExportUse>::new(
+                ".google.cloud.aiplatform.v1.ExportDataConfig.ExportUse",
+            ))
         }
     }
 
@@ -14519,73 +15216,142 @@ pub mod evaluated_annotation {
 
     /// Describes the type of the EvaluatedAnnotation. The type is determined
     #[cfg(feature = "model_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluatedAnnotationType(i32);
-
-    #[cfg(feature = "model_service")]
-    impl EvaluatedAnnotationType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EvaluatedAnnotationType {
         /// Invalid value.
-        pub const EVALUATED_ANNOTATION_TYPE_UNSPECIFIED: EvaluatedAnnotationType =
-            EvaluatedAnnotationType::new(0);
-
+        Unspecified,
         /// The EvaluatedAnnotation is a true positive. It has a prediction created
         /// by the Model and a ground truth Annotation which the prediction matches.
-        pub const TRUE_POSITIVE: EvaluatedAnnotationType = EvaluatedAnnotationType::new(1);
-
+        TruePositive,
         /// The EvaluatedAnnotation is false positive. It has a prediction created by
         /// the Model which does not match any ground truth annotation.
-        pub const FALSE_POSITIVE: EvaluatedAnnotationType = EvaluatedAnnotationType::new(2);
-
+        FalsePositive,
         /// The EvaluatedAnnotation is false negative. It has a ground truth
         /// annotation which is not matched by any of the model created predictions.
-        pub const FALSE_NEGATIVE: EvaluatedAnnotationType = EvaluatedAnnotationType::new(3);
+        FalseNegative,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EvaluatedAnnotationType::value] or
+        /// [EvaluatedAnnotationType::name].
+        UnknownValue(evaluated_annotation_type::UnknownValue),
+    }
 
-        /// Creates a new EvaluatedAnnotationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVALUATED_ANNOTATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRUE_POSITIVE"),
-                2 => std::borrow::Cow::Borrowed("FALSE_POSITIVE"),
-                3 => std::borrow::Cow::Borrowed("FALSE_NEGATIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVALUATED_ANNOTATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVALUATED_ANNOTATION_TYPE_UNSPECIFIED)
-                }
-                "TRUE_POSITIVE" => std::option::Option::Some(Self::TRUE_POSITIVE),
-                "FALSE_POSITIVE" => std::option::Option::Some(Self::FALSE_POSITIVE),
-                "FALSE_NEGATIVE" => std::option::Option::Some(Self::FALSE_NEGATIVE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "model_service")]
+    pub mod evaluated_annotation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "model_service")]
-    impl std::convert::From<i32> for EvaluatedAnnotationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl EvaluatedAnnotationType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TruePositive => std::option::Option::Some(1),
+                Self::FalsePositive => std::option::Option::Some(2),
+                Self::FalseNegative => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("EVALUATED_ANNOTATION_TYPE_UNSPECIFIED")
+                }
+                Self::TruePositive => std::option::Option::Some("TRUE_POSITIVE"),
+                Self::FalsePositive => std::option::Option::Some("FALSE_POSITIVE"),
+                Self::FalseNegative => std::option::Option::Some("FALSE_NEGATIVE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "model_service")]
     impl std::default::Default for EvaluatedAnnotationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl std::fmt::Display for EvaluatedAnnotationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl std::convert::From<i32> for EvaluatedAnnotationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TruePositive,
+                2 => Self::FalsePositive,
+                3 => Self::FalseNegative,
+                _ => Self::UnknownValue(evaluated_annotation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl std::convert::From<&str> for EvaluatedAnnotationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVALUATED_ANNOTATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TRUE_POSITIVE" => Self::TruePositive,
+                "FALSE_POSITIVE" => Self::FalsePositive,
+                "FALSE_NEGATIVE" => Self::FalseNegative,
+                _ => Self::UnknownValue(evaluated_annotation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl serde::ser::Serialize for EvaluatedAnnotationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TruePositive => serializer.serialize_i32(1),
+                Self::FalsePositive => serializer.serialize_i32(2),
+                Self::FalseNegative => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl<'de> serde::de::Deserialize<'de> for EvaluatedAnnotationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<EvaluatedAnnotationType>::new(
+                    ".google.cloud.aiplatform.v1.EvaluatedAnnotation.EvaluatedAnnotationType",
+                ),
+            )
         }
     }
 }
@@ -14782,67 +15548,135 @@ pub mod error_analysis_annotation {
 
     /// The query type used for finding the attributed items.
     #[cfg(feature = "model_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QueryType(i32);
-
-    #[cfg(feature = "model_service")]
-    impl QueryType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum QueryType {
         /// Unspecified query type for model error analysis.
-        pub const QUERY_TYPE_UNSPECIFIED: QueryType = QueryType::new(0);
-
+        Unspecified,
         /// Query similar samples across all classes in the dataset.
-        pub const ALL_SIMILAR: QueryType = QueryType::new(1);
-
+        AllSimilar,
         /// Query similar samples from the same class of the input sample.
-        pub const SAME_CLASS_SIMILAR: QueryType = QueryType::new(2);
-
+        SameClassSimilar,
         /// Query dissimilar samples from the same class of the input sample.
-        pub const SAME_CLASS_DISSIMILAR: QueryType = QueryType::new(3);
+        SameClassDissimilar,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [QueryType::value] or
+        /// [QueryType::name].
+        UnknownValue(query_type::UnknownValue),
+    }
 
-        /// Creates a new QueryType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("QUERY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_SIMILAR"),
-                2 => std::borrow::Cow::Borrowed("SAME_CLASS_SIMILAR"),
-                3 => std::borrow::Cow::Borrowed("SAME_CLASS_DISSIMILAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "QUERY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::QUERY_TYPE_UNSPECIFIED),
-                "ALL_SIMILAR" => std::option::Option::Some(Self::ALL_SIMILAR),
-                "SAME_CLASS_SIMILAR" => std::option::Option::Some(Self::SAME_CLASS_SIMILAR),
-                "SAME_CLASS_DISSIMILAR" => std::option::Option::Some(Self::SAME_CLASS_DISSIMILAR),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "model_service")]
+    pub mod query_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "model_service")]
-    impl std::convert::From<i32> for QueryType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl QueryType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllSimilar => std::option::Option::Some(1),
+                Self::SameClassSimilar => std::option::Option::Some(2),
+                Self::SameClassDissimilar => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("QUERY_TYPE_UNSPECIFIED"),
+                Self::AllSimilar => std::option::Option::Some("ALL_SIMILAR"),
+                Self::SameClassSimilar => std::option::Option::Some("SAME_CLASS_SIMILAR"),
+                Self::SameClassDissimilar => std::option::Option::Some("SAME_CLASS_DISSIMILAR"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "model_service")]
     impl std::default::Default for QueryType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl std::fmt::Display for QueryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl std::convert::From<i32> for QueryType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllSimilar,
+                2 => Self::SameClassSimilar,
+                3 => Self::SameClassDissimilar,
+                _ => Self::UnknownValue(query_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl std::convert::From<&str> for QueryType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "QUERY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALL_SIMILAR" => Self::AllSimilar,
+                "SAME_CLASS_SIMILAR" => Self::SameClassSimilar,
+                "SAME_CLASS_DISSIMILAR" => Self::SameClassDissimilar,
+                _ => Self::UnknownValue(query_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl serde::ser::Serialize for QueryType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllSimilar => serializer.serialize_i32(1),
+                Self::SameClassSimilar => serializer.serialize_i32(2),
+                Self::SameClassDissimilar => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_service")]
+    impl<'de> serde::de::Deserialize<'de> for QueryType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<QueryType>::new(
+                ".google.cloud.aiplatform.v1.ErrorAnalysisAnnotation.QueryType",
+            ))
         }
     }
 }
@@ -21862,60 +22696,122 @@ pub mod comet_spec {
 
     /// Comet version options.
     #[cfg(feature = "evaluation_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CometVersion(i32);
-
-    #[cfg(feature = "evaluation_service")]
-    impl CometVersion {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CometVersion {
         /// Comet version unspecified.
-        pub const COMET_VERSION_UNSPECIFIED: CometVersion = CometVersion::new(0);
-
+        Unspecified,
         /// Comet 22 for translation + source + reference
         /// (source-reference-combined).
-        pub const COMET_22_SRC_REF: CometVersion = CometVersion::new(2);
+        Comet22SrcRef,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CometVersion::value] or
+        /// [CometVersion::name].
+        UnknownValue(comet_version::UnknownValue),
+    }
 
-        /// Creates a new CometVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMET_VERSION_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("COMET_22_SRC_REF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMET_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMET_VERSION_UNSPECIFIED)
-                }
-                "COMET_22_SRC_REF" => std::option::Option::Some(Self::COMET_22_SRC_REF),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "evaluation_service")]
+    pub mod comet_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "evaluation_service")]
-    impl std::convert::From<i32> for CometVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl CometVersion {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Comet22SrcRef => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMET_VERSION_UNSPECIFIED"),
+                Self::Comet22SrcRef => std::option::Option::Some("COMET_22_SRC_REF"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "evaluation_service")]
     impl std::default::Default for CometVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl std::fmt::Display for CometVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl std::convert::From<i32> for CometVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Comet22SrcRef,
+                _ => Self::UnknownValue(comet_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl std::convert::From<&str> for CometVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMET_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "COMET_22_SRC_REF" => Self::Comet22SrcRef,
+                _ => Self::UnknownValue(comet_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl serde::ser::Serialize for CometVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Comet22SrcRef => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl<'de> serde::de::Deserialize<'de> for CometVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CometVersion>::new(
+                ".google.cloud.aiplatform.v1.CometSpec.CometVersion",
+            ))
         }
     }
 }
@@ -22145,70 +23041,136 @@ pub mod metricx_spec {
 
     /// MetricX Version options.
     #[cfg(feature = "evaluation_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricxVersion(i32);
-
-    #[cfg(feature = "evaluation_service")]
-    impl MetricxVersion {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MetricxVersion {
         /// MetricX version unspecified.
-        pub const METRICX_VERSION_UNSPECIFIED: MetricxVersion = MetricxVersion::new(0);
-
+        Unspecified,
         /// MetricX 2024 (2.6) for translation + reference (reference-based).
-        pub const METRICX_24_REF: MetricxVersion = MetricxVersion::new(1);
-
+        Metricx24Ref,
         /// MetricX 2024 (2.6) for translation + source (QE).
-        pub const METRICX_24_SRC: MetricxVersion = MetricxVersion::new(2);
-
+        Metricx24Src,
         /// MetricX 2024 (2.6) for translation + source + reference
         /// (source-reference-combined).
-        pub const METRICX_24_SRC_REF: MetricxVersion = MetricxVersion::new(3);
+        Metricx24SrcRef,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MetricxVersion::value] or
+        /// [MetricxVersion::name].
+        UnknownValue(metricx_version::UnknownValue),
+    }
 
-        /// Creates a new MetricxVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METRICX_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("METRICX_24_REF"),
-                2 => std::borrow::Cow::Borrowed("METRICX_24_SRC"),
-                3 => std::borrow::Cow::Borrowed("METRICX_24_SRC_REF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METRICX_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METRICX_VERSION_UNSPECIFIED)
-                }
-                "METRICX_24_REF" => std::option::Option::Some(Self::METRICX_24_REF),
-                "METRICX_24_SRC" => std::option::Option::Some(Self::METRICX_24_SRC),
-                "METRICX_24_SRC_REF" => std::option::Option::Some(Self::METRICX_24_SRC_REF),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "evaluation_service")]
+    pub mod metricx_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "evaluation_service")]
-    impl std::convert::From<i32> for MetricxVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl MetricxVersion {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Metricx24Ref => std::option::Option::Some(1),
+                Self::Metricx24Src => std::option::Option::Some(2),
+                Self::Metricx24SrcRef => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METRICX_VERSION_UNSPECIFIED"),
+                Self::Metricx24Ref => std::option::Option::Some("METRICX_24_REF"),
+                Self::Metricx24Src => std::option::Option::Some("METRICX_24_SRC"),
+                Self::Metricx24SrcRef => std::option::Option::Some("METRICX_24_SRC_REF"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "evaluation_service")]
     impl std::default::Default for MetricxVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl std::fmt::Display for MetricxVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl std::convert::From<i32> for MetricxVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Metricx24Ref,
+                2 => Self::Metricx24Src,
+                3 => Self::Metricx24SrcRef,
+                _ => Self::UnknownValue(metricx_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl std::convert::From<&str> for MetricxVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METRICX_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "METRICX_24_REF" => Self::Metricx24Ref,
+                "METRICX_24_SRC" => Self::Metricx24Src,
+                "METRICX_24_SRC_REF" => Self::Metricx24SrcRef,
+                _ => Self::UnknownValue(metricx_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl serde::ser::Serialize for MetricxVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Metricx24Ref => serializer.serialize_i32(1),
+                Self::Metricx24Src => serializer.serialize_i32(2),
+                Self::Metricx24SrcRef => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "evaluation_service")]
+    impl<'de> serde::de::Deserialize<'de> for MetricxVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetricxVersion>::new(
+                ".google.cloud.aiplatform.v1.MetricxSpec.MetricxVersion",
+            ))
         }
     }
 }
@@ -22417,62 +23379,128 @@ pub mod event {
 
     /// Describes whether an Event's Artifact is the Execution's input or output.
     #[cfg(feature = "metadata_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    #[cfg(feature = "metadata_service")]
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Unspecified whether input or output of the Execution.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// An input of the Execution.
-        pub const INPUT: Type = Type::new(1);
-
+        Input,
         /// An output of the Execution.
-        pub const OUTPUT: Type = Type::new(2);
+        Output,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INPUT"),
-                2 => std::borrow::Cow::Borrowed("OUTPUT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "INPUT" => std::option::Option::Some(Self::INPUT),
-                "OUTPUT" => std::option::Option::Some(Self::OUTPUT),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "metadata_service")]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "metadata_service")]
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Type {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Input => std::option::Option::Some(1),
+                Self::Output => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Input => std::option::Option::Some("INPUT"),
+                Self::Output => std::option::Option::Some("OUTPUT"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "metadata_service")]
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Input,
+                2 => Self::Output,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INPUT" => Self::Input,
+                "OUTPUT" => Self::Output,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Input => serializer.serialize_i32(1),
+                Self::Output => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.aiplatform.v1.Event.Type",
+            ))
         }
     }
 }
@@ -22678,73 +23706,41 @@ pub mod execution {
         feature = "pipeline_service",
         feature = "schedule_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified Execution state
+        Unspecified,
+        /// The Execution is new
+        New,
+        /// The Execution is running
+        Running,
+        /// The Execution has finished running
+        Complete,
+        /// The Execution has failed
+        Failed,
+        /// The Execution completed through Cache hit.
+        Cached,
+        /// The Execution was cancelled.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "metadata_service",
         feature = "pipeline_service",
         feature = "schedule_service",
     ))]
-    impl State {
-        /// Unspecified Execution state
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Execution is new
-        pub const NEW: State = State::new(1);
-
-        /// The Execution is running
-        pub const RUNNING: State = State::new(2);
-
-        /// The Execution has finished running
-        pub const COMPLETE: State = State::new(3);
-
-        /// The Execution has failed
-        pub const FAILED: State = State::new(4);
-
-        /// The Execution completed through Cache hit.
-        pub const CACHED: State = State::new(5);
-
-        /// The Execution was cancelled.
-        pub const CANCELLED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEW"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("COMPLETE"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("CACHED"),
-                6 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NEW" => std::option::Option::Some(Self::NEW),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CACHED" => std::option::Option::Some(Self::CACHED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -22752,9 +23748,39 @@ pub mod execution {
         feature = "pipeline_service",
         feature = "schedule_service",
     ))]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::New => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Complete => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Cached => std::option::Option::Some(5),
+                Self::Cancelled => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::New => std::option::Option::Some("NEW"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Complete => std::option::Option::Some("COMPLETE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cached => std::option::Option::Some("CACHED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -22765,7 +23791,103 @@ pub mod execution {
     ))]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::New,
+                2 => Self::Running,
+                3 => Self::Complete,
+                4 => Self::Failed,
+                5 => Self::Cached,
+                6 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NEW" => Self::New,
+                "RUNNING" => Self::Running,
+                "COMPLETE" => Self::Complete,
+                "FAILED" => Self::Failed,
+                "CACHED" => Self::Cached,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::New => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Complete => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Cached => serializer.serialize_i32(5),
+                Self::Cancelled => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "metadata_service",
+        feature = "pipeline_service",
+        feature = "schedule_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.Execution.State",
+            ))
         }
     }
 }
@@ -24561,9 +25683,21 @@ pub mod examples {
             feature = "pipeline_service",
             feature = "prediction_service",
         ))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DataFormat(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DataFormat {
+            /// Format unspecified, used when unset.
+            Unspecified,
+            /// Examples are stored in JSONL files.
+            Jsonl,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DataFormat::value] or
+            /// [DataFormat::name].
+            UnknownValue(data_format::UnknownValue),
+        }
 
+        #[doc(hidden)]
         #[cfg(any(
             feature = "dataset_service",
             feature = "deployment_resource_pool_service",
@@ -24573,42 +25707,11 @@ pub mod examples {
             feature = "pipeline_service",
             feature = "prediction_service",
         ))]
-        impl DataFormat {
-            /// Format unspecified, used when unset.
-            pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
-            /// Examples are stored in JSONL files.
-            pub const JSONL: DataFormat = DataFormat::new(1);
-
-            /// Creates a new DataFormat instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("JSONL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DATA_FORMAT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
-                    }
-                    "JSONL" => std::option::Option::Some(Self::JSONL),
-                    _ => std::option::Option::None,
-                }
-            }
+        pub mod data_format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(
@@ -24620,9 +25723,29 @@ pub mod examples {
             feature = "pipeline_service",
             feature = "prediction_service",
         ))]
-        impl std::convert::From<i32> for DataFormat {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl DataFormat {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Jsonl => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+                    Self::Jsonl => std::option::Option::Some("JSONL"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
@@ -24637,7 +25760,111 @@ pub mod examples {
         ))]
         impl std::default::Default for DataFormat {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+            feature = "prediction_service",
+        ))]
+        impl std::fmt::Display for DataFormat {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+            feature = "prediction_service",
+        ))]
+        impl std::convert::From<i32> for DataFormat {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Jsonl,
+                    _ => Self::UnknownValue(data_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+            feature = "prediction_service",
+        ))]
+        impl std::convert::From<&str> for DataFormat {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "JSONL" => Self::Jsonl,
+                    _ => Self::UnknownValue(data_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+            feature = "prediction_service",
+        ))]
+        impl serde::ser::Serialize for DataFormat {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Jsonl => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+            feature = "prediction_service",
+        ))]
+        impl<'de> serde::de::Deserialize<'de> for DataFormat {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+                    ".google.cloud.aiplatform.v1.Examples.ExampleGcsSource.DataFormat",
+                ))
             }
         }
     }
@@ -24787,9 +26014,21 @@ pub mod presets {
         feature = "pipeline_service",
         feature = "prediction_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Query(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Query {
+        /// More precise neighbors as a trade-off against slower response.
+        Precise,
+        /// Faster response as a trade-off against less precise neighbors.
+        Fast,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Query::value] or
+        /// [Query::name].
+        UnknownValue(query::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "dataset_service",
         feature = "deployment_resource_pool_service",
@@ -24799,40 +26038,11 @@ pub mod presets {
         feature = "pipeline_service",
         feature = "prediction_service",
     ))]
-    impl Query {
-        /// More precise neighbors as a trade-off against slower response.
-        pub const PRECISE: Query = Query::new(0);
-
-        /// Faster response as a trade-off against less precise neighbors.
-        pub const FAST: Query = Query::new(1);
-
-        /// Creates a new Query instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRECISE"),
-                1 => std::borrow::Cow::Borrowed("FAST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRECISE" => std::option::Option::Some(Self::PRECISE),
-                "FAST" => std::option::Option::Some(Self::FAST),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod query {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -24844,9 +26054,29 @@ pub mod presets {
         feature = "pipeline_service",
         feature = "prediction_service",
     ))]
-    impl std::convert::From<i32> for Query {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Query {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Precise => std::option::Option::Some(0),
+                Self::Fast => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Precise => std::option::Option::Some("PRECISE"),
+                Self::Fast => std::option::Option::Some("FAST"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -24861,7 +26091,108 @@ pub mod presets {
     ))]
     impl std::default::Default for Query {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl std::fmt::Display for Query {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl std::convert::From<i32> for Query {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Precise,
+                1 => Self::Fast,
+                _ => Self::UnknownValue(query::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl std::convert::From<&str> for Query {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRECISE" => Self::Precise,
+                "FAST" => Self::Fast,
+                _ => Self::UnknownValue(query::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl serde::ser::Serialize for Query {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Precise => serializer.serialize_i32(0),
+                Self::Fast => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for Query {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Query>::new(
+                ".google.cloud.aiplatform.v1.Presets.Query",
+            ))
         }
     }
 
@@ -24875,9 +26206,25 @@ pub mod presets {
         feature = "pipeline_service",
         feature = "prediction_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Modality(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Modality {
+        /// Should not be set. Added as a recommended best practice for enums
+        Unspecified,
+        /// IMAGE modality
+        Image,
+        /// TEXT modality
+        Text,
+        /// TABULAR modality
+        Tabular,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Modality::value] or
+        /// [Modality::name].
+        UnknownValue(modality::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "dataset_service",
         feature = "deployment_resource_pool_service",
@@ -24887,50 +26234,11 @@ pub mod presets {
         feature = "pipeline_service",
         feature = "prediction_service",
     ))]
-    impl Modality {
-        /// Should not be set. Added as a recommended best practice for enums
-        pub const MODALITY_UNSPECIFIED: Modality = Modality::new(0);
-
-        /// IMAGE modality
-        pub const IMAGE: Modality = Modality::new(1);
-
-        /// TEXT modality
-        pub const TEXT: Modality = Modality::new(2);
-
-        /// TABULAR modality
-        pub const TABULAR: Modality = Modality::new(3);
-
-        /// Creates a new Modality instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODALITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMAGE"),
-                2 => std::borrow::Cow::Borrowed("TEXT"),
-                3 => std::borrow::Cow::Borrowed("TABULAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODALITY_UNSPECIFIED" => std::option::Option::Some(Self::MODALITY_UNSPECIFIED),
-                "IMAGE" => std::option::Option::Some(Self::IMAGE),
-                "TEXT" => std::option::Option::Some(Self::TEXT),
-                "TABULAR" => std::option::Option::Some(Self::TABULAR),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod modality {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -24942,9 +26250,33 @@ pub mod presets {
         feature = "pipeline_service",
         feature = "prediction_service",
     ))]
-    impl std::convert::From<i32> for Modality {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Modality {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Image => std::option::Option::Some(1),
+                Self::Text => std::option::Option::Some(2),
+                Self::Tabular => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODALITY_UNSPECIFIED"),
+                Self::Image => std::option::Option::Some("IMAGE"),
+                Self::Text => std::option::Option::Some("TEXT"),
+                Self::Tabular => std::option::Option::Some("TABULAR"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -24959,7 +26291,114 @@ pub mod presets {
     ))]
     impl std::default::Default for Modality {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl std::fmt::Display for Modality {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl std::convert::From<i32> for Modality {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Image,
+                2 => Self::Text,
+                3 => Self::Tabular,
+                _ => Self::UnknownValue(modality::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl std::convert::From<&str> for Modality {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODALITY_UNSPECIFIED" => Self::Unspecified,
+                "IMAGE" => Self::Image,
+                "TEXT" => Self::Text,
+                "TABULAR" => Self::Tabular,
+                _ => Self::UnknownValue(modality::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl serde::ser::Serialize for Modality {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Image => serializer.serialize_i32(1),
+                Self::Text => serializer.serialize_i32(2),
+                Self::Tabular => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "job_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+        feature = "prediction_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for Modality {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Modality>::new(
+                ".google.cloud.aiplatform.v1.Presets.Modality",
+            ))
         }
     }
 }
@@ -25245,64 +26684,128 @@ pub mod examples_override {
 
     /// Data format enum.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl DataFormat {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataFormat {
         /// Unspecified format. Must not be used.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
+        Unspecified,
         /// Provided data is a set of model inputs.
-        pub const INSTANCES: DataFormat = DataFormat::new(1);
-
+        Instances,
         /// Provided data is a set of embeddings.
-        pub const EMBEDDINGS: DataFormat = DataFormat::new(2);
+        Embeddings,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataFormat::value] or
+        /// [DataFormat::name].
+        UnknownValue(data_format::UnknownValue),
+    }
 
-        /// Creates a new DataFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INSTANCES"),
-                2 => std::borrow::Cow::Borrowed("EMBEDDINGS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
-                }
-                "INSTANCES" => std::option::Option::Some(Self::INSTANCES),
-                "EMBEDDINGS" => std::option::Option::Some(Self::EMBEDDINGS),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod data_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for DataFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl DataFormat {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Instances => std::option::Option::Some(1),
+                Self::Embeddings => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+                Self::Instances => std::option::Option::Some("INSTANCES"),
+                Self::Embeddings => std::option::Option::Some("EMBEDDINGS"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for DataFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Instances,
+                2 => Self::Embeddings,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for DataFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "INSTANCES" => Self::Instances,
+                "EMBEDDINGS" => Self::Embeddings,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for DataFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Instances => serializer.serialize_i32(1),
+                Self::Embeddings => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for DataFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+                ".google.cloud.aiplatform.v1.ExamplesOverride.DataFormat",
+            ))
         }
     }
 }
@@ -26107,9 +27610,24 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Type {
+                /// Should not be used.
+                Unspecified,
+                /// Shows which pixel contributed to the image prediction.
+                Pixels,
+                /// Shows which region contributed to the image prediction by outlining
+                /// the region.
+                Outlines,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Type::value] or
+                /// [Type::name].
+                UnknownValue(r#type::UnknownValue),
+            }
 
+            #[doc(hidden)]
             #[cfg(any(
                 feature = "dataset_service",
                 feature = "deployment_resource_pool_service",
@@ -26118,46 +27636,11 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl Type {
-                /// Should not be used.
-                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-                /// Shows which pixel contributed to the image prediction.
-                pub const PIXELS: Type = Type::new(1);
-
-                /// Shows which region contributed to the image prediction by outlining
-                /// the region.
-                pub const OUTLINES: Type = Type::new(2);
-
-                /// Creates a new Type instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("PIXELS"),
-                        2 => std::borrow::Cow::Borrowed("OUTLINES"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                        "PIXELS" => std::option::Option::Some(Self::PIXELS),
-                        "OUTLINES" => std::option::Option::Some(Self::OUTLINES),
-                        _ => std::option::Option::None,
-                    }
-                }
+            pub mod r#type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(any(
@@ -26168,9 +27651,31 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl std::convert::From<i32> for Type {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl Type {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Pixels => std::option::Option::Some(1),
+                        Self::Outlines => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                        Self::Pixels => std::option::Option::Some("PIXELS"),
+                        Self::Outlines => std::option::Option::Some("OUTLINES"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
@@ -26184,7 +27689,108 @@ pub mod explanation_metadata {
             ))]
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::fmt::Display for Type {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Pixels,
+                        2 => Self::Outlines,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<&str> for Type {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "PIXELS" => Self::Pixels,
+                        "OUTLINES" => Self::Outlines,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl serde::ser::Serialize for Type {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Pixels => serializer.serialize_i32(1),
+                        Self::Outlines => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl<'de> serde::de::Deserialize<'de> for Type {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                        ".google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.Visualization.Type"))
                 }
             }
 
@@ -26198,9 +27804,27 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Polarity(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Polarity {
+                /// Default value. This is the same as POSITIVE.
+                Unspecified,
+                /// Highlights the pixels/outlines that were most influential to the
+                /// model's prediction.
+                Positive,
+                /// Setting polarity to negative highlights areas that does not lead to
+                /// the models's current prediction.
+                Negative,
+                /// Shows both positive and negative attributions.
+                Both,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Polarity::value] or
+                /// [Polarity::name].
+                UnknownValue(polarity::UnknownValue),
+            }
 
+            #[doc(hidden)]
             #[cfg(any(
                 feature = "dataset_service",
                 feature = "deployment_resource_pool_service",
@@ -26209,54 +27833,11 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl Polarity {
-                /// Default value. This is the same as POSITIVE.
-                pub const POLARITY_UNSPECIFIED: Polarity = Polarity::new(0);
-
-                /// Highlights the pixels/outlines that were most influential to the
-                /// model's prediction.
-                pub const POSITIVE: Polarity = Polarity::new(1);
-
-                /// Setting polarity to negative highlights areas that does not lead to
-                /// the models's current prediction.
-                pub const NEGATIVE: Polarity = Polarity::new(2);
-
-                /// Shows both positive and negative attributions.
-                pub const BOTH: Polarity = Polarity::new(3);
-
-                /// Creates a new Polarity instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("POLARITY_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("POSITIVE"),
-                        2 => std::borrow::Cow::Borrowed("NEGATIVE"),
-                        3 => std::borrow::Cow::Borrowed("BOTH"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "POLARITY_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::POLARITY_UNSPECIFIED)
-                        }
-                        "POSITIVE" => std::option::Option::Some(Self::POSITIVE),
-                        "NEGATIVE" => std::option::Option::Some(Self::NEGATIVE),
-                        "BOTH" => std::option::Option::Some(Self::BOTH),
-                        _ => std::option::Option::None,
-                    }
-                }
+            pub mod polarity {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(any(
@@ -26267,9 +27848,33 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl std::convert::From<i32> for Polarity {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl Polarity {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Positive => std::option::Option::Some(1),
+                        Self::Negative => std::option::Option::Some(2),
+                        Self::Both => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("POLARITY_UNSPECIFIED"),
+                        Self::Positive => std::option::Option::Some("POSITIVE"),
+                        Self::Negative => std::option::Option::Some("NEGATIVE"),
+                        Self::Both => std::option::Option::Some("BOTH"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
@@ -26283,7 +27888,111 @@ pub mod explanation_metadata {
             ))]
             impl std::default::Default for Polarity {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::fmt::Display for Polarity {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<i32> for Polarity {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Positive,
+                        2 => Self::Negative,
+                        3 => Self::Both,
+                        _ => Self::UnknownValue(polarity::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<&str> for Polarity {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "POLARITY_UNSPECIFIED" => Self::Unspecified,
+                        "POSITIVE" => Self::Positive,
+                        "NEGATIVE" => Self::Negative,
+                        "BOTH" => Self::Both,
+                        _ => Self::UnknownValue(polarity::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl serde::ser::Serialize for Polarity {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Positive => serializer.serialize_i32(1),
+                        Self::Negative => serializer.serialize_i32(2),
+                        Self::Both => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl<'de> serde::de::Deserialize<'de> for Polarity {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Polarity>::new(
+                        ".google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.Visualization.Polarity"))
                 }
             }
 
@@ -26296,9 +28005,33 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ColorMap(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ColorMap {
+                /// Should not be used.
+                Unspecified,
+                /// Positive: green. Negative: pink.
+                PinkGreen,
+                /// Viridis color map: A perceptually uniform color mapping which is
+                /// easier to see by those with colorblindness and progresses from yellow
+                /// to green to blue. Positive: yellow. Negative: blue.
+                Viridis,
+                /// Positive: red. Negative: red.
+                Red,
+                /// Positive: green. Negative: green.
+                Green,
+                /// Positive: green. Negative: red.
+                RedGreen,
+                /// PiYG palette.
+                PinkWhiteGreen,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ColorMap::value] or
+                /// [ColorMap::name].
+                UnknownValue(color_map::UnknownValue),
+            }
 
+            #[doc(hidden)]
             #[cfg(any(
                 feature = "dataset_service",
                 feature = "deployment_resource_pool_service",
@@ -26307,69 +28040,11 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl ColorMap {
-                /// Should not be used.
-                pub const COLOR_MAP_UNSPECIFIED: ColorMap = ColorMap::new(0);
-
-                /// Positive: green. Negative: pink.
-                pub const PINK_GREEN: ColorMap = ColorMap::new(1);
-
-                /// Viridis color map: A perceptually uniform color mapping which is
-                /// easier to see by those with colorblindness and progresses from yellow
-                /// to green to blue. Positive: yellow. Negative: blue.
-                pub const VIRIDIS: ColorMap = ColorMap::new(2);
-
-                /// Positive: red. Negative: red.
-                pub const RED: ColorMap = ColorMap::new(3);
-
-                /// Positive: green. Negative: green.
-                pub const GREEN: ColorMap = ColorMap::new(4);
-
-                /// Positive: green. Negative: red.
-                pub const RED_GREEN: ColorMap = ColorMap::new(6);
-
-                /// PiYG palette.
-                pub const PINK_WHITE_GREEN: ColorMap = ColorMap::new(5);
-
-                /// Creates a new ColorMap instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("COLOR_MAP_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("PINK_GREEN"),
-                        2 => std::borrow::Cow::Borrowed("VIRIDIS"),
-                        3 => std::borrow::Cow::Borrowed("RED"),
-                        4 => std::borrow::Cow::Borrowed("GREEN"),
-                        5 => std::borrow::Cow::Borrowed("PINK_WHITE_GREEN"),
-                        6 => std::borrow::Cow::Borrowed("RED_GREEN"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "COLOR_MAP_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::COLOR_MAP_UNSPECIFIED)
-                        }
-                        "PINK_GREEN" => std::option::Option::Some(Self::PINK_GREEN),
-                        "VIRIDIS" => std::option::Option::Some(Self::VIRIDIS),
-                        "RED" => std::option::Option::Some(Self::RED),
-                        "GREEN" => std::option::Option::Some(Self::GREEN),
-                        "RED_GREEN" => std::option::Option::Some(Self::RED_GREEN),
-                        "PINK_WHITE_GREEN" => std::option::Option::Some(Self::PINK_WHITE_GREEN),
-                        _ => std::option::Option::None,
-                    }
-                }
+            pub mod color_map {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(any(
@@ -26380,9 +28055,39 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl std::convert::From<i32> for ColorMap {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl ColorMap {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::PinkGreen => std::option::Option::Some(1),
+                        Self::Viridis => std::option::Option::Some(2),
+                        Self::Red => std::option::Option::Some(3),
+                        Self::Green => std::option::Option::Some(4),
+                        Self::RedGreen => std::option::Option::Some(6),
+                        Self::PinkWhiteGreen => std::option::Option::Some(5),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("COLOR_MAP_UNSPECIFIED"),
+                        Self::PinkGreen => std::option::Option::Some("PINK_GREEN"),
+                        Self::Viridis => std::option::Option::Some("VIRIDIS"),
+                        Self::Red => std::option::Option::Some("RED"),
+                        Self::Green => std::option::Option::Some("GREEN"),
+                        Self::RedGreen => std::option::Option::Some("RED_GREEN"),
+                        Self::PinkWhiteGreen => std::option::Option::Some("PINK_WHITE_GREEN"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
@@ -26396,7 +28101,120 @@ pub mod explanation_metadata {
             ))]
             impl std::default::Default for ColorMap {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::fmt::Display for ColorMap {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<i32> for ColorMap {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::PinkGreen,
+                        2 => Self::Viridis,
+                        3 => Self::Red,
+                        4 => Self::Green,
+                        5 => Self::PinkWhiteGreen,
+                        6 => Self::RedGreen,
+                        _ => Self::UnknownValue(color_map::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<&str> for ColorMap {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "COLOR_MAP_UNSPECIFIED" => Self::Unspecified,
+                        "PINK_GREEN" => Self::PinkGreen,
+                        "VIRIDIS" => Self::Viridis,
+                        "RED" => Self::Red,
+                        "GREEN" => Self::Green,
+                        "RED_GREEN" => Self::RedGreen,
+                        "PINK_WHITE_GREEN" => Self::PinkWhiteGreen,
+                        _ => Self::UnknownValue(color_map::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl serde::ser::Serialize for ColorMap {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::PinkGreen => serializer.serialize_i32(1),
+                        Self::Viridis => serializer.serialize_i32(2),
+                        Self::Red => serializer.serialize_i32(3),
+                        Self::Green => serializer.serialize_i32(4),
+                        Self::RedGreen => serializer.serialize_i32(6),
+                        Self::PinkWhiteGreen => serializer.serialize_i32(5),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl<'de> serde::de::Deserialize<'de> for ColorMap {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ColorMap>::new(
+                        ".google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.Visualization.ColorMap"))
                 }
             }
 
@@ -26409,9 +28227,29 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct OverlayType(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum OverlayType {
+                /// Default value. This is the same as NONE.
+                Unspecified,
+                /// No overlay.
+                None,
+                /// The attributions are shown on top of the original image.
+                Original,
+                /// The attributions are shown on top of grayscaled version of the
+                /// original image.
+                Grayscale,
+                /// The attributions are used as a mask to reveal predictive parts of
+                /// the image and hide the un-predictive parts.
+                MaskBlack,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [OverlayType::value] or
+                /// [OverlayType::name].
+                UnknownValue(overlay_type::UnknownValue),
+            }
 
+            #[doc(hidden)]
             #[cfg(any(
                 feature = "dataset_service",
                 feature = "deployment_resource_pool_service",
@@ -26420,59 +28258,11 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl OverlayType {
-                /// Default value. This is the same as NONE.
-                pub const OVERLAY_TYPE_UNSPECIFIED: OverlayType = OverlayType::new(0);
-
-                /// No overlay.
-                pub const NONE: OverlayType = OverlayType::new(1);
-
-                /// The attributions are shown on top of the original image.
-                pub const ORIGINAL: OverlayType = OverlayType::new(2);
-
-                /// The attributions are shown on top of grayscaled version of the
-                /// original image.
-                pub const GRAYSCALE: OverlayType = OverlayType::new(3);
-
-                /// The attributions are used as a mask to reveal predictive parts of
-                /// the image and hide the un-predictive parts.
-                pub const MASK_BLACK: OverlayType = OverlayType::new(4);
-
-                /// Creates a new OverlayType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("OVERLAY_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("NONE"),
-                        2 => std::borrow::Cow::Borrowed("ORIGINAL"),
-                        3 => std::borrow::Cow::Borrowed("GRAYSCALE"),
-                        4 => std::borrow::Cow::Borrowed("MASK_BLACK"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "OVERLAY_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::OVERLAY_TYPE_UNSPECIFIED)
-                        }
-                        "NONE" => std::option::Option::Some(Self::NONE),
-                        "ORIGINAL" => std::option::Option::Some(Self::ORIGINAL),
-                        "GRAYSCALE" => std::option::Option::Some(Self::GRAYSCALE),
-                        "MASK_BLACK" => std::option::Option::Some(Self::MASK_BLACK),
-                        _ => std::option::Option::None,
-                    }
-                }
+            pub mod overlay_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(any(
@@ -26483,9 +28273,35 @@ pub mod explanation_metadata {
                 feature = "model_service",
                 feature = "pipeline_service",
             ))]
-            impl std::convert::From<i32> for OverlayType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl OverlayType {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::None => std::option::Option::Some(1),
+                        Self::Original => std::option::Option::Some(2),
+                        Self::Grayscale => std::option::Option::Some(3),
+                        Self::MaskBlack => std::option::Option::Some(4),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("OVERLAY_TYPE_UNSPECIFIED"),
+                        Self::None => std::option::Option::Some("NONE"),
+                        Self::Original => std::option::Option::Some("ORIGINAL"),
+                        Self::Grayscale => std::option::Option::Some("GRAYSCALE"),
+                        Self::MaskBlack => std::option::Option::Some("MASK_BLACK"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
@@ -26499,7 +28315,114 @@ pub mod explanation_metadata {
             ))]
             impl std::default::Default for OverlayType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::fmt::Display for OverlayType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<i32> for OverlayType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::None,
+                        2 => Self::Original,
+                        3 => Self::Grayscale,
+                        4 => Self::MaskBlack,
+                        _ => Self::UnknownValue(overlay_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl std::convert::From<&str> for OverlayType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "OVERLAY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "NONE" => Self::None,
+                        "ORIGINAL" => Self::Original,
+                        "GRAYSCALE" => Self::Grayscale,
+                        "MASK_BLACK" => Self::MaskBlack,
+                        _ => Self::UnknownValue(overlay_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl serde::ser::Serialize for OverlayType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::None => serializer.serialize_i32(1),
+                        Self::Original => serializer.serialize_i32(2),
+                        Self::Grayscale => serializer.serialize_i32(3),
+                        Self::MaskBlack => serializer.serialize_i32(4),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(any(
+                feature = "dataset_service",
+                feature = "deployment_resource_pool_service",
+                feature = "endpoint_service",
+                feature = "job_service",
+                feature = "model_service",
+                feature = "pipeline_service",
+            ))]
+            impl<'de> serde::de::Deserialize<'de> for OverlayType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<OverlayType>::new(
+                        ".google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.Visualization.OverlayType"))
                 }
             }
         }
@@ -26513,24 +28436,13 @@ pub mod explanation_metadata {
             feature = "model_service",
             feature = "pipeline_service",
         ))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Encoding(i32);
-
-        #[cfg(any(
-            feature = "dataset_service",
-            feature = "deployment_resource_pool_service",
-            feature = "endpoint_service",
-            feature = "job_service",
-            feature = "model_service",
-            feature = "pipeline_service",
-        ))]
-        impl Encoding {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Encoding {
             /// Default value. This is the same as IDENTITY.
-            pub const ENCODING_UNSPECIFIED: Encoding = Encoding::new(0);
-
+            Unspecified,
             /// The tensor represents one feature.
-            pub const IDENTITY: Encoding = Encoding::new(1);
-
+            Identity,
             /// The tensor represents a bag of features where each index maps to
             /// a feature.
             /// [InputMetadata.index_feature_mapping][google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]
@@ -26542,8 +28454,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]: crate::model::explanation_metadata::InputMetadata::index_feature_mapping
-            pub const BAG_OF_FEATURES: Encoding = Encoding::new(2);
-
+            BagOfFeatures,
             /// The tensor represents a bag of features where each index maps to a
             /// feature. Zero values in the tensor indicates feature being
             /// non-existent.
@@ -26556,8 +28467,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]: crate::model::explanation_metadata::InputMetadata::index_feature_mapping
-            pub const BAG_OF_FEATURES_SPARSE: Encoding = Encoding::new(3);
-
+            BagOfFeaturesSparse,
             /// The tensor is a list of binaries representing whether a feature exists
             /// or not (1 indicates existence).
             /// [InputMetadata.index_feature_mapping][google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]
@@ -26569,8 +28479,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.index_feature_mapping]: crate::model::explanation_metadata::InputMetadata::index_feature_mapping
-            pub const INDICATOR: Encoding = Encoding::new(4);
-
+            Indicator,
             /// The tensor is encoded into a 1-dimensional array represented by an
             /// encoded tensor.
             /// [InputMetadata.encoded_tensor_name][google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.encoded_tensor_name]
@@ -26582,8 +28491,7 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.encoded_tensor_name]: crate::model::explanation_metadata::InputMetadata::encoded_tensor_name
-            pub const COMBINED_EMBEDDING: Encoding = Encoding::new(5);
-
+            CombinedEmbedding,
             /// Select this encoding when the input tensor is encoded into a
             /// 2-dimensional array represented by an encoded tensor.
             /// [InputMetadata.encoded_tensor_name][google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.encoded_tensor_name]
@@ -26600,47 +28508,28 @@ pub mod explanation_metadata {
             /// ```
             ///
             /// [google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.encoded_tensor_name]: crate::model::explanation_metadata::InputMetadata::encoded_tensor_name
-            pub const CONCAT_EMBEDDING: Encoding = Encoding::new(6);
+            ConcatEmbedding,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Encoding::value] or
+            /// [Encoding::name].
+            UnknownValue(encoding::UnknownValue),
+        }
 
-            /// Creates a new Encoding instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENCODING_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IDENTITY"),
-                    2 => std::borrow::Cow::Borrowed("BAG_OF_FEATURES"),
-                    3 => std::borrow::Cow::Borrowed("BAG_OF_FEATURES_SPARSE"),
-                    4 => std::borrow::Cow::Borrowed("INDICATOR"),
-                    5 => std::borrow::Cow::Borrowed("COMBINED_EMBEDDING"),
-                    6 => std::borrow::Cow::Borrowed("CONCAT_EMBEDDING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENCODING_UNSPECIFIED" => std::option::Option::Some(Self::ENCODING_UNSPECIFIED),
-                    "IDENTITY" => std::option::Option::Some(Self::IDENTITY),
-                    "BAG_OF_FEATURES" => std::option::Option::Some(Self::BAG_OF_FEATURES),
-                    "BAG_OF_FEATURES_SPARSE" => {
-                        std::option::Option::Some(Self::BAG_OF_FEATURES_SPARSE)
-                    }
-                    "INDICATOR" => std::option::Option::Some(Self::INDICATOR),
-                    "COMBINED_EMBEDDING" => std::option::Option::Some(Self::COMBINED_EMBEDDING),
-                    "CONCAT_EMBEDDING" => std::option::Option::Some(Self::CONCAT_EMBEDDING),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        pub mod encoding {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(
@@ -26651,9 +28540,41 @@ pub mod explanation_metadata {
             feature = "model_service",
             feature = "pipeline_service",
         ))]
-        impl std::convert::From<i32> for Encoding {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl Encoding {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Identity => std::option::Option::Some(1),
+                    Self::BagOfFeatures => std::option::Option::Some(2),
+                    Self::BagOfFeaturesSparse => std::option::Option::Some(3),
+                    Self::Indicator => std::option::Option::Some(4),
+                    Self::CombinedEmbedding => std::option::Option::Some(5),
+                    Self::ConcatEmbedding => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENCODING_UNSPECIFIED"),
+                    Self::Identity => std::option::Option::Some("IDENTITY"),
+                    Self::BagOfFeatures => std::option::Option::Some("BAG_OF_FEATURES"),
+                    Self::BagOfFeaturesSparse => {
+                        std::option::Option::Some("BAG_OF_FEATURES_SPARSE")
+                    }
+                    Self::Indicator => std::option::Option::Some("INDICATOR"),
+                    Self::CombinedEmbedding => std::option::Option::Some("COMBINED_EMBEDDING"),
+                    Self::ConcatEmbedding => std::option::Option::Some("CONCAT_EMBEDDING"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
@@ -26667,7 +28588,121 @@ pub mod explanation_metadata {
         ))]
         impl std::default::Default for Encoding {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl std::fmt::Display for Encoding {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl std::convert::From<i32> for Encoding {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Identity,
+                    2 => Self::BagOfFeatures,
+                    3 => Self::BagOfFeaturesSparse,
+                    4 => Self::Indicator,
+                    5 => Self::CombinedEmbedding,
+                    6 => Self::ConcatEmbedding,
+                    _ => Self::UnknownValue(encoding::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl std::convert::From<&str> for Encoding {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENCODING_UNSPECIFIED" => Self::Unspecified,
+                    "IDENTITY" => Self::Identity,
+                    "BAG_OF_FEATURES" => Self::BagOfFeatures,
+                    "BAG_OF_FEATURES_SPARSE" => Self::BagOfFeaturesSparse,
+                    "INDICATOR" => Self::Indicator,
+                    "COMBINED_EMBEDDING" => Self::CombinedEmbedding,
+                    "CONCAT_EMBEDDING" => Self::ConcatEmbedding,
+                    _ => Self::UnknownValue(encoding::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl serde::ser::Serialize for Encoding {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Identity => serializer.serialize_i32(1),
+                    Self::BagOfFeatures => serializer.serialize_i32(2),
+                    Self::BagOfFeaturesSparse => serializer.serialize_i32(3),
+                    Self::Indicator => serializer.serialize_i32(4),
+                    Self::CombinedEmbedding => serializer.serialize_i32(5),
+                    Self::ConcatEmbedding => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "deployment_resource_pool_service",
+            feature = "endpoint_service",
+            feature = "job_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl<'de> serde::de::Deserialize<'de> for Encoding {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Encoding>::new(
+                    ".google.cloud.aiplatform.v1.ExplanationMetadata.InputMetadata.Encoding",
+                ))
             }
         }
     }
@@ -27173,66 +29208,133 @@ pub mod feature {
         /// one of them. Otherwise, this objective should be the same as the
         /// objective in the request.
         #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Objective(i32);
-
-        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
-        impl Objective {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Objective {
             /// If it's OBJECTIVE_UNSPECIFIED, monitoring_stats will be empty.
-            pub const OBJECTIVE_UNSPECIFIED: Objective = Objective::new(0);
-
+            Unspecified,
             /// Stats are generated by Import Feature Analysis.
-            pub const IMPORT_FEATURE_ANALYSIS: Objective = Objective::new(1);
-
+            ImportFeatureAnalysis,
             /// Stats are generated by Snapshot Analysis.
-            pub const SNAPSHOT_ANALYSIS: Objective = Objective::new(2);
+            SnapshotAnalysis,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Objective::value] or
+            /// [Objective::name].
+            UnknownValue(objective::UnknownValue),
+        }
 
-            /// Creates a new Objective instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OBJECTIVE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IMPORT_FEATURE_ANALYSIS"),
-                    2 => std::borrow::Cow::Borrowed("SNAPSHOT_ANALYSIS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OBJECTIVE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::OBJECTIVE_UNSPECIFIED)
-                    }
-                    "IMPORT_FEATURE_ANALYSIS" => {
-                        std::option::Option::Some(Self::IMPORT_FEATURE_ANALYSIS)
-                    }
-                    "SNAPSHOT_ANALYSIS" => std::option::Option::Some(Self::SNAPSHOT_ANALYSIS),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+        pub mod objective {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
-        impl std::convert::From<i32> for Objective {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl Objective {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ImportFeatureAnalysis => std::option::Option::Some(1),
+                    Self::SnapshotAnalysis => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OBJECTIVE_UNSPECIFIED"),
+                    Self::ImportFeatureAnalysis => {
+                        std::option::Option::Some("IMPORT_FEATURE_ANALYSIS")
+                    }
+                    Self::SnapshotAnalysis => std::option::Option::Some("SNAPSHOT_ANALYSIS"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
         impl std::default::Default for Objective {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+        impl std::fmt::Display for Objective {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+        impl std::convert::From<i32> for Objective {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ImportFeatureAnalysis,
+                    2 => Self::SnapshotAnalysis,
+                    _ => Self::UnknownValue(objective::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+        impl std::convert::From<&str> for Objective {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OBJECTIVE_UNSPECIFIED" => Self::Unspecified,
+                    "IMPORT_FEATURE_ANALYSIS" => Self::ImportFeatureAnalysis,
+                    "SNAPSHOT_ANALYSIS" => Self::SnapshotAnalysis,
+                    _ => Self::UnknownValue(objective::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+        impl serde::ser::Serialize for Objective {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ImportFeatureAnalysis => serializer.serialize_i32(1),
+                    Self::SnapshotAnalysis => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+        impl<'de> serde::de::Deserialize<'de> for Objective {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Objective>::new(
+                    ".google.cloud.aiplatform.v1.Feature.MonitoringStatsAnomaly.Objective",
+                ))
             }
         }
     }
@@ -27240,102 +29342,184 @@ pub mod feature {
     /// Only applicable for Vertex AI Legacy Feature Store.
     /// An enum representing the value type of a feature.
     #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(i32);
-
-    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
-    impl ValueType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ValueType {
         /// The value type is unspecified.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
-
+        Unspecified,
         /// Used for Feature that is a boolean.
-        pub const BOOL: ValueType = ValueType::new(1);
-
+        Bool,
         /// Used for Feature that is a list of boolean.
-        pub const BOOL_ARRAY: ValueType = ValueType::new(2);
-
+        BoolArray,
         /// Used for Feature that is double.
-        pub const DOUBLE: ValueType = ValueType::new(3);
-
+        Double,
         /// Used for Feature that is a list of double.
-        pub const DOUBLE_ARRAY: ValueType = ValueType::new(4);
-
+        DoubleArray,
         /// Used for Feature that is INT64.
-        pub const INT64: ValueType = ValueType::new(9);
-
+        Int64,
         /// Used for Feature that is a list of INT64.
-        pub const INT64_ARRAY: ValueType = ValueType::new(10);
-
+        Int64Array,
         /// Used for Feature that is string.
-        pub const STRING: ValueType = ValueType::new(11);
-
+        String,
         /// Used for Feature that is a list of String.
-        pub const STRING_ARRAY: ValueType = ValueType::new(12);
-
+        StringArray,
         /// Used for Feature that is bytes.
-        pub const BYTES: ValueType = ValueType::new(13);
-
+        Bytes,
         /// Used for Feature that is struct.
-        pub const STRUCT: ValueType = ValueType::new(14);
+        Struct,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ValueType::value] or
+        /// [ValueType::name].
+        UnknownValue(value_type::UnknownValue),
+    }
 
-        /// Creates a new ValueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BOOL"),
-                2 => std::borrow::Cow::Borrowed("BOOL_ARRAY"),
-                3 => std::borrow::Cow::Borrowed("DOUBLE"),
-                4 => std::borrow::Cow::Borrowed("DOUBLE_ARRAY"),
-                9 => std::borrow::Cow::Borrowed("INT64"),
-                10 => std::borrow::Cow::Borrowed("INT64_ARRAY"),
-                11 => std::borrow::Cow::Borrowed("STRING"),
-                12 => std::borrow::Cow::Borrowed("STRING_ARRAY"),
-                13 => std::borrow::Cow::Borrowed("BYTES"),
-                14 => std::borrow::Cow::Borrowed("STRUCT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "BOOL_ARRAY" => std::option::Option::Some(Self::BOOL_ARRAY),
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                "DOUBLE_ARRAY" => std::option::Option::Some(Self::DOUBLE_ARRAY),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                "INT64_ARRAY" => std::option::Option::Some(Self::INT64_ARRAY),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "STRING_ARRAY" => std::option::Option::Some(Self::STRING_ARRAY),
-                "BYTES" => std::option::Option::Some(Self::BYTES),
-                "STRUCT" => std::option::Option::Some(Self::STRUCT),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+    pub mod value_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
-    impl std::convert::From<i32> for ValueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl ValueType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bool => std::option::Option::Some(1),
+                Self::BoolArray => std::option::Option::Some(2),
+                Self::Double => std::option::Option::Some(3),
+                Self::DoubleArray => std::option::Option::Some(4),
+                Self::Int64 => std::option::Option::Some(9),
+                Self::Int64Array => std::option::Option::Some(10),
+                Self::String => std::option::Option::Some(11),
+                Self::StringArray => std::option::Option::Some(12),
+                Self::Bytes => std::option::Option::Some(13),
+                Self::Struct => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VALUE_TYPE_UNSPECIFIED"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::BoolArray => std::option::Option::Some("BOOL_ARRAY"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::DoubleArray => std::option::Option::Some("DOUBLE_ARRAY"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::Int64Array => std::option::Option::Some("INT64_ARRAY"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::StringArray => std::option::Option::Some("STRING_ARRAY"),
+                Self::Bytes => std::option::Option::Some("BYTES"),
+                Self::Struct => std::option::Option::Some("STRUCT"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+    impl std::fmt::Display for ValueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bool,
+                2 => Self::BoolArray,
+                3 => Self::Double,
+                4 => Self::DoubleArray,
+                9 => Self::Int64,
+                10 => Self::Int64Array,
+                11 => Self::String,
+                12 => Self::StringArray,
+                13 => Self::Bytes,
+                14 => Self::Struct,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+    impl std::convert::From<&str> for ValueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VALUE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BOOL" => Self::Bool,
+                "BOOL_ARRAY" => Self::BoolArray,
+                "DOUBLE" => Self::Double,
+                "DOUBLE_ARRAY" => Self::DoubleArray,
+                "INT64" => Self::Int64,
+                "INT64_ARRAY" => Self::Int64Array,
+                "STRING" => Self::String,
+                "STRING_ARRAY" => Self::StringArray,
+                "BYTES" => Self::Bytes,
+                "STRUCT" => Self::Struct,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+    impl serde::ser::Serialize for ValueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bool => serializer.serialize_i32(1),
+                Self::BoolArray => serializer.serialize_i32(2),
+                Self::Double => serializer.serialize_i32(3),
+                Self::DoubleArray => serializer.serialize_i32(4),
+                Self::Int64 => serializer.serialize_i32(9),
+                Self::Int64Array => serializer.serialize_i32(10),
+                Self::String => serializer.serialize_i32(11),
+                Self::StringArray => serializer.serialize_i32(12),
+                Self::Bytes => serializer.serialize_i32(13),
+                Self::Struct => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "feature_registry_service", feature = "featurestore_service",))]
+    impl<'de> serde::de::Deserialize<'de> for ValueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueType>::new(
+                ".google.cloud.aiplatform.v1.Feature.ValueType",
+            ))
         }
     }
 }
@@ -27697,8 +29881,8 @@ pub struct FeatureStatsAnomaly {
     /// and
     /// [ModelDeploymentMonitoringObjectiveType.FEATURE_ATTRIBUTION_DRIFT][google.cloud.aiplatform.v1.ModelDeploymentMonitoringObjectiveType.FEATURE_ATTRIBUTION_DRIFT].
     ///
-    /// [google.cloud.aiplatform.v1.ModelDeploymentMonitoringObjectiveType.FEATURE_ATTRIBUTION_DRIFT]: crate::model::model_deployment_monitoring_objective_type::FEATURE_ATTRIBUTION_DRIFT
-    /// [google.cloud.aiplatform.v1.ModelDeploymentMonitoringObjectiveType.FEATURE_ATTRIBUTION_SKEW]: crate::model::model_deployment_monitoring_objective_type::FEATURE_ATTRIBUTION_SKEW
+    /// [google.cloud.aiplatform.v1.ModelDeploymentMonitoringObjectiveType.FEATURE_ATTRIBUTION_DRIFT]: crate::model::ModelDeploymentMonitoringObjectiveType::FeatureAttributionDrift
+    /// [google.cloud.aiplatform.v1.ModelDeploymentMonitoringObjectiveType.FEATURE_ATTRIBUTION_SKEW]: crate::model::ModelDeploymentMonitoringObjectiveType::FeatureAttributionSkew
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub score: f64,
 
@@ -28296,67 +30480,133 @@ pub mod feature_online_store {
 
     /// Possible states a featureOnlineStore can have.
     #[cfg(feature = "feature_online_store_admin_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "feature_online_store_admin_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// State when the featureOnlineStore configuration is not being updated and
         /// the fields reflect the current configuration of the featureOnlineStore.
         /// The featureOnlineStore is usable in this state.
-        pub const STABLE: State = State::new(1);
-
+        Stable,
         /// The state of the featureOnlineStore configuration when it is being
         /// updated. During an update, the fields reflect either the original
         /// configuration or the updated configuration of the featureOnlineStore. The
         /// featureOnlineStore is still usable in this state.
-        pub const UPDATING: State = State::new(2);
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STABLE"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STABLE" => std::option::Option::Some(Self::STABLE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "feature_online_store_admin_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "feature_online_store_admin_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Stable => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Stable => std::option::Option::Some("STABLE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "feature_online_store_admin_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Stable,
+                2 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STABLE" => Self::Stable,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Stable => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.FeatureOnlineStore.State",
+            ))
         }
     }
 
@@ -29872,7 +32122,7 @@ pub struct FetchFeatureValuesRequest {
     /// [FeatureViewDataFormat.KEY_VALUE][google.cloud.aiplatform.v1.FeatureViewDataFormat.KEY_VALUE]
     /// will be used.
     ///
-    /// [google.cloud.aiplatform.v1.FeatureViewDataFormat.KEY_VALUE]: crate::model::feature_view_data_format::KEY_VALUE
+    /// [google.cloud.aiplatform.v1.FeatureViewDataFormat.KEY_VALUE]: crate::model::FeatureViewDataFormat::KeyValue
     pub data_format: crate::model::FeatureViewDataFormat,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -30672,82 +32922,159 @@ pub mod nearest_neighbor_query {
         /// Datapoints for which Operator is true relative to the query's Value
         /// field will be allowlisted.
         #[cfg(feature = "feature_online_store_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
-
-        #[cfg(feature = "feature_online_store_service")]
-        impl Operator {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
             /// Unspecified operator.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
+            Unspecified,
             /// Entities are eligible if their value is < the query's.
-            pub const LESS: Operator = Operator::new(1);
-
+            Less,
             /// Entities are eligible if their value is <= the query's.
-            pub const LESS_EQUAL: Operator = Operator::new(2);
-
+            LessEqual,
             /// Entities are eligible if their value is == the query's.
-            pub const EQUAL: Operator = Operator::new(3);
-
+            Equal,
             /// Entities are eligible if their value is >= the query's.
-            pub const GREATER_EQUAL: Operator = Operator::new(4);
-
+            GreaterEqual,
             /// Entities are eligible if their value is > the query's.
-            pub const GREATER: Operator = Operator::new(5);
-
+            Greater,
             /// Entities are eligible if their value is != the query's.
-            pub const NOT_EQUAL: Operator = Operator::new(6);
+            NotEqual,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
 
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("LESS"),
-                    2 => std::borrow::Cow::Borrowed("LESS_EQUAL"),
-                    3 => std::borrow::Cow::Borrowed("EQUAL"),
-                    4 => std::borrow::Cow::Borrowed("GREATER_EQUAL"),
-                    5 => std::borrow::Cow::Borrowed("GREATER"),
-                    6 => std::borrow::Cow::Borrowed("NOT_EQUAL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "LESS" => std::option::Option::Some(Self::LESS),
-                    "LESS_EQUAL" => std::option::Option::Some(Self::LESS_EQUAL),
-                    "EQUAL" => std::option::Option::Some(Self::EQUAL),
-                    "GREATER_EQUAL" => std::option::Option::Some(Self::GREATER_EQUAL),
-                    "GREATER" => std::option::Option::Some(Self::GREATER),
-                    "NOT_EQUAL" => std::option::Option::Some(Self::NOT_EQUAL),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "feature_online_store_service")]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "feature_online_store_service")]
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl Operator {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Less => std::option::Option::Some(1),
+                    Self::LessEqual => std::option::Option::Some(2),
+                    Self::Equal => std::option::Option::Some(3),
+                    Self::GreaterEqual => std::option::Option::Some(4),
+                    Self::Greater => std::option::Option::Some(5),
+                    Self::NotEqual => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::Less => std::option::Option::Some("LESS"),
+                    Self::LessEqual => std::option::Option::Some("LESS_EQUAL"),
+                    Self::Equal => std::option::Option::Some("EQUAL"),
+                    Self::GreaterEqual => std::option::Option::Some("GREATER_EQUAL"),
+                    Self::Greater => std::option::Option::Some("GREATER"),
+                    Self::NotEqual => std::option::Option::Some("NOT_EQUAL"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "feature_online_store_service")]
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_service")]
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_service")]
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Less,
+                    2 => Self::LessEqual,
+                    3 => Self::Equal,
+                    4 => Self::GreaterEqual,
+                    5 => Self::Greater,
+                    6 => Self::NotEqual,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_service")]
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "LESS" => Self::Less,
+                    "LESS_EQUAL" => Self::LessEqual,
+                    "EQUAL" => Self::Equal,
+                    "GREATER_EQUAL" => Self::GreaterEqual,
+                    "GREATER" => Self::Greater,
+                    "NOT_EQUAL" => Self::NotEqual,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_service")]
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Less => serializer.serialize_i32(1),
+                    Self::LessEqual => serializer.serialize_i32(2),
+                    Self::Equal => serializer.serialize_i32(3),
+                    Self::GreaterEqual => serializer.serialize_i32(4),
+                    Self::Greater => serializer.serialize_i32(5),
+                    Self::NotEqual => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_service")]
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.cloud.aiplatform.v1.NearestNeighborQuery.NumericFilter.Operator",
+                ))
             }
         }
 
@@ -32535,18 +34862,13 @@ pub mod feature_view {
 
         /// The distance measure used in nearest neighbor search.
         #[cfg(feature = "feature_online_store_admin_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DistanceMeasureType(i32);
-
-        #[cfg(feature = "feature_online_store_admin_service")]
-        impl DistanceMeasureType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DistanceMeasureType {
             /// Should not be set.
-            pub const DISTANCE_MEASURE_TYPE_UNSPECIFIED: DistanceMeasureType =
-                DistanceMeasureType::new(0);
-
+            Unspecified,
             /// Euclidean (L_2) Distance.
-            pub const SQUARED_L2_DISTANCE: DistanceMeasureType = DistanceMeasureType::new(1);
-
+            SquaredL2Distance,
             /// Cosine Distance. Defined as 1 - cosine similarity.
             ///
             /// We strongly suggest using DOT_PRODUCT_DISTANCE + UNIT_L2_NORM instead
@@ -32554,57 +34876,134 @@ pub mod feature_view {
             /// DOT_PRODUCT distance which, when combined with UNIT_L2_NORM, is
             /// mathematically equivalent to COSINE distance and results in the same
             /// ranking.
-            pub const COSINE_DISTANCE: DistanceMeasureType = DistanceMeasureType::new(2);
-
+            CosineDistance,
             /// Dot Product Distance. Defined as a negative of the dot product.
-            pub const DOT_PRODUCT_DISTANCE: DistanceMeasureType = DistanceMeasureType::new(3);
+            DotProductDistance,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DistanceMeasureType::value] or
+            /// [DistanceMeasureType::name].
+            UnknownValue(distance_measure_type::UnknownValue),
+        }
 
-            /// Creates a new DistanceMeasureType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DISTANCE_MEASURE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SQUARED_L2_DISTANCE"),
-                    2 => std::borrow::Cow::Borrowed("COSINE_DISTANCE"),
-                    3 => std::borrow::Cow::Borrowed("DOT_PRODUCT_DISTANCE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DISTANCE_MEASURE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DISTANCE_MEASURE_TYPE_UNSPECIFIED)
-                    }
-                    "SQUARED_L2_DISTANCE" => std::option::Option::Some(Self::SQUARED_L2_DISTANCE),
-                    "COSINE_DISTANCE" => std::option::Option::Some(Self::COSINE_DISTANCE),
-                    "DOT_PRODUCT_DISTANCE" => std::option::Option::Some(Self::DOT_PRODUCT_DISTANCE),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "feature_online_store_admin_service")]
+        pub mod distance_measure_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "feature_online_store_admin_service")]
-        impl std::convert::From<i32> for DistanceMeasureType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl DistanceMeasureType {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SquaredL2Distance => std::option::Option::Some(1),
+                    Self::CosineDistance => std::option::Option::Some(2),
+                    Self::DotProductDistance => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("DISTANCE_MEASURE_TYPE_UNSPECIFIED")
+                    }
+                    Self::SquaredL2Distance => std::option::Option::Some("SQUARED_L2_DISTANCE"),
+                    Self::CosineDistance => std::option::Option::Some("COSINE_DISTANCE"),
+                    Self::DotProductDistance => std::option::Option::Some("DOT_PRODUCT_DISTANCE"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "feature_online_store_admin_service")]
         impl std::default::Default for DistanceMeasureType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_admin_service")]
+        impl std::fmt::Display for DistanceMeasureType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_admin_service")]
+        impl std::convert::From<i32> for DistanceMeasureType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SquaredL2Distance,
+                    2 => Self::CosineDistance,
+                    3 => Self::DotProductDistance,
+                    _ => Self::UnknownValue(distance_measure_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_admin_service")]
+        impl std::convert::From<&str> for DistanceMeasureType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DISTANCE_MEASURE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SQUARED_L2_DISTANCE" => Self::SquaredL2Distance,
+                    "COSINE_DISTANCE" => Self::CosineDistance,
+                    "DOT_PRODUCT_DISTANCE" => Self::DotProductDistance,
+                    _ => Self::UnknownValue(distance_measure_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_admin_service")]
+        impl serde::ser::Serialize for DistanceMeasureType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SquaredL2Distance => serializer.serialize_i32(1),
+                    Self::CosineDistance => serializer.serialize_i32(2),
+                    Self::DotProductDistance => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "feature_online_store_admin_service")]
+        impl<'de> serde::de::Deserialize<'de> for DistanceMeasureType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(
+                    wkt::internal::EnumVisitor::<DistanceMeasureType>::new(
+                        ".google.cloud.aiplatform.v1.FeatureView.IndexConfig.DistanceMeasureType",
+                    ),
+                )
             }
         }
 
@@ -32852,72 +35251,132 @@ pub mod feature_view {
 
     /// Service agent type used during data sync.
     #[cfg(feature = "feature_online_store_admin_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServiceAgentType(i32);
-
-    #[cfg(feature = "feature_online_store_admin_service")]
-    impl ServiceAgentType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ServiceAgentType {
         /// By default, the project-level Vertex AI Service Agent is enabled.
-        pub const SERVICE_AGENT_TYPE_UNSPECIFIED: ServiceAgentType = ServiceAgentType::new(0);
-
+        Unspecified,
         /// Indicates the project-level Vertex AI Service Agent
         /// (<https://cloud.google.com/vertex-ai/docs/general/access-control#service-agents>)
         /// will be used during sync jobs.
-        pub const SERVICE_AGENT_TYPE_PROJECT: ServiceAgentType = ServiceAgentType::new(1);
-
+        Project,
         /// Enable a FeatureView service account to be created by Vertex AI and
         /// output in the field `service_account_email`. This service account will
         /// be used to read from the source BigQuery table during sync.
-        pub const SERVICE_AGENT_TYPE_FEATURE_VIEW: ServiceAgentType = ServiceAgentType::new(2);
+        FeatureView,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ServiceAgentType::value] or
+        /// [ServiceAgentType::name].
+        UnknownValue(service_agent_type::UnknownValue),
+    }
 
-        /// Creates a new ServiceAgentType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SERVICE_AGENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVICE_AGENT_TYPE_PROJECT"),
-                2 => std::borrow::Cow::Borrowed("SERVICE_AGENT_TYPE_FEATURE_VIEW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SERVICE_AGENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SERVICE_AGENT_TYPE_UNSPECIFIED)
-                }
-                "SERVICE_AGENT_TYPE_PROJECT" => {
-                    std::option::Option::Some(Self::SERVICE_AGENT_TYPE_PROJECT)
-                }
-                "SERVICE_AGENT_TYPE_FEATURE_VIEW" => {
-                    std::option::Option::Some(Self::SERVICE_AGENT_TYPE_FEATURE_VIEW)
-                }
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "feature_online_store_admin_service")]
+    pub mod service_agent_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "feature_online_store_admin_service")]
-    impl std::convert::From<i32> for ServiceAgentType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl ServiceAgentType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Project => std::option::Option::Some(1),
+                Self::FeatureView => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SERVICE_AGENT_TYPE_UNSPECIFIED"),
+                Self::Project => std::option::Option::Some("SERVICE_AGENT_TYPE_PROJECT"),
+                Self::FeatureView => std::option::Option::Some("SERVICE_AGENT_TYPE_FEATURE_VIEW"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "feature_online_store_admin_service")]
     impl std::default::Default for ServiceAgentType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl std::fmt::Display for ServiceAgentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl std::convert::From<i32> for ServiceAgentType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Project,
+                2 => Self::FeatureView,
+                _ => Self::UnknownValue(service_agent_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl std::convert::From<&str> for ServiceAgentType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SERVICE_AGENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SERVICE_AGENT_TYPE_PROJECT" => Self::Project,
+                "SERVICE_AGENT_TYPE_FEATURE_VIEW" => Self::FeatureView,
+                _ => Self::UnknownValue(service_agent_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl serde::ser::Serialize for ServiceAgentType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Project => serializer.serialize_i32(1),
+                Self::FeatureView => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "feature_online_store_admin_service")]
+    impl<'de> serde::de::Deserialize<'de> for ServiceAgentType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceAgentType>::new(
+                ".google.cloud.aiplatform.v1.FeatureView.ServiceAgentType",
+            ))
         }
     }
 
@@ -33443,19 +35902,15 @@ pub mod featurestore {
 
     /// Possible states a featurestore can have.
     #[cfg(feature = "featurestore_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "featurestore_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// State when the featurestore configuration is not being updated and the
         /// fields reflect the current configuration of the featurestore. The
         /// featurestore is usable in this state.
-        pub const STABLE: State = State::new(1);
-
+        Stable,
         /// The state of the featurestore configuration when it is being updated.
         /// During an update, the fields reflect either the original configuration
         /// or the updated configuration of the featurestore. For example,
@@ -33466,50 +35921,120 @@ pub mod featurestore {
         /// update completes, the actual number of nodes can still be the original
         /// value of `fixed_node_count`. The featurestore is still usable in this
         /// state.
-        pub const UPDATING: State = State::new(2);
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STABLE"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STABLE" => std::option::Option::Some(Self::STABLE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "featurestore_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "featurestore_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Stable => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Stable => std::option::Option::Some("STABLE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "featurestore_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "featurestore_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "featurestore_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Stable,
+                2 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "featurestore_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STABLE" => Self::Stable,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "featurestore_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Stable => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "featurestore_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.Featurestore.State",
+            ))
         }
     }
 }
@@ -33769,76 +36294,146 @@ pub mod featurestore_monitoring_config {
 
         /// The state defines whether to enable ImportFeature analysis.
         #[cfg(feature = "featurestore_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        #[cfg(feature = "featurestore_service")]
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// Should not be used.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// The default behavior of whether to enable the monitoring.
             /// EntityType-level config: disabled.
             /// Feature-level config: inherited from the configuration of EntityType
             /// this Feature belongs to.
-            pub const DEFAULT: State = State::new(1);
-
+            Default,
             /// Explicitly enables import features analysis.
             /// EntityType-level config: by default enables import features analysis
             /// for all Features under it. Feature-level config: enables import
             /// features analysis regardless of the EntityType-level config.
-            pub const ENABLED: State = State::new(2);
-
+            Enabled,
             /// Explicitly disables import features analysis.
             /// EntityType-level config: by default disables import features analysis
             /// for all Features under it. Feature-level config: disables import
             /// features analysis regardless of the EntityType-level config.
-            pub const DISABLED: State = State::new(3);
+            Disabled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                    2 => std::borrow::Cow::Borrowed("ENABLED"),
-                    3 => std::borrow::Cow::Borrowed("DISABLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                    "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "featurestore_service")]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "featurestore_service")]
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl State {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Default => std::option::Option::Some(1),
+                    Self::Enabled => std::option::Option::Some(2),
+                    Self::Disabled => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Default => std::option::Option::Some("DEFAULT"),
+                    Self::Enabled => std::option::Option::Some("ENABLED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "featurestore_service")]
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Default,
+                    2 => Self::Enabled,
+                    3 => Self::Disabled,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "DEFAULT" => Self::Default,
+                    "ENABLED" => Self::Enabled,
+                    "DISABLED" => Self::Disabled,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Default => serializer.serialize_i32(1),
+                    Self::Enabled => serializer.serialize_i32(2),
+                    Self::Disabled => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.aiplatform.v1.FeaturestoreMonitoringConfig.ImportFeaturesAnalysis.State"))
             }
         }
 
@@ -33849,75 +36444,145 @@ pub mod featurestore_monitoring_config {
         ///
         /// [google.cloud.aiplatform.v1.FeaturestoreService.ImportFeatureValues]: crate::client::FeaturestoreService::import_feature_values
         #[cfg(feature = "featurestore_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Baseline(i32);
-
-        #[cfg(feature = "featurestore_service")]
-        impl Baseline {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Baseline {
             /// Should not be used.
-            pub const BASELINE_UNSPECIFIED: Baseline = Baseline::new(0);
-
+            Unspecified,
             /// Choose the later one statistics generated by either most recent
             /// snapshot analysis or previous import features analysis. If non of them
             /// exists, skip anomaly detection and only generate a statistics.
-            pub const LATEST_STATS: Baseline = Baseline::new(1);
-
+            LatestStats,
             /// Use the statistics generated by the most recent snapshot analysis if
             /// exists.
-            pub const MOST_RECENT_SNAPSHOT_STATS: Baseline = Baseline::new(2);
-
+            MostRecentSnapshotStats,
             /// Use the statistics generated by the previous import features analysis
             /// if exists.
-            pub const PREVIOUS_IMPORT_FEATURES_STATS: Baseline = Baseline::new(3);
+            PreviousImportFeaturesStats,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Baseline::value] or
+            /// [Baseline::name].
+            UnknownValue(baseline::UnknownValue),
+        }
 
-            /// Creates a new Baseline instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("BASELINE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("LATEST_STATS"),
-                    2 => std::borrow::Cow::Borrowed("MOST_RECENT_SNAPSHOT_STATS"),
-                    3 => std::borrow::Cow::Borrowed("PREVIOUS_IMPORT_FEATURES_STATS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "BASELINE_UNSPECIFIED" => std::option::Option::Some(Self::BASELINE_UNSPECIFIED),
-                    "LATEST_STATS" => std::option::Option::Some(Self::LATEST_STATS),
-                    "MOST_RECENT_SNAPSHOT_STATS" => {
-                        std::option::Option::Some(Self::MOST_RECENT_SNAPSHOT_STATS)
-                    }
-                    "PREVIOUS_IMPORT_FEATURES_STATS" => {
-                        std::option::Option::Some(Self::PREVIOUS_IMPORT_FEATURES_STATS)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "featurestore_service")]
+        pub mod baseline {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "featurestore_service")]
-        impl std::convert::From<i32> for Baseline {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl Baseline {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::LatestStats => std::option::Option::Some(1),
+                    Self::MostRecentSnapshotStats => std::option::Option::Some(2),
+                    Self::PreviousImportFeaturesStats => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("BASELINE_UNSPECIFIED"),
+                    Self::LatestStats => std::option::Option::Some("LATEST_STATS"),
+                    Self::MostRecentSnapshotStats => {
+                        std::option::Option::Some("MOST_RECENT_SNAPSHOT_STATS")
+                    }
+                    Self::PreviousImportFeaturesStats => {
+                        std::option::Option::Some("PREVIOUS_IMPORT_FEATURES_STATS")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "featurestore_service")]
         impl std::default::Default for Baseline {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl std::fmt::Display for Baseline {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl std::convert::From<i32> for Baseline {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::LatestStats,
+                    2 => Self::MostRecentSnapshotStats,
+                    3 => Self::PreviousImportFeaturesStats,
+                    _ => Self::UnknownValue(baseline::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl std::convert::From<&str> for Baseline {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "BASELINE_UNSPECIFIED" => Self::Unspecified,
+                    "LATEST_STATS" => Self::LatestStats,
+                    "MOST_RECENT_SNAPSHOT_STATS" => Self::MostRecentSnapshotStats,
+                    "PREVIOUS_IMPORT_FEATURES_STATS" => Self::PreviousImportFeaturesStats,
+                    _ => Self::UnknownValue(baseline::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl serde::ser::Serialize for Baseline {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::LatestStats => serializer.serialize_i32(1),
+                    Self::MostRecentSnapshotStats => serializer.serialize_i32(2),
+                    Self::PreviousImportFeaturesStats => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "featurestore_service")]
+        impl<'de> serde::de::Deserialize<'de> for Baseline {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Baseline>::new(
+                    ".google.cloud.aiplatform.v1.FeaturestoreMonitoringConfig.ImportFeaturesAnalysis.Baseline"))
             }
         }
     }
@@ -40641,67 +43306,131 @@ pub mod index {
 
     /// The update method of an Index.
     #[cfg(feature = "index_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexUpdateMethod(i32);
-
-    #[cfg(feature = "index_service")]
-    impl IndexUpdateMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IndexUpdateMethod {
         /// Should not be used.
-        pub const INDEX_UPDATE_METHOD_UNSPECIFIED: IndexUpdateMethod = IndexUpdateMethod::new(0);
-
+        Unspecified,
         /// BatchUpdate: user can call UpdateIndex with files on Cloud Storage of
         /// Datapoints to update.
-        pub const BATCH_UPDATE: IndexUpdateMethod = IndexUpdateMethod::new(1);
-
+        BatchUpdate,
         /// StreamUpdate: user can call UpsertDatapoints/DeleteDatapoints to update
         /// the Index and the updates will be applied in corresponding
         /// DeployedIndexes in nearly real-time.
-        pub const STREAM_UPDATE: IndexUpdateMethod = IndexUpdateMethod::new(2);
+        StreamUpdate,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IndexUpdateMethod::value] or
+        /// [IndexUpdateMethod::name].
+        UnknownValue(index_update_method::UnknownValue),
+    }
 
-        /// Creates a new IndexUpdateMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INDEX_UPDATE_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BATCH_UPDATE"),
-                2 => std::borrow::Cow::Borrowed("STREAM_UPDATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INDEX_UPDATE_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INDEX_UPDATE_METHOD_UNSPECIFIED)
-                }
-                "BATCH_UPDATE" => std::option::Option::Some(Self::BATCH_UPDATE),
-                "STREAM_UPDATE" => std::option::Option::Some(Self::STREAM_UPDATE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "index_service")]
+    pub mod index_update_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "index_service")]
-    impl std::convert::From<i32> for IndexUpdateMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl IndexUpdateMethod {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BatchUpdate => std::option::Option::Some(1),
+                Self::StreamUpdate => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INDEX_UPDATE_METHOD_UNSPECIFIED"),
+                Self::BatchUpdate => std::option::Option::Some("BATCH_UPDATE"),
+                Self::StreamUpdate => std::option::Option::Some("STREAM_UPDATE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "index_service")]
     impl std::default::Default for IndexUpdateMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "index_service")]
+    impl std::fmt::Display for IndexUpdateMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "index_service")]
+    impl std::convert::From<i32> for IndexUpdateMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BatchUpdate,
+                2 => Self::StreamUpdate,
+                _ => Self::UnknownValue(index_update_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "index_service")]
+    impl std::convert::From<&str> for IndexUpdateMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INDEX_UPDATE_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "BATCH_UPDATE" => Self::BatchUpdate,
+                "STREAM_UPDATE" => Self::StreamUpdate,
+                _ => Self::UnknownValue(index_update_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "index_service")]
+    impl serde::ser::Serialize for IndexUpdateMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BatchUpdate => serializer.serialize_i32(1),
+                Self::StreamUpdate => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "index_service")]
+    impl<'de> serde::de::Deserialize<'de> for IndexUpdateMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndexUpdateMethod>::new(
+                ".google.cloud.aiplatform.v1.Index.IndexUpdateMethod",
+            ))
         }
     }
 }
@@ -41112,82 +43841,159 @@ pub mod index_datapoint {
         /// Datapoints for which Operator is true relative to the query's Value
         /// field will be allowlisted.
         #[cfg(any(feature = "index_service", feature = "match_service",))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
-
-        #[cfg(any(feature = "index_service", feature = "match_service",))]
-        impl Operator {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
             /// Default value of the enum.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
+            Unspecified,
             /// Datapoints are eligible iff their value is < the query's.
-            pub const LESS: Operator = Operator::new(1);
-
+            Less,
             /// Datapoints are eligible iff their value is <= the query's.
-            pub const LESS_EQUAL: Operator = Operator::new(2);
-
+            LessEqual,
             /// Datapoints are eligible iff their value is == the query's.
-            pub const EQUAL: Operator = Operator::new(3);
-
+            Equal,
             /// Datapoints are eligible iff their value is >= the query's.
-            pub const GREATER_EQUAL: Operator = Operator::new(4);
-
+            GreaterEqual,
             /// Datapoints are eligible iff their value is > the query's.
-            pub const GREATER: Operator = Operator::new(5);
-
+            Greater,
             /// Datapoints are eligible iff their value is != the query's.
-            pub const NOT_EQUAL: Operator = Operator::new(6);
+            NotEqual,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
 
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("LESS"),
-                    2 => std::borrow::Cow::Borrowed("LESS_EQUAL"),
-                    3 => std::borrow::Cow::Borrowed("EQUAL"),
-                    4 => std::borrow::Cow::Borrowed("GREATER_EQUAL"),
-                    5 => std::borrow::Cow::Borrowed("GREATER"),
-                    6 => std::borrow::Cow::Borrowed("NOT_EQUAL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "LESS" => std::option::Option::Some(Self::LESS),
-                    "LESS_EQUAL" => std::option::Option::Some(Self::LESS_EQUAL),
-                    "EQUAL" => std::option::Option::Some(Self::EQUAL),
-                    "GREATER_EQUAL" => std::option::Option::Some(Self::GREATER_EQUAL),
-                    "GREATER" => std::option::Option::Some(Self::GREATER),
-                    "NOT_EQUAL" => std::option::Option::Some(Self::NOT_EQUAL),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(any(feature = "index_service", feature = "match_service",))]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(feature = "index_service", feature = "match_service",))]
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl Operator {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Less => std::option::Option::Some(1),
+                    Self::LessEqual => std::option::Option::Some(2),
+                    Self::Equal => std::option::Option::Some(3),
+                    Self::GreaterEqual => std::option::Option::Some(4),
+                    Self::Greater => std::option::Option::Some(5),
+                    Self::NotEqual => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::Less => std::option::Option::Some("LESS"),
+                    Self::LessEqual => std::option::Option::Some("LESS_EQUAL"),
+                    Self::Equal => std::option::Option::Some("EQUAL"),
+                    Self::GreaterEqual => std::option::Option::Some("GREATER_EQUAL"),
+                    Self::Greater => std::option::Option::Some("GREATER"),
+                    Self::NotEqual => std::option::Option::Some("NOT_EQUAL"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(any(feature = "index_service", feature = "match_service",))]
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(feature = "index_service", feature = "match_service",))]
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(feature = "index_service", feature = "match_service",))]
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Less,
+                    2 => Self::LessEqual,
+                    3 => Self::Equal,
+                    4 => Self::GreaterEqual,
+                    5 => Self::Greater,
+                    6 => Self::NotEqual,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "index_service", feature = "match_service",))]
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "LESS" => Self::Less,
+                    "LESS_EQUAL" => Self::LessEqual,
+                    "EQUAL" => Self::Equal,
+                    "GREATER_EQUAL" => Self::GreaterEqual,
+                    "GREATER" => Self::Greater,
+                    "NOT_EQUAL" => Self::NotEqual,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "index_service", feature = "match_service",))]
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Less => serializer.serialize_i32(1),
+                    Self::LessEqual => serializer.serialize_i32(2),
+                    Self::Equal => serializer.serialize_i32(3),
+                    Self::GreaterEqual => serializer.serialize_i32(4),
+                    Self::Greater => serializer.serialize_i32(5),
+                    Self::NotEqual => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "index_service", feature = "match_service",))]
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.cloud.aiplatform.v1.IndexDatapoint.NumericRestriction.Operator",
+                ))
             }
         }
 
@@ -43718,149 +46524,245 @@ pub mod nearest_neighbor_search_operation_metadata {
         use super::*;
 
         #[cfg(feature = "index_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RecordErrorType(i32);
-
-        #[cfg(feature = "index_service")]
-        impl RecordErrorType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum RecordErrorType {
             /// Default, shall not be used.
-            pub const ERROR_TYPE_UNSPECIFIED: RecordErrorType = RecordErrorType::new(0);
-
+            ErrorTypeUnspecified,
             /// The record is empty.
-            pub const EMPTY_LINE: RecordErrorType = RecordErrorType::new(1);
-
+            EmptyLine,
             /// Invalid json format.
-            pub const INVALID_JSON_SYNTAX: RecordErrorType = RecordErrorType::new(2);
-
+            InvalidJsonSyntax,
             /// Invalid csv format.
-            pub const INVALID_CSV_SYNTAX: RecordErrorType = RecordErrorType::new(3);
-
+            InvalidCsvSyntax,
             /// Invalid avro format.
-            pub const INVALID_AVRO_SYNTAX: RecordErrorType = RecordErrorType::new(4);
-
+            InvalidAvroSyntax,
             /// The embedding id is not valid.
-            pub const INVALID_EMBEDDING_ID: RecordErrorType = RecordErrorType::new(5);
-
+            InvalidEmbeddingId,
             /// The size of the dense embedding vectors does not match with the
             /// specified dimension.
-            pub const EMBEDDING_SIZE_MISMATCH: RecordErrorType = RecordErrorType::new(6);
-
+            EmbeddingSizeMismatch,
             /// The `namespace` field is missing.
-            pub const NAMESPACE_MISSING: RecordErrorType = RecordErrorType::new(7);
-
+            NamespaceMissing,
             /// Generic catch-all error. Only used for validation failure where the
             /// root cause cannot be easily retrieved programmatically.
-            pub const PARSING_ERROR: RecordErrorType = RecordErrorType::new(8);
-
+            ParsingError,
             /// There are multiple restricts with the same `namespace` value.
-            pub const DUPLICATE_NAMESPACE: RecordErrorType = RecordErrorType::new(9);
-
+            DuplicateNamespace,
             /// Numeric restrict has operator specified in datapoint.
-            pub const OP_IN_DATAPOINT: RecordErrorType = RecordErrorType::new(10);
-
+            OpInDatapoint,
             /// Numeric restrict has multiple values specified.
-            pub const MULTIPLE_VALUES: RecordErrorType = RecordErrorType::new(11);
-
+            MultipleValues,
             /// Numeric restrict has invalid numeric value specified.
-            pub const INVALID_NUMERIC_VALUE: RecordErrorType = RecordErrorType::new(12);
-
+            InvalidNumericValue,
             /// File is not in UTF_8 format.
-            pub const INVALID_ENCODING: RecordErrorType = RecordErrorType::new(13);
-
+            InvalidEncoding,
             /// Error parsing sparse dimensions field.
-            pub const INVALID_SPARSE_DIMENSIONS: RecordErrorType = RecordErrorType::new(14);
-
+            InvalidSparseDimensions,
             /// Token restrict value is invalid.
-            pub const INVALID_TOKEN_VALUE: RecordErrorType = RecordErrorType::new(15);
-
+            InvalidTokenValue,
             /// Invalid sparse embedding.
-            pub const INVALID_SPARSE_EMBEDDING: RecordErrorType = RecordErrorType::new(16);
-
+            InvalidSparseEmbedding,
             /// Invalid dense embedding.
-            pub const INVALID_EMBEDDING: RecordErrorType = RecordErrorType::new(17);
+            InvalidEmbedding,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [RecordErrorType::value] or
+            /// [RecordErrorType::name].
+            UnknownValue(record_error_type::UnknownValue),
+        }
 
-            /// Creates a new RecordErrorType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ERROR_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EMPTY_LINE"),
-                    2 => std::borrow::Cow::Borrowed("INVALID_JSON_SYNTAX"),
-                    3 => std::borrow::Cow::Borrowed("INVALID_CSV_SYNTAX"),
-                    4 => std::borrow::Cow::Borrowed("INVALID_AVRO_SYNTAX"),
-                    5 => std::borrow::Cow::Borrowed("INVALID_EMBEDDING_ID"),
-                    6 => std::borrow::Cow::Borrowed("EMBEDDING_SIZE_MISMATCH"),
-                    7 => std::borrow::Cow::Borrowed("NAMESPACE_MISSING"),
-                    8 => std::borrow::Cow::Borrowed("PARSING_ERROR"),
-                    9 => std::borrow::Cow::Borrowed("DUPLICATE_NAMESPACE"),
-                    10 => std::borrow::Cow::Borrowed("OP_IN_DATAPOINT"),
-                    11 => std::borrow::Cow::Borrowed("MULTIPLE_VALUES"),
-                    12 => std::borrow::Cow::Borrowed("INVALID_NUMERIC_VALUE"),
-                    13 => std::borrow::Cow::Borrowed("INVALID_ENCODING"),
-                    14 => std::borrow::Cow::Borrowed("INVALID_SPARSE_DIMENSIONS"),
-                    15 => std::borrow::Cow::Borrowed("INVALID_TOKEN_VALUE"),
-                    16 => std::borrow::Cow::Borrowed("INVALID_SPARSE_EMBEDDING"),
-                    17 => std::borrow::Cow::Borrowed("INVALID_EMBEDDING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ERROR_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ERROR_TYPE_UNSPECIFIED)
-                    }
-                    "EMPTY_LINE" => std::option::Option::Some(Self::EMPTY_LINE),
-                    "INVALID_JSON_SYNTAX" => std::option::Option::Some(Self::INVALID_JSON_SYNTAX),
-                    "INVALID_CSV_SYNTAX" => std::option::Option::Some(Self::INVALID_CSV_SYNTAX),
-                    "INVALID_AVRO_SYNTAX" => std::option::Option::Some(Self::INVALID_AVRO_SYNTAX),
-                    "INVALID_EMBEDDING_ID" => std::option::Option::Some(Self::INVALID_EMBEDDING_ID),
-                    "EMBEDDING_SIZE_MISMATCH" => {
-                        std::option::Option::Some(Self::EMBEDDING_SIZE_MISMATCH)
-                    }
-                    "NAMESPACE_MISSING" => std::option::Option::Some(Self::NAMESPACE_MISSING),
-                    "PARSING_ERROR" => std::option::Option::Some(Self::PARSING_ERROR),
-                    "DUPLICATE_NAMESPACE" => std::option::Option::Some(Self::DUPLICATE_NAMESPACE),
-                    "OP_IN_DATAPOINT" => std::option::Option::Some(Self::OP_IN_DATAPOINT),
-                    "MULTIPLE_VALUES" => std::option::Option::Some(Self::MULTIPLE_VALUES),
-                    "INVALID_NUMERIC_VALUE" => {
-                        std::option::Option::Some(Self::INVALID_NUMERIC_VALUE)
-                    }
-                    "INVALID_ENCODING" => std::option::Option::Some(Self::INVALID_ENCODING),
-                    "INVALID_SPARSE_DIMENSIONS" => {
-                        std::option::Option::Some(Self::INVALID_SPARSE_DIMENSIONS)
-                    }
-                    "INVALID_TOKEN_VALUE" => std::option::Option::Some(Self::INVALID_TOKEN_VALUE),
-                    "INVALID_SPARSE_EMBEDDING" => {
-                        std::option::Option::Some(Self::INVALID_SPARSE_EMBEDDING)
-                    }
-                    "INVALID_EMBEDDING" => std::option::Option::Some(Self::INVALID_EMBEDDING),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "index_service")]
+        pub mod record_error_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "index_service")]
-        impl std::convert::From<i32> for RecordErrorType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl RecordErrorType {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::ErrorTypeUnspecified => std::option::Option::Some(0),
+                    Self::EmptyLine => std::option::Option::Some(1),
+                    Self::InvalidJsonSyntax => std::option::Option::Some(2),
+                    Self::InvalidCsvSyntax => std::option::Option::Some(3),
+                    Self::InvalidAvroSyntax => std::option::Option::Some(4),
+                    Self::InvalidEmbeddingId => std::option::Option::Some(5),
+                    Self::EmbeddingSizeMismatch => std::option::Option::Some(6),
+                    Self::NamespaceMissing => std::option::Option::Some(7),
+                    Self::ParsingError => std::option::Option::Some(8),
+                    Self::DuplicateNamespace => std::option::Option::Some(9),
+                    Self::OpInDatapoint => std::option::Option::Some(10),
+                    Self::MultipleValues => std::option::Option::Some(11),
+                    Self::InvalidNumericValue => std::option::Option::Some(12),
+                    Self::InvalidEncoding => std::option::Option::Some(13),
+                    Self::InvalidSparseDimensions => std::option::Option::Some(14),
+                    Self::InvalidTokenValue => std::option::Option::Some(15),
+                    Self::InvalidSparseEmbedding => std::option::Option::Some(16),
+                    Self::InvalidEmbedding => std::option::Option::Some(17),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::ErrorTypeUnspecified => {
+                        std::option::Option::Some("ERROR_TYPE_UNSPECIFIED")
+                    }
+                    Self::EmptyLine => std::option::Option::Some("EMPTY_LINE"),
+                    Self::InvalidJsonSyntax => std::option::Option::Some("INVALID_JSON_SYNTAX"),
+                    Self::InvalidCsvSyntax => std::option::Option::Some("INVALID_CSV_SYNTAX"),
+                    Self::InvalidAvroSyntax => std::option::Option::Some("INVALID_AVRO_SYNTAX"),
+                    Self::InvalidEmbeddingId => std::option::Option::Some("INVALID_EMBEDDING_ID"),
+                    Self::EmbeddingSizeMismatch => {
+                        std::option::Option::Some("EMBEDDING_SIZE_MISMATCH")
+                    }
+                    Self::NamespaceMissing => std::option::Option::Some("NAMESPACE_MISSING"),
+                    Self::ParsingError => std::option::Option::Some("PARSING_ERROR"),
+                    Self::DuplicateNamespace => std::option::Option::Some("DUPLICATE_NAMESPACE"),
+                    Self::OpInDatapoint => std::option::Option::Some("OP_IN_DATAPOINT"),
+                    Self::MultipleValues => std::option::Option::Some("MULTIPLE_VALUES"),
+                    Self::InvalidNumericValue => std::option::Option::Some("INVALID_NUMERIC_VALUE"),
+                    Self::InvalidEncoding => std::option::Option::Some("INVALID_ENCODING"),
+                    Self::InvalidSparseDimensions => {
+                        std::option::Option::Some("INVALID_SPARSE_DIMENSIONS")
+                    }
+                    Self::InvalidTokenValue => std::option::Option::Some("INVALID_TOKEN_VALUE"),
+                    Self::InvalidSparseEmbedding => {
+                        std::option::Option::Some("INVALID_SPARSE_EMBEDDING")
+                    }
+                    Self::InvalidEmbedding => std::option::Option::Some("INVALID_EMBEDDING"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "index_service")]
         impl std::default::Default for RecordErrorType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "index_service")]
+        impl std::fmt::Display for RecordErrorType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "index_service")]
+        impl std::convert::From<i32> for RecordErrorType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::ErrorTypeUnspecified,
+                    1 => Self::EmptyLine,
+                    2 => Self::InvalidJsonSyntax,
+                    3 => Self::InvalidCsvSyntax,
+                    4 => Self::InvalidAvroSyntax,
+                    5 => Self::InvalidEmbeddingId,
+                    6 => Self::EmbeddingSizeMismatch,
+                    7 => Self::NamespaceMissing,
+                    8 => Self::ParsingError,
+                    9 => Self::DuplicateNamespace,
+                    10 => Self::OpInDatapoint,
+                    11 => Self::MultipleValues,
+                    12 => Self::InvalidNumericValue,
+                    13 => Self::InvalidEncoding,
+                    14 => Self::InvalidSparseDimensions,
+                    15 => Self::InvalidTokenValue,
+                    16 => Self::InvalidSparseEmbedding,
+                    17 => Self::InvalidEmbedding,
+                    _ => Self::UnknownValue(record_error_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "index_service")]
+        impl std::convert::From<&str> for RecordErrorType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ERROR_TYPE_UNSPECIFIED" => Self::ErrorTypeUnspecified,
+                    "EMPTY_LINE" => Self::EmptyLine,
+                    "INVALID_JSON_SYNTAX" => Self::InvalidJsonSyntax,
+                    "INVALID_CSV_SYNTAX" => Self::InvalidCsvSyntax,
+                    "INVALID_AVRO_SYNTAX" => Self::InvalidAvroSyntax,
+                    "INVALID_EMBEDDING_ID" => Self::InvalidEmbeddingId,
+                    "EMBEDDING_SIZE_MISMATCH" => Self::EmbeddingSizeMismatch,
+                    "NAMESPACE_MISSING" => Self::NamespaceMissing,
+                    "PARSING_ERROR" => Self::ParsingError,
+                    "DUPLICATE_NAMESPACE" => Self::DuplicateNamespace,
+                    "OP_IN_DATAPOINT" => Self::OpInDatapoint,
+                    "MULTIPLE_VALUES" => Self::MultipleValues,
+                    "INVALID_NUMERIC_VALUE" => Self::InvalidNumericValue,
+                    "INVALID_ENCODING" => Self::InvalidEncoding,
+                    "INVALID_SPARSE_DIMENSIONS" => Self::InvalidSparseDimensions,
+                    "INVALID_TOKEN_VALUE" => Self::InvalidTokenValue,
+                    "INVALID_SPARSE_EMBEDDING" => Self::InvalidSparseEmbedding,
+                    "INVALID_EMBEDDING" => Self::InvalidEmbedding,
+                    _ => Self::UnknownValue(record_error_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "index_service")]
+        impl serde::ser::Serialize for RecordErrorType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::ErrorTypeUnspecified => serializer.serialize_i32(0),
+                    Self::EmptyLine => serializer.serialize_i32(1),
+                    Self::InvalidJsonSyntax => serializer.serialize_i32(2),
+                    Self::InvalidCsvSyntax => serializer.serialize_i32(3),
+                    Self::InvalidAvroSyntax => serializer.serialize_i32(4),
+                    Self::InvalidEmbeddingId => serializer.serialize_i32(5),
+                    Self::EmbeddingSizeMismatch => serializer.serialize_i32(6),
+                    Self::NamespaceMissing => serializer.serialize_i32(7),
+                    Self::ParsingError => serializer.serialize_i32(8),
+                    Self::DuplicateNamespace => serializer.serialize_i32(9),
+                    Self::OpInDatapoint => serializer.serialize_i32(10),
+                    Self::MultipleValues => serializer.serialize_i32(11),
+                    Self::InvalidNumericValue => serializer.serialize_i32(12),
+                    Self::InvalidEncoding => serializer.serialize_i32(13),
+                    Self::InvalidSparseDimensions => serializer.serialize_i32(14),
+                    Self::InvalidTokenValue => serializer.serialize_i32(15),
+                    Self::InvalidSparseEmbedding => serializer.serialize_i32(16),
+                    Self::InvalidEmbedding => serializer.serialize_i32(17),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "index_service")]
+        impl<'de> serde::de::Deserialize<'de> for RecordErrorType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<RecordErrorType>::new(
+                    ".google.cloud.aiplatform.v1.NearestNeighborSearchOperationMetadata.RecordError.RecordErrorType"))
             }
         }
     }
@@ -44522,64 +47424,131 @@ pub mod google_drive_source {
 
         /// The type of the Google Drive resource.
         #[cfg(feature = "vertex_rag_data_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ResourceType(i32);
-
-        #[cfg(feature = "vertex_rag_data_service")]
-        impl ResourceType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ResourceType {
             /// Unspecified resource type.
-            pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
-
+            Unspecified,
             /// File resource type.
-            pub const RESOURCE_TYPE_FILE: ResourceType = ResourceType::new(1);
-
+            File,
             /// Folder resource type.
-            pub const RESOURCE_TYPE_FOLDER: ResourceType = ResourceType::new(2);
+            Folder,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ResourceType::value] or
+            /// [ResourceType::name].
+            UnknownValue(resource_type::UnknownValue),
+        }
 
-            /// Creates a new ResourceType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_FILE"),
-                    2 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_FOLDER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "RESOURCE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
-                    }
-                    "RESOURCE_TYPE_FILE" => std::option::Option::Some(Self::RESOURCE_TYPE_FILE),
-                    "RESOURCE_TYPE_FOLDER" => std::option::Option::Some(Self::RESOURCE_TYPE_FOLDER),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "vertex_rag_data_service")]
+        pub mod resource_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "vertex_rag_data_service")]
-        impl std::convert::From<i32> for ResourceType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl ResourceType {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::File => std::option::Option::Some(1),
+                    Self::Folder => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("RESOURCE_TYPE_UNSPECIFIED"),
+                    Self::File => std::option::Option::Some("RESOURCE_TYPE_FILE"),
+                    Self::Folder => std::option::Option::Some("RESOURCE_TYPE_FOLDER"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "vertex_rag_data_service")]
         impl std::default::Default for ResourceType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "vertex_rag_data_service")]
+        impl std::fmt::Display for ResourceType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "vertex_rag_data_service")]
+        impl std::convert::From<i32> for ResourceType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::File,
+                    2 => Self::Folder,
+                    _ => Self::UnknownValue(resource_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "vertex_rag_data_service")]
+        impl std::convert::From<&str> for ResourceType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "RESOURCE_TYPE_FILE" => Self::File,
+                    "RESOURCE_TYPE_FOLDER" => Self::Folder,
+                    _ => Self::UnknownValue(resource_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "vertex_rag_data_service")]
+        impl serde::ser::Serialize for ResourceType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::File => serializer.serialize_i32(1),
+                    Self::Folder => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "vertex_rag_data_service")]
+        impl<'de> serde::de::Deserialize<'de> for ResourceType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceType>::new(
+                    ".google.cloud.aiplatform.v1.GoogleDriveSource.ResourceId.ResourceType",
+                ))
             }
         }
     }
@@ -49749,69 +52718,135 @@ pub mod metadata_schema {
 
     /// Describes the type of the MetadataSchema.
     #[cfg(feature = "metadata_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetadataSchemaType(i32);
-
-    #[cfg(feature = "metadata_service")]
-    impl MetadataSchemaType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MetadataSchemaType {
         /// Unspecified type for the MetadataSchema.
-        pub const METADATA_SCHEMA_TYPE_UNSPECIFIED: MetadataSchemaType = MetadataSchemaType::new(0);
-
+        Unspecified,
         /// A type indicating that the MetadataSchema will be used by Artifacts.
-        pub const ARTIFACT_TYPE: MetadataSchemaType = MetadataSchemaType::new(1);
-
+        ArtifactType,
         /// A typee indicating that the MetadataSchema will be used by Executions.
-        pub const EXECUTION_TYPE: MetadataSchemaType = MetadataSchemaType::new(2);
-
+        ExecutionType,
         /// A state indicating that the MetadataSchema will be used by Contexts.
-        pub const CONTEXT_TYPE: MetadataSchemaType = MetadataSchemaType::new(3);
+        ContextType,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MetadataSchemaType::value] or
+        /// [MetadataSchemaType::name].
+        UnknownValue(metadata_schema_type::UnknownValue),
+    }
 
-        /// Creates a new MetadataSchemaType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METADATA_SCHEMA_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ARTIFACT_TYPE"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_TYPE"),
-                3 => std::borrow::Cow::Borrowed("CONTEXT_TYPE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METADATA_SCHEMA_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METADATA_SCHEMA_TYPE_UNSPECIFIED)
-                }
-                "ARTIFACT_TYPE" => std::option::Option::Some(Self::ARTIFACT_TYPE),
-                "EXECUTION_TYPE" => std::option::Option::Some(Self::EXECUTION_TYPE),
-                "CONTEXT_TYPE" => std::option::Option::Some(Self::CONTEXT_TYPE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "metadata_service")]
+    pub mod metadata_schema_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "metadata_service")]
-    impl std::convert::From<i32> for MetadataSchemaType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl MetadataSchemaType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ArtifactType => std::option::Option::Some(1),
+                Self::ExecutionType => std::option::Option::Some(2),
+                Self::ContextType => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METADATA_SCHEMA_TYPE_UNSPECIFIED"),
+                Self::ArtifactType => std::option::Option::Some("ARTIFACT_TYPE"),
+                Self::ExecutionType => std::option::Option::Some("EXECUTION_TYPE"),
+                Self::ContextType => std::option::Option::Some("CONTEXT_TYPE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "metadata_service")]
     impl std::default::Default for MetadataSchemaType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl std::fmt::Display for MetadataSchemaType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl std::convert::From<i32> for MetadataSchemaType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ArtifactType,
+                2 => Self::ExecutionType,
+                3 => Self::ContextType,
+                _ => Self::UnknownValue(metadata_schema_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl std::convert::From<&str> for MetadataSchemaType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METADATA_SCHEMA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ARTIFACT_TYPE" => Self::ArtifactType,
+                "EXECUTION_TYPE" => Self::ExecutionType,
+                "CONTEXT_TYPE" => Self::ContextType,
+                _ => Self::UnknownValue(metadata_schema_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl serde::ser::Serialize for MetadataSchemaType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ArtifactType => serializer.serialize_i32(1),
+                Self::ExecutionType => serializer.serialize_i32(2),
+                Self::ContextType => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "metadata_service")]
+    impl<'de> serde::de::Deserialize<'de> for MetadataSchemaType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetadataSchemaType>::new(
+                ".google.cloud.aiplatform.v1.MetadataSchema.MetadataSchemaType",
+            ))
         }
     }
 }
@@ -55495,26 +58530,18 @@ pub mod model {
             feature = "model_service",
             feature = "pipeline_service",
         ))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ExportableContent(i32);
-
-        #[cfg(any(
-            feature = "dataset_service",
-            feature = "model_service",
-            feature = "pipeline_service",
-        ))]
-        impl ExportableContent {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ExportableContent {
             /// Should not be used.
-            pub const EXPORTABLE_CONTENT_UNSPECIFIED: ExportableContent = ExportableContent::new(0);
-
+            Unspecified,
             /// Model artifact and any of its supported files. Will be exported to the
             /// location specified by the `artifactDestination` field of the
             /// [ExportModelRequest.output_config][google.cloud.aiplatform.v1.ExportModelRequest.output_config]
             /// object.
             ///
             /// [google.cloud.aiplatform.v1.ExportModelRequest.output_config]: crate::model::ExportModelRequest::output_config
-            pub const ARTIFACT: ExportableContent = ExportableContent::new(1);
-
+            Artifact,
             /// The container image that is to be used when deploying this Model. Will
             /// be exported to the location specified by the `imageDestination` field
             /// of the
@@ -55522,39 +58549,25 @@ pub mod model {
             /// object.
             ///
             /// [google.cloud.aiplatform.v1.ExportModelRequest.output_config]: crate::model::ExportModelRequest::output_config
-            pub const IMAGE: ExportableContent = ExportableContent::new(2);
+            Image,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ExportableContent::value] or
+            /// [ExportableContent::name].
+            UnknownValue(exportable_content::UnknownValue),
+        }
 
-            /// Creates a new ExportableContent instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("EXPORTABLE_CONTENT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ARTIFACT"),
-                    2 => std::borrow::Cow::Borrowed("IMAGE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "EXPORTABLE_CONTENT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::EXPORTABLE_CONTENT_UNSPECIFIED)
-                    }
-                    "ARTIFACT" => std::option::Option::Some(Self::ARTIFACT),
-                    "IMAGE" => std::option::Option::Some(Self::IMAGE),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        pub mod exportable_content {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(
@@ -55562,9 +58575,33 @@ pub mod model {
             feature = "model_service",
             feature = "pipeline_service",
         ))]
-        impl std::convert::From<i32> for ExportableContent {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl ExportableContent {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Artifact => std::option::Option::Some(1),
+                    Self::Image => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("EXPORTABLE_CONTENT_UNSPECIFIED")
+                    }
+                    Self::Artifact => std::option::Option::Some("ARTIFACT"),
+                    Self::Image => std::option::Option::Some("IMAGE"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
@@ -55575,7 +58612,94 @@ pub mod model {
         ))]
         impl std::default::Default for ExportableContent {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl std::fmt::Display for ExportableContent {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl std::convert::From<i32> for ExportableContent {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Artifact,
+                    2 => Self::Image,
+                    _ => Self::UnknownValue(exportable_content::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl std::convert::From<&str> for ExportableContent {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "EXPORTABLE_CONTENT_UNSPECIFIED" => Self::Unspecified,
+                    "ARTIFACT" => Self::Artifact,
+                    "IMAGE" => Self::Image,
+                    _ => Self::UnknownValue(exportable_content::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl serde::ser::Serialize for ExportableContent {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Artifact => serializer.serialize_i32(1),
+                    Self::Image => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(
+            feature = "dataset_service",
+            feature = "model_service",
+            feature = "pipeline_service",
+        ))]
+        impl<'de> serde::de::Deserialize<'de> for ExportableContent {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExportableContent>::new(
+                    ".google.cloud.aiplatform.v1.Model.ExportFormat.ExportableContent",
+                ))
             }
         }
     }
@@ -55894,30 +59018,20 @@ pub mod model {
         feature = "model_service",
         feature = "pipeline_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeploymentResourcesType(i32);
-
-    #[cfg(any(
-        feature = "dataset_service",
-        feature = "model_service",
-        feature = "pipeline_service",
-    ))]
-    impl DeploymentResourcesType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DeploymentResourcesType {
         /// Should not be used.
-        pub const DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED: DeploymentResourcesType =
-            DeploymentResourcesType::new(0);
-
+        Unspecified,
         /// Resources that are dedicated to the
         /// [DeployedModel][google.cloud.aiplatform.v1.DeployedModel], and that need
         /// a higher degree of manual configuration.
         ///
         /// [google.cloud.aiplatform.v1.DeployedModel]: crate::model::DeployedModel
-        pub const DEDICATED_RESOURCES: DeploymentResourcesType = DeploymentResourcesType::new(1);
-
+        DedicatedResources,
         /// Resources that to large degree are decided by Vertex AI, and require
         /// only a modest additional configuration.
-        pub const AUTOMATIC_RESOURCES: DeploymentResourcesType = DeploymentResourcesType::new(2);
-
+        AutomaticResources,
         /// Resources that can be shared by multiple
         /// [DeployedModels][google.cloud.aiplatform.v1.DeployedModel]. A
         /// pre-configured
@@ -55926,41 +59040,25 @@ pub mod model {
         ///
         /// [google.cloud.aiplatform.v1.DeployedModel]: crate::model::DeployedModel
         /// [google.cloud.aiplatform.v1.DeploymentResourcePool]: crate::model::DeploymentResourcePool
-        pub const SHARED_RESOURCES: DeploymentResourcesType = DeploymentResourcesType::new(3);
+        SharedResources,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DeploymentResourcesType::value] or
+        /// [DeploymentResourcesType::name].
+        UnknownValue(deployment_resources_type::UnknownValue),
+    }
 
-        /// Creates a new DeploymentResourcesType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEDICATED_RESOURCES"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATIC_RESOURCES"),
-                3 => std::borrow::Cow::Borrowed("SHARED_RESOURCES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED)
-                }
-                "DEDICATED_RESOURCES" => std::option::Option::Some(Self::DEDICATED_RESOURCES),
-                "AUTOMATIC_RESOURCES" => std::option::Option::Some(Self::AUTOMATIC_RESOURCES),
-                "SHARED_RESOURCES" => std::option::Option::Some(Self::SHARED_RESOURCES),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    pub mod deployment_resources_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -55968,9 +59066,35 @@ pub mod model {
         feature = "model_service",
         feature = "pipeline_service",
     ))]
-    impl std::convert::From<i32> for DeploymentResourcesType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl DeploymentResourcesType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DedicatedResources => std::option::Option::Some(1),
+                Self::AutomaticResources => std::option::Option::Some(2),
+                Self::SharedResources => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED")
+                }
+                Self::DedicatedResources => std::option::Option::Some("DEDICATED_RESOURCES"),
+                Self::AutomaticResources => std::option::Option::Some("AUTOMATIC_RESOURCES"),
+                Self::SharedResources => std::option::Option::Some("SHARED_RESOURCES"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -55981,7 +59105,96 @@ pub mod model {
     ))]
     impl std::default::Default for DeploymentResourcesType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl std::fmt::Display for DeploymentResourcesType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl std::convert::From<i32> for DeploymentResourcesType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DedicatedResources,
+                2 => Self::AutomaticResources,
+                3 => Self::SharedResources,
+                _ => Self::UnknownValue(deployment_resources_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl std::convert::From<&str> for DeploymentResourcesType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEPLOYMENT_RESOURCES_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DEDICATED_RESOURCES" => Self::DedicatedResources,
+                "AUTOMATIC_RESOURCES" => Self::AutomaticResources,
+                "SHARED_RESOURCES" => Self::SharedResources,
+                _ => Self::UnknownValue(deployment_resources_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl serde::ser::Serialize for DeploymentResourcesType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DedicatedResources => serializer.serialize_i32(1),
+                Self::AutomaticResources => serializer.serialize_i32(2),
+                Self::SharedResources => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for DeploymentResourcesType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<DeploymentResourcesType>::new(
+                    ".google.cloud.aiplatform.v1.Model.DeploymentResourcesType",
+                ),
+            )
         }
     }
 }
@@ -56852,80 +60065,43 @@ pub mod model_source_info {
         feature = "model_service",
         feature = "pipeline_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelSourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelSourceType {
+        /// Should not be used.
+        Unspecified,
+        /// The Model is uploaded by automl training pipeline.
+        Automl,
+        /// The Model is uploaded by user or custom training pipeline.
+        Custom,
+        /// The Model is registered and sync'ed from BigQuery ML.
+        Bqml,
+        /// The Model is saved or tuned from Model Garden.
+        ModelGarden,
+        /// The Model is saved or tuned from Genie.
+        Genie,
+        /// The Model is uploaded by text embedding finetuning pipeline.
+        CustomTextEmbedding,
+        /// The Model is saved or tuned from Marketplace.
+        Marketplace,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelSourceType::value] or
+        /// [ModelSourceType::name].
+        UnknownValue(model_source_type::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "dataset_service",
         feature = "model_service",
         feature = "pipeline_service",
     ))]
-    impl ModelSourceType {
-        /// Should not be used.
-        pub const MODEL_SOURCE_TYPE_UNSPECIFIED: ModelSourceType = ModelSourceType::new(0);
-
-        /// The Model is uploaded by automl training pipeline.
-        pub const AUTOML: ModelSourceType = ModelSourceType::new(1);
-
-        /// The Model is uploaded by user or custom training pipeline.
-        pub const CUSTOM: ModelSourceType = ModelSourceType::new(2);
-
-        /// The Model is registered and sync'ed from BigQuery ML.
-        pub const BQML: ModelSourceType = ModelSourceType::new(3);
-
-        /// The Model is saved or tuned from Model Garden.
-        pub const MODEL_GARDEN: ModelSourceType = ModelSourceType::new(4);
-
-        /// The Model is saved or tuned from Genie.
-        pub const GENIE: ModelSourceType = ModelSourceType::new(5);
-
-        /// The Model is uploaded by text embedding finetuning pipeline.
-        pub const CUSTOM_TEXT_EMBEDDING: ModelSourceType = ModelSourceType::new(6);
-
-        /// The Model is saved or tuned from Marketplace.
-        pub const MARKETPLACE: ModelSourceType = ModelSourceType::new(7);
-
-        /// Creates a new ModelSourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOML"),
-                2 => std::borrow::Cow::Borrowed("CUSTOM"),
-                3 => std::borrow::Cow::Borrowed("BQML"),
-                4 => std::borrow::Cow::Borrowed("MODEL_GARDEN"),
-                5 => std::borrow::Cow::Borrowed("GENIE"),
-                6 => std::borrow::Cow::Borrowed("CUSTOM_TEXT_EMBEDDING"),
-                7 => std::borrow::Cow::Borrowed("MARKETPLACE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MODEL_SOURCE_TYPE_UNSPECIFIED)
-                }
-                "AUTOML" => std::option::Option::Some(Self::AUTOML),
-                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                "BQML" => std::option::Option::Some(Self::BQML),
-                "MODEL_GARDEN" => std::option::Option::Some(Self::MODEL_GARDEN),
-                "GENIE" => std::option::Option::Some(Self::GENIE),
-                "CUSTOM_TEXT_EMBEDDING" => std::option::Option::Some(Self::CUSTOM_TEXT_EMBEDDING),
-                "MARKETPLACE" => std::option::Option::Some(Self::MARKETPLACE),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod model_source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -56933,9 +60109,41 @@ pub mod model_source_info {
         feature = "model_service",
         feature = "pipeline_service",
     ))]
-    impl std::convert::From<i32> for ModelSourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl ModelSourceType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automl => std::option::Option::Some(1),
+                Self::Custom => std::option::Option::Some(2),
+                Self::Bqml => std::option::Option::Some(3),
+                Self::ModelGarden => std::option::Option::Some(4),
+                Self::Genie => std::option::Option::Some(5),
+                Self::CustomTextEmbedding => std::option::Option::Some(6),
+                Self::Marketplace => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_SOURCE_TYPE_UNSPECIFIED"),
+                Self::Automl => std::option::Option::Some("AUTOML"),
+                Self::Custom => std::option::Option::Some("CUSTOM"),
+                Self::Bqml => std::option::Option::Some("BQML"),
+                Self::ModelGarden => std::option::Option::Some("MODEL_GARDEN"),
+                Self::Genie => std::option::Option::Some("GENIE"),
+                Self::CustomTextEmbedding => std::option::Option::Some("CUSTOM_TEXT_EMBEDDING"),
+                Self::Marketplace => std::option::Option::Some("MARKETPLACE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -56946,7 +60154,106 @@ pub mod model_source_info {
     ))]
     impl std::default::Default for ModelSourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl std::fmt::Display for ModelSourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl std::convert::From<i32> for ModelSourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automl,
+                2 => Self::Custom,
+                3 => Self::Bqml,
+                4 => Self::ModelGarden,
+                5 => Self::Genie,
+                6 => Self::CustomTextEmbedding,
+                7 => Self::Marketplace,
+                _ => Self::UnknownValue(model_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl std::convert::From<&str> for ModelSourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOML" => Self::Automl,
+                "CUSTOM" => Self::Custom,
+                "BQML" => Self::Bqml,
+                "MODEL_GARDEN" => Self::ModelGarden,
+                "GENIE" => Self::Genie,
+                "CUSTOM_TEXT_EMBEDDING" => Self::CustomTextEmbedding,
+                "MARKETPLACE" => Self::Marketplace,
+                _ => Self::UnknownValue(model_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl serde::ser::Serialize for ModelSourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automl => serializer.serialize_i32(1),
+                Self::Custom => serializer.serialize_i32(2),
+                Self::Bqml => serializer.serialize_i32(3),
+                Self::ModelGarden => serializer.serialize_i32(4),
+                Self::Genie => serializer.serialize_i32(5),
+                Self::CustomTextEmbedding => serializer.serialize_i32(6),
+                Self::Marketplace => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "dataset_service",
+        feature = "model_service",
+        feature = "pipeline_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for ModelSourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelSourceType>::new(
+                ".google.cloud.aiplatform.v1.ModelSourceInfo.ModelSourceType",
+            ))
         }
     }
 }
@@ -58060,70 +61367,136 @@ pub mod model_deployment_monitoring_job {
 
     /// The state to Specify the monitoring pipeline.
     #[cfg(feature = "job_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MonitoringScheduleState(i32);
-
-    #[cfg(feature = "job_service")]
-    impl MonitoringScheduleState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MonitoringScheduleState {
         /// Unspecified state.
-        pub const MONITORING_SCHEDULE_STATE_UNSPECIFIED: MonitoringScheduleState =
-            MonitoringScheduleState::new(0);
-
+        Unspecified,
         /// The pipeline is picked up and wait to run.
-        pub const PENDING: MonitoringScheduleState = MonitoringScheduleState::new(1);
-
+        Pending,
         /// The pipeline is offline and will be scheduled for next run.
-        pub const OFFLINE: MonitoringScheduleState = MonitoringScheduleState::new(2);
-
+        Offline,
         /// The pipeline is running.
-        pub const RUNNING: MonitoringScheduleState = MonitoringScheduleState::new(3);
+        Running,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MonitoringScheduleState::value] or
+        /// [MonitoringScheduleState::name].
+        UnknownValue(monitoring_schedule_state::UnknownValue),
+    }
 
-        /// Creates a new MonitoringScheduleState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MONITORING_SCHEDULE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("OFFLINE"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MONITORING_SCHEDULE_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MONITORING_SCHEDULE_STATE_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "job_service")]
+    pub mod monitoring_schedule_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "job_service")]
-    impl std::convert::From<i32> for MonitoringScheduleState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl MonitoringScheduleState {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Offline => std::option::Option::Some(2),
+                Self::Running => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("MONITORING_SCHEDULE_STATE_UNSPECIFIED")
+                }
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Offline => std::option::Option::Some("OFFLINE"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "job_service")]
     impl std::default::Default for MonitoringScheduleState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::fmt::Display for MonitoringScheduleState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<i32> for MonitoringScheduleState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Offline,
+                3 => Self::Running,
+                _ => Self::UnknownValue(monitoring_schedule_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<&str> for MonitoringScheduleState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MONITORING_SCHEDULE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "OFFLINE" => Self::Offline,
+                "RUNNING" => Self::Running,
+                _ => Self::UnknownValue(monitoring_schedule_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl serde::ser::Serialize for MonitoringScheduleState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Offline => serializer.serialize_i32(2),
+                Self::Running => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl<'de> serde::de::Deserialize<'de> for MonitoringScheduleState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MonitoringScheduleState>::new(
+                ".google.cloud.aiplatform.v1.ModelDeploymentMonitoringJob.MonitoringScheduleState"))
         }
     }
 }
@@ -58221,123 +61594,255 @@ pub mod model_deployment_monitoring_big_query_table {
 
     /// Indicates where does the log come from.
     #[cfg(feature = "job_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSource(i32);
-
-    #[cfg(feature = "job_service")]
-    impl LogSource {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogSource {
         /// Unspecified source.
-        pub const LOG_SOURCE_UNSPECIFIED: LogSource = LogSource::new(0);
-
+        Unspecified,
         /// Logs coming from Training dataset.
-        pub const TRAINING: LogSource = LogSource::new(1);
-
+        Training,
         /// Logs coming from Serving traffic.
-        pub const SERVING: LogSource = LogSource::new(2);
+        Serving,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogSource::value] or
+        /// [LogSource::name].
+        UnknownValue(log_source::UnknownValue),
+    }
 
-        /// Creates a new LogSource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_SOURCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRAINING"),
-                2 => std::borrow::Cow::Borrowed("SERVING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_SOURCE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_SOURCE_UNSPECIFIED),
-                "TRAINING" => std::option::Option::Some(Self::TRAINING),
-                "SERVING" => std::option::Option::Some(Self::SERVING),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "job_service")]
+    pub mod log_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "job_service")]
-    impl std::convert::From<i32> for LogSource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl LogSource {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Training => std::option::Option::Some(1),
+                Self::Serving => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_SOURCE_UNSPECIFIED"),
+                Self::Training => std::option::Option::Some("TRAINING"),
+                Self::Serving => std::option::Option::Some("SERVING"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "job_service")]
     impl std::default::Default for LogSource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::fmt::Display for LogSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<i32> for LogSource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Training,
+                2 => Self::Serving,
+                _ => Self::UnknownValue(log_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<&str> for LogSource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "TRAINING" => Self::Training,
+                "SERVING" => Self::Serving,
+                _ => Self::UnknownValue(log_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl serde::ser::Serialize for LogSource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Training => serializer.serialize_i32(1),
+                Self::Serving => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl<'de> serde::de::Deserialize<'de> for LogSource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogSource>::new(
+                ".google.cloud.aiplatform.v1.ModelDeploymentMonitoringBigQueryTable.LogSource",
+            ))
         }
     }
 
     /// Indicates what type of traffic does the log belong to.
     #[cfg(feature = "job_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogType(i32);
-
-    #[cfg(feature = "job_service")]
-    impl LogType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogType {
         /// Unspecified type.
-        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new(0);
-
+        Unspecified,
         /// Predict logs.
-        pub const PREDICT: LogType = LogType::new(1);
-
+        Predict,
         /// Explain logs.
-        pub const EXPLAIN: LogType = LogType::new(2);
+        Explain,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogType::value] or
+        /// [LogType::name].
+        UnknownValue(log_type::UnknownValue),
+    }
 
-        /// Creates a new LogType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PREDICT"),
-                2 => std::borrow::Cow::Borrowed("EXPLAIN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_TYPE_UNSPECIFIED),
-                "PREDICT" => std::option::Option::Some(Self::PREDICT),
-                "EXPLAIN" => std::option::Option::Some(Self::EXPLAIN),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "job_service")]
+    pub mod log_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "job_service")]
-    impl std::convert::From<i32> for LogType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl LogType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Predict => std::option::Option::Some(1),
+                Self::Explain => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_TYPE_UNSPECIFIED"),
+                Self::Predict => std::option::Option::Some("PREDICT"),
+                Self::Explain => std::option::Option::Some("EXPLAIN"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "job_service")]
     impl std::default::Default for LogType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::fmt::Display for LogType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<i32> for LogType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Predict,
+                2 => Self::Explain,
+                _ => Self::UnknownValue(log_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<&str> for LogType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PREDICT" => Self::Predict,
+                "EXPLAIN" => Self::Explain,
+                _ => Self::UnknownValue(log_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl serde::ser::Serialize for LogType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Predict => serializer.serialize_i32(1),
+                Self::Explain => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl<'de> serde::de::Deserialize<'de> for LogType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogType>::new(
+                ".google.cloud.aiplatform.v1.ModelDeploymentMonitoringBigQueryTable.LogType",
+            ))
         }
     }
 }
@@ -60310,65 +63815,132 @@ pub mod model_monitoring_objective_config {
 
             /// The storage format of the predictions generated BatchPrediction job.
             #[cfg(feature = "job_service")]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct PredictionFormat(i32);
-
-            #[cfg(feature = "job_service")]
-            impl PredictionFormat {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum PredictionFormat {
                 /// Should not be set.
-                pub const PREDICTION_FORMAT_UNSPECIFIED: PredictionFormat =
-                    PredictionFormat::new(0);
-
+                Unspecified,
                 /// Predictions are in JSONL files.
-                pub const JSONL: PredictionFormat = PredictionFormat::new(2);
-
+                Jsonl,
                 /// Predictions are in BigQuery.
-                pub const BIGQUERY: PredictionFormat = PredictionFormat::new(3);
+                Bigquery,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [PredictionFormat::value] or
+                /// [PredictionFormat::name].
+                UnknownValue(prediction_format::UnknownValue),
+            }
 
-                /// Creates a new PredictionFormat instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("PREDICTION_FORMAT_UNSPECIFIED"),
-                        2 => std::borrow::Cow::Borrowed("JSONL"),
-                        3 => std::borrow::Cow::Borrowed("BIGQUERY"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "PREDICTION_FORMAT_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::PREDICTION_FORMAT_UNSPECIFIED)
-                        }
-                        "JSONL" => std::option::Option::Some(Self::JSONL),
-                        "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-                        _ => std::option::Option::None,
-                    }
-                }
+            #[doc(hidden)]
+            #[cfg(feature = "job_service")]
+            pub mod prediction_format {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(feature = "job_service")]
-            impl std::convert::From<i32> for PredictionFormat {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl PredictionFormat {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Jsonl => std::option::Option::Some(2),
+                        Self::Bigquery => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("PREDICTION_FORMAT_UNSPECIFIED")
+                        }
+                        Self::Jsonl => std::option::Option::Some("JSONL"),
+                        Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
             #[cfg(feature = "job_service")]
             impl std::default::Default for PredictionFormat {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl std::fmt::Display for PredictionFormat {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl std::convert::From<i32> for PredictionFormat {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        2 => Self::Jsonl,
+                        3 => Self::Bigquery,
+                        _ => Self::UnknownValue(prediction_format::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl std::convert::From<&str> for PredictionFormat {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "PREDICTION_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                        "JSONL" => Self::Jsonl,
+                        "BIGQUERY" => Self::Bigquery,
+                        _ => Self::UnknownValue(prediction_format::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl serde::ser::Serialize for PredictionFormat {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Jsonl => serializer.serialize_i32(2),
+                        Self::Bigquery => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl<'de> serde::de::Deserialize<'de> for PredictionFormat {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<PredictionFormat>::new(
+                        ".google.cloud.aiplatform.v1.ModelMonitoringObjectiveConfig.ExplanationConfig.ExplanationBaseline.PredictionFormat"))
                 }
             }
 
@@ -63716,64 +67288,130 @@ pub mod nas_job_spec {
 
             /// The available types of optimization goals.
             #[cfg(feature = "job_service")]
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct GoalType(i32);
-
-            #[cfg(feature = "job_service")]
-            impl GoalType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum GoalType {
                 /// Goal Type will default to maximize.
-                pub const GOAL_TYPE_UNSPECIFIED: GoalType = GoalType::new(0);
-
+                Unspecified,
                 /// Maximize the goal metric.
-                pub const MAXIMIZE: GoalType = GoalType::new(1);
-
+                Maximize,
                 /// Minimize the goal metric.
-                pub const MINIMIZE: GoalType = GoalType::new(2);
+                Minimize,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [GoalType::value] or
+                /// [GoalType::name].
+                UnknownValue(goal_type::UnknownValue),
+            }
 
-                /// Creates a new GoalType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
-                /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
-                }
-
-                /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("GOAL_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("MAXIMIZE"),
-                        2 => std::borrow::Cow::Borrowed("MINIMIZE"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "GOAL_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::GOAL_TYPE_UNSPECIFIED)
-                        }
-                        "MAXIMIZE" => std::option::Option::Some(Self::MAXIMIZE),
-                        "MINIMIZE" => std::option::Option::Some(Self::MINIMIZE),
-                        _ => std::option::Option::None,
-                    }
-                }
+            #[doc(hidden)]
+            #[cfg(feature = "job_service")]
+            pub mod goal_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
             }
 
             #[cfg(feature = "job_service")]
-            impl std::convert::From<i32> for GoalType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
+            impl GoalType {
+                /// Gets the enum value.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Maximize => std::option::Option::Some(1),
+                        Self::Minimize => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
+                }
+
+                /// Gets the enum value as a string.
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("GOAL_TYPE_UNSPECIFIED"),
+                        Self::Maximize => std::option::Option::Some("MAXIMIZE"),
+                        Self::Minimize => std::option::Option::Some("MINIMIZE"),
+                        Self::UnknownValue(u) => u.0.name(),
+                    }
                 }
             }
 
             #[cfg(feature = "job_service")]
             impl std::default::Default for GoalType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl std::fmt::Display for GoalType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl std::convert::From<i32> for GoalType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Maximize,
+                        2 => Self::Minimize,
+                        _ => Self::UnknownValue(goal_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl std::convert::From<&str> for GoalType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "GOAL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "MAXIMIZE" => Self::Maximize,
+                        "MINIMIZE" => Self::Minimize,
+                        _ => Self::UnknownValue(goal_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl serde::ser::Serialize for GoalType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Maximize => serializer.serialize_i32(1),
+                        Self::Minimize => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            #[cfg(feature = "job_service")]
+            impl<'de> serde::de::Deserialize<'de> for GoalType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<GoalType>::new(
+                        ".google.cloud.aiplatform.v1.NasJobSpec.MultiTrialAlgorithmSpec.MetricSpec.GoalType"))
                 }
             }
         }
@@ -63926,69 +67564,136 @@ pub mod nas_job_spec {
 
         /// The available types of multi-trial algorithms.
         #[cfg(feature = "job_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MultiTrialAlgorithm(i32);
-
-        #[cfg(feature = "job_service")]
-        impl MultiTrialAlgorithm {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MultiTrialAlgorithm {
             /// Defaults to `REINFORCEMENT_LEARNING`.
-            pub const MULTI_TRIAL_ALGORITHM_UNSPECIFIED: MultiTrialAlgorithm =
-                MultiTrialAlgorithm::new(0);
-
+            Unspecified,
             /// The Reinforcement Learning Algorithm for Multi-trial Neural
             /// Architecture Search (NAS).
-            pub const REINFORCEMENT_LEARNING: MultiTrialAlgorithm = MultiTrialAlgorithm::new(1);
-
+            ReinforcementLearning,
             /// The Grid Search Algorithm for Multi-trial Neural
             /// Architecture Search (NAS).
-            pub const GRID_SEARCH: MultiTrialAlgorithm = MultiTrialAlgorithm::new(2);
+            GridSearch,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MultiTrialAlgorithm::value] or
+            /// [MultiTrialAlgorithm::name].
+            UnknownValue(multi_trial_algorithm::UnknownValue),
+        }
 
-            /// Creates a new MultiTrialAlgorithm instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MULTI_TRIAL_ALGORITHM_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("REINFORCEMENT_LEARNING"),
-                    2 => std::borrow::Cow::Borrowed("GRID_SEARCH"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MULTI_TRIAL_ALGORITHM_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::MULTI_TRIAL_ALGORITHM_UNSPECIFIED)
-                    }
-                    "REINFORCEMENT_LEARNING" => {
-                        std::option::Option::Some(Self::REINFORCEMENT_LEARNING)
-                    }
-                    "GRID_SEARCH" => std::option::Option::Some(Self::GRID_SEARCH),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "job_service")]
+        pub mod multi_trial_algorithm {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "job_service")]
-        impl std::convert::From<i32> for MultiTrialAlgorithm {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl MultiTrialAlgorithm {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ReinforcementLearning => std::option::Option::Some(1),
+                    Self::GridSearch => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("MULTI_TRIAL_ALGORITHM_UNSPECIFIED")
+                    }
+                    Self::ReinforcementLearning => {
+                        std::option::Option::Some("REINFORCEMENT_LEARNING")
+                    }
+                    Self::GridSearch => std::option::Option::Some("GRID_SEARCH"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "job_service")]
         impl std::default::Default for MultiTrialAlgorithm {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "job_service")]
+        impl std::fmt::Display for MultiTrialAlgorithm {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "job_service")]
+        impl std::convert::From<i32> for MultiTrialAlgorithm {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ReinforcementLearning,
+                    2 => Self::GridSearch,
+                    _ => Self::UnknownValue(multi_trial_algorithm::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "job_service")]
+        impl std::convert::From<&str> for MultiTrialAlgorithm {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MULTI_TRIAL_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                    "REINFORCEMENT_LEARNING" => Self::ReinforcementLearning,
+                    "GRID_SEARCH" => Self::GridSearch,
+                    _ => Self::UnknownValue(multi_trial_algorithm::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "job_service")]
+        impl serde::ser::Serialize for MultiTrialAlgorithm {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ReinforcementLearning => serializer.serialize_i32(1),
+                    Self::GridSearch => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "job_service")]
+        impl<'de> serde::de::Deserialize<'de> for MultiTrialAlgorithm {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MultiTrialAlgorithm>::new(
+                    ".google.cloud.aiplatform.v1.NasJobSpec.MultiTrialAlgorithmSpec.MultiTrialAlgorithm"))
             }
         }
     }
@@ -64252,80 +67957,152 @@ pub mod nas_trial {
 
     /// Describes a NasTrial state.
     #[cfg(feature = "job_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "job_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The NasTrial state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Indicates that a specific NasTrial has been requested, but it has not yet
         /// been suggested by the service.
-        pub const REQUESTED: State = State::new(1);
-
+        Requested,
         /// Indicates that the NasTrial has been suggested.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// Indicates that the NasTrial should stop according to the service.
-        pub const STOPPING: State = State::new(3);
-
+        Stopping,
         /// Indicates that the NasTrial is completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
+        Succeeded,
         /// Indicates that the NasTrial should not be attempted again.
         /// The service will set a NasTrial to INFEASIBLE when it's done but missing
         /// the final_measurement.
-        pub const INFEASIBLE: State = State::new(5);
+        Infeasible,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REQUESTED"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("STOPPING"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("INFEASIBLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "REQUESTED" => std::option::Option::Some(Self::REQUESTED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "INFEASIBLE" => std::option::Option::Some(Self::INFEASIBLE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "job_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "job_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Requested => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Stopping => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Infeasible => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Requested => std::option::Option::Some("REQUESTED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Infeasible => std::option::Option::Some("INFEASIBLE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "job_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Requested,
+                2 => Self::Active,
+                3 => Self::Stopping,
+                4 => Self::Succeeded,
+                5 => Self::Infeasible,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "REQUESTED" => Self::Requested,
+                "ACTIVE" => Self::Active,
+                "STOPPING" => Self::Stopping,
+                "SUCCEEDED" => Self::Succeeded,
+                "INFEASIBLE" => Self::Infeasible,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Requested => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Stopping => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Infeasible => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "job_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.NasTrial.State",
+            ))
         }
     }
 }
@@ -66092,154 +69869,292 @@ pub mod notebook_runtime {
 
     /// The substate of the NotebookRuntime to display health information.
     #[cfg(feature = "notebook_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HealthState(i32);
-
-    #[cfg(feature = "notebook_service")]
-    impl HealthState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HealthState {
         /// Unspecified health state.
-        pub const HEALTH_STATE_UNSPECIFIED: HealthState = HealthState::new(0);
-
+        Unspecified,
         /// NotebookRuntime is in healthy state. Applies to ACTIVE state.
-        pub const HEALTHY: HealthState = HealthState::new(1);
-
+        Healthy,
         /// NotebookRuntime is in unhealthy state. Applies to ACTIVE state.
-        pub const UNHEALTHY: HealthState = HealthState::new(2);
+        Unhealthy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HealthState::value] or
+        /// [HealthState::name].
+        UnknownValue(health_state::UnknownValue),
+    }
 
-        /// Creates a new HealthState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HEALTH_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HEALTHY"),
-                2 => std::borrow::Cow::Borrowed("UNHEALTHY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HEALTH_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HEALTH_STATE_UNSPECIFIED)
-                }
-                "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
-                "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "notebook_service")]
+    pub mod health_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "notebook_service")]
-    impl std::convert::From<i32> for HealthState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl HealthState {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Healthy => std::option::Option::Some(1),
+                Self::Unhealthy => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HEALTH_STATE_UNSPECIFIED"),
+                Self::Healthy => std::option::Option::Some("HEALTHY"),
+                Self::Unhealthy => std::option::Option::Some("UNHEALTHY"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "notebook_service")]
     impl std::default::Default for HealthState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::fmt::Display for HealthState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::convert::From<i32> for HealthState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Healthy,
+                2 => Self::Unhealthy,
+                _ => Self::UnknownValue(health_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::convert::From<&str> for HealthState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HEALTH_STATE_UNSPECIFIED" => Self::Unspecified,
+                "HEALTHY" => Self::Healthy,
+                "UNHEALTHY" => Self::Unhealthy,
+                _ => Self::UnknownValue(health_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl serde::ser::Serialize for HealthState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Healthy => serializer.serialize_i32(1),
+                Self::Unhealthy => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl<'de> serde::de::Deserialize<'de> for HealthState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HealthState>::new(
+                ".google.cloud.aiplatform.v1.NotebookRuntime.HealthState",
+            ))
         }
     }
 
     /// The substate of the NotebookRuntime to display state of runtime.
     /// The resource of NotebookRuntime is in ACTIVE state for these sub state.
     #[cfg(feature = "notebook_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RuntimeState(i32);
-
-    #[cfg(feature = "notebook_service")]
-    impl RuntimeState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RuntimeState {
         /// Unspecified runtime state.
-        pub const RUNTIME_STATE_UNSPECIFIED: RuntimeState = RuntimeState::new(0);
-
+        Unspecified,
         /// NotebookRuntime is in running state.
-        pub const RUNNING: RuntimeState = RuntimeState::new(1);
-
+        Running,
         /// NotebookRuntime is in starting state.
-        pub const BEING_STARTED: RuntimeState = RuntimeState::new(2);
-
+        BeingStarted,
         /// NotebookRuntime is in stopping state.
-        pub const BEING_STOPPED: RuntimeState = RuntimeState::new(3);
-
+        BeingStopped,
         /// NotebookRuntime is in stopped state.
-        pub const STOPPED: RuntimeState = RuntimeState::new(4);
-
+        Stopped,
         /// NotebookRuntime is in upgrading state. It is in the middle of upgrading
         /// process.
-        pub const BEING_UPGRADED: RuntimeState = RuntimeState::new(5);
-
+        BeingUpgraded,
         /// NotebookRuntime was unable to start/stop properly.
-        pub const ERROR: RuntimeState = RuntimeState::new(100);
-
+        Error,
         /// NotebookRuntime is in invalid state. Cannot be recovered.
-        pub const INVALID: RuntimeState = RuntimeState::new(101);
+        Invalid,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RuntimeState::value] or
+        /// [RuntimeState::name].
+        UnknownValue(runtime_state::UnknownValue),
+    }
 
-        /// Creates a new RuntimeState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RUNTIME_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("BEING_STARTED"),
-                3 => std::borrow::Cow::Borrowed("BEING_STOPPED"),
-                4 => std::borrow::Cow::Borrowed("STOPPED"),
-                5 => std::borrow::Cow::Borrowed("BEING_UPGRADED"),
-                100 => std::borrow::Cow::Borrowed("ERROR"),
-                101 => std::borrow::Cow::Borrowed("INVALID"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RUNTIME_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RUNTIME_STATE_UNSPECIFIED)
-                }
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "BEING_STARTED" => std::option::Option::Some(Self::BEING_STARTED),
-                "BEING_STOPPED" => std::option::Option::Some(Self::BEING_STOPPED),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "BEING_UPGRADED" => std::option::Option::Some(Self::BEING_UPGRADED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "INVALID" => std::option::Option::Some(Self::INVALID),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "notebook_service")]
+    pub mod runtime_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "notebook_service")]
-    impl std::convert::From<i32> for RuntimeState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl RuntimeState {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::BeingStarted => std::option::Option::Some(2),
+                Self::BeingStopped => std::option::Option::Some(3),
+                Self::Stopped => std::option::Option::Some(4),
+                Self::BeingUpgraded => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(100),
+                Self::Invalid => std::option::Option::Some(101),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RUNTIME_STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::BeingStarted => std::option::Option::Some("BEING_STARTED"),
+                Self::BeingStopped => std::option::Option::Some("BEING_STOPPED"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::BeingUpgraded => std::option::Option::Some("BEING_UPGRADED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Invalid => std::option::Option::Some("INVALID"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "notebook_service")]
     impl std::default::Default for RuntimeState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::fmt::Display for RuntimeState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::convert::From<i32> for RuntimeState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::BeingStarted,
+                3 => Self::BeingStopped,
+                4 => Self::Stopped,
+                5 => Self::BeingUpgraded,
+                100 => Self::Error,
+                101 => Self::Invalid,
+                _ => Self::UnknownValue(runtime_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::convert::From<&str> for RuntimeState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RUNTIME_STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "BEING_STARTED" => Self::BeingStarted,
+                "BEING_STOPPED" => Self::BeingStopped,
+                "STOPPED" => Self::Stopped,
+                "BEING_UPGRADED" => Self::BeingUpgraded,
+                "ERROR" => Self::Error,
+                "INVALID" => Self::Invalid,
+                _ => Self::UnknownValue(runtime_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl serde::ser::Serialize for RuntimeState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::BeingStarted => serializer.serialize_i32(2),
+                Self::BeingStopped => serializer.serialize_i32(3),
+                Self::Stopped => serializer.serialize_i32(4),
+                Self::BeingUpgraded => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(100),
+                Self::Invalid => serializer.serialize_i32(101),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl<'de> serde::de::Deserialize<'de> for RuntimeState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RuntimeState>::new(
+                ".google.cloud.aiplatform.v1.NotebookRuntime.RuntimeState",
+            ))
         }
     }
 }
@@ -68009,73 +71924,141 @@ pub mod post_startup_script_config {
 
     /// Represents a notebook runtime post startup script behavior.
     #[cfg(feature = "notebook_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PostStartupScriptBehavior(i32);
-
-    #[cfg(feature = "notebook_service")]
-    impl PostStartupScriptBehavior {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PostStartupScriptBehavior {
         /// Unspecified post startup script behavior.
-        pub const POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED: PostStartupScriptBehavior =
-            PostStartupScriptBehavior::new(0);
-
+        Unspecified,
         /// Run post startup script after runtime is started.
-        pub const RUN_ONCE: PostStartupScriptBehavior = PostStartupScriptBehavior::new(1);
-
+        RunOnce,
         /// Run post startup script after runtime is stopped.
-        pub const RUN_EVERY_START: PostStartupScriptBehavior = PostStartupScriptBehavior::new(2);
-
+        RunEveryStart,
         /// Download and run post startup script every time runtime is started.
-        pub const DOWNLOAD_AND_RUN_EVERY_START: PostStartupScriptBehavior =
-            PostStartupScriptBehavior::new(3);
+        DownloadAndRunEveryStart,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PostStartupScriptBehavior::value] or
+        /// [PostStartupScriptBehavior::name].
+        UnknownValue(post_startup_script_behavior::UnknownValue),
+    }
 
-        /// Creates a new PostStartupScriptBehavior instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUN_ONCE"),
-                2 => std::borrow::Cow::Borrowed("RUN_EVERY_START"),
-                3 => std::borrow::Cow::Borrowed("DOWNLOAD_AND_RUN_EVERY_START"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED)
-                }
-                "RUN_ONCE" => std::option::Option::Some(Self::RUN_ONCE),
-                "RUN_EVERY_START" => std::option::Option::Some(Self::RUN_EVERY_START),
-                "DOWNLOAD_AND_RUN_EVERY_START" => {
-                    std::option::Option::Some(Self::DOWNLOAD_AND_RUN_EVERY_START)
-                }
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "notebook_service")]
+    pub mod post_startup_script_behavior {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "notebook_service")]
-    impl std::convert::From<i32> for PostStartupScriptBehavior {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl PostStartupScriptBehavior {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RunOnce => std::option::Option::Some(1),
+                Self::RunEveryStart => std::option::Option::Some(2),
+                Self::DownloadAndRunEveryStart => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED")
+                }
+                Self::RunOnce => std::option::Option::Some("RUN_ONCE"),
+                Self::RunEveryStart => std::option::Option::Some("RUN_EVERY_START"),
+                Self::DownloadAndRunEveryStart => {
+                    std::option::Option::Some("DOWNLOAD_AND_RUN_EVERY_START")
+                }
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "notebook_service")]
     impl std::default::Default for PostStartupScriptBehavior {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::fmt::Display for PostStartupScriptBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::convert::From<i32> for PostStartupScriptBehavior {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RunOnce,
+                2 => Self::RunEveryStart,
+                3 => Self::DownloadAndRunEveryStart,
+                _ => Self::UnknownValue(post_startup_script_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl std::convert::From<&str> for PostStartupScriptBehavior {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POST_STARTUP_SCRIPT_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+                "RUN_ONCE" => Self::RunOnce,
+                "RUN_EVERY_START" => Self::RunEveryStart,
+                "DOWNLOAD_AND_RUN_EVERY_START" => Self::DownloadAndRunEveryStart,
+                _ => Self::UnknownValue(post_startup_script_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl serde::ser::Serialize for PostStartupScriptBehavior {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RunOnce => serializer.serialize_i32(1),
+                Self::RunEveryStart => serializer.serialize_i32(2),
+                Self::DownloadAndRunEveryStart => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "notebook_service")]
+    impl<'de> serde::de::Deserialize<'de> for PostStartupScriptBehavior {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<PostStartupScriptBehavior>::new(
+                    ".google.cloud.aiplatform.v1.PostStartupScriptConfig.PostStartupScriptBehavior",
+                ),
+            )
         }
     }
 }
@@ -68955,86 +72938,160 @@ pub mod persistent_resource {
 
     /// Describes the PersistentResource state.
     #[cfg(feature = "persistent_resource_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "persistent_resource_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the persistent resources is being
         /// created.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the persistent resource is healthy and fully
         /// usable.
-        pub const RUNNING: State = State::new(3);
-
+        Running,
         /// The STOPPING state indicates the persistent resource is being deleted.
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The ERROR state indicates the persistent resource may be unusable.
         /// Details can be found in the `error` field.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// The REBOOTING state indicates the persistent resource is being rebooted
         /// (PR is not available right now but is expected to be ready again later).
-        pub const REBOOTING: State = State::new(6);
-
+        Rebooting,
         /// The UPDATING state indicates the persistent resource is being updated.
-        pub const UPDATING: State = State::new(7);
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("REBOOTING"),
-                7 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "REBOOTING" => std::option::Option::Some(Self::REBOOTING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "persistent_resource_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "persistent_resource_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Rebooting => std::option::Option::Some(6),
+                Self::Updating => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Rebooting => std::option::Option::Some("REBOOTING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "persistent_resource_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "persistent_resource_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "persistent_resource_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                3 => Self::Running,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Rebooting,
+                7 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "persistent_resource_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "REBOOTING" => Self::Rebooting,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "persistent_resource_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Rebooting => serializer.serialize_i32(6),
+                Self::Updating => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "persistent_resource_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.PersistentResource.State",
+            ))
         }
     }
 }
@@ -71111,102 +75168,182 @@ pub mod pipeline_task_detail {
 
     /// Specifies state of TaskExecution
     #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Specifies pending state for the task.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// Specifies task is being executed.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// Specifies task completed successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// Specifies Task cancel is in pending state.
-        pub const CANCEL_PENDING: State = State::new(4);
-
+        CancelPending,
         /// Specifies task is being cancelled.
-        pub const CANCELLING: State = State::new(5);
-
+        Cancelling,
         /// Specifies task was cancelled.
-        pub const CANCELLED: State = State::new(6);
-
+        Cancelled,
         /// Specifies task failed.
-        pub const FAILED: State = State::new(7);
-
+        Failed,
         /// Specifies task was skipped due to cache hit.
-        pub const SKIPPED: State = State::new(8);
-
+        Skipped,
         /// Specifies that the task was not triggered because the task's trigger
         /// policy is not satisfied. The trigger policy is specified in the
         /// `condition` field of
         /// [PipelineJob.pipeline_spec][google.cloud.aiplatform.v1.PipelineJob.pipeline_spec].
         ///
         /// [google.cloud.aiplatform.v1.PipelineJob.pipeline_spec]: crate::model::PipelineJob::pipeline_spec
-        pub const NOT_TRIGGERED: State = State::new(9);
+        NotTriggered,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("CANCEL_PENDING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLING"),
-                6 => std::borrow::Cow::Borrowed("CANCELLED"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                8 => std::borrow::Cow::Borrowed("SKIPPED"),
-                9 => std::borrow::Cow::Borrowed("NOT_TRIGGERED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCEL_PENDING" => std::option::Option::Some(Self::CANCEL_PENDING),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                "NOT_TRIGGERED" => std::option::Option::Some(Self::NOT_TRIGGERED),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::CancelPending => std::option::Option::Some(4),
+                Self::Cancelling => std::option::Option::Some(5),
+                Self::Cancelled => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::Skipped => std::option::Option::Some(8),
+                Self::NotTriggered => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::CancelPending => std::option::Option::Some("CANCEL_PENDING"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Skipped => std::option::Option::Some("SKIPPED"),
+                Self::NotTriggered => std::option::Option::Some("NOT_TRIGGERED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::CancelPending,
+                5 => Self::Cancelling,
+                6 => Self::Cancelled,
+                7 => Self::Failed,
+                8 => Self::Skipped,
+                9 => Self::NotTriggered,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCEL_PENDING" => Self::CancelPending,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                "SKIPPED" => Self::Skipped,
+                "NOT_TRIGGERED" => Self::NotTriggered,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::CancelPending => serializer.serialize_i32(4),
+                Self::Cancelling => serializer.serialize_i32(5),
+                Self::Cancelled => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::Skipped => serializer.serialize_i32(8),
+                Self::NotTriggered => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.PipelineTaskDetail.State",
+            ))
         }
     }
 }
@@ -74343,75 +78480,145 @@ pub mod generate_content_response {
 
         /// Blocked reason enumeration.
         #[cfg(feature = "prediction_service")]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BlockedReason(i32);
-
-        #[cfg(feature = "prediction_service")]
-        impl BlockedReason {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum BlockedReason {
             /// Unspecified blocked reason.
-            pub const BLOCKED_REASON_UNSPECIFIED: BlockedReason = BlockedReason::new(0);
-
+            Unspecified,
             /// Candidates blocked due to safety.
-            pub const SAFETY: BlockedReason = BlockedReason::new(1);
-
+            Safety,
             /// Candidates blocked due to other reason.
-            pub const OTHER: BlockedReason = BlockedReason::new(2);
-
+            Other,
             /// Candidates blocked due to the terms which are included from the
             /// terminology blocklist.
-            pub const BLOCKLIST: BlockedReason = BlockedReason::new(3);
-
+            Blocklist,
             /// Candidates blocked due to prohibited content.
-            pub const PROHIBITED_CONTENT: BlockedReason = BlockedReason::new(4);
+            ProhibitedContent,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [BlockedReason::value] or
+            /// [BlockedReason::name].
+            UnknownValue(blocked_reason::UnknownValue),
+        }
 
-            /// Creates a new BlockedReason instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("BLOCKED_REASON_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SAFETY"),
-                    2 => std::borrow::Cow::Borrowed("OTHER"),
-                    3 => std::borrow::Cow::Borrowed("BLOCKLIST"),
-                    4 => std::borrow::Cow::Borrowed("PROHIBITED_CONTENT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "BLOCKED_REASON_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::BLOCKED_REASON_UNSPECIFIED)
-                    }
-                    "SAFETY" => std::option::Option::Some(Self::SAFETY),
-                    "OTHER" => std::option::Option::Some(Self::OTHER),
-                    "BLOCKLIST" => std::option::Option::Some(Self::BLOCKLIST),
-                    "PROHIBITED_CONTENT" => std::option::Option::Some(Self::PROHIBITED_CONTENT),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(feature = "prediction_service")]
+        pub mod blocked_reason {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(feature = "prediction_service")]
-        impl std::convert::From<i32> for BlockedReason {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl BlockedReason {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Safety => std::option::Option::Some(1),
+                    Self::Other => std::option::Option::Some(2),
+                    Self::Blocklist => std::option::Option::Some(3),
+                    Self::ProhibitedContent => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("BLOCKED_REASON_UNSPECIFIED"),
+                    Self::Safety => std::option::Option::Some("SAFETY"),
+                    Self::Other => std::option::Option::Some("OTHER"),
+                    Self::Blocklist => std::option::Option::Some("BLOCKLIST"),
+                    Self::ProhibitedContent => std::option::Option::Some("PROHIBITED_CONTENT"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(feature = "prediction_service")]
         impl std::default::Default for BlockedReason {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(feature = "prediction_service")]
+        impl std::fmt::Display for BlockedReason {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(feature = "prediction_service")]
+        impl std::convert::From<i32> for BlockedReason {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Safety,
+                    2 => Self::Other,
+                    3 => Self::Blocklist,
+                    4 => Self::ProhibitedContent,
+                    _ => Self::UnknownValue(blocked_reason::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "prediction_service")]
+        impl std::convert::From<&str> for BlockedReason {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "BLOCKED_REASON_UNSPECIFIED" => Self::Unspecified,
+                    "SAFETY" => Self::Safety,
+                    "OTHER" => Self::Other,
+                    "BLOCKLIST" => Self::Blocklist,
+                    "PROHIBITED_CONTENT" => Self::ProhibitedContent,
+                    _ => Self::UnknownValue(blocked_reason::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(feature = "prediction_service")]
+        impl serde::ser::Serialize for BlockedReason {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Safety => serializer.serialize_i32(1),
+                    Self::Other => serializer.serialize_i32(2),
+                    Self::Blocklist => serializer.serialize_i32(3),
+                    Self::ProhibitedContent => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(feature = "prediction_service")]
+        impl<'de> serde::de::Deserialize<'de> for BlockedReason {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<BlockedReason>::new(
+                    ".google.cloud.aiplatform.v1.GenerateContentResponse.PromptFeedback.BlockedReason"))
             }
         }
     }
@@ -75820,231 +80027,435 @@ pub mod publisher_model {
 
     /// An enum representing the open source category of a PublisherModel.
     #[cfg(feature = "model_garden_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OpenSourceCategory(i32);
-
-    #[cfg(feature = "model_garden_service")]
-    impl OpenSourceCategory {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OpenSourceCategory {
         /// The open source category is unspecified, which should not be used.
-        pub const OPEN_SOURCE_CATEGORY_UNSPECIFIED: OpenSourceCategory = OpenSourceCategory::new(0);
-
+        Unspecified,
         /// Used to indicate the PublisherModel is not open sourced.
-        pub const PROPRIETARY: OpenSourceCategory = OpenSourceCategory::new(1);
-
+        Proprietary,
         /// Used to indicate the PublisherModel is a Google-owned open source model
         /// w/ Google checkpoint.
-        pub const GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT: OpenSourceCategory =
-            OpenSourceCategory::new(2);
-
+        GoogleOwnedOssWithGoogleCheckpoint,
         /// Used to indicate the PublisherModel is a 3p-owned open source model w/
         /// Google checkpoint.
-        pub const THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT: OpenSourceCategory =
-            OpenSourceCategory::new(3);
-
+        ThirdPartyOwnedOssWithGoogleCheckpoint,
         /// Used to indicate the PublisherModel is a Google-owned pure open source
         /// model.
-        pub const GOOGLE_OWNED_OSS: OpenSourceCategory = OpenSourceCategory::new(4);
-
+        GoogleOwnedOss,
         /// Used to indicate the PublisherModel is a 3p-owned pure open source model.
-        pub const THIRD_PARTY_OWNED_OSS: OpenSourceCategory = OpenSourceCategory::new(5);
+        ThirdPartyOwnedOss,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OpenSourceCategory::value] or
+        /// [OpenSourceCategory::name].
+        UnknownValue(open_source_category::UnknownValue),
+    }
 
-        /// Creates a new OpenSourceCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPEN_SOURCE_CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROPRIETARY"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT"),
-                3 => std::borrow::Cow::Borrowed("THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT"),
-                4 => std::borrow::Cow::Borrowed("GOOGLE_OWNED_OSS"),
-                5 => std::borrow::Cow::Borrowed("THIRD_PARTY_OWNED_OSS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPEN_SOURCE_CATEGORY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OPEN_SOURCE_CATEGORY_UNSPECIFIED)
-                }
-                "PROPRIETARY" => std::option::Option::Some(Self::PROPRIETARY),
-                "GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT" => {
-                    std::option::Option::Some(Self::GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT)
-                }
-                "THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT" => {
-                    std::option::Option::Some(Self::THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT)
-                }
-                "GOOGLE_OWNED_OSS" => std::option::Option::Some(Self::GOOGLE_OWNED_OSS),
-                "THIRD_PARTY_OWNED_OSS" => std::option::Option::Some(Self::THIRD_PARTY_OWNED_OSS),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "model_garden_service")]
+    pub mod open_source_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "model_garden_service")]
-    impl std::convert::From<i32> for OpenSourceCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl OpenSourceCategory {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Proprietary => std::option::Option::Some(1),
+                Self::GoogleOwnedOssWithGoogleCheckpoint => std::option::Option::Some(2),
+                Self::ThirdPartyOwnedOssWithGoogleCheckpoint => std::option::Option::Some(3),
+                Self::GoogleOwnedOss => std::option::Option::Some(4),
+                Self::ThirdPartyOwnedOss => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPEN_SOURCE_CATEGORY_UNSPECIFIED"),
+                Self::Proprietary => std::option::Option::Some("PROPRIETARY"),
+                Self::GoogleOwnedOssWithGoogleCheckpoint => {
+                    std::option::Option::Some("GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT")
+                }
+                Self::ThirdPartyOwnedOssWithGoogleCheckpoint => {
+                    std::option::Option::Some("THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT")
+                }
+                Self::GoogleOwnedOss => std::option::Option::Some("GOOGLE_OWNED_OSS"),
+                Self::ThirdPartyOwnedOss => std::option::Option::Some("THIRD_PARTY_OWNED_OSS"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "model_garden_service")]
     impl std::default::Default for OpenSourceCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::fmt::Display for OpenSourceCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::convert::From<i32> for OpenSourceCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Proprietary,
+                2 => Self::GoogleOwnedOssWithGoogleCheckpoint,
+                3 => Self::ThirdPartyOwnedOssWithGoogleCheckpoint,
+                4 => Self::GoogleOwnedOss,
+                5 => Self::ThirdPartyOwnedOss,
+                _ => Self::UnknownValue(open_source_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::convert::From<&str> for OpenSourceCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPEN_SOURCE_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "PROPRIETARY" => Self::Proprietary,
+                "GOOGLE_OWNED_OSS_WITH_GOOGLE_CHECKPOINT" => {
+                    Self::GoogleOwnedOssWithGoogleCheckpoint
+                }
+                "THIRD_PARTY_OWNED_OSS_WITH_GOOGLE_CHECKPOINT" => {
+                    Self::ThirdPartyOwnedOssWithGoogleCheckpoint
+                }
+                "GOOGLE_OWNED_OSS" => Self::GoogleOwnedOss,
+                "THIRD_PARTY_OWNED_OSS" => Self::ThirdPartyOwnedOss,
+                _ => Self::UnknownValue(open_source_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl serde::ser::Serialize for OpenSourceCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Proprietary => serializer.serialize_i32(1),
+                Self::GoogleOwnedOssWithGoogleCheckpoint => serializer.serialize_i32(2),
+                Self::ThirdPartyOwnedOssWithGoogleCheckpoint => serializer.serialize_i32(3),
+                Self::GoogleOwnedOss => serializer.serialize_i32(4),
+                Self::ThirdPartyOwnedOss => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl<'de> serde::de::Deserialize<'de> for OpenSourceCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OpenSourceCategory>::new(
+                ".google.cloud.aiplatform.v1.PublisherModel.OpenSourceCategory",
+            ))
         }
     }
 
     /// An enum representing the launch stage of a PublisherModel.
     #[cfg(feature = "model_garden_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LaunchStage(i32);
-
-    #[cfg(feature = "model_garden_service")]
-    impl LaunchStage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LaunchStage {
         /// The model launch stage is unspecified.
-        pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new(0);
-
+        Unspecified,
         /// Used to indicate the PublisherModel is at Experimental launch stage,
         /// available to a small set of customers.
-        pub const EXPERIMENTAL: LaunchStage = LaunchStage::new(1);
-
+        Experimental,
         /// Used to indicate the PublisherModel is at Private Preview launch stage,
         /// only available to a small set of customers, although a larger set of
         /// customers than an Experimental launch. Previews are the first launch
         /// stage used to get feedback from customers.
-        pub const PRIVATE_PREVIEW: LaunchStage = LaunchStage::new(2);
-
+        PrivatePreview,
         /// Used to indicate the PublisherModel is at Public Preview launch stage,
         /// available to all customers, although not supported for production
         /// workloads.
-        pub const PUBLIC_PREVIEW: LaunchStage = LaunchStage::new(3);
-
+        PublicPreview,
         /// Used to indicate the PublisherModel is at GA launch stage, available to
         /// all customers and ready for production workload.
-        pub const GA: LaunchStage = LaunchStage::new(4);
+        Ga,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LaunchStage::value] or
+        /// [LaunchStage::name].
+        UnknownValue(launch_stage::UnknownValue),
+    }
 
-        /// Creates a new LaunchStage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LAUNCH_STAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXPERIMENTAL"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE_PREVIEW"),
-                3 => std::borrow::Cow::Borrowed("PUBLIC_PREVIEW"),
-                4 => std::borrow::Cow::Borrowed("GA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LAUNCH_STAGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LAUNCH_STAGE_UNSPECIFIED)
-                }
-                "EXPERIMENTAL" => std::option::Option::Some(Self::EXPERIMENTAL),
-                "PRIVATE_PREVIEW" => std::option::Option::Some(Self::PRIVATE_PREVIEW),
-                "PUBLIC_PREVIEW" => std::option::Option::Some(Self::PUBLIC_PREVIEW),
-                "GA" => std::option::Option::Some(Self::GA),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "model_garden_service")]
+    pub mod launch_stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "model_garden_service")]
-    impl std::convert::From<i32> for LaunchStage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl LaunchStage {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Experimental => std::option::Option::Some(1),
+                Self::PrivatePreview => std::option::Option::Some(2),
+                Self::PublicPreview => std::option::Option::Some(3),
+                Self::Ga => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LAUNCH_STAGE_UNSPECIFIED"),
+                Self::Experimental => std::option::Option::Some("EXPERIMENTAL"),
+                Self::PrivatePreview => std::option::Option::Some("PRIVATE_PREVIEW"),
+                Self::PublicPreview => std::option::Option::Some("PUBLIC_PREVIEW"),
+                Self::Ga => std::option::Option::Some("GA"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "model_garden_service")]
     impl std::default::Default for LaunchStage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::fmt::Display for LaunchStage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::convert::From<i32> for LaunchStage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Experimental,
+                2 => Self::PrivatePreview,
+                3 => Self::PublicPreview,
+                4 => Self::Ga,
+                _ => Self::UnknownValue(launch_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::convert::From<&str> for LaunchStage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LAUNCH_STAGE_UNSPECIFIED" => Self::Unspecified,
+                "EXPERIMENTAL" => Self::Experimental,
+                "PRIVATE_PREVIEW" => Self::PrivatePreview,
+                "PUBLIC_PREVIEW" => Self::PublicPreview,
+                "GA" => Self::Ga,
+                _ => Self::UnknownValue(launch_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl serde::ser::Serialize for LaunchStage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Experimental => serializer.serialize_i32(1),
+                Self::PrivatePreview => serializer.serialize_i32(2),
+                Self::PublicPreview => serializer.serialize_i32(3),
+                Self::Ga => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl<'de> serde::de::Deserialize<'de> for LaunchStage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LaunchStage>::new(
+                ".google.cloud.aiplatform.v1.PublisherModel.LaunchStage",
+            ))
         }
     }
 
     /// An enum representing the state of the PublicModelVersion.
     #[cfg(feature = "model_garden_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionState(i32);
-
-    #[cfg(feature = "model_garden_service")]
-    impl VersionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VersionState {
         /// The version state is unspecified.
-        pub const VERSION_STATE_UNSPECIFIED: VersionState = VersionState::new(0);
-
+        Unspecified,
         /// Used to indicate the version is stable.
-        pub const VERSION_STATE_STABLE: VersionState = VersionState::new(1);
-
+        Stable,
         /// Used to indicate the version is unstable.
-        pub const VERSION_STATE_UNSTABLE: VersionState = VersionState::new(2);
+        Unstable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VersionState::value] or
+        /// [VersionState::name].
+        UnknownValue(version_state::UnknownValue),
+    }
 
-        /// Creates a new VersionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VERSION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VERSION_STATE_STABLE"),
-                2 => std::borrow::Cow::Borrowed("VERSION_STATE_UNSTABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VERSION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VERSION_STATE_UNSPECIFIED)
-                }
-                "VERSION_STATE_STABLE" => std::option::Option::Some(Self::VERSION_STATE_STABLE),
-                "VERSION_STATE_UNSTABLE" => std::option::Option::Some(Self::VERSION_STATE_UNSTABLE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "model_garden_service")]
+    pub mod version_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "model_garden_service")]
-    impl std::convert::From<i32> for VersionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl VersionState {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Stable => std::option::Option::Some(1),
+                Self::Unstable => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VERSION_STATE_UNSPECIFIED"),
+                Self::Stable => std::option::Option::Some("VERSION_STATE_STABLE"),
+                Self::Unstable => std::option::Option::Some("VERSION_STATE_UNSTABLE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "model_garden_service")]
     impl std::default::Default for VersionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::fmt::Display for VersionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::convert::From<i32> for VersionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Stable,
+                2 => Self::Unstable,
+                _ => Self::UnknownValue(version_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl std::convert::From<&str> for VersionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VERSION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "VERSION_STATE_STABLE" => Self::Stable,
+                "VERSION_STATE_UNSTABLE" => Self::Unstable,
+                _ => Self::UnknownValue(version_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl serde::ser::Serialize for VersionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Stable => serializer.serialize_i32(1),
+                Self::Unstable => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "model_garden_service")]
+    impl<'de> serde::de::Deserialize<'de> for VersionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionState>::new(
+                ".google.cloud.aiplatform.v1.PublisherModel.VersionState",
+            ))
         }
     }
 }
@@ -77108,9 +81519,26 @@ pub mod reservation_affinity {
         feature = "persistent_resource_service",
         feature = "schedule_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Default value. This should not be used.
+        Unspecified,
+        /// Do not consume from any reserved capacity, only use on-demand.
+        NoReservation,
+        /// Consume any reservation available, falling back to on-demand.
+        AnyReservation,
+        /// Consume from a specific reservation. When chosen, the reservation
+        /// must be identified via the `key` and `values` fields.
+        SpecificReservation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "deployment_resource_pool_service",
         feature = "endpoint_service",
@@ -77121,51 +81549,11 @@ pub mod reservation_affinity {
         feature = "persistent_resource_service",
         feature = "schedule_service",
     ))]
-    impl Type {
-        /// Default value. This should not be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Do not consume from any reserved capacity, only use on-demand.
-        pub const NO_RESERVATION: Type = Type::new(1);
-
-        /// Consume any reservation available, falling back to on-demand.
-        pub const ANY_RESERVATION: Type = Type::new(2);
-
-        /// Consume from a specific reservation. When chosen, the reservation
-        /// must be identified via the `key` and `values` fields.
-        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
-                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
-                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
-                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -77178,9 +81566,33 @@ pub mod reservation_affinity {
         feature = "persistent_resource_service",
         feature = "schedule_service",
     ))]
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Type {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoReservation => std::option::Option::Some(1),
+                Self::AnyReservation => std::option::Option::Some(2),
+                Self::SpecificReservation => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::NoReservation => std::option::Option::Some("NO_RESERVATION"),
+                Self::AnyReservation => std::option::Option::Some("ANY_RESERVATION"),
+                Self::SpecificReservation => std::option::Option::Some("SPECIFIC_RESERVATION"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -77196,7 +81608,119 @@ pub mod reservation_affinity {
     ))]
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "index_endpoint_service",
+        feature = "job_service",
+        feature = "model_garden_service",
+        feature = "notebook_service",
+        feature = "persistent_resource_service",
+        feature = "schedule_service",
+    ))]
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "index_endpoint_service",
+        feature = "job_service",
+        feature = "model_garden_service",
+        feature = "notebook_service",
+        feature = "persistent_resource_service",
+        feature = "schedule_service",
+    ))]
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoReservation,
+                2 => Self::AnyReservation,
+                3 => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "index_endpoint_service",
+        feature = "job_service",
+        feature = "model_garden_service",
+        feature = "notebook_service",
+        feature = "persistent_resource_service",
+        feature = "schedule_service",
+    ))]
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NO_RESERVATION" => Self::NoReservation,
+                "ANY_RESERVATION" => Self::AnyReservation,
+                "SPECIFIC_RESERVATION" => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "index_endpoint_service",
+        feature = "job_service",
+        feature = "model_garden_service",
+        feature = "notebook_service",
+        feature = "persistent_resource_service",
+        feature = "schedule_service",
+    ))]
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoReservation => serializer.serialize_i32(1),
+                Self::AnyReservation => serializer.serialize_i32(2),
+                Self::SpecificReservation => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "deployment_resource_pool_service",
+        feature = "endpoint_service",
+        feature = "index_endpoint_service",
+        feature = "job_service",
+        feature = "model_garden_service",
+        feature = "notebook_service",
+        feature = "persistent_resource_service",
+        feature = "schedule_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.aiplatform.v1.ReservationAffinity.Type",
+            ))
         }
     }
 }
@@ -77782,71 +82306,139 @@ pub mod schedule {
 
     /// Possible state of the schedule.
     #[cfg(feature = "schedule_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "schedule_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The Schedule is active. Runs are being scheduled on the user-specified
         /// timespec.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The schedule is paused. No new runs will be created until the schedule
         /// is resumed. Already started runs will be allowed to complete.
-        pub const PAUSED: State = State::new(2);
-
+        Paused,
         /// The Schedule is completed. No new runs will be scheduled. Already started
         /// runs will be allowed to complete. Schedules in completed state cannot be
         /// paused or resumed.
-        pub const COMPLETED: State = State::new(3);
+        Completed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("COMPLETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "schedule_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "schedule_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Completed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "schedule_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "schedule_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "schedule_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Paused,
+                3 => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "schedule_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "PAUSED" => Self::Paused,
+                "COMPLETED" => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "schedule_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Completed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "schedule_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.Schedule.State",
+            ))
         }
     }
 
@@ -79226,68 +83818,136 @@ pub mod study {
 
     /// Describes the Study state.
     #[cfg(feature = "vizier_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "vizier_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The study state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The study is active.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The study is stopped due to an internal error.
-        pub const INACTIVE: State = State::new(2);
-
+        Inactive,
         /// The study is done when the service exhausts the parameter search space
         /// or max_trial_count is reached.
-        pub const COMPLETED: State = State::new(3);
+        Completed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("INACTIVE"),
-                3 => std::borrow::Cow::Borrowed("COMPLETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "vizier_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "vizier_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Inactive => std::option::Option::Some(2),
+                Self::Completed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "vizier_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "vizier_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "vizier_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Inactive,
+                3 => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "vizier_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "INACTIVE" => Self::Inactive,
+                "COMPLETED" => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "vizier_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Inactive => serializer.serialize_i32(2),
+                Self::Completed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "vizier_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.Study.State",
+            ))
         }
     }
 }
@@ -79564,80 +84224,152 @@ pub mod trial {
 
     /// Describes a Trial state.
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The Trial state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Indicates that a specific Trial has been requested, but it has not yet
         /// been suggested by the service.
-        pub const REQUESTED: State = State::new(1);
-
+        Requested,
         /// Indicates that the Trial has been suggested.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// Indicates that the Trial should stop according to the service.
-        pub const STOPPING: State = State::new(3);
-
+        Stopping,
         /// Indicates that the Trial is completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
+        Succeeded,
         /// Indicates that the Trial should not be attempted again.
         /// The service will set a Trial to INFEASIBLE when it's done but missing
         /// the final_measurement.
-        pub const INFEASIBLE: State = State::new(5);
+        Infeasible,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REQUESTED"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("STOPPING"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("INFEASIBLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "REQUESTED" => std::option::Option::Some(Self::REQUESTED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "INFEASIBLE" => std::option::Option::Some(Self::INFEASIBLE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Requested => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Stopping => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Infeasible => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Requested => std::option::Option::Some("REQUESTED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Infeasible => std::option::Option::Some("INFEASIBLE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Requested,
+                2 => Self::Active,
+                3 => Self::Stopping,
+                4 => Self::Succeeded,
+                5 => Self::Infeasible,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "REQUESTED" => Self::Requested,
+                "ACTIVE" => Self::Active,
+                "STOPPING" => Self::Stopping,
+                "SUCCEEDED" => Self::Succeeded,
+                "INFEASIBLE" => Self::Infeasible,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Requested => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Stopping => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Infeasible => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.Trial.State",
+            ))
         }
     }
 }
@@ -80186,64 +84918,131 @@ pub mod study_spec {
 
         /// The available types of optimization goals.
         #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct GoalType(i32);
-
-        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-        impl GoalType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum GoalType {
             /// Goal Type will default to maximize.
-            pub const GOAL_TYPE_UNSPECIFIED: GoalType = GoalType::new(0);
-
+            Unspecified,
             /// Maximize the goal metric.
-            pub const MAXIMIZE: GoalType = GoalType::new(1);
-
+            Maximize,
             /// Minimize the goal metric.
-            pub const MINIMIZE: GoalType = GoalType::new(2);
+            Minimize,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [GoalType::value] or
+            /// [GoalType::name].
+            UnknownValue(goal_type::UnknownValue),
+        }
 
-            /// Creates a new GoalType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("GOAL_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MAXIMIZE"),
-                    2 => std::borrow::Cow::Borrowed("MINIMIZE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "GOAL_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::GOAL_TYPE_UNSPECIFIED)
-                    }
-                    "MAXIMIZE" => std::option::Option::Some(Self::MAXIMIZE),
-                    "MINIMIZE" => std::option::Option::Some(Self::MINIMIZE),
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        pub mod goal_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-        impl std::convert::From<i32> for GoalType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl GoalType {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Maximize => std::option::Option::Some(1),
+                    Self::Minimize => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("GOAL_TYPE_UNSPECIFIED"),
+                    Self::Maximize => std::option::Option::Some("MAXIMIZE"),
+                    Self::Minimize => std::option::Option::Some("MINIMIZE"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(any(feature = "job_service", feature = "vizier_service",))]
         impl std::default::Default for GoalType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl std::fmt::Display for GoalType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl std::convert::From<i32> for GoalType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Maximize,
+                    2 => Self::Minimize,
+                    _ => Self::UnknownValue(goal_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl std::convert::From<&str> for GoalType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "GOAL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "MAXIMIZE" => Self::Maximize,
+                    "MINIMIZE" => Self::Minimize,
+                    _ => Self::UnknownValue(goal_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl serde::ser::Serialize for GoalType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Maximize => serializer.serialize_i32(1),
+                    Self::Minimize => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl<'de> serde::de::Deserialize<'de> for GoalType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<GoalType>::new(
+                    ".google.cloud.aiplatform.v1.StudySpec.MetricSpec.GoalType",
+                ))
             }
         }
     }
@@ -81042,75 +85841,144 @@ pub mod study_spec {
 
         /// The type of scaling that should be applied to this parameter.
         #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ScaleType(i32);
-
-        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-        impl ScaleType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ScaleType {
             /// By default, no scaling is applied.
-            pub const SCALE_TYPE_UNSPECIFIED: ScaleType = ScaleType::new(0);
-
+            Unspecified,
             /// Scales the feasible space to (0, 1) linearly.
-            pub const UNIT_LINEAR_SCALE: ScaleType = ScaleType::new(1);
-
+            UnitLinearScale,
             /// Scales the feasible space logarithmically to (0, 1). The entire
             /// feasible space must be strictly positive.
-            pub const UNIT_LOG_SCALE: ScaleType = ScaleType::new(2);
-
+            UnitLogScale,
             /// Scales the feasible space "reverse" logarithmically to (0, 1). The
             /// result is that values close to the top of the feasible space are spread
             /// out more than points near the bottom. The entire feasible space must be
             /// strictly positive.
-            pub const UNIT_REVERSE_LOG_SCALE: ScaleType = ScaleType::new(3);
+            UnitReverseLogScale,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ScaleType::value] or
+            /// [ScaleType::name].
+            UnknownValue(scale_type::UnknownValue),
+        }
 
-            /// Creates a new ScaleType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SCALE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("UNIT_LINEAR_SCALE"),
-                    2 => std::borrow::Cow::Borrowed("UNIT_LOG_SCALE"),
-                    3 => std::borrow::Cow::Borrowed("UNIT_REVERSE_LOG_SCALE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SCALE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SCALE_TYPE_UNSPECIFIED)
-                    }
-                    "UNIT_LINEAR_SCALE" => std::option::Option::Some(Self::UNIT_LINEAR_SCALE),
-                    "UNIT_LOG_SCALE" => std::option::Option::Some(Self::UNIT_LOG_SCALE),
-                    "UNIT_REVERSE_LOG_SCALE" => {
-                        std::option::Option::Some(Self::UNIT_REVERSE_LOG_SCALE)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
+        #[doc(hidden)]
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        pub mod scale_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
         }
 
         #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-        impl std::convert::From<i32> for ScaleType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        impl ScaleType {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::UnitLinearScale => std::option::Option::Some(1),
+                    Self::UnitLogScale => std::option::Option::Some(2),
+                    Self::UnitReverseLogScale => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SCALE_TYPE_UNSPECIFIED"),
+                    Self::UnitLinearScale => std::option::Option::Some("UNIT_LINEAR_SCALE"),
+                    Self::UnitLogScale => std::option::Option::Some("UNIT_LOG_SCALE"),
+                    Self::UnitReverseLogScale => {
+                        std::option::Option::Some("UNIT_REVERSE_LOG_SCALE")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         #[cfg(any(feature = "job_service", feature = "vizier_service",))]
         impl std::default::Default for ScaleType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl std::fmt::Display for ScaleType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl std::convert::From<i32> for ScaleType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::UnitLinearScale,
+                    2 => Self::UnitLogScale,
+                    3 => Self::UnitReverseLogScale,
+                    _ => Self::UnknownValue(scale_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl std::convert::From<&str> for ScaleType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SCALE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "UNIT_LINEAR_SCALE" => Self::UnitLinearScale,
+                    "UNIT_LOG_SCALE" => Self::UnitLogScale,
+                    "UNIT_REVERSE_LOG_SCALE" => Self::UnitReverseLogScale,
+                    _ => Self::UnknownValue(scale_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl serde::ser::Serialize for ScaleType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::UnitLinearScale => serializer.serialize_i32(1),
+                    Self::UnitLogScale => serializer.serialize_i32(2),
+                    Self::UnitReverseLogScale => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+        impl<'de> serde::de::Deserialize<'de> for ScaleType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ScaleType>::new(
+                    ".google.cloud.aiplatform.v1.StudySpec.ParameterSpec.ScaleType",
+                ))
             }
         }
 
@@ -81517,65 +86385,131 @@ pub mod study_spec {
 
     /// The available search algorithms for the Study.
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Algorithm(i32);
-
-    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl Algorithm {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Algorithm {
         /// The default algorithm used by Vertex AI for [hyperparameter
         /// tuning](https://cloud.google.com/vertex-ai/docs/training/hyperparameter-tuning-overview)
         /// and [Vertex AI Vizier](https://cloud.google.com/vertex-ai/docs/vizier).
-        pub const ALGORITHM_UNSPECIFIED: Algorithm = Algorithm::new(0);
-
+        Unspecified,
         /// Simple grid search within the feasible space. To use grid search,
         /// all parameters must be `INTEGER`, `CATEGORICAL`, or `DISCRETE`.
-        pub const GRID_SEARCH: Algorithm = Algorithm::new(2);
-
+        GridSearch,
         /// Simple random search within the feasible space.
-        pub const RANDOM_SEARCH: Algorithm = Algorithm::new(3);
+        RandomSearch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Algorithm::value] or
+        /// [Algorithm::name].
+        UnknownValue(algorithm::UnknownValue),
+    }
 
-        /// Creates a new Algorithm instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ALGORITHM_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("GRID_SEARCH"),
-                3 => std::borrow::Cow::Borrowed("RANDOM_SEARCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ALGORITHM_UNSPECIFIED" => std::option::Option::Some(Self::ALGORITHM_UNSPECIFIED),
-                "GRID_SEARCH" => std::option::Option::Some(Self::GRID_SEARCH),
-                "RANDOM_SEARCH" => std::option::Option::Some(Self::RANDOM_SEARCH),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    pub mod algorithm {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl std::convert::From<i32> for Algorithm {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Algorithm {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GridSearch => std::option::Option::Some(2),
+                Self::RandomSearch => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ALGORITHM_UNSPECIFIED"),
+                Self::GridSearch => std::option::Option::Some("GRID_SEARCH"),
+                Self::RandomSearch => std::option::Option::Some("RANDOM_SEARCH"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
     impl std::default::Default for Algorithm {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::fmt::Display for Algorithm {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<i32> for Algorithm {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::GridSearch,
+                3 => Self::RandomSearch,
+                _ => Self::UnknownValue(algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<&str> for Algorithm {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                "GRID_SEARCH" => Self::GridSearch,
+                "RANDOM_SEARCH" => Self::RandomSearch,
+                _ => Self::UnknownValue(algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl serde::ser::Serialize for Algorithm {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GridSearch => serializer.serialize_i32(2),
+                Self::RandomSearch => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl<'de> serde::de::Deserialize<'de> for Algorithm {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Algorithm>::new(
+                ".google.cloud.aiplatform.v1.StudySpec.Algorithm",
+            ))
         }
     }
 
@@ -81584,67 +86518,131 @@ pub mod study_spec {
     /// "Noisy" means that the repeated observations with the same Trial parameters
     /// may lead to different metric evaluations.
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ObservationNoise(i32);
-
-    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl ObservationNoise {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ObservationNoise {
         /// The default noise level chosen by Vertex AI.
-        pub const OBSERVATION_NOISE_UNSPECIFIED: ObservationNoise = ObservationNoise::new(0);
-
+        Unspecified,
         /// Vertex AI assumes that the objective function is (nearly)
         /// perfectly reproducible, and will never repeat the same Trial
         /// parameters.
-        pub const LOW: ObservationNoise = ObservationNoise::new(1);
-
+        Low,
         /// Vertex AI will estimate the amount of noise in metric
         /// evaluations, it may repeat the same Trial parameters more than once.
-        pub const HIGH: ObservationNoise = ObservationNoise::new(2);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ObservationNoise::value] or
+        /// [ObservationNoise::name].
+        UnknownValue(observation_noise::UnknownValue),
+    }
 
-        /// Creates a new ObservationNoise instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OBSERVATION_NOISE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOW"),
-                2 => std::borrow::Cow::Borrowed("HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OBSERVATION_NOISE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OBSERVATION_NOISE_UNSPECIFIED)
-                }
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    pub mod observation_noise {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl std::convert::From<i32> for ObservationNoise {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl ObservationNoise {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OBSERVATION_NOISE_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
     impl std::default::Default for ObservationNoise {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::fmt::Display for ObservationNoise {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<i32> for ObservationNoise {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::High,
+                _ => Self::UnknownValue(observation_noise::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<&str> for ObservationNoise {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OBSERVATION_NOISE_UNSPECIFIED" => Self::Unspecified,
+                "LOW" => Self::Low,
+                "HIGH" => Self::High,
+                _ => Self::UnknownValue(observation_noise::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl serde::ser::Serialize for ObservationNoise {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl<'de> serde::de::Deserialize<'de> for ObservationNoise {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ObservationNoise>::new(
+                ".google.cloud.aiplatform.v1.StudySpec.ObservationNoise",
+            ))
         }
     }
 
@@ -81662,65 +86660,132 @@ pub mod study_spec {
     /// If both or neither of (A) and (B) apply, it doesn't matter which
     /// selection type is chosen.
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MeasurementSelectionType(i32);
-
-    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl MeasurementSelectionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MeasurementSelectionType {
         /// Will be treated as LAST_MEASUREMENT.
-        pub const MEASUREMENT_SELECTION_TYPE_UNSPECIFIED: MeasurementSelectionType =
-            MeasurementSelectionType::new(0);
-
+        Unspecified,
         /// Use the last measurement reported.
-        pub const LAST_MEASUREMENT: MeasurementSelectionType = MeasurementSelectionType::new(1);
-
+        LastMeasurement,
         /// Use the best measurement reported.
-        pub const BEST_MEASUREMENT: MeasurementSelectionType = MeasurementSelectionType::new(2);
+        BestMeasurement,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MeasurementSelectionType::value] or
+        /// [MeasurementSelectionType::name].
+        UnknownValue(measurement_selection_type::UnknownValue),
+    }
 
-        /// Creates a new MeasurementSelectionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MEASUREMENT_SELECTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LAST_MEASUREMENT"),
-                2 => std::borrow::Cow::Borrowed("BEST_MEASUREMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MEASUREMENT_SELECTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MEASUREMENT_SELECTION_TYPE_UNSPECIFIED)
-                }
-                "LAST_MEASUREMENT" => std::option::Option::Some(Self::LAST_MEASUREMENT),
-                "BEST_MEASUREMENT" => std::option::Option::Some(Self::BEST_MEASUREMENT),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    pub mod measurement_selection_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
-    impl std::convert::From<i32> for MeasurementSelectionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl MeasurementSelectionType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LastMeasurement => std::option::Option::Some(1),
+                Self::BestMeasurement => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("MEASUREMENT_SELECTION_TYPE_UNSPECIFIED")
+                }
+                Self::LastMeasurement => std::option::Option::Some("LAST_MEASUREMENT"),
+                Self::BestMeasurement => std::option::Option::Some("BEST_MEASUREMENT"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "job_service", feature = "vizier_service",))]
     impl std::default::Default for MeasurementSelectionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::fmt::Display for MeasurementSelectionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<i32> for MeasurementSelectionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LastMeasurement,
+                2 => Self::BestMeasurement,
+                _ => Self::UnknownValue(measurement_selection_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl std::convert::From<&str> for MeasurementSelectionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MEASUREMENT_SELECTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LAST_MEASUREMENT" => Self::LastMeasurement,
+                "BEST_MEASUREMENT" => Self::BestMeasurement,
+                _ => Self::UnknownValue(measurement_selection_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl serde::ser::Serialize for MeasurementSelectionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LastMeasurement => serializer.serialize_i32(1),
+                Self::BestMeasurement => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "job_service", feature = "vizier_service",))]
+    impl<'de> serde::de::Deserialize<'de> for MeasurementSelectionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<MeasurementSelectionType>::new(
+                    ".google.cloud.aiplatform.v1.StudySpec.MeasurementSelectionType",
+                ),
+            )
         }
     }
 
@@ -85708,70 +90773,138 @@ pub mod tensorboard_time_series {
 
     /// An enum representing the value type of a TensorboardTimeSeries.
     #[cfg(feature = "tensorboard_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(i32);
-
-    #[cfg(feature = "tensorboard_service")]
-    impl ValueType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ValueType {
         /// The value type is unspecified.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
-
+        Unspecified,
         /// Used for TensorboardTimeSeries that is a list of scalars.
         /// E.g. accuracy of a model over epochs/time.
-        pub const SCALAR: ValueType = ValueType::new(1);
-
+        Scalar,
         /// Used for TensorboardTimeSeries that is a list of tensors.
         /// E.g. histograms of weights of layer in a model over epoch/time.
-        pub const TENSOR: ValueType = ValueType::new(2);
-
+        Tensor,
         /// Used for TensorboardTimeSeries that is a list of blob sequences.
         /// E.g. set of sample images with labels over epochs/time.
-        pub const BLOB_SEQUENCE: ValueType = ValueType::new(3);
+        BlobSequence,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ValueType::value] or
+        /// [ValueType::name].
+        UnknownValue(value_type::UnknownValue),
+    }
 
-        /// Creates a new ValueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCALAR"),
-                2 => std::borrow::Cow::Borrowed("TENSOR"),
-                3 => std::borrow::Cow::Borrowed("BLOB_SEQUENCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
-                "SCALAR" => std::option::Option::Some(Self::SCALAR),
-                "TENSOR" => std::option::Option::Some(Self::TENSOR),
-                "BLOB_SEQUENCE" => std::option::Option::Some(Self::BLOB_SEQUENCE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "tensorboard_service")]
+    pub mod value_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "tensorboard_service")]
-    impl std::convert::From<i32> for ValueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl ValueType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Scalar => std::option::Option::Some(1),
+                Self::Tensor => std::option::Option::Some(2),
+                Self::BlobSequence => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VALUE_TYPE_UNSPECIFIED"),
+                Self::Scalar => std::option::Option::Some("SCALAR"),
+                Self::Tensor => std::option::Option::Some("TENSOR"),
+                Self::BlobSequence => std::option::Option::Some("BLOB_SEQUENCE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "tensorboard_service")]
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "tensorboard_service")]
+    impl std::fmt::Display for ValueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "tensorboard_service")]
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Scalar,
+                2 => Self::Tensor,
+                3 => Self::BlobSequence,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "tensorboard_service")]
+    impl std::convert::From<&str> for ValueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VALUE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCALAR" => Self::Scalar,
+                "TENSOR" => Self::Tensor,
+                "BLOB_SEQUENCE" => Self::BlobSequence,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "tensorboard_service")]
+    impl serde::ser::Serialize for ValueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Scalar => serializer.serialize_i32(1),
+                Self::Tensor => serializer.serialize_i32(2),
+                Self::BlobSequence => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "tensorboard_service")]
+    impl<'de> serde::de::Deserialize<'de> for ValueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueType>::new(
+                ".google.cloud.aiplatform.v1.TensorboardTimeSeries.ValueType",
+            ))
         }
     }
 }
@@ -86354,9 +91487,21 @@ pub mod executable_code {
         feature = "prediction_service",
         feature = "vertex_rag_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Language(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Language {
+        /// Unspecified language. This value should not be used.
+        Unspecified,
+        /// Python >= 3.10, with numpy and simpy available.
+        Python,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Language::value] or
+        /// [Language::name].
+        UnknownValue(language::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "gen_ai_cache_service",
         feature = "gen_ai_tuning_service",
@@ -86364,40 +91509,11 @@ pub mod executable_code {
         feature = "prediction_service",
         feature = "vertex_rag_service",
     ))]
-    impl Language {
-        /// Unspecified language. This value should not be used.
-        pub const LANGUAGE_UNSPECIFIED: Language = Language::new(0);
-
-        /// Python >= 3.10, with numpy and simpy available.
-        pub const PYTHON: Language = Language::new(1);
-
-        /// Creates a new Language instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LANGUAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PYTHON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LANGUAGE_UNSPECIFIED" => std::option::Option::Some(Self::LANGUAGE_UNSPECIFIED),
-                "PYTHON" => std::option::Option::Some(Self::PYTHON),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod language {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -86407,9 +91523,29 @@ pub mod executable_code {
         feature = "prediction_service",
         feature = "vertex_rag_service",
     ))]
-    impl std::convert::From<i32> for Language {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Language {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Python => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LANGUAGE_UNSPECIFIED"),
+                Self::Python => std::option::Option::Some("PYTHON"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -86422,7 +91558,98 @@ pub mod executable_code {
     ))]
     impl std::default::Default for Language {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl std::fmt::Display for Language {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl std::convert::From<i32> for Language {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Python,
+                _ => Self::UnknownValue(language::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl std::convert::From<&str> for Language {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LANGUAGE_UNSPECIFIED" => Self::Unspecified,
+                "PYTHON" => Self::Python,
+                _ => Self::UnknownValue(language::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl serde::ser::Serialize for Language {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Python => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for Language {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Language>::new(
+                ".google.cloud.aiplatform.v1.ExecutableCode.Language",
+            ))
         }
     }
 }
@@ -86515,9 +91742,27 @@ pub mod code_execution_result {
         feature = "prediction_service",
         feature = "vertex_rag_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Outcome(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Outcome {
+        /// Unspecified status. This value should not be used.
+        Unspecified,
+        /// Code execution completed successfully.
+        Ok,
+        /// Code execution finished but with a failure. `stderr` should contain the
+        /// reason.
+        Failed,
+        /// Code execution ran for too long, and was cancelled. There may or may not
+        /// be a partial output present.
+        DeadlineExceeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Outcome::value] or
+        /// [Outcome::name].
+        UnknownValue(outcome::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "gen_ai_cache_service",
         feature = "gen_ai_tuning_service",
@@ -86525,54 +91770,11 @@ pub mod code_execution_result {
         feature = "prediction_service",
         feature = "vertex_rag_service",
     ))]
-    impl Outcome {
-        /// Unspecified status. This value should not be used.
-        pub const OUTCOME_UNSPECIFIED: Outcome = Outcome::new(0);
-
-        /// Code execution completed successfully.
-        pub const OUTCOME_OK: Outcome = Outcome::new(1);
-
-        /// Code execution finished but with a failure. `stderr` should contain the
-        /// reason.
-        pub const OUTCOME_FAILED: Outcome = Outcome::new(2);
-
-        /// Code execution ran for too long, and was cancelled. There may or may not
-        /// be a partial output present.
-        pub const OUTCOME_DEADLINE_EXCEEDED: Outcome = Outcome::new(3);
-
-        /// Creates a new Outcome instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OUTCOME_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OUTCOME_OK"),
-                2 => std::borrow::Cow::Borrowed("OUTCOME_FAILED"),
-                3 => std::borrow::Cow::Borrowed("OUTCOME_DEADLINE_EXCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OUTCOME_UNSPECIFIED" => std::option::Option::Some(Self::OUTCOME_UNSPECIFIED),
-                "OUTCOME_OK" => std::option::Option::Some(Self::OUTCOME_OK),
-                "OUTCOME_FAILED" => std::option::Option::Some(Self::OUTCOME_FAILED),
-                "OUTCOME_DEADLINE_EXCEEDED" => {
-                    std::option::Option::Some(Self::OUTCOME_DEADLINE_EXCEEDED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod outcome {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -86582,9 +91784,33 @@ pub mod code_execution_result {
         feature = "prediction_service",
         feature = "vertex_rag_service",
     ))]
-    impl std::convert::From<i32> for Outcome {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Outcome {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::DeadlineExceeded => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OUTCOME_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OUTCOME_OK"),
+                Self::Failed => std::option::Option::Some("OUTCOME_FAILED"),
+                Self::DeadlineExceeded => std::option::Option::Some("OUTCOME_DEADLINE_EXCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -86597,7 +91823,104 @@ pub mod code_execution_result {
     ))]
     impl std::default::Default for Outcome {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl std::convert::From<i32> for Outcome {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ok,
+                2 => Self::Failed,
+                3 => Self::DeadlineExceeded,
+                _ => Self::UnknownValue(outcome::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl std::convert::From<&str> for Outcome {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OUTCOME_UNSPECIFIED" => Self::Unspecified,
+                "OUTCOME_OK" => Self::Ok,
+                "OUTCOME_FAILED" => Self::Failed,
+                "OUTCOME_DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+                _ => Self::UnknownValue(outcome::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl serde::ser::Serialize for Outcome {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::DeadlineExceeded => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "gen_ai_tuning_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+        feature = "vertex_rag_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for Outcome {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Outcome>::new(
+                ".google.cloud.aiplatform.v1.CodeExecutionResult.Outcome",
+            ))
         }
     }
 }
@@ -87165,48 +92488,31 @@ pub mod dynamic_retrieval_config {
         feature = "llm_utility_service",
         feature = "prediction_service",
     ))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Always trigger retrieval.
+        Unspecified,
+        /// Run retrieval only when system decides it is necessary.
+        Dynamic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
 
+    #[doc(hidden)]
     #[cfg(any(
         feature = "gen_ai_cache_service",
         feature = "llm_utility_service",
         feature = "prediction_service",
     ))]
-    impl Mode {
-        /// Always trigger retrieval.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// Run retrieval only when system decides it is necessary.
-        pub const MODE_DYNAMIC: Mode = Mode::new(1);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODE_DYNAMIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "MODE_DYNAMIC" => std::option::Option::Some(Self::MODE_DYNAMIC),
-                _ => std::option::Option::None,
-            }
-        }
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(
@@ -87214,9 +92520,29 @@ pub mod dynamic_retrieval_config {
         feature = "llm_utility_service",
         feature = "prediction_service",
     ))]
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Mode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dynamic => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Dynamic => std::option::Option::Some("MODE_DYNAMIC"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
@@ -87227,7 +92553,88 @@ pub mod dynamic_retrieval_config {
     ))]
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+    ))]
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+    ))]
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dynamic,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+    ))]
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "MODE_DYNAMIC" => Self::Dynamic,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+    ))]
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dynamic => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(
+        feature = "gen_ai_cache_service",
+        feature = "llm_utility_service",
+        feature = "prediction_service",
+    ))]
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.aiplatform.v1.DynamicRetrievalConfig.Mode",
+            ))
         }
     }
 }
@@ -87349,72 +92756,140 @@ pub mod function_calling_config {
 
     /// Function calling mode.
     #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
-
-    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
-    impl Mode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
         /// Unspecified function calling mode. This value should not be used.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+        Unspecified,
         /// Default model behavior, model decides to predict either function calls
         /// or natural language response.
-        pub const AUTO: Mode = Mode::new(1);
-
+        Auto,
         /// Model is constrained to always predicting function calls only.
         /// If "allowed_function_names" are set, the predicted function calls will be
         /// limited to any one of "allowed_function_names", else the predicted
         /// function calls will be any one of the provided "function_declarations".
-        pub const ANY: Mode = Mode::new(2);
-
+        Any,
         /// Model will not predict any function calls. Model behavior is same as when
         /// not passing any function declarations.
-        pub const NONE: Mode = Mode::new(3);
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
 
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTO"),
-                2 => std::borrow::Cow::Borrowed("ANY"),
-                3 => std::borrow::Cow::Borrowed("NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "AUTO" => std::option::Option::Some(Self::AUTO),
-                "ANY" => std::option::Option::Some(Self::ANY),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl Mode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Auto => std::option::Option::Some(1),
+                Self::Any => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Auto => std::option::Option::Some("AUTO"),
+                Self::Any => std::option::Option::Some("ANY"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Auto,
+                2 => Self::Any,
+                3 => Self::None,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTO" => Self::Auto,
+                "ANY" => Self::Any,
+                "NONE" => Self::None,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Auto => serializer.serialize_i32(1),
+                Self::Any => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "gen_ai_cache_service", feature = "prediction_service",))]
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.aiplatform.v1.FunctionCallingConfig.Mode",
+            ))
         }
     }
 }
@@ -90132,74 +95607,142 @@ pub mod supervised_hyper_parameters {
 
     /// Supported adapter sizes for tuning.
     #[cfg(feature = "gen_ai_tuning_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AdapterSize(i32);
-
-    #[cfg(feature = "gen_ai_tuning_service")]
-    impl AdapterSize {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AdapterSize {
         /// Adapter size is unspecified.
-        pub const ADAPTER_SIZE_UNSPECIFIED: AdapterSize = AdapterSize::new(0);
-
+        Unspecified,
         /// Adapter size 1.
-        pub const ADAPTER_SIZE_ONE: AdapterSize = AdapterSize::new(1);
-
+        One,
         /// Adapter size 4.
-        pub const ADAPTER_SIZE_FOUR: AdapterSize = AdapterSize::new(2);
-
+        Four,
         /// Adapter size 8.
-        pub const ADAPTER_SIZE_EIGHT: AdapterSize = AdapterSize::new(3);
-
+        Eight,
         /// Adapter size 16.
-        pub const ADAPTER_SIZE_SIXTEEN: AdapterSize = AdapterSize::new(4);
+        Sixteen,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AdapterSize::value] or
+        /// [AdapterSize::name].
+        UnknownValue(adapter_size::UnknownValue),
+    }
 
-        /// Creates a new AdapterSize instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_ONE"),
-                2 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_FOUR"),
-                3 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_EIGHT"),
-                4 => std::borrow::Cow::Borrowed("ADAPTER_SIZE_SIXTEEN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ADAPTER_SIZE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ADAPTER_SIZE_UNSPECIFIED)
-                }
-                "ADAPTER_SIZE_ONE" => std::option::Option::Some(Self::ADAPTER_SIZE_ONE),
-                "ADAPTER_SIZE_FOUR" => std::option::Option::Some(Self::ADAPTER_SIZE_FOUR),
-                "ADAPTER_SIZE_EIGHT" => std::option::Option::Some(Self::ADAPTER_SIZE_EIGHT),
-                "ADAPTER_SIZE_SIXTEEN" => std::option::Option::Some(Self::ADAPTER_SIZE_SIXTEEN),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "gen_ai_tuning_service")]
+    pub mod adapter_size {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "gen_ai_tuning_service")]
-    impl std::convert::From<i32> for AdapterSize {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl AdapterSize {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::One => std::option::Option::Some(1),
+                Self::Four => std::option::Option::Some(2),
+                Self::Eight => std::option::Option::Some(3),
+                Self::Sixteen => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ADAPTER_SIZE_UNSPECIFIED"),
+                Self::One => std::option::Option::Some("ADAPTER_SIZE_ONE"),
+                Self::Four => std::option::Option::Some("ADAPTER_SIZE_FOUR"),
+                Self::Eight => std::option::Option::Some("ADAPTER_SIZE_EIGHT"),
+                Self::Sixteen => std::option::Option::Some("ADAPTER_SIZE_SIXTEEN"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "gen_ai_tuning_service")]
     impl std::default::Default for AdapterSize {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "gen_ai_tuning_service")]
+    impl std::fmt::Display for AdapterSize {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "gen_ai_tuning_service")]
+    impl std::convert::From<i32> for AdapterSize {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::One,
+                2 => Self::Four,
+                3 => Self::Eight,
+                4 => Self::Sixteen,
+                _ => Self::UnknownValue(adapter_size::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "gen_ai_tuning_service")]
+    impl std::convert::From<&str> for AdapterSize {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ADAPTER_SIZE_UNSPECIFIED" => Self::Unspecified,
+                "ADAPTER_SIZE_ONE" => Self::One,
+                "ADAPTER_SIZE_FOUR" => Self::Four,
+                "ADAPTER_SIZE_EIGHT" => Self::Eight,
+                "ADAPTER_SIZE_SIXTEEN" => Self::Sixteen,
+                _ => Self::UnknownValue(adapter_size::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "gen_ai_tuning_service")]
+    impl serde::ser::Serialize for AdapterSize {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::One => serializer.serialize_i32(1),
+                Self::Four => serializer.serialize_i32(2),
+                Self::Eight => serializer.serialize_i32(3),
+                Self::Sixteen => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "gen_ai_tuning_service")]
+    impl<'de> serde::de::Deserialize<'de> for AdapterSize {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AdapterSize>::new(
+                ".google.cloud.aiplatform.v1.SupervisedHyperParameters.AdapterSize",
+            ))
         }
     }
 }
@@ -90632,32 +96175,32 @@ pub struct Tensor {
     ///
     /// [BOOL][google.cloud.aiplatform.v1.Tensor.DataType.BOOL]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.BOOL]: crate::model::tensor::data_type::BOOL
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.BOOL]: crate::model::tensor::DataType::Bool
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub bool_val: std::vec::Vec<bool>,
 
     /// [STRING][google.cloud.aiplatform.v1.Tensor.DataType.STRING]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.STRING]: crate::model::tensor::data_type::STRING
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.STRING]: crate::model::tensor::DataType::String
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub string_val: std::vec::Vec<std::string::String>,
 
     /// [STRING][google.cloud.aiplatform.v1.Tensor.DataType.STRING]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.STRING]: crate::model::tensor::data_type::STRING
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.STRING]: crate::model::tensor::DataType::String
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     #[serde_as(as = "std::vec::Vec<serde_with::base64::Base64>")]
     pub bytes_val: std::vec::Vec<::bytes::Bytes>,
 
     /// [FLOAT][google.cloud.aiplatform.v1.Tensor.DataType.FLOAT]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.FLOAT]: crate::model::tensor::data_type::FLOAT
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.FLOAT]: crate::model::tensor::DataType::Float
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub float_val: std::vec::Vec<f32>,
 
     /// [DOUBLE][google.cloud.aiplatform.v1.Tensor.DataType.DOUBLE]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.DOUBLE]: crate::model::tensor::data_type::DOUBLE
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.DOUBLE]: crate::model::tensor::DataType::Double
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub double_val: std::vec::Vec<f64>,
 
@@ -90665,15 +96208,15 @@ pub struct Tensor {
     /// [INT_16][google.cloud.aiplatform.v1.Tensor.DataType.INT16]
     /// [INT_32][google.cloud.aiplatform.v1.Tensor.DataType.INT32]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT16]: crate::model::tensor::data_type::INT16
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT32]: crate::model::tensor::data_type::INT32
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT8]: crate::model::tensor::data_type::INT8
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT16]: crate::model::tensor::DataType::Int16
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT32]: crate::model::tensor::DataType::Int32
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT8]: crate::model::tensor::DataType::Int8
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub int_val: std::vec::Vec<i32>,
 
     /// [INT64][google.cloud.aiplatform.v1.Tensor.DataType.INT64]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT64]: crate::model::tensor::data_type::INT64
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.INT64]: crate::model::tensor::DataType::Int64
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
     pub int64_val: std::vec::Vec<i64>,
@@ -90682,15 +96225,15 @@ pub struct Tensor {
     /// [UINT16][google.cloud.aiplatform.v1.Tensor.DataType.UINT16]
     /// [UINT32][google.cloud.aiplatform.v1.Tensor.DataType.UINT32]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT16]: crate::model::tensor::data_type::UINT16
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT32]: crate::model::tensor::data_type::UINT32
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT8]: crate::model::tensor::data_type::UINT8
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT16]: crate::model::tensor::DataType::Uint16
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT32]: crate::model::tensor::DataType::Uint32
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT8]: crate::model::tensor::DataType::Uint8
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub uint_val: std::vec::Vec<u32>,
 
     /// [UINT64][google.cloud.aiplatform.v1.Tensor.DataType.UINT64]
     ///
-    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT64]: crate::model::tensor::data_type::UINT64
+    /// [google.cloud.aiplatform.v1.Tensor.DataType.UINT64]: crate::model::tensor::DataType::Uint64
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     #[serde_as(as = "std::vec::Vec<serde_with::DisplayFromStr>")]
     pub uint64_val: std::vec::Vec<u64>,
@@ -90882,103 +96425,189 @@ pub mod tensor {
 
     /// Data type of the tensor.
     #[cfg(feature = "prediction_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataType(i32);
-
-    #[cfg(feature = "prediction_service")]
-    impl DataType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataType {
         /// Not a legal value for DataType. Used to indicate a DataType field has not
         /// been set.
-        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
-
+        Unspecified,
         /// Data types that all computation devices are expected to be
         /// capable to support.
-        pub const BOOL: DataType = DataType::new(1);
+        Bool,
+        String,
+        Float,
+        Double,
+        Int8,
+        Int16,
+        Int32,
+        Int64,
+        Uint8,
+        Uint16,
+        Uint32,
+        Uint64,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataType::value] or
+        /// [DataType::name].
+        UnknownValue(data_type::UnknownValue),
+    }
 
-        pub const STRING: DataType = DataType::new(2);
-
-        pub const FLOAT: DataType = DataType::new(3);
-
-        pub const DOUBLE: DataType = DataType::new(4);
-
-        pub const INT8: DataType = DataType::new(5);
-
-        pub const INT16: DataType = DataType::new(6);
-
-        pub const INT32: DataType = DataType::new(7);
-
-        pub const INT64: DataType = DataType::new(8);
-
-        pub const UINT8: DataType = DataType::new(9);
-
-        pub const UINT16: DataType = DataType::new(10);
-
-        pub const UINT32: DataType = DataType::new(11);
-
-        pub const UINT64: DataType = DataType::new(12);
-
-        /// Creates a new DataType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BOOL"),
-                2 => std::borrow::Cow::Borrowed("STRING"),
-                3 => std::borrow::Cow::Borrowed("FLOAT"),
-                4 => std::borrow::Cow::Borrowed("DOUBLE"),
-                5 => std::borrow::Cow::Borrowed("INT8"),
-                6 => std::borrow::Cow::Borrowed("INT16"),
-                7 => std::borrow::Cow::Borrowed("INT32"),
-                8 => std::borrow::Cow::Borrowed("INT64"),
-                9 => std::borrow::Cow::Borrowed("UINT8"),
-                10 => std::borrow::Cow::Borrowed("UINT16"),
-                11 => std::borrow::Cow::Borrowed("UINT32"),
-                12 => std::borrow::Cow::Borrowed("UINT64"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "FLOAT" => std::option::Option::Some(Self::FLOAT),
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                "INT8" => std::option::Option::Some(Self::INT8),
-                "INT16" => std::option::Option::Some(Self::INT16),
-                "INT32" => std::option::Option::Some(Self::INT32),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                "UINT8" => std::option::Option::Some(Self::UINT8),
-                "UINT16" => std::option::Option::Some(Self::UINT16),
-                "UINT32" => std::option::Option::Some(Self::UINT32),
-                "UINT64" => std::option::Option::Some(Self::UINT64),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "prediction_service")]
+    pub mod data_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "prediction_service")]
-    impl std::convert::From<i32> for DataType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl DataType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bool => std::option::Option::Some(1),
+                Self::String => std::option::Option::Some(2),
+                Self::Float => std::option::Option::Some(3),
+                Self::Double => std::option::Option::Some(4),
+                Self::Int8 => std::option::Option::Some(5),
+                Self::Int16 => std::option::Option::Some(6),
+                Self::Int32 => std::option::Option::Some(7),
+                Self::Int64 => std::option::Option::Some(8),
+                Self::Uint8 => std::option::Option::Some(9),
+                Self::Uint16 => std::option::Option::Some(10),
+                Self::Uint32 => std::option::Option::Some(11),
+                Self::Uint64 => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_TYPE_UNSPECIFIED"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Float => std::option::Option::Some("FLOAT"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::Int8 => std::option::Option::Some("INT8"),
+                Self::Int16 => std::option::Option::Some("INT16"),
+                Self::Int32 => std::option::Option::Some("INT32"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::Uint8 => std::option::Option::Some("UINT8"),
+                Self::Uint16 => std::option::Option::Some("UINT16"),
+                Self::Uint32 => std::option::Option::Some("UINT32"),
+                Self::Uint64 => std::option::Option::Some("UINT64"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "prediction_service")]
     impl std::default::Default for DataType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<i32> for DataType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bool,
+                2 => Self::String,
+                3 => Self::Float,
+                4 => Self::Double,
+                5 => Self::Int8,
+                6 => Self::Int16,
+                7 => Self::Int32,
+                8 => Self::Int64,
+                9 => Self::Uint8,
+                10 => Self::Uint16,
+                11 => Self::Uint32,
+                12 => Self::Uint64,
+                _ => Self::UnknownValue(data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl std::convert::From<&str> for DataType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BOOL" => Self::Bool,
+                "STRING" => Self::String,
+                "FLOAT" => Self::Float,
+                "DOUBLE" => Self::Double,
+                "INT8" => Self::Int8,
+                "INT16" => Self::Int16,
+                "INT32" => Self::Int32,
+                "INT64" => Self::Int64,
+                "UINT8" => Self::Uint8,
+                "UINT16" => Self::Uint16,
+                "UINT32" => Self::Uint32,
+                "UINT64" => Self::Uint64,
+                _ => Self::UnknownValue(data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl serde::ser::Serialize for DataType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bool => serializer.serialize_i32(1),
+                Self::String => serializer.serialize_i32(2),
+                Self::Float => serializer.serialize_i32(3),
+                Self::Double => serializer.serialize_i32(4),
+                Self::Int8 => serializer.serialize_i32(5),
+                Self::Int16 => serializer.serialize_i32(6),
+                Self::Int32 => serializer.serialize_i32(7),
+                Self::Int64 => serializer.serialize_i32(8),
+                Self::Uint8 => serializer.serialize_i32(9),
+                Self::Uint16 => serializer.serialize_i32(10),
+                Self::Uint32 => serializer.serialize_i32(11),
+                Self::Uint64 => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "prediction_service")]
+    impl<'de> serde::de::Deserialize<'de> for DataType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataType>::new(
+                ".google.cloud.aiplatform.v1.Tensor.DataType",
+            ))
         }
     }
 }
@@ -91835,63 +97464,129 @@ pub mod file_status {
 
     /// RagFile state.
     #[cfg(feature = "vertex_rag_data_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "vertex_rag_data_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// RagFile state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// RagFile resource has been created and indexed successfully.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// RagFile resource is in a problematic state.
         /// See `error_message` field for details.
-        pub const ERROR: State = State::new(2);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "vertex_rag_data_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "vertex_rag_data_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "vertex_rag_data_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.FileStatus.State",
+            ))
         }
     }
 }
@@ -91989,68 +97684,136 @@ pub mod corpus_status {
 
     /// RagCorpus life state.
     #[cfg(feature = "vertex_rag_data_service")]
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    #[cfg(feature = "vertex_rag_data_service")]
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// This state is not supposed to happen.
-        pub const UNKNOWN: State = State::new(0);
-
+        Unknown,
         /// RagCorpus resource entry is initialized, but hasn't done validation.
-        pub const INITIALIZED: State = State::new(1);
-
+        Initialized,
         /// RagCorpus is provisioned successfully and is ready to serve.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// RagCorpus is in a problematic situation.
         /// See `error_message` field for details.
-        pub const ERROR: State = State::new(3);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("INITIALIZED"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "INITIALIZED" => std::option::Option::Some(Self::INITIALIZED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
+    #[doc(hidden)]
+    #[cfg(feature = "vertex_rag_data_service")]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
     }
 
     #[cfg(feature = "vertex_rag_data_service")]
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    impl State {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Initialized => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Initialized => std::option::Option::Some("INITIALIZED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     #[cfg(feature = "vertex_rag_data_service")]
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Initialized,
+                2 => Self::Active,
+                3 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "INITIALIZED" => Self::Initialized,
+                "ACTIVE" => Self::Active,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Initialized => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    #[cfg(feature = "vertex_rag_data_service")]
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.aiplatform.v1.CorpusStatus.State",
+            ))
         }
     }
 }
@@ -97039,9 +102802,48 @@ impl wkt::message::Message for ListOptimalTrialsResponse {
     feature = "persistent_resource_service",
     feature = "schedule_service",
 ))]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AcceleratorType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AcceleratorType {
+    /// Unspecified accelerator type, which means no accelerator.
+    Unspecified,
+    /// Deprecated: Nvidia Tesla K80 GPU has reached end of support,
+    /// see <https://cloud.google.com/compute/docs/eol/k80-eol>.
+    NvidiaTeslaK80,
+    /// Nvidia Tesla P100 GPU.
+    NvidiaTeslaP100,
+    /// Nvidia Tesla V100 GPU.
+    NvidiaTeslaV100,
+    /// Nvidia Tesla P4 GPU.
+    NvidiaTeslaP4,
+    /// Nvidia Tesla T4 GPU.
+    NvidiaTeslaT4,
+    /// Nvidia Tesla A100 GPU.
+    NvidiaTeslaA100,
+    /// Nvidia A100 80GB GPU.
+    NvidiaA10080Gb,
+    /// Nvidia L4 GPU.
+    NvidiaL4,
+    /// Nvidia H100 80Gb GPU.
+    NvidiaH10080Gb,
+    /// Nvidia H100 Mega 80Gb GPU.
+    NvidiaH100Mega80Gb,
+    /// TPU v2.
+    TpuV2,
+    /// TPU v3.
+    TpuV3,
+    /// TPU v4.
+    TpuV4Pod,
+    /// TPU v5.
+    TpuV5Litepod,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AcceleratorType::value] or
+    /// [AcceleratorType::name].
+    UnknownValue(accelerator_type::UnknownValue),
+}
 
+#[doc(hidden)]
 #[cfg(any(
     feature = "deployment_resource_pool_service",
     feature = "endpoint_service",
@@ -97052,108 +102854,11 @@ pub struct AcceleratorType(i32);
     feature = "persistent_resource_service",
     feature = "schedule_service",
 ))]
-impl AcceleratorType {
-    /// Unspecified accelerator type, which means no accelerator.
-    pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType = AcceleratorType::new(0);
-
-    /// Deprecated: Nvidia Tesla K80 GPU has reached end of support,
-    /// see <https://cloud.google.com/compute/docs/eol/k80-eol>.
-    pub const NVIDIA_TESLA_K80: AcceleratorType = AcceleratorType::new(1);
-
-    /// Nvidia Tesla P100 GPU.
-    pub const NVIDIA_TESLA_P100: AcceleratorType = AcceleratorType::new(2);
-
-    /// Nvidia Tesla V100 GPU.
-    pub const NVIDIA_TESLA_V100: AcceleratorType = AcceleratorType::new(3);
-
-    /// Nvidia Tesla P4 GPU.
-    pub const NVIDIA_TESLA_P4: AcceleratorType = AcceleratorType::new(4);
-
-    /// Nvidia Tesla T4 GPU.
-    pub const NVIDIA_TESLA_T4: AcceleratorType = AcceleratorType::new(5);
-
-    /// Nvidia Tesla A100 GPU.
-    pub const NVIDIA_TESLA_A100: AcceleratorType = AcceleratorType::new(8);
-
-    /// Nvidia A100 80GB GPU.
-    pub const NVIDIA_A100_80GB: AcceleratorType = AcceleratorType::new(9);
-
-    /// Nvidia L4 GPU.
-    pub const NVIDIA_L4: AcceleratorType = AcceleratorType::new(11);
-
-    /// Nvidia H100 80Gb GPU.
-    pub const NVIDIA_H100_80GB: AcceleratorType = AcceleratorType::new(13);
-
-    /// Nvidia H100 Mega 80Gb GPU.
-    pub const NVIDIA_H100_MEGA_80GB: AcceleratorType = AcceleratorType::new(14);
-
-    /// TPU v2.
-    pub const TPU_V2: AcceleratorType = AcceleratorType::new(6);
-
-    /// TPU v3.
-    pub const TPU_V3: AcceleratorType = AcceleratorType::new(7);
-
-    /// TPU v4.
-    pub const TPU_V4_POD: AcceleratorType = AcceleratorType::new(10);
-
-    /// TPU v5.
-    pub const TPU_V5_LITEPOD: AcceleratorType = AcceleratorType::new(12);
-
-    /// Creates a new AcceleratorType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ACCELERATOR_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_K80"),
-            2 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P100"),
-            3 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_V100"),
-            4 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P4"),
-            5 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_T4"),
-            6 => std::borrow::Cow::Borrowed("TPU_V2"),
-            7 => std::borrow::Cow::Borrowed("TPU_V3"),
-            8 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_A100"),
-            9 => std::borrow::Cow::Borrowed("NVIDIA_A100_80GB"),
-            10 => std::borrow::Cow::Borrowed("TPU_V4_POD"),
-            11 => std::borrow::Cow::Borrowed("NVIDIA_L4"),
-            12 => std::borrow::Cow::Borrowed("TPU_V5_LITEPOD"),
-            13 => std::borrow::Cow::Borrowed("NVIDIA_H100_80GB"),
-            14 => std::borrow::Cow::Borrowed("NVIDIA_H100_MEGA_80GB"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ACCELERATOR_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ACCELERATOR_TYPE_UNSPECIFIED)
-            }
-            "NVIDIA_TESLA_K80" => std::option::Option::Some(Self::NVIDIA_TESLA_K80),
-            "NVIDIA_TESLA_P100" => std::option::Option::Some(Self::NVIDIA_TESLA_P100),
-            "NVIDIA_TESLA_V100" => std::option::Option::Some(Self::NVIDIA_TESLA_V100),
-            "NVIDIA_TESLA_P4" => std::option::Option::Some(Self::NVIDIA_TESLA_P4),
-            "NVIDIA_TESLA_T4" => std::option::Option::Some(Self::NVIDIA_TESLA_T4),
-            "NVIDIA_TESLA_A100" => std::option::Option::Some(Self::NVIDIA_TESLA_A100),
-            "NVIDIA_A100_80GB" => std::option::Option::Some(Self::NVIDIA_A100_80GB),
-            "NVIDIA_L4" => std::option::Option::Some(Self::NVIDIA_L4),
-            "NVIDIA_H100_80GB" => std::option::Option::Some(Self::NVIDIA_H100_80GB),
-            "NVIDIA_H100_MEGA_80GB" => std::option::Option::Some(Self::NVIDIA_H100_MEGA_80GB),
-            "TPU_V2" => std::option::Option::Some(Self::TPU_V2),
-            "TPU_V3" => std::option::Option::Some(Self::TPU_V3),
-            "TPU_V4_POD" => std::option::Option::Some(Self::TPU_V4_POD),
-            "TPU_V5_LITEPOD" => std::option::Option::Some(Self::TPU_V5_LITEPOD),
-            _ => std::option::Option::None,
-        }
-    }
+pub mod accelerator_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(any(
@@ -97166,9 +102871,55 @@ impl AcceleratorType {
     feature = "persistent_resource_service",
     feature = "schedule_service",
 ))]
-impl std::convert::From<i32> for AcceleratorType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl AcceleratorType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NvidiaTeslaK80 => std::option::Option::Some(1),
+            Self::NvidiaTeslaP100 => std::option::Option::Some(2),
+            Self::NvidiaTeslaV100 => std::option::Option::Some(3),
+            Self::NvidiaTeslaP4 => std::option::Option::Some(4),
+            Self::NvidiaTeslaT4 => std::option::Option::Some(5),
+            Self::NvidiaTeslaA100 => std::option::Option::Some(8),
+            Self::NvidiaA10080Gb => std::option::Option::Some(9),
+            Self::NvidiaL4 => std::option::Option::Some(11),
+            Self::NvidiaH10080Gb => std::option::Option::Some(13),
+            Self::NvidiaH100Mega80Gb => std::option::Option::Some(14),
+            Self::TpuV2 => std::option::Option::Some(6),
+            Self::TpuV3 => std::option::Option::Some(7),
+            Self::TpuV4Pod => std::option::Option::Some(10),
+            Self::TpuV5Litepod => std::option::Option::Some(12),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ACCELERATOR_TYPE_UNSPECIFIED"),
+            Self::NvidiaTeslaK80 => std::option::Option::Some("NVIDIA_TESLA_K80"),
+            Self::NvidiaTeslaP100 => std::option::Option::Some("NVIDIA_TESLA_P100"),
+            Self::NvidiaTeslaV100 => std::option::Option::Some("NVIDIA_TESLA_V100"),
+            Self::NvidiaTeslaP4 => std::option::Option::Some("NVIDIA_TESLA_P4"),
+            Self::NvidiaTeslaT4 => std::option::Option::Some("NVIDIA_TESLA_T4"),
+            Self::NvidiaTeslaA100 => std::option::Option::Some("NVIDIA_TESLA_A100"),
+            Self::NvidiaA10080Gb => std::option::Option::Some("NVIDIA_A100_80GB"),
+            Self::NvidiaL4 => std::option::Option::Some("NVIDIA_L4"),
+            Self::NvidiaH10080Gb => std::option::Option::Some("NVIDIA_H100_80GB"),
+            Self::NvidiaH100Mega80Gb => std::option::Option::Some("NVIDIA_H100_MEGA_80GB"),
+            Self::TpuV2 => std::option::Option::Some("TPU_V2"),
+            Self::TpuV3 => std::option::Option::Some("TPU_V3"),
+            Self::TpuV4Pod => std::option::Option::Some("TPU_V4_POD"),
+            Self::TpuV5Litepod => std::option::Option::Some("TPU_V5_LITEPOD"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
@@ -97184,301 +102935,709 @@ impl std::convert::From<i32> for AcceleratorType {
 ))]
 impl std::default::Default for AcceleratorType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(any(
+    feature = "deployment_resource_pool_service",
+    feature = "endpoint_service",
+    feature = "index_endpoint_service",
+    feature = "job_service",
+    feature = "model_garden_service",
+    feature = "notebook_service",
+    feature = "persistent_resource_service",
+    feature = "schedule_service",
+))]
+impl std::fmt::Display for AcceleratorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(any(
+    feature = "deployment_resource_pool_service",
+    feature = "endpoint_service",
+    feature = "index_endpoint_service",
+    feature = "job_service",
+    feature = "model_garden_service",
+    feature = "notebook_service",
+    feature = "persistent_resource_service",
+    feature = "schedule_service",
+))]
+impl std::convert::From<i32> for AcceleratorType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NvidiaTeslaK80,
+            2 => Self::NvidiaTeslaP100,
+            3 => Self::NvidiaTeslaV100,
+            4 => Self::NvidiaTeslaP4,
+            5 => Self::NvidiaTeslaT4,
+            6 => Self::TpuV2,
+            7 => Self::TpuV3,
+            8 => Self::NvidiaTeslaA100,
+            9 => Self::NvidiaA10080Gb,
+            10 => Self::TpuV4Pod,
+            11 => Self::NvidiaL4,
+            12 => Self::TpuV5Litepod,
+            13 => Self::NvidiaH10080Gb,
+            14 => Self::NvidiaH100Mega80Gb,
+            _ => Self::UnknownValue(accelerator_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "deployment_resource_pool_service",
+    feature = "endpoint_service",
+    feature = "index_endpoint_service",
+    feature = "job_service",
+    feature = "model_garden_service",
+    feature = "notebook_service",
+    feature = "persistent_resource_service",
+    feature = "schedule_service",
+))]
+impl std::convert::From<&str> for AcceleratorType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ACCELERATOR_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "NVIDIA_TESLA_K80" => Self::NvidiaTeslaK80,
+            "NVIDIA_TESLA_P100" => Self::NvidiaTeslaP100,
+            "NVIDIA_TESLA_V100" => Self::NvidiaTeslaV100,
+            "NVIDIA_TESLA_P4" => Self::NvidiaTeslaP4,
+            "NVIDIA_TESLA_T4" => Self::NvidiaTeslaT4,
+            "NVIDIA_TESLA_A100" => Self::NvidiaTeslaA100,
+            "NVIDIA_A100_80GB" => Self::NvidiaA10080Gb,
+            "NVIDIA_L4" => Self::NvidiaL4,
+            "NVIDIA_H100_80GB" => Self::NvidiaH10080Gb,
+            "NVIDIA_H100_MEGA_80GB" => Self::NvidiaH100Mega80Gb,
+            "TPU_V2" => Self::TpuV2,
+            "TPU_V3" => Self::TpuV3,
+            "TPU_V4_POD" => Self::TpuV4Pod,
+            "TPU_V5_LITEPOD" => Self::TpuV5Litepod,
+            _ => Self::UnknownValue(accelerator_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "deployment_resource_pool_service",
+    feature = "endpoint_service",
+    feature = "index_endpoint_service",
+    feature = "job_service",
+    feature = "model_garden_service",
+    feature = "notebook_service",
+    feature = "persistent_resource_service",
+    feature = "schedule_service",
+))]
+impl serde::ser::Serialize for AcceleratorType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NvidiaTeslaK80 => serializer.serialize_i32(1),
+            Self::NvidiaTeslaP100 => serializer.serialize_i32(2),
+            Self::NvidiaTeslaV100 => serializer.serialize_i32(3),
+            Self::NvidiaTeslaP4 => serializer.serialize_i32(4),
+            Self::NvidiaTeslaT4 => serializer.serialize_i32(5),
+            Self::NvidiaTeslaA100 => serializer.serialize_i32(8),
+            Self::NvidiaA10080Gb => serializer.serialize_i32(9),
+            Self::NvidiaL4 => serializer.serialize_i32(11),
+            Self::NvidiaH10080Gb => serializer.serialize_i32(13),
+            Self::NvidiaH100Mega80Gb => serializer.serialize_i32(14),
+            Self::TpuV2 => serializer.serialize_i32(6),
+            Self::TpuV3 => serializer.serialize_i32(7),
+            Self::TpuV4Pod => serializer.serialize_i32(10),
+            Self::TpuV5Litepod => serializer.serialize_i32(12),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "deployment_resource_pool_service",
+    feature = "endpoint_service",
+    feature = "index_endpoint_service",
+    feature = "job_service",
+    feature = "model_garden_service",
+    feature = "notebook_service",
+    feature = "persistent_resource_service",
+    feature = "schedule_service",
+))]
+impl<'de> serde::de::Deserialize<'de> for AcceleratorType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AcceleratorType>::new(
+            ".google.cloud.aiplatform.v1.AcceleratorType",
+        ))
     }
 }
 
 /// Harm categories that will block the content.
 #[cfg(feature = "prediction_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HarmCategory(i32);
-
-#[cfg(feature = "prediction_service")]
-impl HarmCategory {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HarmCategory {
     /// The harm category is unspecified.
-    pub const HARM_CATEGORY_UNSPECIFIED: HarmCategory = HarmCategory::new(0);
-
+    Unspecified,
     /// The harm category is hate speech.
-    pub const HARM_CATEGORY_HATE_SPEECH: HarmCategory = HarmCategory::new(1);
-
+    HateSpeech,
     /// The harm category is dangerous content.
-    pub const HARM_CATEGORY_DANGEROUS_CONTENT: HarmCategory = HarmCategory::new(2);
-
+    DangerousContent,
     /// The harm category is harassment.
-    pub const HARM_CATEGORY_HARASSMENT: HarmCategory = HarmCategory::new(3);
-
+    Harassment,
     /// The harm category is sexually explicit content.
-    pub const HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmCategory = HarmCategory::new(4);
-
+    SexuallyExplicit,
     /// The harm category is civic integrity.
-    pub const HARM_CATEGORY_CIVIC_INTEGRITY: HarmCategory = HarmCategory::new(5);
+    CivicIntegrity,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HarmCategory::value] or
+    /// [HarmCategory::name].
+    UnknownValue(harm_category::UnknownValue),
+}
 
-    /// Creates a new HarmCategory instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HARM_CATEGORY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HARM_CATEGORY_HATE_SPEECH"),
-            2 => std::borrow::Cow::Borrowed("HARM_CATEGORY_DANGEROUS_CONTENT"),
-            3 => std::borrow::Cow::Borrowed("HARM_CATEGORY_HARASSMENT"),
-            4 => std::borrow::Cow::Borrowed("HARM_CATEGORY_SEXUALLY_EXPLICIT"),
-            5 => std::borrow::Cow::Borrowed("HARM_CATEGORY_CIVIC_INTEGRITY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HARM_CATEGORY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_UNSPECIFIED)
-            }
-            "HARM_CATEGORY_HATE_SPEECH" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_HATE_SPEECH)
-            }
-            "HARM_CATEGORY_DANGEROUS_CONTENT" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_DANGEROUS_CONTENT)
-            }
-            "HARM_CATEGORY_HARASSMENT" => std::option::Option::Some(Self::HARM_CATEGORY_HARASSMENT),
-            "HARM_CATEGORY_SEXUALLY_EXPLICIT" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_SEXUALLY_EXPLICIT)
-            }
-            "HARM_CATEGORY_CIVIC_INTEGRITY" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_CIVIC_INTEGRITY)
-            }
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "prediction_service")]
+pub mod harm_category {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "prediction_service")]
-impl std::convert::From<i32> for HarmCategory {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl HarmCategory {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::HateSpeech => std::option::Option::Some(1),
+            Self::DangerousContent => std::option::Option::Some(2),
+            Self::Harassment => std::option::Option::Some(3),
+            Self::SexuallyExplicit => std::option::Option::Some(4),
+            Self::CivicIntegrity => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HARM_CATEGORY_UNSPECIFIED"),
+            Self::HateSpeech => std::option::Option::Some("HARM_CATEGORY_HATE_SPEECH"),
+            Self::DangerousContent => std::option::Option::Some("HARM_CATEGORY_DANGEROUS_CONTENT"),
+            Self::Harassment => std::option::Option::Some("HARM_CATEGORY_HARASSMENT"),
+            Self::SexuallyExplicit => std::option::Option::Some("HARM_CATEGORY_SEXUALLY_EXPLICIT"),
+            Self::CivicIntegrity => std::option::Option::Some("HARM_CATEGORY_CIVIC_INTEGRITY"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "prediction_service")]
 impl std::default::Default for HarmCategory {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "prediction_service")]
+impl std::fmt::Display for HarmCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "prediction_service")]
+impl std::convert::From<i32> for HarmCategory {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::HateSpeech,
+            2 => Self::DangerousContent,
+            3 => Self::Harassment,
+            4 => Self::SexuallyExplicit,
+            5 => Self::CivicIntegrity,
+            _ => Self::UnknownValue(harm_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "prediction_service")]
+impl std::convert::From<&str> for HarmCategory {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HARM_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+            "HARM_CATEGORY_HATE_SPEECH" => Self::HateSpeech,
+            "HARM_CATEGORY_DANGEROUS_CONTENT" => Self::DangerousContent,
+            "HARM_CATEGORY_HARASSMENT" => Self::Harassment,
+            "HARM_CATEGORY_SEXUALLY_EXPLICIT" => Self::SexuallyExplicit,
+            "HARM_CATEGORY_CIVIC_INTEGRITY" => Self::CivicIntegrity,
+            _ => Self::UnknownValue(harm_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "prediction_service")]
+impl serde::ser::Serialize for HarmCategory {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::HateSpeech => serializer.serialize_i32(1),
+            Self::DangerousContent => serializer.serialize_i32(2),
+            Self::Harassment => serializer.serialize_i32(3),
+            Self::SexuallyExplicit => serializer.serialize_i32(4),
+            Self::CivicIntegrity => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "prediction_service")]
+impl<'de> serde::de::Deserialize<'de> for HarmCategory {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmCategory>::new(
+            ".google.cloud.aiplatform.v1.HarmCategory",
+        ))
     }
 }
 
 /// Content Part modality
 #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Modality(i32);
-
-#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
-impl Modality {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Modality {
     /// Unspecified modality.
-    pub const MODALITY_UNSPECIFIED: Modality = Modality::new(0);
-
+    Unspecified,
     /// Plain text.
-    pub const TEXT: Modality = Modality::new(1);
-
+    Text,
     /// Image.
-    pub const IMAGE: Modality = Modality::new(2);
-
+    Image,
     /// Video.
-    pub const VIDEO: Modality = Modality::new(3);
-
+    Video,
     /// Audio.
-    pub const AUDIO: Modality = Modality::new(4);
-
+    Audio,
     /// Document, e.g. PDF.
-    pub const DOCUMENT: Modality = Modality::new(5);
+    Document,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Modality::value] or
+    /// [Modality::name].
+    UnknownValue(modality::UnknownValue),
+}
 
-    /// Creates a new Modality instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MODALITY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TEXT"),
-            2 => std::borrow::Cow::Borrowed("IMAGE"),
-            3 => std::borrow::Cow::Borrowed("VIDEO"),
-            4 => std::borrow::Cow::Borrowed("AUDIO"),
-            5 => std::borrow::Cow::Borrowed("DOCUMENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MODALITY_UNSPECIFIED" => std::option::Option::Some(Self::MODALITY_UNSPECIFIED),
-            "TEXT" => std::option::Option::Some(Self::TEXT),
-            "IMAGE" => std::option::Option::Some(Self::IMAGE),
-            "VIDEO" => std::option::Option::Some(Self::VIDEO),
-            "AUDIO" => std::option::Option::Some(Self::AUDIO),
-            "DOCUMENT" => std::option::Option::Some(Self::DOCUMENT),
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+pub mod modality {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
-impl std::convert::From<i32> for Modality {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl Modality {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Text => std::option::Option::Some(1),
+            Self::Image => std::option::Option::Some(2),
+            Self::Video => std::option::Option::Some(3),
+            Self::Audio => std::option::Option::Some(4),
+            Self::Document => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MODALITY_UNSPECIFIED"),
+            Self::Text => std::option::Option::Some("TEXT"),
+            Self::Image => std::option::Option::Some("IMAGE"),
+            Self::Video => std::option::Option::Some("VIDEO"),
+            Self::Audio => std::option::Option::Some("AUDIO"),
+            Self::Document => std::option::Option::Some("DOCUMENT"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
 impl std::default::Default for Modality {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+impl std::fmt::Display for Modality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+impl std::convert::From<i32> for Modality {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Text,
+            2 => Self::Image,
+            3 => Self::Video,
+            4 => Self::Audio,
+            5 => Self::Document,
+            _ => Self::UnknownValue(modality::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+impl std::convert::From<&str> for Modality {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MODALITY_UNSPECIFIED" => Self::Unspecified,
+            "TEXT" => Self::Text,
+            "IMAGE" => Self::Image,
+            "VIDEO" => Self::Video,
+            "AUDIO" => Self::Audio,
+            "DOCUMENT" => Self::Document,
+            _ => Self::UnknownValue(modality::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+impl serde::ser::Serialize for Modality {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Text => serializer.serialize_i32(1),
+            Self::Image => serializer.serialize_i32(2),
+            Self::Video => serializer.serialize_i32(3),
+            Self::Audio => serializer.serialize_i32(4),
+            Self::Document => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(any(feature = "llm_utility_service", feature = "prediction_service",))]
+impl<'de> serde::de::Deserialize<'de> for Modality {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Modality>::new(
+            ".google.cloud.aiplatform.v1.Modality",
+        ))
     }
 }
 
 /// Pairwise prediction autorater preference.
 #[cfg(feature = "evaluation_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PairwiseChoice(i32);
-
-#[cfg(feature = "evaluation_service")]
-impl PairwiseChoice {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PairwiseChoice {
     /// Unspecified prediction choice.
-    pub const PAIRWISE_CHOICE_UNSPECIFIED: PairwiseChoice = PairwiseChoice::new(0);
-
+    Unspecified,
     /// Baseline prediction wins
-    pub const BASELINE: PairwiseChoice = PairwiseChoice::new(1);
-
+    Baseline,
     /// Candidate prediction wins
-    pub const CANDIDATE: PairwiseChoice = PairwiseChoice::new(2);
-
+    Candidate,
     /// Winner cannot be determined
-    pub const TIE: PairwiseChoice = PairwiseChoice::new(3);
+    Tie,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PairwiseChoice::value] or
+    /// [PairwiseChoice::name].
+    UnknownValue(pairwise_choice::UnknownValue),
+}
 
-    /// Creates a new PairwiseChoice instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PAIRWISE_CHOICE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASELINE"),
-            2 => std::borrow::Cow::Borrowed("CANDIDATE"),
-            3 => std::borrow::Cow::Borrowed("TIE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PAIRWISE_CHOICE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PAIRWISE_CHOICE_UNSPECIFIED)
-            }
-            "BASELINE" => std::option::Option::Some(Self::BASELINE),
-            "CANDIDATE" => std::option::Option::Some(Self::CANDIDATE),
-            "TIE" => std::option::Option::Some(Self::TIE),
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "evaluation_service")]
+pub mod pairwise_choice {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "evaluation_service")]
-impl std::convert::From<i32> for PairwiseChoice {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl PairwiseChoice {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Baseline => std::option::Option::Some(1),
+            Self::Candidate => std::option::Option::Some(2),
+            Self::Tie => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PAIRWISE_CHOICE_UNSPECIFIED"),
+            Self::Baseline => std::option::Option::Some("BASELINE"),
+            Self::Candidate => std::option::Option::Some("CANDIDATE"),
+            Self::Tie => std::option::Option::Some("TIE"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "evaluation_service")]
 impl std::default::Default for PairwiseChoice {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "evaluation_service")]
+impl std::fmt::Display for PairwiseChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "evaluation_service")]
+impl std::convert::From<i32> for PairwiseChoice {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Baseline,
+            2 => Self::Candidate,
+            3 => Self::Tie,
+            _ => Self::UnknownValue(pairwise_choice::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "evaluation_service")]
+impl std::convert::From<&str> for PairwiseChoice {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PAIRWISE_CHOICE_UNSPECIFIED" => Self::Unspecified,
+            "BASELINE" => Self::Baseline,
+            "CANDIDATE" => Self::Candidate,
+            "TIE" => Self::Tie,
+            _ => Self::UnknownValue(pairwise_choice::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "evaluation_service")]
+impl serde::ser::Serialize for PairwiseChoice {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Baseline => serializer.serialize_i32(1),
+            Self::Candidate => serializer.serialize_i32(2),
+            Self::Tie => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "evaluation_service")]
+impl<'de> serde::de::Deserialize<'de> for PairwiseChoice {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PairwiseChoice>::new(
+            ".google.cloud.aiplatform.v1.PairwiseChoice",
+        ))
     }
 }
 
 /// Format of the data in the Feature View.
 #[cfg(feature = "feature_online_store_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FeatureViewDataFormat(i32);
-
-#[cfg(feature = "feature_online_store_service")]
-impl FeatureViewDataFormat {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FeatureViewDataFormat {
     /// Not set. Will be treated as the KeyValue format.
-    pub const FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED: FeatureViewDataFormat =
-        FeatureViewDataFormat::new(0);
-
+    Unspecified,
     /// Return response data in key-value format.
-    pub const KEY_VALUE: FeatureViewDataFormat = FeatureViewDataFormat::new(1);
-
+    KeyValue,
     /// Return response data in proto Struct format.
-    pub const PROTO_STRUCT: FeatureViewDataFormat = FeatureViewDataFormat::new(2);
+    ProtoStruct,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FeatureViewDataFormat::value] or
+    /// [FeatureViewDataFormat::name].
+    UnknownValue(feature_view_data_format::UnknownValue),
+}
 
-    /// Creates a new FeatureViewDataFormat instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("KEY_VALUE"),
-            2 => std::borrow::Cow::Borrowed("PROTO_STRUCT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED)
-            }
-            "KEY_VALUE" => std::option::Option::Some(Self::KEY_VALUE),
-            "PROTO_STRUCT" => std::option::Option::Some(Self::PROTO_STRUCT),
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "feature_online_store_service")]
+pub mod feature_view_data_format {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "feature_online_store_service")]
-impl std::convert::From<i32> for FeatureViewDataFormat {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl FeatureViewDataFormat {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::KeyValue => std::option::Option::Some(1),
+            Self::ProtoStruct => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED"),
+            Self::KeyValue => std::option::Option::Some("KEY_VALUE"),
+            Self::ProtoStruct => std::option::Option::Some("PROTO_STRUCT"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "feature_online_store_service")]
 impl std::default::Default for FeatureViewDataFormat {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "feature_online_store_service")]
+impl std::fmt::Display for FeatureViewDataFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "feature_online_store_service")]
+impl std::convert::From<i32> for FeatureViewDataFormat {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::KeyValue,
+            2 => Self::ProtoStruct,
+            _ => Self::UnknownValue(feature_view_data_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "feature_online_store_service")]
+impl std::convert::From<&str> for FeatureViewDataFormat {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FEATURE_VIEW_DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+            "KEY_VALUE" => Self::KeyValue,
+            "PROTO_STRUCT" => Self::ProtoStruct,
+            _ => Self::UnknownValue(feature_view_data_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "feature_online_store_service")]
+impl serde::ser::Serialize for FeatureViewDataFormat {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::KeyValue => serializer.serialize_i32(1),
+            Self::ProtoStruct => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "feature_online_store_service")]
+impl<'de> serde::de::Deserialize<'de> for FeatureViewDataFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FeatureViewDataFormat>::new(
+            ".google.cloud.aiplatform.v1.FeatureViewDataFormat",
+        ))
     }
 }
 
@@ -97489,103 +103648,54 @@ impl std::default::Default for FeatureViewDataFormat {
     feature = "notebook_service",
     feature = "schedule_service",
 ))]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum JobState {
+    /// The job state is unspecified.
+    Unspecified,
+    /// The job has been just created or resumed and processing has not yet begun.
+    Queued,
+    /// The service is preparing to run the job.
+    Pending,
+    /// The job is in progress.
+    Running,
+    /// The job completed successfully.
+    Succeeded,
+    /// The job failed.
+    Failed,
+    /// The job is being cancelled. From this state the job may only go to
+    /// either `JOB_STATE_SUCCEEDED`, `JOB_STATE_FAILED` or `JOB_STATE_CANCELLED`.
+    Cancelling,
+    /// The job has been cancelled.
+    Cancelled,
+    /// The job has been stopped, and can be resumed.
+    Paused,
+    /// The job has expired.
+    Expired,
+    /// The job is being updated. Only jobs in the `RUNNING` state can be updated.
+    /// After updating, the job goes back to the `RUNNING` state.
+    Updating,
+    /// The job is partially succeeded, some results may be missing due to errors.
+    PartiallySucceeded,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [JobState::value] or
+    /// [JobState::name].
+    UnknownValue(job_state::UnknownValue),
+}
 
+#[doc(hidden)]
 #[cfg(any(
     feature = "gen_ai_tuning_service",
     feature = "job_service",
     feature = "notebook_service",
     feature = "schedule_service",
 ))]
-impl JobState {
-    /// The job state is unspecified.
-    pub const JOB_STATE_UNSPECIFIED: JobState = JobState::new(0);
-
-    /// The job has been just created or resumed and processing has not yet begun.
-    pub const JOB_STATE_QUEUED: JobState = JobState::new(1);
-
-    /// The service is preparing to run the job.
-    pub const JOB_STATE_PENDING: JobState = JobState::new(2);
-
-    /// The job is in progress.
-    pub const JOB_STATE_RUNNING: JobState = JobState::new(3);
-
-    /// The job completed successfully.
-    pub const JOB_STATE_SUCCEEDED: JobState = JobState::new(4);
-
-    /// The job failed.
-    pub const JOB_STATE_FAILED: JobState = JobState::new(5);
-
-    /// The job is being cancelled. From this state the job may only go to
-    /// either `JOB_STATE_SUCCEEDED`, `JOB_STATE_FAILED` or `JOB_STATE_CANCELLED`.
-    pub const JOB_STATE_CANCELLING: JobState = JobState::new(6);
-
-    /// The job has been cancelled.
-    pub const JOB_STATE_CANCELLED: JobState = JobState::new(7);
-
-    /// The job has been stopped, and can be resumed.
-    pub const JOB_STATE_PAUSED: JobState = JobState::new(8);
-
-    /// The job has expired.
-    pub const JOB_STATE_EXPIRED: JobState = JobState::new(9);
-
-    /// The job is being updated. Only jobs in the `RUNNING` state can be updated.
-    /// After updating, the job goes back to the `RUNNING` state.
-    pub const JOB_STATE_UPDATING: JobState = JobState::new(10);
-
-    /// The job is partially succeeded, some results may be missing due to errors.
-    pub const JOB_STATE_PARTIALLY_SUCCEEDED: JobState = JobState::new(11);
-
-    /// Creates a new JobState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("JOB_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("JOB_STATE_QUEUED"),
-            2 => std::borrow::Cow::Borrowed("JOB_STATE_PENDING"),
-            3 => std::borrow::Cow::Borrowed("JOB_STATE_RUNNING"),
-            4 => std::borrow::Cow::Borrowed("JOB_STATE_SUCCEEDED"),
-            5 => std::borrow::Cow::Borrowed("JOB_STATE_FAILED"),
-            6 => std::borrow::Cow::Borrowed("JOB_STATE_CANCELLING"),
-            7 => std::borrow::Cow::Borrowed("JOB_STATE_CANCELLED"),
-            8 => std::borrow::Cow::Borrowed("JOB_STATE_PAUSED"),
-            9 => std::borrow::Cow::Borrowed("JOB_STATE_EXPIRED"),
-            10 => std::borrow::Cow::Borrowed("JOB_STATE_UPDATING"),
-            11 => std::borrow::Cow::Borrowed("JOB_STATE_PARTIALLY_SUCCEEDED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "JOB_STATE_UNSPECIFIED" => std::option::Option::Some(Self::JOB_STATE_UNSPECIFIED),
-            "JOB_STATE_QUEUED" => std::option::Option::Some(Self::JOB_STATE_QUEUED),
-            "JOB_STATE_PENDING" => std::option::Option::Some(Self::JOB_STATE_PENDING),
-            "JOB_STATE_RUNNING" => std::option::Option::Some(Self::JOB_STATE_RUNNING),
-            "JOB_STATE_SUCCEEDED" => std::option::Option::Some(Self::JOB_STATE_SUCCEEDED),
-            "JOB_STATE_FAILED" => std::option::Option::Some(Self::JOB_STATE_FAILED),
-            "JOB_STATE_CANCELLING" => std::option::Option::Some(Self::JOB_STATE_CANCELLING),
-            "JOB_STATE_CANCELLED" => std::option::Option::Some(Self::JOB_STATE_CANCELLED),
-            "JOB_STATE_PAUSED" => std::option::Option::Some(Self::JOB_STATE_PAUSED),
-            "JOB_STATE_EXPIRED" => std::option::Option::Some(Self::JOB_STATE_EXPIRED),
-            "JOB_STATE_UPDATING" => std::option::Option::Some(Self::JOB_STATE_UPDATING),
-            "JOB_STATE_PARTIALLY_SUCCEEDED" => {
-                std::option::Option::Some(Self::JOB_STATE_PARTIALLY_SUCCEEDED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
+pub mod job_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(any(
@@ -97594,9 +103704,49 @@ impl JobState {
     feature = "notebook_service",
     feature = "schedule_service",
 ))]
-impl std::convert::From<i32> for JobState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl JobState {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Queued => std::option::Option::Some(1),
+            Self::Pending => std::option::Option::Some(2),
+            Self::Running => std::option::Option::Some(3),
+            Self::Succeeded => std::option::Option::Some(4),
+            Self::Failed => std::option::Option::Some(5),
+            Self::Cancelling => std::option::Option::Some(6),
+            Self::Cancelled => std::option::Option::Some(7),
+            Self::Paused => std::option::Option::Some(8),
+            Self::Expired => std::option::Option::Some(9),
+            Self::Updating => std::option::Option::Some(10),
+            Self::PartiallySucceeded => std::option::Option::Some(11),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("JOB_STATE_UNSPECIFIED"),
+            Self::Queued => std::option::Option::Some("JOB_STATE_QUEUED"),
+            Self::Pending => std::option::Option::Some("JOB_STATE_PENDING"),
+            Self::Running => std::option::Option::Some("JOB_STATE_RUNNING"),
+            Self::Succeeded => std::option::Option::Some("JOB_STATE_SUCCEEDED"),
+            Self::Failed => std::option::Option::Some("JOB_STATE_FAILED"),
+            Self::Cancelling => std::option::Option::Some("JOB_STATE_CANCELLING"),
+            Self::Cancelled => std::option::Option::Some("JOB_STATE_CANCELLED"),
+            Self::Paused => std::option::Option::Some("JOB_STATE_PAUSED"),
+            Self::Expired => std::option::Option::Some("JOB_STATE_EXPIRED"),
+            Self::Updating => std::option::Option::Some("JOB_STATE_UPDATING"),
+            Self::PartiallySucceeded => std::option::Option::Some("JOB_STATE_PARTIALLY_SUCCEEDED"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
@@ -97608,302 +103758,666 @@ impl std::convert::From<i32> for JobState {
 ))]
 impl std::default::Default for JobState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_tuning_service",
+    feature = "job_service",
+    feature = "notebook_service",
+    feature = "schedule_service",
+))]
+impl std::fmt::Display for JobState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_tuning_service",
+    feature = "job_service",
+    feature = "notebook_service",
+    feature = "schedule_service",
+))]
+impl std::convert::From<i32> for JobState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Queued,
+            2 => Self::Pending,
+            3 => Self::Running,
+            4 => Self::Succeeded,
+            5 => Self::Failed,
+            6 => Self::Cancelling,
+            7 => Self::Cancelled,
+            8 => Self::Paused,
+            9 => Self::Expired,
+            10 => Self::Updating,
+            11 => Self::PartiallySucceeded,
+            _ => Self::UnknownValue(job_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_tuning_service",
+    feature = "job_service",
+    feature = "notebook_service",
+    feature = "schedule_service",
+))]
+impl std::convert::From<&str> for JobState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "JOB_STATE_UNSPECIFIED" => Self::Unspecified,
+            "JOB_STATE_QUEUED" => Self::Queued,
+            "JOB_STATE_PENDING" => Self::Pending,
+            "JOB_STATE_RUNNING" => Self::Running,
+            "JOB_STATE_SUCCEEDED" => Self::Succeeded,
+            "JOB_STATE_FAILED" => Self::Failed,
+            "JOB_STATE_CANCELLING" => Self::Cancelling,
+            "JOB_STATE_CANCELLED" => Self::Cancelled,
+            "JOB_STATE_PAUSED" => Self::Paused,
+            "JOB_STATE_EXPIRED" => Self::Expired,
+            "JOB_STATE_UPDATING" => Self::Updating,
+            "JOB_STATE_PARTIALLY_SUCCEEDED" => Self::PartiallySucceeded,
+            _ => Self::UnknownValue(job_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_tuning_service",
+    feature = "job_service",
+    feature = "notebook_service",
+    feature = "schedule_service",
+))]
+impl serde::ser::Serialize for JobState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Queued => serializer.serialize_i32(1),
+            Self::Pending => serializer.serialize_i32(2),
+            Self::Running => serializer.serialize_i32(3),
+            Self::Succeeded => serializer.serialize_i32(4),
+            Self::Failed => serializer.serialize_i32(5),
+            Self::Cancelling => serializer.serialize_i32(6),
+            Self::Cancelled => serializer.serialize_i32(7),
+            Self::Paused => serializer.serialize_i32(8),
+            Self::Expired => serializer.serialize_i32(9),
+            Self::Updating => serializer.serialize_i32(10),
+            Self::PartiallySucceeded => serializer.serialize_i32(11),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_tuning_service",
+    feature = "job_service",
+    feature = "notebook_service",
+    feature = "schedule_service",
+))]
+impl<'de> serde::de::Deserialize<'de> for JobState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobState>::new(
+            ".google.cloud.aiplatform.v1.JobState",
+        ))
     }
 }
 
 /// The Model Monitoring Objective types.
 #[cfg(feature = "job_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ModelDeploymentMonitoringObjectiveType(i32);
-
-#[cfg(feature = "job_service")]
-impl ModelDeploymentMonitoringObjectiveType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ModelDeploymentMonitoringObjectiveType {
     /// Default value, should not be set.
-    pub const MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED:
-        ModelDeploymentMonitoringObjectiveType = ModelDeploymentMonitoringObjectiveType::new(0);
-
+    Unspecified,
     /// Raw feature values' stats to detect skew between Training-Prediction
     /// datasets.
-    pub const RAW_FEATURE_SKEW: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new(1);
-
+    RawFeatureSkew,
     /// Raw feature values' stats to detect drift between Serving-Prediction
     /// datasets.
-    pub const RAW_FEATURE_DRIFT: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new(2);
-
+    RawFeatureDrift,
     /// Feature attribution scores to detect skew between Training-Prediction
     /// datasets.
-    pub const FEATURE_ATTRIBUTION_SKEW: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new(3);
-
+    FeatureAttributionSkew,
     /// Feature attribution scores to detect skew between Prediction datasets
     /// collected within different time windows.
-    pub const FEATURE_ATTRIBUTION_DRIFT: ModelDeploymentMonitoringObjectiveType =
-        ModelDeploymentMonitoringObjectiveType::new(4);
+    FeatureAttributionDrift,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ModelDeploymentMonitoringObjectiveType::value] or
+    /// [ModelDeploymentMonitoringObjectiveType::name].
+    UnknownValue(model_deployment_monitoring_objective_type::UnknownValue),
+}
 
-    /// Creates a new ModelDeploymentMonitoringObjectiveType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => {
-                std::borrow::Cow::Borrowed("MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED")
-            }
-            1 => std::borrow::Cow::Borrowed("RAW_FEATURE_SKEW"),
-            2 => std::borrow::Cow::Borrowed("RAW_FEATURE_DRIFT"),
-            3 => std::borrow::Cow::Borrowed("FEATURE_ATTRIBUTION_SKEW"),
-            4 => std::borrow::Cow::Borrowed("FEATURE_ATTRIBUTION_DRIFT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED" => std::option::Option::Some(
-                Self::MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED,
-            ),
-            "RAW_FEATURE_SKEW" => std::option::Option::Some(Self::RAW_FEATURE_SKEW),
-            "RAW_FEATURE_DRIFT" => std::option::Option::Some(Self::RAW_FEATURE_DRIFT),
-            "FEATURE_ATTRIBUTION_SKEW" => std::option::Option::Some(Self::FEATURE_ATTRIBUTION_SKEW),
-            "FEATURE_ATTRIBUTION_DRIFT" => {
-                std::option::Option::Some(Self::FEATURE_ATTRIBUTION_DRIFT)
-            }
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "job_service")]
+pub mod model_deployment_monitoring_objective_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "job_service")]
-impl std::convert::From<i32> for ModelDeploymentMonitoringObjectiveType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl ModelDeploymentMonitoringObjectiveType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RawFeatureSkew => std::option::Option::Some(1),
+            Self::RawFeatureDrift => std::option::Option::Some(2),
+            Self::FeatureAttributionSkew => std::option::Option::Some(3),
+            Self::FeatureAttributionDrift => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED")
+            }
+            Self::RawFeatureSkew => std::option::Option::Some("RAW_FEATURE_SKEW"),
+            Self::RawFeatureDrift => std::option::Option::Some("RAW_FEATURE_DRIFT"),
+            Self::FeatureAttributionSkew => std::option::Option::Some("FEATURE_ATTRIBUTION_SKEW"),
+            Self::FeatureAttributionDrift => std::option::Option::Some("FEATURE_ATTRIBUTION_DRIFT"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "job_service")]
 impl std::default::Default for ModelDeploymentMonitoringObjectiveType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "job_service")]
+impl std::fmt::Display for ModelDeploymentMonitoringObjectiveType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "job_service")]
+impl std::convert::From<i32> for ModelDeploymentMonitoringObjectiveType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RawFeatureSkew,
+            2 => Self::RawFeatureDrift,
+            3 => Self::FeatureAttributionSkew,
+            4 => Self::FeatureAttributionDrift,
+            _ => Self::UnknownValue(model_deployment_monitoring_objective_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "job_service")]
+impl std::convert::From<&str> for ModelDeploymentMonitoringObjectiveType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MODEL_DEPLOYMENT_MONITORING_OBJECTIVE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "RAW_FEATURE_SKEW" => Self::RawFeatureSkew,
+            "RAW_FEATURE_DRIFT" => Self::RawFeatureDrift,
+            "FEATURE_ATTRIBUTION_SKEW" => Self::FeatureAttributionSkew,
+            "FEATURE_ATTRIBUTION_DRIFT" => Self::FeatureAttributionDrift,
+            _ => Self::UnknownValue(model_deployment_monitoring_objective_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "job_service")]
+impl serde::ser::Serialize for ModelDeploymentMonitoringObjectiveType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RawFeatureSkew => serializer.serialize_i32(1),
+            Self::RawFeatureDrift => serializer.serialize_i32(2),
+            Self::FeatureAttributionSkew => serializer.serialize_i32(3),
+            Self::FeatureAttributionDrift => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "job_service")]
+impl<'de> serde::de::Deserialize<'de> for ModelDeploymentMonitoringObjectiveType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<
+            ModelDeploymentMonitoringObjectiveType,
+        >::new(
+            ".google.cloud.aiplatform.v1.ModelDeploymentMonitoringObjectiveType",
+        ))
     }
 }
 
 /// View enumeration of PublisherModel.
 #[cfg(feature = "model_garden_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PublisherModelView(i32);
-
-#[cfg(feature = "model_garden_service")]
-impl PublisherModelView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PublisherModelView {
     /// The default / unset value. The API will default to the BASIC view.
-    pub const PUBLISHER_MODEL_VIEW_UNSPECIFIED: PublisherModelView = PublisherModelView::new(0);
-
+    Unspecified,
     /// Include basic metadata about the publisher model, but not the full
     /// contents.
-    pub const PUBLISHER_MODEL_VIEW_BASIC: PublisherModelView = PublisherModelView::new(1);
-
+    Basic,
     /// Include everything.
-    pub const PUBLISHER_MODEL_VIEW_FULL: PublisherModelView = PublisherModelView::new(2);
-
+    Full,
     /// Include: VersionId, ModelVersionExternalName, and SupportedActions.
-    pub const PUBLISHER_MODEL_VERSION_VIEW_BASIC: PublisherModelView = PublisherModelView::new(3);
+    PublisherModelVersionViewBasic,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PublisherModelView::value] or
+    /// [PublisherModelView::name].
+    UnknownValue(publisher_model_view::UnknownValue),
+}
 
-    /// Creates a new PublisherModelView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VIEW_FULL"),
-            3 => std::borrow::Cow::Borrowed("PUBLISHER_MODEL_VERSION_VIEW_BASIC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PUBLISHER_MODEL_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PUBLISHER_MODEL_VIEW_UNSPECIFIED)
-            }
-            "PUBLISHER_MODEL_VIEW_BASIC" => {
-                std::option::Option::Some(Self::PUBLISHER_MODEL_VIEW_BASIC)
-            }
-            "PUBLISHER_MODEL_VIEW_FULL" => {
-                std::option::Option::Some(Self::PUBLISHER_MODEL_VIEW_FULL)
-            }
-            "PUBLISHER_MODEL_VERSION_VIEW_BASIC" => {
-                std::option::Option::Some(Self::PUBLISHER_MODEL_VERSION_VIEW_BASIC)
-            }
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "model_garden_service")]
+pub mod publisher_model_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "model_garden_service")]
-impl std::convert::From<i32> for PublisherModelView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl PublisherModelView {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::PublisherModelVersionViewBasic => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PUBLISHER_MODEL_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("PUBLISHER_MODEL_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("PUBLISHER_MODEL_VIEW_FULL"),
+            Self::PublisherModelVersionViewBasic => {
+                std::option::Option::Some("PUBLISHER_MODEL_VERSION_VIEW_BASIC")
+            }
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "model_garden_service")]
 impl std::default::Default for PublisherModelView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "model_garden_service")]
+impl std::fmt::Display for PublisherModelView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "model_garden_service")]
+impl std::convert::From<i32> for PublisherModelView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            3 => Self::PublisherModelVersionViewBasic,
+            _ => Self::UnknownValue(publisher_model_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "model_garden_service")]
+impl std::convert::From<&str> for PublisherModelView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PUBLISHER_MODEL_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "PUBLISHER_MODEL_VIEW_BASIC" => Self::Basic,
+            "PUBLISHER_MODEL_VIEW_FULL" => Self::Full,
+            "PUBLISHER_MODEL_VERSION_VIEW_BASIC" => Self::PublisherModelVersionViewBasic,
+            _ => Self::UnknownValue(publisher_model_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "model_garden_service")]
+impl serde::ser::Serialize for PublisherModelView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::PublisherModelVersionViewBasic => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "model_garden_service")]
+impl<'de> serde::de::Deserialize<'de> for PublisherModelView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PublisherModelView>::new(
+            ".google.cloud.aiplatform.v1.PublisherModelView",
+        ))
     }
 }
 
 /// Represents a notebook runtime type.
 #[cfg(feature = "notebook_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotebookRuntimeType(i32);
-
-#[cfg(feature = "notebook_service")]
-impl NotebookRuntimeType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NotebookRuntimeType {
     /// Unspecified notebook runtime type, NotebookRuntimeType will default to
     /// USER_DEFINED.
-    pub const NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED: NotebookRuntimeType = NotebookRuntimeType::new(0);
-
+    Unspecified,
     /// runtime or template with coustomized configurations from user.
-    pub const USER_DEFINED: NotebookRuntimeType = NotebookRuntimeType::new(1);
-
+    UserDefined,
     /// runtime or template with system defined configurations.
-    pub const ONE_CLICK: NotebookRuntimeType = NotebookRuntimeType::new(2);
+    OneClick,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NotebookRuntimeType::value] or
+    /// [NotebookRuntimeType::name].
+    UnknownValue(notebook_runtime_type::UnknownValue),
+}
 
-    /// Creates a new NotebookRuntimeType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("USER_DEFINED"),
-            2 => std::borrow::Cow::Borrowed("ONE_CLICK"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED)
-            }
-            "USER_DEFINED" => std::option::Option::Some(Self::USER_DEFINED),
-            "ONE_CLICK" => std::option::Option::Some(Self::ONE_CLICK),
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "notebook_service")]
+pub mod notebook_runtime_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "notebook_service")]
-impl std::convert::From<i32> for NotebookRuntimeType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl NotebookRuntimeType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::UserDefined => std::option::Option::Some(1),
+            Self::OneClick => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED"),
+            Self::UserDefined => std::option::Option::Some("USER_DEFINED"),
+            Self::OneClick => std::option::Option::Some("ONE_CLICK"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "notebook_service")]
 impl std::default::Default for NotebookRuntimeType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl std::fmt::Display for NotebookRuntimeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl std::convert::From<i32> for NotebookRuntimeType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::UserDefined,
+            2 => Self::OneClick,
+            _ => Self::UnknownValue(notebook_runtime_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl std::convert::From<&str> for NotebookRuntimeType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NOTEBOOK_RUNTIME_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "USER_DEFINED" => Self::UserDefined,
+            "ONE_CLICK" => Self::OneClick,
+            _ => Self::UnknownValue(notebook_runtime_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl serde::ser::Serialize for NotebookRuntimeType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::UserDefined => serializer.serialize_i32(1),
+            Self::OneClick => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl<'de> serde::de::Deserialize<'de> for NotebookRuntimeType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NotebookRuntimeType>::new(
+            ".google.cloud.aiplatform.v1.NotebookRuntimeType",
+        ))
     }
 }
 
 /// Views for Get/List NotebookExecutionJob
 #[cfg(feature = "notebook_service")]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotebookExecutionJobView(i32);
-
-#[cfg(feature = "notebook_service")]
-impl NotebookExecutionJobView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NotebookExecutionJobView {
     /// When unspecified, the API defaults to the BASIC view.
-    pub const NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED: NotebookExecutionJobView =
-        NotebookExecutionJobView::new(0);
-
+    Unspecified,
     /// Includes all fields except for direct notebook inputs.
-    pub const NOTEBOOK_EXECUTION_JOB_VIEW_BASIC: NotebookExecutionJobView =
-        NotebookExecutionJobView::new(1);
-
+    Basic,
     /// Includes all fields.
-    pub const NOTEBOOK_EXECUTION_JOB_VIEW_FULL: NotebookExecutionJobView =
-        NotebookExecutionJobView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NotebookExecutionJobView::value] or
+    /// [NotebookExecutionJobView::name].
+    UnknownValue(notebook_execution_job_view::UnknownValue),
+}
 
-    /// Creates a new NotebookExecutionJobView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NOTEBOOK_EXECUTION_JOB_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("NOTEBOOK_EXECUTION_JOB_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED)
-            }
-            "NOTEBOOK_EXECUTION_JOB_VIEW_BASIC" => {
-                std::option::Option::Some(Self::NOTEBOOK_EXECUTION_JOB_VIEW_BASIC)
-            }
-            "NOTEBOOK_EXECUTION_JOB_VIEW_FULL" => {
-                std::option::Option::Some(Self::NOTEBOOK_EXECUTION_JOB_VIEW_FULL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(feature = "notebook_service")]
+pub mod notebook_execution_job_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(feature = "notebook_service")]
-impl std::convert::From<i32> for NotebookExecutionJobView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl NotebookExecutionJobView {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED")
+            }
+            Self::Basic => std::option::Option::Some("NOTEBOOK_EXECUTION_JOB_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("NOTEBOOK_EXECUTION_JOB_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(feature = "notebook_service")]
 impl std::default::Default for NotebookExecutionJobView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl std::fmt::Display for NotebookExecutionJobView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl std::convert::From<i32> for NotebookExecutionJobView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(notebook_execution_job_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl std::convert::From<&str> for NotebookExecutionJobView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NOTEBOOK_EXECUTION_JOB_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "NOTEBOOK_EXECUTION_JOB_VIEW_BASIC" => Self::Basic,
+            "NOTEBOOK_EXECUTION_JOB_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(notebook_execution_job_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl serde::ser::Serialize for NotebookExecutionJobView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(feature = "notebook_service")]
+impl<'de> serde::de::Deserialize<'de> for NotebookExecutionJobView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NotebookExecutionJobView>::new(
+            ".google.cloud.aiplatform.v1.NotebookExecutionJobView",
+        ))
     }
 }
 
@@ -97914,73 +104428,41 @@ impl std::default::Default for NotebookExecutionJobView {
     feature = "llm_utility_service",
     feature = "prediction_service",
 ))]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Type(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Type {
+    /// Not specified, should not be used.
+    Unspecified,
+    /// OpenAPI string type
+    String,
+    /// OpenAPI number type
+    Number,
+    /// OpenAPI integer type
+    Integer,
+    /// OpenAPI boolean type
+    Boolean,
+    /// OpenAPI array type
+    Array,
+    /// OpenAPI object type
+    Object,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Type::value] or
+    /// [Type::name].
+    UnknownValue(r#type::UnknownValue),
+}
 
+#[doc(hidden)]
 #[cfg(any(
     feature = "gen_ai_cache_service",
     feature = "llm_utility_service",
     feature = "prediction_service",
 ))]
-impl Type {
-    /// Not specified, should not be used.
-    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-    /// OpenAPI string type
-    pub const STRING: Type = Type::new(1);
-
-    /// OpenAPI number type
-    pub const NUMBER: Type = Type::new(2);
-
-    /// OpenAPI integer type
-    pub const INTEGER: Type = Type::new(3);
-
-    /// OpenAPI boolean type
-    pub const BOOLEAN: Type = Type::new(4);
-
-    /// OpenAPI array type
-    pub const ARRAY: Type = Type::new(5);
-
-    /// OpenAPI object type
-    pub const OBJECT: Type = Type::new(6);
-
-    /// Creates a new Type instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("STRING"),
-            2 => std::borrow::Cow::Borrowed("NUMBER"),
-            3 => std::borrow::Cow::Borrowed("INTEGER"),
-            4 => std::borrow::Cow::Borrowed("BOOLEAN"),
-            5 => std::borrow::Cow::Borrowed("ARRAY"),
-            6 => std::borrow::Cow::Borrowed("OBJECT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-            "STRING" => std::option::Option::Some(Self::STRING),
-            "NUMBER" => std::option::Option::Some(Self::NUMBER),
-            "INTEGER" => std::option::Option::Some(Self::INTEGER),
-            "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
-            "ARRAY" => std::option::Option::Some(Self::ARRAY),
-            "OBJECT" => std::option::Option::Some(Self::OBJECT),
-            _ => std::option::Option::None,
-        }
-    }
+pub mod r#type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(any(
@@ -97988,9 +104470,39 @@ impl Type {
     feature = "llm_utility_service",
     feature = "prediction_service",
 ))]
-impl std::convert::From<i32> for Type {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl Type {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::String => std::option::Option::Some(1),
+            Self::Number => std::option::Option::Some(2),
+            Self::Integer => std::option::Option::Some(3),
+            Self::Boolean => std::option::Option::Some(4),
+            Self::Array => std::option::Option::Some(5),
+            Self::Object => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+            Self::String => std::option::Option::Some("STRING"),
+            Self::Number => std::option::Option::Some("NUMBER"),
+            Self::Integer => std::option::Option::Some("INTEGER"),
+            Self::Boolean => std::option::Option::Some("BOOLEAN"),
+            Self::Array => std::option::Option::Some("ARRAY"),
+            Self::Object => std::option::Option::Some("OBJECT"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
@@ -98001,7 +104513,103 @@ impl std::convert::From<i32> for Type {
 ))]
 impl std::default::Default for Type {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_cache_service",
+    feature = "llm_utility_service",
+    feature = "prediction_service",
+))]
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_cache_service",
+    feature = "llm_utility_service",
+    feature = "prediction_service",
+))]
+impl std::convert::From<i32> for Type {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::String,
+            2 => Self::Number,
+            3 => Self::Integer,
+            4 => Self::Boolean,
+            5 => Self::Array,
+            6 => Self::Object,
+            _ => Self::UnknownValue(r#type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_cache_service",
+    feature = "llm_utility_service",
+    feature = "prediction_service",
+))]
+impl std::convert::From<&str> for Type {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TYPE_UNSPECIFIED" => Self::Unspecified,
+            "STRING" => Self::String,
+            "NUMBER" => Self::Number,
+            "INTEGER" => Self::Integer,
+            "BOOLEAN" => Self::Boolean,
+            "ARRAY" => Self::Array,
+            "OBJECT" => Self::Object,
+            _ => Self::UnknownValue(r#type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_cache_service",
+    feature = "llm_utility_service",
+    feature = "prediction_service",
+))]
+impl serde::ser::Serialize for Type {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::String => serializer.serialize_i32(1),
+            Self::Number => serializer.serialize_i32(2),
+            Self::Integer => serializer.serialize_i32(3),
+            Self::Boolean => serializer.serialize_i32(4),
+            Self::Array => serializer.serialize_i32(5),
+            Self::Object => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(any(
+    feature = "gen_ai_cache_service",
+    feature = "llm_utility_service",
+    feature = "prediction_service",
+))]
+impl<'de> serde::de::Deserialize<'de> for Type {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+            ".google.cloud.aiplatform.v1.Type",
+        ))
     }
 }
 
@@ -98012,170 +104620,301 @@ impl std::default::Default for Type {
 /// any new tasks when a task has failed. Any scheduled tasks will continue to
 /// completion.
 #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PipelineFailurePolicy(i32);
-
-#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-impl PipelineFailurePolicy {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PipelineFailurePolicy {
     /// Default value, and follows fail slow behavior.
-    pub const PIPELINE_FAILURE_POLICY_UNSPECIFIED: PipelineFailurePolicy =
-        PipelineFailurePolicy::new(0);
-
+    Unspecified,
     /// Indicates that the pipeline should continue to run until all possible
     /// tasks have been scheduled and completed.
-    pub const PIPELINE_FAILURE_POLICY_FAIL_SLOW: PipelineFailurePolicy =
-        PipelineFailurePolicy::new(1);
-
+    FailSlow,
     /// Indicates that the pipeline should stop scheduling new tasks after a task
     /// has failed.
-    pub const PIPELINE_FAILURE_POLICY_FAIL_FAST: PipelineFailurePolicy =
-        PipelineFailurePolicy::new(2);
+    FailFast,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PipelineFailurePolicy::value] or
+    /// [PipelineFailurePolicy::name].
+    UnknownValue(pipeline_failure_policy::UnknownValue),
+}
 
-    /// Creates a new PipelineFailurePolicy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PIPELINE_FAILURE_POLICY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PIPELINE_FAILURE_POLICY_FAIL_SLOW"),
-            2 => std::borrow::Cow::Borrowed("PIPELINE_FAILURE_POLICY_FAIL_FAST"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PIPELINE_FAILURE_POLICY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PIPELINE_FAILURE_POLICY_UNSPECIFIED)
-            }
-            "PIPELINE_FAILURE_POLICY_FAIL_SLOW" => {
-                std::option::Option::Some(Self::PIPELINE_FAILURE_POLICY_FAIL_SLOW)
-            }
-            "PIPELINE_FAILURE_POLICY_FAIL_FAST" => {
-                std::option::Option::Some(Self::PIPELINE_FAILURE_POLICY_FAIL_FAST)
-            }
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+pub mod pipeline_failure_policy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-impl std::convert::From<i32> for PipelineFailurePolicy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl PipelineFailurePolicy {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::FailSlow => std::option::Option::Some(1),
+            Self::FailFast => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PIPELINE_FAILURE_POLICY_UNSPECIFIED"),
+            Self::FailSlow => std::option::Option::Some("PIPELINE_FAILURE_POLICY_FAIL_SLOW"),
+            Self::FailFast => std::option::Option::Some("PIPELINE_FAILURE_POLICY_FAIL_FAST"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
 impl std::default::Default for PipelineFailurePolicy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl std::fmt::Display for PipelineFailurePolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl std::convert::From<i32> for PipelineFailurePolicy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::FailSlow,
+            2 => Self::FailFast,
+            _ => Self::UnknownValue(pipeline_failure_policy::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl std::convert::From<&str> for PipelineFailurePolicy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PIPELINE_FAILURE_POLICY_UNSPECIFIED" => Self::Unspecified,
+            "PIPELINE_FAILURE_POLICY_FAIL_SLOW" => Self::FailSlow,
+            "PIPELINE_FAILURE_POLICY_FAIL_FAST" => Self::FailFast,
+            _ => Self::UnknownValue(pipeline_failure_policy::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl serde::ser::Serialize for PipelineFailurePolicy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::FailSlow => serializer.serialize_i32(1),
+            Self::FailFast => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl<'de> serde::de::Deserialize<'de> for PipelineFailurePolicy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PipelineFailurePolicy>::new(
+            ".google.cloud.aiplatform.v1.PipelineFailurePolicy",
+        ))
     }
 }
 
 /// Describes the state of a pipeline.
 #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PipelineState(i32);
-
-#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-impl PipelineState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PipelineState {
     /// The pipeline state is unspecified.
-    pub const PIPELINE_STATE_UNSPECIFIED: PipelineState = PipelineState::new(0);
-
+    Unspecified,
     /// The pipeline has been created or resumed, and processing has not yet
     /// begun.
-    pub const PIPELINE_STATE_QUEUED: PipelineState = PipelineState::new(1);
-
+    Queued,
     /// The service is preparing to run the pipeline.
-    pub const PIPELINE_STATE_PENDING: PipelineState = PipelineState::new(2);
-
+    Pending,
     /// The pipeline is in progress.
-    pub const PIPELINE_STATE_RUNNING: PipelineState = PipelineState::new(3);
-
+    Running,
     /// The pipeline completed successfully.
-    pub const PIPELINE_STATE_SUCCEEDED: PipelineState = PipelineState::new(4);
-
+    Succeeded,
     /// The pipeline failed.
-    pub const PIPELINE_STATE_FAILED: PipelineState = PipelineState::new(5);
-
+    Failed,
     /// The pipeline is being cancelled. From this state, the pipeline may only go
     /// to either PIPELINE_STATE_SUCCEEDED, PIPELINE_STATE_FAILED or
     /// PIPELINE_STATE_CANCELLED.
-    pub const PIPELINE_STATE_CANCELLING: PipelineState = PipelineState::new(6);
-
+    Cancelling,
     /// The pipeline has been cancelled.
-    pub const PIPELINE_STATE_CANCELLED: PipelineState = PipelineState::new(7);
-
+    Cancelled,
     /// The pipeline has been stopped, and can be resumed.
-    pub const PIPELINE_STATE_PAUSED: PipelineState = PipelineState::new(8);
+    Paused,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PipelineState::value] or
+    /// [PipelineState::name].
+    UnknownValue(pipeline_state::UnknownValue),
+}
 
-    /// Creates a new PipelineState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PIPELINE_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PIPELINE_STATE_QUEUED"),
-            2 => std::borrow::Cow::Borrowed("PIPELINE_STATE_PENDING"),
-            3 => std::borrow::Cow::Borrowed("PIPELINE_STATE_RUNNING"),
-            4 => std::borrow::Cow::Borrowed("PIPELINE_STATE_SUCCEEDED"),
-            5 => std::borrow::Cow::Borrowed("PIPELINE_STATE_FAILED"),
-            6 => std::borrow::Cow::Borrowed("PIPELINE_STATE_CANCELLING"),
-            7 => std::borrow::Cow::Borrowed("PIPELINE_STATE_CANCELLED"),
-            8 => std::borrow::Cow::Borrowed("PIPELINE_STATE_PAUSED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PIPELINE_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PIPELINE_STATE_UNSPECIFIED)
-            }
-            "PIPELINE_STATE_QUEUED" => std::option::Option::Some(Self::PIPELINE_STATE_QUEUED),
-            "PIPELINE_STATE_PENDING" => std::option::Option::Some(Self::PIPELINE_STATE_PENDING),
-            "PIPELINE_STATE_RUNNING" => std::option::Option::Some(Self::PIPELINE_STATE_RUNNING),
-            "PIPELINE_STATE_SUCCEEDED" => std::option::Option::Some(Self::PIPELINE_STATE_SUCCEEDED),
-            "PIPELINE_STATE_FAILED" => std::option::Option::Some(Self::PIPELINE_STATE_FAILED),
-            "PIPELINE_STATE_CANCELLING" => {
-                std::option::Option::Some(Self::PIPELINE_STATE_CANCELLING)
-            }
-            "PIPELINE_STATE_CANCELLED" => std::option::Option::Some(Self::PIPELINE_STATE_CANCELLED),
-            "PIPELINE_STATE_PAUSED" => std::option::Option::Some(Self::PIPELINE_STATE_PAUSED),
-            _ => std::option::Option::None,
-        }
-    }
+#[doc(hidden)]
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+pub mod pipeline_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
 }
 
 #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
-impl std::convert::From<i32> for PipelineState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+impl PipelineState {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Queued => std::option::Option::Some(1),
+            Self::Pending => std::option::Option::Some(2),
+            Self::Running => std::option::Option::Some(3),
+            Self::Succeeded => std::option::Option::Some(4),
+            Self::Failed => std::option::Option::Some(5),
+            Self::Cancelling => std::option::Option::Some(6),
+            Self::Cancelled => std::option::Option::Some(7),
+            Self::Paused => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PIPELINE_STATE_UNSPECIFIED"),
+            Self::Queued => std::option::Option::Some("PIPELINE_STATE_QUEUED"),
+            Self::Pending => std::option::Option::Some("PIPELINE_STATE_PENDING"),
+            Self::Running => std::option::Option::Some("PIPELINE_STATE_RUNNING"),
+            Self::Succeeded => std::option::Option::Some("PIPELINE_STATE_SUCCEEDED"),
+            Self::Failed => std::option::Option::Some("PIPELINE_STATE_FAILED"),
+            Self::Cancelling => std::option::Option::Some("PIPELINE_STATE_CANCELLING"),
+            Self::Cancelled => std::option::Option::Some("PIPELINE_STATE_CANCELLED"),
+            Self::Paused => std::option::Option::Some("PIPELINE_STATE_PAUSED"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 #[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
 impl std::default::Default for PipelineState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl std::fmt::Display for PipelineState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl std::convert::From<i32> for PipelineState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Queued,
+            2 => Self::Pending,
+            3 => Self::Running,
+            4 => Self::Succeeded,
+            5 => Self::Failed,
+            6 => Self::Cancelling,
+            7 => Self::Cancelled,
+            8 => Self::Paused,
+            _ => Self::UnknownValue(pipeline_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl std::convert::From<&str> for PipelineState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PIPELINE_STATE_UNSPECIFIED" => Self::Unspecified,
+            "PIPELINE_STATE_QUEUED" => Self::Queued,
+            "PIPELINE_STATE_PENDING" => Self::Pending,
+            "PIPELINE_STATE_RUNNING" => Self::Running,
+            "PIPELINE_STATE_SUCCEEDED" => Self::Succeeded,
+            "PIPELINE_STATE_FAILED" => Self::Failed,
+            "PIPELINE_STATE_CANCELLING" => Self::Cancelling,
+            "PIPELINE_STATE_CANCELLED" => Self::Cancelled,
+            "PIPELINE_STATE_PAUSED" => Self::Paused,
+            _ => Self::UnknownValue(pipeline_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl serde::ser::Serialize for PipelineState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Queued => serializer.serialize_i32(1),
+            Self::Pending => serializer.serialize_i32(2),
+            Self::Running => serializer.serialize_i32(3),
+            Self::Succeeded => serializer.serialize_i32(4),
+            Self::Failed => serializer.serialize_i32(5),
+            Self::Cancelling => serializer.serialize_i32(6),
+            Self::Cancelled => serializer.serialize_i32(7),
+            Self::Paused => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(any(feature = "pipeline_service", feature = "schedule_service",))]
+impl<'de> serde::de::Deserialize<'de> for PipelineState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PipelineState>::new(
+            ".google.cloud.aiplatform.v1.PipelineState",
+        ))
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -9240,7 +9240,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("isHuggingFaceModel", &req.is_hugging_face_model)]);
         let builder = builder.query(&[("huggingFaceToken", &req.hugging_face_token)]);
         self.inner
@@ -10527,7 +10527,7 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -10554,7 +10554,7 @@ impl super::stub::NotebookService for NotebookService {
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/alloydb/connectors/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/connectors/v1/src/model.rs
@@ -92,59 +92,120 @@ pub mod metadata_exchange_request {
     use super::*;
 
     /// AuthType contains all supported authentication types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AuthType {
+        /// Authentication type is unspecified and DB_NATIVE is used by default
+        Unspecified,
+        /// Database native authentication (user/password)
+        DbNative,
+        /// Automatic IAM authentication
+        AutoIam,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AuthType::value] or
+        /// [AuthType::name].
+        UnknownValue(auth_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod auth_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AuthType {
-        /// Authentication type is unspecified and DB_NATIVE is used by default
-        pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new(0);
-
-        /// Database native authentication (user/password)
-        pub const DB_NATIVE: AuthType = AuthType::new(1);
-
-        /// Automatic IAM authentication
-        pub const AUTO_IAM: AuthType = AuthType::new(2);
-
-        /// Creates a new AuthType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DbNative => std::option::Option::Some(1),
+                Self::AutoIam => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTH_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DB_NATIVE"),
-                2 => std::borrow::Cow::Borrowed("AUTO_IAM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTH_TYPE_UNSPECIFIED"),
+                Self::DbNative => std::option::Option::Some("DB_NATIVE"),
+                Self::AutoIam => std::option::Option::Some("AUTO_IAM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::AUTH_TYPE_UNSPECIFIED),
-                "DB_NATIVE" => std::option::Option::Some(Self::DB_NATIVE),
-                "AUTO_IAM" => std::option::Option::Some(Self::AUTO_IAM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AuthType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AuthType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AuthType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DbNative,
+                2 => Self::AutoIam,
+                _ => Self::UnknownValue(auth_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AuthType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTH_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DB_NATIVE" => Self::DbNative,
+                "AUTO_IAM" => Self::AutoIam,
+                _ => Self::UnknownValue(auth_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AuthType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DbNative => serializer.serialize_i32(1),
+                Self::AutoIam => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AuthType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthType>::new(
+                ".google.cloud.alloydb.connectors.v1.MetadataExchangeRequest.AuthType",
+            ))
         }
     }
 }
@@ -203,61 +264,120 @@ pub mod metadata_exchange_response {
     use super::*;
 
     /// Response code.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseCode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResponseCode {
+        /// Unknown response code
+        Unspecified,
+        /// Success
+        Ok,
+        /// Failure
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResponseCode::value] or
+        /// [ResponseCode::name].
+        UnknownValue(response_code::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod response_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ResponseCode {
-        /// Unknown response code
-        pub const RESPONSE_CODE_UNSPECIFIED: ResponseCode = ResponseCode::new(0);
-
-        /// Success
-        pub const OK: ResponseCode = ResponseCode::new(1);
-
-        /// Failure
-        pub const ERROR: ResponseCode = ResponseCode::new(2);
-
-        /// Creates a new ResponseCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESPONSE_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OK"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESPONSE_CODE_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESPONSE_CODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESPONSE_CODE_UNSPECIFIED)
-                }
-                "OK" => std::option::Option::Some(Self::OK),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResponseCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResponseCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResponseCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ok,
+                2 => Self::Error,
+                _ => Self::UnknownValue(response_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResponseCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESPONSE_CODE_UNSPECIFIED" => Self::Unspecified,
+                "OK" => Self::Ok,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(response_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResponseCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResponseCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseCode>::new(
+                ".google.cloud.alloydb.connectors.v1.MetadataExchangeResponse.ResponseCode",
+            ))
         }
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -327,57 +327,113 @@ pub mod migration_source {
     use super::*;
 
     /// Denote the type of migration source that created this cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MigrationSourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MigrationSourceType {
+        /// Migration source is unknown.
+        Unspecified,
+        /// DMS source means the cluster was created via DMS migration job.
+        Dms,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MigrationSourceType::value] or
+        /// [MigrationSourceType::name].
+        UnknownValue(migration_source_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod migration_source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MigrationSourceType {
-        /// Migration source is unknown.
-        pub const MIGRATION_SOURCE_TYPE_UNSPECIFIED: MigrationSourceType =
-            MigrationSourceType::new(0);
-
-        /// DMS source means the cluster was created via DMS migration job.
-        pub const DMS: MigrationSourceType = MigrationSourceType::new(1);
-
-        /// Creates a new MigrationSourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dms => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MIGRATION_SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DMS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MIGRATION_SOURCE_TYPE_UNSPECIFIED"),
+                Self::Dms => std::option::Option::Some("DMS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MIGRATION_SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MIGRATION_SOURCE_TYPE_UNSPECIFIED)
-                }
-                "DMS" => std::option::Option::Some(Self::DMS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MigrationSourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MigrationSourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MigrationSourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MigrationSourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dms,
+                _ => Self::UnknownValue(migration_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MigrationSourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MIGRATION_SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DMS" => Self::Dms,
+                _ => Self::UnknownValue(migration_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MigrationSourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dms => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MigrationSourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MigrationSourceType>::new(
+                ".google.cloud.alloydb.v1.MigrationSource.MigrationSourceType",
+            ))
         }
     }
 }
@@ -473,65 +529,126 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Encryption type not specified. Defaults to GOOGLE_DEFAULT_ENCRYPTION.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The data is encrypted at rest with a key that is fully managed by Google.
         /// No key version will be populated. This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new(1);
-
+        GoogleDefaultEncryption,
         /// The data is encrypted at rest with a key that is managed by the customer.
         /// KMS key versions will be populated.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new(2);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(1),
+                Self::CustomerManagedEncryption => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
                 }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleDefaultEncryption,
+                2 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(1),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.alloydb.v1.EncryptionInfo.Type",
+            ))
         }
     }
 }
@@ -589,133 +706,259 @@ pub mod ssl_config {
     use super::*;
 
     /// SSL mode options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslMode(i32);
-
-    impl SslMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SslMode {
         /// SSL mode is not specified. Defaults to ENCRYPTED_ONLY.
-        pub const SSL_MODE_UNSPECIFIED: SslMode = SslMode::new(0);
-
+        Unspecified,
         /// SSL connections are optional. CA verification not enforced.
-        pub const SSL_MODE_ALLOW: SslMode = SslMode::new(1);
-
+        Allow,
         /// SSL connections are required. CA verification not enforced.
         /// Clients may use locally self-signed certificates (default psql client
         /// behavior).
-        pub const SSL_MODE_REQUIRE: SslMode = SslMode::new(2);
-
+        Require,
         /// SSL connections are required. CA verification enforced.
         /// Clients must have certificates signed by a Cluster CA, for example, using
         /// GenerateClientCertificate.
-        pub const SSL_MODE_VERIFY_CA: SslMode = SslMode::new(3);
-
+        VerifyCa,
         /// SSL connections are optional. CA verification not enforced.
-        pub const ALLOW_UNENCRYPTED_AND_ENCRYPTED: SslMode = SslMode::new(4);
-
+        AllowUnencryptedAndEncrypted,
         /// SSL connections are required. CA verification not enforced.
-        pub const ENCRYPTED_ONLY: SslMode = SslMode::new(5);
+        EncryptedOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SslMode::value] or
+        /// [SslMode::name].
+        UnknownValue(ssl_mode::UnknownValue),
+    }
 
-        /// Creates a new SslMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod ssl_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SslMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Require => std::option::Option::Some(2),
+                Self::VerifyCa => std::option::Option::Some(3),
+                Self::AllowUnencryptedAndEncrypted => std::option::Option::Some(4),
+                Self::EncryptedOnly => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SSL_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SSL_MODE_ALLOW"),
-                2 => std::borrow::Cow::Borrowed("SSL_MODE_REQUIRE"),
-                3 => std::borrow::Cow::Borrowed("SSL_MODE_VERIFY_CA"),
-                4 => std::borrow::Cow::Borrowed("ALLOW_UNENCRYPTED_AND_ENCRYPTED"),
-                5 => std::borrow::Cow::Borrowed("ENCRYPTED_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SSL_MODE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_MODE_UNSPECIFIED),
-                "SSL_MODE_ALLOW" => std::option::Option::Some(Self::SSL_MODE_ALLOW),
-                "SSL_MODE_REQUIRE" => std::option::Option::Some(Self::SSL_MODE_REQUIRE),
-                "SSL_MODE_VERIFY_CA" => std::option::Option::Some(Self::SSL_MODE_VERIFY_CA),
-                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => {
-                    std::option::Option::Some(Self::ALLOW_UNENCRYPTED_AND_ENCRYPTED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SSL_MODE_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("SSL_MODE_ALLOW"),
+                Self::Require => std::option::Option::Some("SSL_MODE_REQUIRE"),
+                Self::VerifyCa => std::option::Option::Some("SSL_MODE_VERIFY_CA"),
+                Self::AllowUnencryptedAndEncrypted => {
+                    std::option::Option::Some("ALLOW_UNENCRYPTED_AND_ENCRYPTED")
                 }
-                "ENCRYPTED_ONLY" => std::option::Option::Some(Self::ENCRYPTED_ONLY),
-                _ => std::option::Option::None,
+                Self::EncryptedOnly => std::option::Option::Some("ENCRYPTED_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SslMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SslMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SslMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SslMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Require,
+                3 => Self::VerifyCa,
+                4 => Self::AllowUnencryptedAndEncrypted,
+                5 => Self::EncryptedOnly,
+                _ => Self::UnknownValue(ssl_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SslMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SSL_MODE_UNSPECIFIED" => Self::Unspecified,
+                "SSL_MODE_ALLOW" => Self::Allow,
+                "SSL_MODE_REQUIRE" => Self::Require,
+                "SSL_MODE_VERIFY_CA" => Self::VerifyCa,
+                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => Self::AllowUnencryptedAndEncrypted,
+                "ENCRYPTED_ONLY" => Self::EncryptedOnly,
+                _ => Self::UnknownValue(ssl_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SslMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Require => serializer.serialize_i32(2),
+                Self::VerifyCa => serializer.serialize_i32(3),
+                Self::AllowUnencryptedAndEncrypted => serializer.serialize_i32(4),
+                Self::EncryptedOnly => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SslMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SslMode>::new(
+                ".google.cloud.alloydb.v1.SslConfig.SslMode",
+            ))
         }
     }
 
     /// Certificate Authority (CA) source for SSL/TLS certificates.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CaSource(i32);
-
-    impl CaSource {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CaSource {
         /// Certificate Authority (CA) source not specified. Defaults to
         /// CA_SOURCE_MANAGED.
-        pub const CA_SOURCE_UNSPECIFIED: CaSource = CaSource::new(0);
-
+        Unspecified,
         /// Certificate Authority (CA) managed by the AlloyDB Cluster.
-        pub const CA_SOURCE_MANAGED: CaSource = CaSource::new(1);
+        Managed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CaSource::value] or
+        /// [CaSource::name].
+        UnknownValue(ca_source::UnknownValue),
+    }
 
-        /// Creates a new CaSource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod ca_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CaSource {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Managed => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CA_SOURCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CA_SOURCE_MANAGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CA_SOURCE_UNSPECIFIED"),
+                Self::Managed => std::option::Option::Some("CA_SOURCE_MANAGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CA_SOURCE_UNSPECIFIED" => std::option::Option::Some(Self::CA_SOURCE_UNSPECIFIED),
-                "CA_SOURCE_MANAGED" => std::option::Option::Some(Self::CA_SOURCE_MANAGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CaSource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CaSource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CaSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CaSource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Managed,
+                _ => Self::UnknownValue(ca_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CaSource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CA_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "CA_SOURCE_MANAGED" => Self::Managed,
+                _ => Self::UnknownValue(ca_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CaSource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Managed => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CaSource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CaSource>::new(
+                ".google.cloud.alloydb.v1.SslConfig.CaSource",
+            ))
         }
     }
 }
@@ -2321,162 +2564,296 @@ pub mod cluster {
     }
 
     /// Cluster State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the cluster is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The cluster is active and running.
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// The cluster is stopped. All instances in the cluster are stopped.
         /// Customers can start a stopped cluster at any point and all their
         /// instances will come back to life with same names and IP resources. In
         /// this state, customer pays for storage.
         /// Associated backups could also be present in a stopped cluster.
-        pub const STOPPED: State = State::new(2);
-
+        Stopped,
         /// The cluster is empty and has no associated resources.
         /// All instances, associated storage and backups have been deleted.
-        pub const EMPTY: State = State::new(3);
-
+        Empty,
         /// The cluster is being created.
-        pub const CREATING: State = State::new(4);
-
+        Creating,
         /// The cluster is being deleted.
-        pub const DELETING: State = State::new(5);
-
+        Deleting,
         /// The creation of the cluster failed.
-        pub const FAILED: State = State::new(6);
-
+        Failed,
         /// The cluster is bootstrapping with data from some other source.
         /// Direct mutations to the cluster (e.g. adding read pool) are not allowed.
-        pub const BOOTSTRAPPING: State = State::new(7);
-
+        Bootstrapping,
         /// The cluster is under maintenance. AlloyDB regularly performs maintenance
         /// and upgrades on customer clusters. Updates on the cluster are
         /// not allowed while the cluster is in this state.
-        pub const MAINTENANCE: State = State::new(8);
-
+        Maintenance,
         /// The cluster is being promoted.
-        pub const PROMOTING: State = State::new(9);
+        Promoting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Stopped => std::option::Option::Some(2),
+                Self::Empty => std::option::Option::Some(3),
+                Self::Creating => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Bootstrapping => std::option::Option::Some(7),
+                Self::Maintenance => std::option::Option::Some(8),
+                Self::Promoting => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("STOPPED"),
-                3 => std::borrow::Cow::Borrowed("EMPTY"),
-                4 => std::borrow::Cow::Borrowed("CREATING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("BOOTSTRAPPING"),
-                8 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                9 => std::borrow::Cow::Borrowed("PROMOTING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Empty => std::option::Option::Some("EMPTY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Bootstrapping => std::option::Option::Some("BOOTSTRAPPING"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Promoting => std::option::Option::Some("PROMOTING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "EMPTY" => std::option::Option::Some(Self::EMPTY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "BOOTSTRAPPING" => std::option::Option::Some(Self::BOOTSTRAPPING),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "PROMOTING" => std::option::Option::Some(Self::PROMOTING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Stopped,
+                3 => Self::Empty,
+                4 => Self::Creating,
+                5 => Self::Deleting,
+                6 => Self::Failed,
+                7 => Self::Bootstrapping,
+                8 => Self::Maintenance,
+                9 => Self::Promoting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "STOPPED" => Self::Stopped,
+                "EMPTY" => Self::Empty,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "BOOTSTRAPPING" => Self::Bootstrapping,
+                "MAINTENANCE" => Self::Maintenance,
+                "PROMOTING" => Self::Promoting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Stopped => serializer.serialize_i32(2),
+                Self::Empty => serializer.serialize_i32(3),
+                Self::Creating => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Bootstrapping => serializer.serialize_i32(7),
+                Self::Maintenance => serializer.serialize_i32(8),
+                Self::Promoting => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.alloydb.v1.Cluster.State",
+            ))
         }
     }
 
     /// Type of Cluster
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterType(i32);
-
-    impl ClusterType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ClusterType {
         /// The type of the cluster is unknown.
-        pub const CLUSTER_TYPE_UNSPECIFIED: ClusterType = ClusterType::new(0);
-
+        Unspecified,
         /// Primary cluster that support read and write operations.
-        pub const PRIMARY: ClusterType = ClusterType::new(1);
-
+        Primary,
         /// Secondary cluster that is replicating from another region.
         /// This only supports read.
-        pub const SECONDARY: ClusterType = ClusterType::new(2);
+        Secondary,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ClusterType::value] or
+        /// [ClusterType::name].
+        UnknownValue(cluster_type::UnknownValue),
+    }
 
-        /// Creates a new ClusterType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cluster_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ClusterType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Primary => std::option::Option::Some(1),
+                Self::Secondary => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLUSTER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIMARY"),
-                2 => std::borrow::Cow::Borrowed("SECONDARY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CLUSTER_TYPE_UNSPECIFIED"),
+                Self::Primary => std::option::Option::Some("PRIMARY"),
+                Self::Secondary => std::option::Option::Some("SECONDARY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLUSTER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLUSTER_TYPE_UNSPECIFIED)
-                }
-                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-                "SECONDARY" => std::option::Option::Some(Self::SECONDARY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ClusterType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ClusterType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ClusterType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Primary,
+                2 => Self::Secondary,
+                _ => Self::UnknownValue(cluster_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ClusterType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLUSTER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PRIMARY" => Self::Primary,
+                "SECONDARY" => Self::Secondary,
+                _ => Self::UnknownValue(cluster_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ClusterType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Primary => serializer.serialize_i32(1),
+                Self::Secondary => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ClusterType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ClusterType>::new(
+                ".google.cloud.alloydb.v1.Cluster.ClusterType",
+            ))
         }
     }
 
@@ -3349,165 +3726,299 @@ pub mod instance {
     }
 
     /// Instance State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the instance is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The instance is active and running.
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// The instance is stopped. Instance name and IP resources are preserved.
-        pub const STOPPED: State = State::new(2);
-
+        Stopped,
         /// The instance is being created.
-        pub const CREATING: State = State::new(3);
-
+        Creating,
         /// The instance is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The instance is down for maintenance.
-        pub const MAINTENANCE: State = State::new(5);
-
+        Maintenance,
         /// The creation of the instance failed or a fatal error occurred during
         /// an operation on the instance.
         /// Note: Instances in this state would tried to be auto-repaired. And
         /// Customers should be able to restart, update or delete these instances.
-        pub const FAILED: State = State::new(6);
-
+        Failed,
         /// Index 7 is used in the producer apis for ROLLED_BACK state. Keeping that
         /// index unused in case that state also needs to exposed via consumer apis
         /// in future.
         /// The instance has been configured to sync data from some other source.
-        pub const BOOTSTRAPPING: State = State::new(8);
-
+        Bootstrapping,
         /// The instance is being promoted.
-        pub const PROMOTING: State = State::new(9);
+        Promoting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Stopped => std::option::Option::Some(2),
+                Self::Creating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Maintenance => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Bootstrapping => std::option::Option::Some(8),
+                Self::Promoting => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("STOPPED"),
-                3 => std::borrow::Cow::Borrowed("CREATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                8 => std::borrow::Cow::Borrowed("BOOTSTRAPPING"),
-                9 => std::borrow::Cow::Borrowed("PROMOTING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Bootstrapping => std::option::Option::Some("BOOTSTRAPPING"),
+                Self::Promoting => std::option::Option::Some("PROMOTING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "BOOTSTRAPPING" => std::option::Option::Some(Self::BOOTSTRAPPING),
-                "PROMOTING" => std::option::Option::Some(Self::PROMOTING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Stopped,
+                3 => Self::Creating,
+                4 => Self::Deleting,
+                5 => Self::Maintenance,
+                6 => Self::Failed,
+                8 => Self::Bootstrapping,
+                9 => Self::Promoting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "STOPPED" => Self::Stopped,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "MAINTENANCE" => Self::Maintenance,
+                "FAILED" => Self::Failed,
+                "BOOTSTRAPPING" => Self::Bootstrapping,
+                "PROMOTING" => Self::Promoting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Stopped => serializer.serialize_i32(2),
+                Self::Creating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Maintenance => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Bootstrapping => serializer.serialize_i32(8),
+                Self::Promoting => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.alloydb.v1.Instance.State",
+            ))
         }
     }
 
     /// Type of an Instance
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceType(i32);
-
-    impl InstanceType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstanceType {
         /// The type of the instance is unknown.
-        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType = InstanceType::new(0);
-
+        Unspecified,
         /// PRIMARY instances support read and write operations.
-        pub const PRIMARY: InstanceType = InstanceType::new(1);
-
+        Primary,
         /// READ POOL instances support read operations only. Each read pool instance
         /// consists of one or more homogeneous nodes.
         ///
         /// * Read pool of size 1 can only have zonal availability.
         /// * Read pools with node count of 2 or more can have regional
         ///   availability (nodes are present in 2 or more zones in a region).
-        pub const READ_POOL: InstanceType = InstanceType::new(2);
-
+        ReadPool,
         /// SECONDARY instances support read operations only. SECONDARY instance
         /// is a cross-region read replica
-        pub const SECONDARY: InstanceType = InstanceType::new(3);
+        Secondary,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstanceType::value] or
+        /// [InstanceType::name].
+        UnknownValue(instance_type::UnknownValue),
+    }
 
-        /// Creates a new InstanceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod instance_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl InstanceType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Primary => std::option::Option::Some(1),
+                Self::ReadPool => std::option::Option::Some(2),
+                Self::Secondary => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIMARY"),
-                2 => std::borrow::Cow::Borrowed("READ_POOL"),
-                3 => std::borrow::Cow::Borrowed("SECONDARY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INSTANCE_TYPE_UNSPECIFIED"),
+                Self::Primary => std::option::Option::Some("PRIMARY"),
+                Self::ReadPool => std::option::Option::Some("READ_POOL"),
+                Self::Secondary => std::option::Option::Some("SECONDARY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_TYPE_UNSPECIFIED)
-                }
-                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-                "READ_POOL" => std::option::Option::Some(Self::READ_POOL),
-                "SECONDARY" => std::option::Option::Some(Self::SECONDARY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InstanceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstanceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstanceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Primary,
+                2 => Self::ReadPool,
+                3 => Self::Secondary,
+                _ => Self::UnknownValue(instance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstanceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PRIMARY" => Self::Primary,
+                "READ_POOL" => Self::ReadPool,
+                "SECONDARY" => Self::Secondary,
+                _ => Self::UnknownValue(instance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstanceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Primary => serializer.serialize_i32(1),
+                Self::ReadPool => serializer.serialize_i32(2),
+                Self::Secondary => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstanceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstanceType>::new(
+                ".google.cloud.alloydb.v1.Instance.InstanceType",
+            ))
         }
     }
 
@@ -3517,61 +4028,120 @@ pub mod instance {
     ///   zone affect instance availability.
     /// - REGIONAL: The instance can serve data from more than one zone in a
     ///   region (it is highly available).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AvailabilityType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AvailabilityType {
+        /// This is an unknown Availability type.
+        Unspecified,
+        /// Zonal available instance.
+        Zonal,
+        /// Regional (or Highly) available instance.
+        Regional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AvailabilityType::value] or
+        /// [AvailabilityType::name].
+        UnknownValue(availability_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod availability_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AvailabilityType {
-        /// This is an unknown Availability type.
-        pub const AVAILABILITY_TYPE_UNSPECIFIED: AvailabilityType = AvailabilityType::new(0);
-
-        /// Zonal available instance.
-        pub const ZONAL: AvailabilityType = AvailabilityType::new(1);
-
-        /// Regional (or Highly) available instance.
-        pub const REGIONAL: AvailabilityType = AvailabilityType::new(2);
-
-        /// Creates a new AvailabilityType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Zonal => std::option::Option::Some(1),
+                Self::Regional => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AVAILABILITY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ZONAL"),
-                2 => std::borrow::Cow::Borrowed("REGIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AVAILABILITY_TYPE_UNSPECIFIED"),
+                Self::Zonal => std::option::Option::Some("ZONAL"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AVAILABILITY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AVAILABILITY_TYPE_UNSPECIFIED)
-                }
-                "ZONAL" => std::option::Option::Some(Self::ZONAL),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AvailabilityType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AvailabilityType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AvailabilityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AvailabilityType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Zonal,
+                2 => Self::Regional,
+                _ => Self::UnknownValue(availability_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AvailabilityType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AVAILABILITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ZONAL" => Self::Zonal,
+                "REGIONAL" => Self::Regional,
+                _ => Self::UnknownValue(availability_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AvailabilityType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Zonal => serializer.serialize_i32(1),
+                Self::Regional => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AvailabilityType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AvailabilityType>::new(
+                ".google.cloud.alloydb.v1.Instance.AvailabilityType",
+            ))
         }
     }
 }
@@ -4041,134 +4611,262 @@ pub mod backup {
     }
 
     /// Backup State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the backup is unknown.
+        Unspecified,
+        /// The backup is ready.
+        Ready,
+        /// The backup is creating.
+        Creating,
+        /// The backup failed.
+        Failed,
+        /// The backup is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the backup is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The backup is ready.
-        pub const READY: State = State::new(1);
-
-        /// The backup is creating.
-        pub const CREATING: State = State::new(2);
-
-        /// The backup failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The backup is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.alloydb.v1.Backup.State",
+            ))
         }
     }
 
     /// Backup Type
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Backup Type is unknown.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// ON_DEMAND backups that were triggered by the customer (e.g., not
         /// AUTOMATED).
-        pub const ON_DEMAND: Type = Type::new(1);
-
+        OnDemand,
         /// AUTOMATED backups triggered by the automated backups scheduler pursuant
         /// to an automated backup policy.
-        pub const AUTOMATED: Type = Type::new(2);
-
+        Automated,
         /// CONTINUOUS backups triggered by the automated backups scheduler
         /// due to a continuous backup policy.
-        pub const CONTINUOUS: Type = Type::new(3);
+        Continuous,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OnDemand => std::option::Option::Some(1),
+                Self::Automated => std::option::Option::Some(2),
+                Self::Continuous => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATED"),
-                3 => std::borrow::Cow::Borrowed("CONTINUOUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::Automated => std::option::Option::Some("AUTOMATED"),
+                Self::Continuous => std::option::Option::Some("CONTINUOUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
-                "CONTINUOUS" => std::option::Option::Some(Self::CONTINUOUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OnDemand,
+                2 => Self::Automated,
+                3 => Self::Continuous,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ON_DEMAND" => Self::OnDemand,
+                "AUTOMATED" => Self::Automated,
+                "CONTINUOUS" => Self::Continuous,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OnDemand => serializer.serialize_i32(1),
+                Self::Automated => serializer.serialize_i32(2),
+                Self::Continuous => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.alloydb.v1.Backup.Type",
+            ))
         }
     }
 }
@@ -4463,69 +5161,134 @@ pub mod supported_database_flag {
     /// ValueType describes the semantic type of the value that the flag accepts.
     /// Regardless of the ValueType, the Instance.database_flags field accepts the
     /// stringified version of the value, i.e. "20" or "3.14".
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ValueType {
+        /// This is an unknown flag type.
+        Unspecified,
+        /// String type flag.
+        String,
+        /// Integer type flag.
+        Integer,
+        /// Float type flag.
+        Float,
+        /// Denotes that the flag does not accept any values.
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ValueType::value] or
+        /// [ValueType::name].
+        UnknownValue(value_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod value_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ValueType {
-        /// This is an unknown flag type.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
-
-        /// String type flag.
-        pub const STRING: ValueType = ValueType::new(1);
-
-        /// Integer type flag.
-        pub const INTEGER: ValueType = ValueType::new(2);
-
-        /// Float type flag.
-        pub const FLOAT: ValueType = ValueType::new(3);
-
-        /// Denotes that the flag does not accept any values.
-        pub const NONE: ValueType = ValueType::new(4);
-
-        /// Creates a new ValueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::String => std::option::Option::Some(1),
+                Self::Integer => std::option::Option::Some(2),
+                Self::Float => std::option::Option::Some(3),
+                Self::None => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STRING"),
-                2 => std::borrow::Cow::Borrowed("INTEGER"),
-                3 => std::borrow::Cow::Borrowed("FLOAT"),
-                4 => std::borrow::Cow::Borrowed("NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VALUE_TYPE_UNSPECIFIED"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Integer => std::option::Option::Some("INTEGER"),
+                Self::Float => std::option::Option::Some("FLOAT"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "INTEGER" => std::option::Option::Some(Self::INTEGER),
-                "FLOAT" => std::option::Option::Some(Self::FLOAT),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ValueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ValueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::String,
+                2 => Self::Integer,
+                3 => Self::Float,
+                4 => Self::None,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ValueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VALUE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STRING" => Self::String,
+                "INTEGER" => Self::Integer,
+                "FLOAT" => Self::Float,
+                "NONE" => Self::None,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ValueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::String => serializer.serialize_i32(1),
+                Self::Integer => serializer.serialize_i32(2),
+                Self::Float => serializer.serialize_i32(3),
+                Self::None => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ValueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueType>::new(
+                ".google.cloud.alloydb.v1.SupportedDatabaseFlag.ValueType",
+            ))
         }
     }
 
@@ -4633,60 +5396,121 @@ pub mod user {
     use super::*;
 
     /// Enum that details the user type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserType(i32);
-
-    impl UserType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserType {
         /// Unspecified user type.
-        pub const USER_TYPE_UNSPECIFIED: UserType = UserType::new(0);
-
+        Unspecified,
         /// The default user type that authenticates via password-based
         /// authentication.
-        pub const ALLOYDB_BUILT_IN: UserType = UserType::new(1);
-
+        AlloydbBuiltIn,
         /// Database user that can authenticate via IAM-Based authentication.
-        pub const ALLOYDB_IAM_USER: UserType = UserType::new(2);
+        AlloydbIamUser,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserType::value] or
+        /// [UserType::name].
+        UnknownValue(user_type::UnknownValue),
+    }
 
-        /// Creates a new UserType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod user_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl UserType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AlloydbBuiltIn => std::option::Option::Some(1),
+                Self::AlloydbIamUser => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOYDB_BUILT_IN"),
-                2 => std::borrow::Cow::Borrowed("ALLOYDB_IAM_USER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("USER_TYPE_UNSPECIFIED"),
+                Self::AlloydbBuiltIn => std::option::Option::Some("ALLOYDB_BUILT_IN"),
+                Self::AlloydbIamUser => std::option::Option::Some("ALLOYDB_IAM_USER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::USER_TYPE_UNSPECIFIED),
-                "ALLOYDB_BUILT_IN" => std::option::Option::Some(Self::ALLOYDB_BUILT_IN),
-                "ALLOYDB_IAM_USER" => std::option::Option::Some(Self::ALLOYDB_IAM_USER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UserType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UserType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AlloydbBuiltIn,
+                2 => Self::AlloydbIamUser,
+                _ => Self::UnknownValue(user_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALLOYDB_BUILT_IN" => Self::AlloydbBuiltIn,
+                "ALLOYDB_IAM_USER" => Self::AlloydbIamUser,
+                _ => Self::UnknownValue(user_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AlloydbBuiltIn => serializer.serialize_i32(1),
+                Self::AlloydbIamUser => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserType>::new(
+                ".google.cloud.alloydb.v1.User.UserType",
+            ))
         }
     }
 }
@@ -6332,82 +7156,151 @@ pub mod batch_create_instance_status {
     /// State contains all valid instance states for the BatchCreateInstances
     /// operation. This is mainly used for status reporting through the LRO
     /// metadata.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the instance is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Instance is pending creation and has not yet been picked up for
         /// processing in the backend.
-        pub const PENDING_CREATE: State = State::new(1);
-
+        PendingCreate,
         /// The instance is active and running.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The instance is being created.
-        pub const CREATING: State = State::new(3);
-
+        Creating,
         /// The instance is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The creation of the instance failed or a fatal error occurred during
         /// an operation on the instance or a batch of instances.
-        pub const FAILED: State = State::new(5);
-
+        Failed,
         /// The instance was created successfully, but was rolled back and deleted
         /// due to some other failure during BatchCreateInstances operation.
-        pub const ROLLED_BACK: State = State::new(6);
+        RolledBack,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PendingCreate => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Creating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::RolledBack => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING_CREATE"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("CREATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("ROLLED_BACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::PendingCreate => std::option::Option::Some("PENDING_CREATE"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::RolledBack => std::option::Option::Some("ROLLED_BACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING_CREATE" => std::option::Option::Some(Self::PENDING_CREATE),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ROLLED_BACK" => std::option::Option::Some(Self::ROLLED_BACK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PendingCreate,
+                2 => Self::Ready,
+                3 => Self::Creating,
+                4 => Self::Deleting,
+                5 => Self::Failed,
+                6 => Self::RolledBack,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING_CREATE" => Self::PendingCreate,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "ROLLED_BACK" => Self::RolledBack,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PendingCreate => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Creating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::RolledBack => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.alloydb.v1.BatchCreateInstanceStatus.State",
+            ))
         }
     }
 }
@@ -6741,54 +7634,113 @@ pub mod inject_fault_request {
 
     /// FaultType contains all valid types of faults that can be injected to an
     /// instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FaultType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FaultType {
+        /// The fault type is unknown.
+        Unspecified,
+        /// Stop the VM
+        StopVm,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FaultType::value] or
+        /// [FaultType::name].
+        UnknownValue(fault_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod fault_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FaultType {
-        /// The fault type is unknown.
-        pub const FAULT_TYPE_UNSPECIFIED: FaultType = FaultType::new(0);
-
-        /// Stop the VM
-        pub const STOP_VM: FaultType = FaultType::new(1);
-
-        /// Creates a new FaultType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StopVm => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FAULT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STOP_VM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FAULT_TYPE_UNSPECIFIED"),
+                Self::StopVm => std::option::Option::Some("STOP_VM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FAULT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FAULT_TYPE_UNSPECIFIED),
-                "STOP_VM" => std::option::Option::Some(Self::STOP_VM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FaultType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FaultType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FaultType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FaultType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StopVm,
+                _ => Self::UnknownValue(fault_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FaultType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FAULT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STOP_VM" => Self::StopVm,
+                _ => Self::UnknownValue(fault_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FaultType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StopVm => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FaultType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FaultType>::new(
+                ".google.cloud.alloydb.v1.InjectFaultRequest.FaultType",
+            ))
         }
     }
 }
@@ -7135,72 +8087,135 @@ pub mod execute_sql_metadata {
     use super::*;
 
     /// Status contains all valid Status a SQL execution can end up in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// The status is unknown.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+        Unspecified,
         /// No error during SQL execution i.e. All SQL statements ran to completion.
         /// The "message" will be empty.
-        pub const OK: Status = Status::new(1);
-
+        Ok,
         /// Same as OK, except indicates that only partial results were
         /// returned. The "message" field will contain details on why results were
         /// truncated.
-        pub const PARTIAL: Status = Status::new(2);
-
+        Partial,
         /// Error during SQL execution. Atleast 1 SQL statement execution resulted in
         /// a error. Side effects of other statements are rolled back.  The "message"
         /// field will contain human readable error given by Postgres of the first
         /// bad SQL statement. SQL execution errors don't constitute API errors as
         /// defined in <https://google.aip.dev/193> but will be returned as part of
         /// this message.
-        pub const ERROR: Status = Status::new(3);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(1),
+                Self::Partial => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OK"),
-                2 => std::borrow::Cow::Borrowed("PARTIAL"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::Partial => std::option::Option::Some("PARTIAL"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "OK" => std::option::Option::Some(Self::OK),
-                "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ok,
+                2 => Self::Partial,
+                3 => Self::Error,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "OK" => Self::Ok,
+                "PARTIAL" => Self::Partial,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(1),
+                Self::Partial => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.cloud.alloydb.v1.ExecuteSqlMetadata.Status",
+            ))
         }
     }
 }
@@ -8702,258 +9717,498 @@ impl gax::paginator::internal::PageableResponse for ListDatabasesResponse {
 
 /// View on Instance. Pass this enum to rpcs that returns an Instance message to
 /// control which subsets of fields to get.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InstanceView(i32);
-
-impl InstanceView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum InstanceView {
     /// INSTANCE_VIEW_UNSPECIFIED Not specified, equivalent to BASIC.
-    pub const INSTANCE_VIEW_UNSPECIFIED: InstanceView = InstanceView::new(0);
-
+    Unspecified,
     /// BASIC server responses for a primary or read instance include all the
     /// relevant instance details, excluding the details of each node in the
     /// instance. The default value.
-    pub const INSTANCE_VIEW_BASIC: InstanceView = InstanceView::new(1);
-
+    Basic,
     /// FULL response is equivalent to BASIC for primary instance (for now).
     /// For read pool instance, this includes details of each node in the pool.
-    pub const INSTANCE_VIEW_FULL: InstanceView = InstanceView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [InstanceView::value] or
+    /// [InstanceView::name].
+    UnknownValue(instance_view::UnknownValue),
+}
 
-    /// Creates a new InstanceView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod instance_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl InstanceView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INSTANCE_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INSTANCE_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("INSTANCE_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INSTANCE_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("INSTANCE_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("INSTANCE_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INSTANCE_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INSTANCE_VIEW_UNSPECIFIED)
-            }
-            "INSTANCE_VIEW_BASIC" => std::option::Option::Some(Self::INSTANCE_VIEW_BASIC),
-            "INSTANCE_VIEW_FULL" => std::option::Option::Some(Self::INSTANCE_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for InstanceView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for InstanceView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for InstanceView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for InstanceView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(instance_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for InstanceView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INSTANCE_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "INSTANCE_VIEW_BASIC" => Self::Basic,
+            "INSTANCE_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(instance_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for InstanceView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for InstanceView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstanceView>::new(
+            ".google.cloud.alloydb.v1.InstanceView",
+        ))
     }
 }
 
 /// View on Cluster. Pass this enum to rpcs that returns a cluster message to
 /// control which subsets of fields to get.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClusterView(i32);
-
-impl ClusterView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ClusterView {
     /// CLUSTER_VIEW_UNSPECIFIED Not specified, equivalent to BASIC.
-    pub const CLUSTER_VIEW_UNSPECIFIED: ClusterView = ClusterView::new(0);
-
+    Unspecified,
     /// BASIC server responses include all the relevant cluster details, excluding
     /// Cluster.ContinuousBackupInfo.EarliestRestorableTime and other view-specific
     /// fields. The default value.
-    pub const CLUSTER_VIEW_BASIC: ClusterView = ClusterView::new(1);
-
+    Basic,
     /// CONTINUOUS_BACKUP response returns all the fields from BASIC plus
     /// the earliest restorable time if continuous backups are enabled.
     /// May increase latency.
-    pub const CLUSTER_VIEW_CONTINUOUS_BACKUP: ClusterView = ClusterView::new(2);
+    ContinuousBackup,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ClusterView::value] or
+    /// [ClusterView::name].
+    UnknownValue(cluster_view::UnknownValue),
+}
 
-    /// Creates a new ClusterView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod cluster_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ClusterView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::ContinuousBackup => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CLUSTER_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CLUSTER_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("CLUSTER_VIEW_CONTINUOUS_BACKUP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CLUSTER_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("CLUSTER_VIEW_BASIC"),
+            Self::ContinuousBackup => std::option::Option::Some("CLUSTER_VIEW_CONTINUOUS_BACKUP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CLUSTER_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::CLUSTER_VIEW_UNSPECIFIED),
-            "CLUSTER_VIEW_BASIC" => std::option::Option::Some(Self::CLUSTER_VIEW_BASIC),
-            "CLUSTER_VIEW_CONTINUOUS_BACKUP" => {
-                std::option::Option::Some(Self::CLUSTER_VIEW_CONTINUOUS_BACKUP)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ClusterView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ClusterView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ClusterView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ClusterView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::ContinuousBackup,
+            _ => Self::UnknownValue(cluster_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ClusterView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CLUSTER_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "CLUSTER_VIEW_BASIC" => Self::Basic,
+            "CLUSTER_VIEW_CONTINUOUS_BACKUP" => Self::ContinuousBackup,
+            _ => Self::UnknownValue(cluster_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ClusterView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::ContinuousBackup => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ClusterView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ClusterView>::new(
+            ".google.cloud.alloydb.v1.ClusterView",
+        ))
     }
 }
 
 /// The supported database engine versions.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseVersion(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatabaseVersion {
+    /// This is an unknown database version.
+    Unspecified,
+    /// DEPRECATED - The database version is Postgres 13.
+    Postgres13,
+    /// The database version is Postgres 14.
+    Postgres14,
+    /// The database version is Postgres 15.
+    Postgres15,
+    /// The database version is Postgres 16.
+    Postgres16,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatabaseVersion::value] or
+    /// [DatabaseVersion::name].
+    UnknownValue(database_version::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod database_version {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DatabaseVersion {
-    /// This is an unknown database version.
-    pub const DATABASE_VERSION_UNSPECIFIED: DatabaseVersion = DatabaseVersion::new(0);
-
-    /// DEPRECATED - The database version is Postgres 13.
-    pub const POSTGRES_13: DatabaseVersion = DatabaseVersion::new(1);
-
-    /// The database version is Postgres 14.
-    pub const POSTGRES_14: DatabaseVersion = DatabaseVersion::new(2);
-
-    /// The database version is Postgres 15.
-    pub const POSTGRES_15: DatabaseVersion = DatabaseVersion::new(3);
-
-    /// The database version is Postgres 16.
-    pub const POSTGRES_16: DatabaseVersion = DatabaseVersion::new(4);
-
-    /// Creates a new DatabaseVersion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Postgres13 => std::option::Option::Some(1),
+            Self::Postgres14 => std::option::Option::Some(2),
+            Self::Postgres15 => std::option::Option::Some(3),
+            Self::Postgres16 => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATABASE_VERSION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("POSTGRES_13"),
-            2 => std::borrow::Cow::Borrowed("POSTGRES_14"),
-            3 => std::borrow::Cow::Borrowed("POSTGRES_15"),
-            4 => std::borrow::Cow::Borrowed("POSTGRES_16"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATABASE_VERSION_UNSPECIFIED"),
+            Self::Postgres13 => std::option::Option::Some("POSTGRES_13"),
+            Self::Postgres14 => std::option::Option::Some("POSTGRES_14"),
+            Self::Postgres15 => std::option::Option::Some("POSTGRES_15"),
+            Self::Postgres16 => std::option::Option::Some("POSTGRES_16"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATABASE_VERSION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATABASE_VERSION_UNSPECIFIED)
-            }
-            "POSTGRES_13" => std::option::Option::Some(Self::POSTGRES_13),
-            "POSTGRES_14" => std::option::Option::Some(Self::POSTGRES_14),
-            "POSTGRES_15" => std::option::Option::Some(Self::POSTGRES_15),
-            "POSTGRES_16" => std::option::Option::Some(Self::POSTGRES_16),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatabaseVersion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseVersion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatabaseVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatabaseVersion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Postgres13,
+            2 => Self::Postgres14,
+            3 => Self::Postgres15,
+            4 => Self::Postgres16,
+            _ => Self::UnknownValue(database_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatabaseVersion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATABASE_VERSION_UNSPECIFIED" => Self::Unspecified,
+            "POSTGRES_13" => Self::Postgres13,
+            "POSTGRES_14" => Self::Postgres14,
+            "POSTGRES_15" => Self::Postgres15,
+            "POSTGRES_16" => Self::Postgres16,
+            _ => Self::UnknownValue(database_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatabaseVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Postgres13 => serializer.serialize_i32(1),
+            Self::Postgres14 => serializer.serialize_i32(2),
+            Self::Postgres15 => serializer.serialize_i32(3),
+            Self::Postgres16 => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatabaseVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseVersion>::new(
+            ".google.cloud.alloydb.v1.DatabaseVersion",
+        ))
     }
 }
 
 /// Subscription_type added to distinguish between Standard and Trial
 /// subscriptions. By default, a subscription type is considered STANDARD unless
 /// explicitly specified.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SubscriptionType(i32);
-
-impl SubscriptionType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SubscriptionType {
     /// This is an unknown subscription type. By default, the subscription type is
     /// STANDARD.
-    pub const SUBSCRIPTION_TYPE_UNSPECIFIED: SubscriptionType = SubscriptionType::new(0);
-
+    Unspecified,
     /// Standard subscription.
-    pub const STANDARD: SubscriptionType = SubscriptionType::new(1);
-
+    Standard,
     /// Trial subscription.
-    pub const TRIAL: SubscriptionType = SubscriptionType::new(2);
+    Trial,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SubscriptionType::value] or
+    /// [SubscriptionType::name].
+    UnknownValue(subscription_type::UnknownValue),
+}
 
-    /// Creates a new SubscriptionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod subscription_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SubscriptionType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Standard => std::option::Option::Some(1),
+            Self::Trial => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SUBSCRIPTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("STANDARD"),
-            2 => std::borrow::Cow::Borrowed("TRIAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SUBSCRIPTION_TYPE_UNSPECIFIED"),
+            Self::Standard => std::option::Option::Some("STANDARD"),
+            Self::Trial => std::option::Option::Some("TRIAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SUBSCRIPTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SUBSCRIPTION_TYPE_UNSPECIFIED)
-            }
-            "STANDARD" => std::option::Option::Some(Self::STANDARD),
-            "TRIAL" => std::option::Option::Some(Self::TRIAL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SubscriptionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SubscriptionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SubscriptionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SubscriptionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Standard,
+            2 => Self::Trial,
+            _ => Self::UnknownValue(subscription_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SubscriptionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SUBSCRIPTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "STANDARD" => Self::Standard,
+            "TRIAL" => Self::Trial,
+            _ => Self::UnknownValue(subscription_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SubscriptionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Standard => serializer.serialize_i32(1),
+            Self::Trial => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SubscriptionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SubscriptionType>::new(
+            ".google.cloud.alloydb.v1.SubscriptionType",
+        ))
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -77,7 +77,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -290,7 +290,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -147,74 +147,141 @@ pub mod api {
     use super::*;
 
     /// All the possible API states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// API does not have a state yet.
+        Unspecified,
+        /// API is being created.
+        Creating,
+        /// API is active.
+        Active,
+        /// API creation failed.
+        Failed,
+        /// API is being deleted.
+        Deleting,
+        /// API is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// API does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// API is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// API is active.
-        pub const ACTIVE: State = State::new(2);
-
-        /// API creation failed.
-        pub const FAILED: State = State::new(3);
-
-        /// API is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// API is being updated.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apigateway.v1.Api.State",
+            ))
         }
     }
 }
@@ -559,80 +626,149 @@ pub mod api_config {
     }
 
     /// All the possible API Config states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// API Config does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// API Config is being created and deployed to the API Controller.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// API Config is ready for use by Gateways.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// API Config creation failed.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// API Config is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// API Config is being updated.
-        pub const UPDATING: State = State::new(5);
-
+        Updating,
         /// API Config settings are being activated in downstream systems.
         /// API Configs in this state cannot be used by Gateways.
-        pub const ACTIVATING: State = State::new(6);
+        Activating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::Activating => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                6 => std::borrow::Cow::Borrowed("ACTIVATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Activating => std::option::Option::Some("ACTIVATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                5 => Self::Updating,
+                6 => Self::Activating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "ACTIVATING" => Self::Activating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::Activating => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apigateway.v1.ApiConfig.State",
+            ))
         }
     }
 }
@@ -766,74 +902,141 @@ pub mod gateway {
     use super::*;
 
     /// All the possible Gateway states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Gateway does not have a state yet.
+        Unspecified,
+        /// Gateway is being created.
+        Creating,
+        /// Gateway is running and ready for requests.
+        Active,
+        /// Gateway creation failed.
+        Failed,
+        /// Gateway is being deleted.
+        Deleting,
+        /// Gateway is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Gateway does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Gateway is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Gateway is running and ready for requests.
-        pub const ACTIVE: State = State::new(2);
-
-        /// Gateway creation failed.
-        pub const FAILED: State = State::new(3);
-
-        /// Gateway is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Gateway is being updated.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apigateway.v1.Gateway.State",
+            ))
         }
     }
 }
@@ -1687,60 +1890,119 @@ pub mod get_api_config_request {
     use super::*;
 
     /// Enum to control which fields should be included in the response.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConfigView(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConfigView {
+        Unspecified,
+        /// Do not include configuration source files.
+        Basic,
+        /// Include configuration source files.
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConfigView::value] or
+        /// [ConfigView::name].
+        UnknownValue(config_view::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod config_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConfigView {
-        pub const CONFIG_VIEW_UNSPECIFIED: ConfigView = ConfigView::new(0);
-
-        /// Do not include configuration source files.
-        pub const BASIC: ConfigView = ConfigView::new(1);
-
-        /// Include configuration source files.
-        pub const FULL: ConfigView = ConfigView::new(2);
-
-        /// Creates a new ConfigView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONFIG_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONFIG_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONFIG_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONFIG_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConfigView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConfigView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConfigView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConfigView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Full,
+                _ => Self::UnknownValue(config_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConfigView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONFIG_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(config_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConfigView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConfigView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConfigView>::new(
+                ".google.cloud.apigateway.v1.GetApiConfigRequest.ConfigView",
+            ))
         }
     }
 }

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -306,7 +306,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -879,169 +879,348 @@ impl wkt::message::Message for HttpResponse {
 }
 
 /// The action taken by agent.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Action(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Action {
+    /// Unspecified Action.
+    Unspecified,
+    /// Indicates that agent should open a new stream.
+    OpenNewStream,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Action::value] or
+    /// [Action::name].
+    UnknownValue(action::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod action {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Action {
-    /// Unspecified Action.
-    pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-    /// Indicates that agent should open a new stream.
-    pub const OPEN_NEW_STREAM: Action = Action::new(1);
-
-    /// Creates a new Action instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::OpenNewStream => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OPEN_NEW_STREAM"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+            Self::OpenNewStream => std::option::Option::Some("OPEN_NEW_STREAM"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-            "OPEN_NEW_STREAM" => std::option::Option::Some(Self::OPEN_NEW_STREAM),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Action {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Action {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Action {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Action {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::OpenNewStream,
+            _ => Self::UnknownValue(action::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Action {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ACTION_UNSPECIFIED" => Self::Unspecified,
+            "OPEN_NEW_STREAM" => Self::OpenNewStream,
+            _ => Self::UnknownValue(action::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Action {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::OpenNewStream => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Action {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+            ".google.cloud.apigeeconnect.v1.Action",
+        ))
     }
 }
 
 /// Endpoint indicates where the messages will be delivered.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TetherEndpoint(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TetherEndpoint {
+    /// Unspecified tether endpoint.
+    Unspecified,
+    /// Apigee MART endpoint.
+    ApigeeMart,
+    /// Apigee Runtime endpoint.
+    ApigeeRuntime,
+    /// Apigee Mint Rating endpoint.
+    ApigeeMintRating,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TetherEndpoint::value] or
+    /// [TetherEndpoint::name].
+    UnknownValue(tether_endpoint::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod tether_endpoint {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TetherEndpoint {
-    /// Unspecified tether endpoint.
-    pub const TETHER_ENDPOINT_UNSPECIFIED: TetherEndpoint = TetherEndpoint::new(0);
-
-    /// Apigee MART endpoint.
-    pub const APIGEE_MART: TetherEndpoint = TetherEndpoint::new(1);
-
-    /// Apigee Runtime endpoint.
-    pub const APIGEE_RUNTIME: TetherEndpoint = TetherEndpoint::new(2);
-
-    /// Apigee Mint Rating endpoint.
-    pub const APIGEE_MINT_RATING: TetherEndpoint = TetherEndpoint::new(3);
-
-    /// Creates a new TetherEndpoint instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ApigeeMart => std::option::Option::Some(1),
+            Self::ApigeeRuntime => std::option::Option::Some(2),
+            Self::ApigeeMintRating => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TETHER_ENDPOINT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("APIGEE_MART"),
-            2 => std::borrow::Cow::Borrowed("APIGEE_RUNTIME"),
-            3 => std::borrow::Cow::Borrowed("APIGEE_MINT_RATING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TETHER_ENDPOINT_UNSPECIFIED"),
+            Self::ApigeeMart => std::option::Option::Some("APIGEE_MART"),
+            Self::ApigeeRuntime => std::option::Option::Some("APIGEE_RUNTIME"),
+            Self::ApigeeMintRating => std::option::Option::Some("APIGEE_MINT_RATING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TETHER_ENDPOINT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TETHER_ENDPOINT_UNSPECIFIED)
-            }
-            "APIGEE_MART" => std::option::Option::Some(Self::APIGEE_MART),
-            "APIGEE_RUNTIME" => std::option::Option::Some(Self::APIGEE_RUNTIME),
-            "APIGEE_MINT_RATING" => std::option::Option::Some(Self::APIGEE_MINT_RATING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TetherEndpoint {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TetherEndpoint {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TetherEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TetherEndpoint {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ApigeeMart,
+            2 => Self::ApigeeRuntime,
+            3 => Self::ApigeeMintRating,
+            _ => Self::UnknownValue(tether_endpoint::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TetherEndpoint {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TETHER_ENDPOINT_UNSPECIFIED" => Self::Unspecified,
+            "APIGEE_MART" => Self::ApigeeMart,
+            "APIGEE_RUNTIME" => Self::ApigeeRuntime,
+            "APIGEE_MINT_RATING" => Self::ApigeeMintRating,
+            _ => Self::UnknownValue(tether_endpoint::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TetherEndpoint {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ApigeeMart => serializer.serialize_i32(1),
+            Self::ApigeeRuntime => serializer.serialize_i32(2),
+            Self::ApigeeMintRating => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TetherEndpoint {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TetherEndpoint>::new(
+            ".google.cloud.apigeeconnect.v1.TetherEndpoint",
+        ))
     }
 }
 
 /// HTTP Scheme.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Scheme(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Scheme {
+    /// Unspecified scheme.
+    Unspecified,
+    /// HTTPS protocol.
+    Https,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Scheme::value] or
+    /// [Scheme::name].
+    UnknownValue(scheme::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod scheme {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Scheme {
-    /// Unspecified scheme.
-    pub const SCHEME_UNSPECIFIED: Scheme = Scheme::new(0);
-
-    /// HTTPS protocol.
-    pub const HTTPS: Scheme = Scheme::new(1);
-
-    /// Creates a new Scheme instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Https => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SCHEME_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HTTPS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SCHEME_UNSPECIFIED"),
+            Self::Https => std::option::Option::Some("HTTPS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SCHEME_UNSPECIFIED" => std::option::Option::Some(Self::SCHEME_UNSPECIFIED),
-            "HTTPS" => std::option::Option::Some(Self::HTTPS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Scheme {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Scheme {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Scheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Scheme {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Https,
+            _ => Self::UnknownValue(scheme::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Scheme {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SCHEME_UNSPECIFIED" => Self::Unspecified,
+            "HTTPS" => Self::Https,
+            _ => Self::UnknownValue(scheme::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Scheme {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Https => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Scheme {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scheme>::new(
+            ".google.cloud.apigeeconnect.v1.Scheme",
+        ))
     }
 }

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -4179,63 +4179,122 @@ pub mod spec {
     /// - `STRICT`: Parsing errors in the specification content result in failure
     ///   of the API call.
     ///   If not specified, defaults to `RELAXED`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ParsingMode(i32);
-
-    impl ParsingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ParsingMode {
         /// Defaults to `RELAXED`.
-        pub const PARSING_MODE_UNSPECIFIED: ParsingMode = ParsingMode::new(0);
-
+        Unspecified,
         /// Parsing of the Spec on create and update is relaxed, meaning that
         /// parsing errors the spec contents will not fail the API call.
-        pub const RELAXED: ParsingMode = ParsingMode::new(1);
-
+        Relaxed,
         /// Parsing of the Spec on create and update is strict, meaning that
         /// parsing errors in the spec contents will fail the API call.
-        pub const STRICT: ParsingMode = ParsingMode::new(2);
+        Strict,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ParsingMode::value] or
+        /// [ParsingMode::name].
+        UnknownValue(parsing_mode::UnknownValue),
+    }
 
-        /// Creates a new ParsingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod parsing_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ParsingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Relaxed => std::option::Option::Some(1),
+                Self::Strict => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PARSING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RELAXED"),
-                2 => std::borrow::Cow::Borrowed("STRICT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PARSING_MODE_UNSPECIFIED"),
+                Self::Relaxed => std::option::Option::Some("RELAXED"),
+                Self::Strict => std::option::Option::Some("STRICT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PARSING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PARSING_MODE_UNSPECIFIED)
-                }
-                "RELAXED" => std::option::Option::Some(Self::RELAXED),
-                "STRICT" => std::option::Option::Some(Self::STRICT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ParsingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ParsingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ParsingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ParsingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Relaxed,
+                2 => Self::Strict,
+                _ => Self::UnknownValue(parsing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ParsingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PARSING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "RELAXED" => Self::Relaxed,
+                "STRICT" => Self::Strict,
+                _ => Self::UnknownValue(parsing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ParsingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Relaxed => serializer.serialize_i32(1),
+                Self::Strict => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ParsingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ParsingMode>::new(
+                ".google.cloud.apihub.v1.Spec.ParsingMode",
+            ))
         }
     }
 }
@@ -4734,54 +4793,113 @@ pub mod definition {
     use super::*;
 
     /// Enumeration of definition types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Definition type unspecified.
+        Unspecified,
+        /// Definition type schema.
+        Schema,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Definition type unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Definition type schema.
-        pub const SCHEMA: Type = Type::new(1);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Schema => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCHEMA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Schema => std::option::Option::Some("SCHEMA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "SCHEMA" => std::option::Option::Some(Self::SCHEMA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Schema,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCHEMA" => Self::Schema,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Schema => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.apihub.v1.Definition.Type",
+            ))
         }
     }
 
@@ -5041,217 +5159,414 @@ pub mod attribute {
     }
 
     /// Enumeration of attribute definition types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DefinitionType(i32);
-
-    impl DefinitionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DefinitionType {
         /// Attribute definition type unspecified.
-        pub const DEFINITION_TYPE_UNSPECIFIED: DefinitionType = DefinitionType::new(0);
-
+        Unspecified,
         /// The attribute is predefined by the API Hub. Note that only the list of
         /// allowed values can be updated in this case via UpdateAttribute method.
-        pub const SYSTEM_DEFINED: DefinitionType = DefinitionType::new(1);
-
+        SystemDefined,
         /// The attribute is defined by the user.
-        pub const USER_DEFINED: DefinitionType = DefinitionType::new(2);
+        UserDefined,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DefinitionType::value] or
+        /// [DefinitionType::name].
+        UnknownValue(definition_type::UnknownValue),
+    }
 
-        /// Creates a new DefinitionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod definition_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DefinitionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SystemDefined => std::option::Option::Some(1),
+                Self::UserDefined => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEFINITION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SYSTEM_DEFINED"),
-                2 => std::borrow::Cow::Borrowed("USER_DEFINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DEFINITION_TYPE_UNSPECIFIED"),
+                Self::SystemDefined => std::option::Option::Some("SYSTEM_DEFINED"),
+                Self::UserDefined => std::option::Option::Some("USER_DEFINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEFINITION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DEFINITION_TYPE_UNSPECIFIED)
-                }
-                "SYSTEM_DEFINED" => std::option::Option::Some(Self::SYSTEM_DEFINED),
-                "USER_DEFINED" => std::option::Option::Some(Self::USER_DEFINED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DefinitionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DefinitionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DefinitionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DefinitionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SystemDefined,
+                2 => Self::UserDefined,
+                _ => Self::UnknownValue(definition_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DefinitionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEFINITION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SYSTEM_DEFINED" => Self::SystemDefined,
+                "USER_DEFINED" => Self::UserDefined,
+                _ => Self::UnknownValue(definition_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DefinitionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SystemDefined => serializer.serialize_i32(1),
+                Self::UserDefined => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DefinitionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DefinitionType>::new(
+                ".google.cloud.apihub.v1.Attribute.DefinitionType",
+            ))
         }
     }
 
     /// Enumeration for the scope of the attribute representing the resource in the
     /// API Hub to which the attribute can be linked.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
+        /// Scope Unspecified.
+        Unspecified,
+        /// Attribute can be linked to an API.
+        Api,
+        /// Attribute can be linked to an API version.
+        Version,
+        /// Attribute can be linked to a Spec.
+        Spec,
+        /// Attribute can be linked to an API Operation.
+        ApiOperation,
+        /// Attribute can be linked to a Deployment.
+        Deployment,
+        /// Attribute can be linked to a Dependency.
+        Dependency,
+        /// Attribute can be linked to a definition.
+        Definition,
+        /// Attribute can be linked to a ExternalAPI.
+        ExternalApi,
+        /// Attribute can be linked to a Plugin.
+        Plugin,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Scope {
-        /// Scope Unspecified.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
-
-        /// Attribute can be linked to an API.
-        pub const API: Scope = Scope::new(1);
-
-        /// Attribute can be linked to an API version.
-        pub const VERSION: Scope = Scope::new(2);
-
-        /// Attribute can be linked to a Spec.
-        pub const SPEC: Scope = Scope::new(3);
-
-        /// Attribute can be linked to an API Operation.
-        pub const API_OPERATION: Scope = Scope::new(4);
-
-        /// Attribute can be linked to a Deployment.
-        pub const DEPLOYMENT: Scope = Scope::new(5);
-
-        /// Attribute can be linked to a Dependency.
-        pub const DEPENDENCY: Scope = Scope::new(6);
-
-        /// Attribute can be linked to a definition.
-        pub const DEFINITION: Scope = Scope::new(7);
-
-        /// Attribute can be linked to a ExternalAPI.
-        pub const EXTERNAL_API: Scope = Scope::new(8);
-
-        /// Attribute can be linked to a Plugin.
-        pub const PLUGIN: Scope = Scope::new(9);
-
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Api => std::option::Option::Some(1),
+                Self::Version => std::option::Option::Some(2),
+                Self::Spec => std::option::Option::Some(3),
+                Self::ApiOperation => std::option::Option::Some(4),
+                Self::Deployment => std::option::Option::Some(5),
+                Self::Dependency => std::option::Option::Some(6),
+                Self::Definition => std::option::Option::Some(7),
+                Self::ExternalApi => std::option::Option::Some(8),
+                Self::Plugin => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("API"),
-                2 => std::borrow::Cow::Borrowed("VERSION"),
-                3 => std::borrow::Cow::Borrowed("SPEC"),
-                4 => std::borrow::Cow::Borrowed("API_OPERATION"),
-                5 => std::borrow::Cow::Borrowed("DEPLOYMENT"),
-                6 => std::borrow::Cow::Borrowed("DEPENDENCY"),
-                7 => std::borrow::Cow::Borrowed("DEFINITION"),
-                8 => std::borrow::Cow::Borrowed("EXTERNAL_API"),
-                9 => std::borrow::Cow::Borrowed("PLUGIN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCOPE_UNSPECIFIED"),
+                Self::Api => std::option::Option::Some("API"),
+                Self::Version => std::option::Option::Some("VERSION"),
+                Self::Spec => std::option::Option::Some("SPEC"),
+                Self::ApiOperation => std::option::Option::Some("API_OPERATION"),
+                Self::Deployment => std::option::Option::Some("DEPLOYMENT"),
+                Self::Dependency => std::option::Option::Some("DEPENDENCY"),
+                Self::Definition => std::option::Option::Some("DEFINITION"),
+                Self::ExternalApi => std::option::Option::Some("EXTERNAL_API"),
+                Self::Plugin => std::option::Option::Some("PLUGIN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
-                "API" => std::option::Option::Some(Self::API),
-                "VERSION" => std::option::Option::Some(Self::VERSION),
-                "SPEC" => std::option::Option::Some(Self::SPEC),
-                "API_OPERATION" => std::option::Option::Some(Self::API_OPERATION),
-                "DEPLOYMENT" => std::option::Option::Some(Self::DEPLOYMENT),
-                "DEPENDENCY" => std::option::Option::Some(Self::DEPENDENCY),
-                "DEFINITION" => std::option::Option::Some(Self::DEFINITION),
-                "EXTERNAL_API" => std::option::Option::Some(Self::EXTERNAL_API),
-                "PLUGIN" => std::option::Option::Some(Self::PLUGIN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Api,
+                2 => Self::Version,
+                3 => Self::Spec,
+                4 => Self::ApiOperation,
+                5 => Self::Deployment,
+                6 => Self::Dependency,
+                7 => Self::Definition,
+                8 => Self::ExternalApi,
+                9 => Self::Plugin,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "API" => Self::Api,
+                "VERSION" => Self::Version,
+                "SPEC" => Self::Spec,
+                "API_OPERATION" => Self::ApiOperation,
+                "DEPLOYMENT" => Self::Deployment,
+                "DEPENDENCY" => Self::Dependency,
+                "DEFINITION" => Self::Definition,
+                "EXTERNAL_API" => Self::ExternalApi,
+                "PLUGIN" => Self::Plugin,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Api => serializer.serialize_i32(1),
+                Self::Version => serializer.serialize_i32(2),
+                Self::Spec => serializer.serialize_i32(3),
+                Self::ApiOperation => serializer.serialize_i32(4),
+                Self::Deployment => serializer.serialize_i32(5),
+                Self::Dependency => serializer.serialize_i32(6),
+                Self::Definition => serializer.serialize_i32(7),
+                Self::ExternalApi => serializer.serialize_i32(8),
+                Self::Plugin => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".google.cloud.apihub.v1.Attribute.Scope",
+            ))
         }
     }
 
     /// Enumeration of attribute's data type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataType {
+        /// Attribute data type unspecified.
+        Unspecified,
+        /// Attribute's value is of type enum.
+        Enum,
+        /// Attribute's value is of type json.
+        Json,
+        /// Attribute's value is of type string.
+        String,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataType::value] or
+        /// [DataType::name].
+        UnknownValue(data_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataType {
-        /// Attribute data type unspecified.
-        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
-
-        /// Attribute's value is of type enum.
-        pub const ENUM: DataType = DataType::new(1);
-
-        /// Attribute's value is of type json.
-        pub const JSON: DataType = DataType::new(2);
-
-        /// Attribute's value is of type string.
-        pub const STRING: DataType = DataType::new(3);
-
-        /// Creates a new DataType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enum => std::option::Option::Some(1),
+                Self::Json => std::option::Option::Some(2),
+                Self::String => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENUM"),
-                2 => std::borrow::Cow::Borrowed("JSON"),
-                3 => std::borrow::Cow::Borrowed("STRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_TYPE_UNSPECIFIED"),
+                Self::Enum => std::option::Option::Some("ENUM"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
-                "ENUM" => std::option::Option::Some(Self::ENUM),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enum,
+                2 => Self::Json,
+                3 => Self::String,
+                _ => Self::UnknownValue(data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ENUM" => Self::Enum,
+                "JSON" => Self::Json,
+                "STRING" => Self::String,
+                _ => Self::UnknownValue(data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enum => serializer.serialize_i32(1),
+                Self::Json => serializer.serialize_i32(2),
+                Self::String => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataType>::new(
+                ".google.cloud.apihub.v1.Attribute.DataType",
+            ))
         }
     }
 }
@@ -5471,64 +5786,127 @@ pub mod open_api_spec_details {
     use super::*;
 
     /// Enumeration of spec formats.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Format {
+        /// SpecFile type unspecified.
+        Unspecified,
+        /// OpenAPI Spec v2.0.
+        OpenApiSpec20,
+        /// OpenAPI Spec v3.0.
+        OpenApiSpec30,
+        /// OpenAPI Spec v3.1.
+        OpenApiSpec31,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Format::value] or
+        /// [Format::name].
+        UnknownValue(format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Format {
-        /// SpecFile type unspecified.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
-
-        /// OpenAPI Spec v2.0.
-        pub const OPEN_API_SPEC_2_0: Format = Format::new(1);
-
-        /// OpenAPI Spec v3.0.
-        pub const OPEN_API_SPEC_3_0: Format = Format::new(2);
-
-        /// OpenAPI Spec v3.1.
-        pub const OPEN_API_SPEC_3_1: Format = Format::new(3);
-
-        /// Creates a new Format instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OpenApiSpec20 => std::option::Option::Some(1),
+                Self::OpenApiSpec30 => std::option::Option::Some(2),
+                Self::OpenApiSpec31 => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OPEN_API_SPEC_2_0"),
-                2 => std::borrow::Cow::Borrowed("OPEN_API_SPEC_3_0"),
-                3 => std::borrow::Cow::Borrowed("OPEN_API_SPEC_3_1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FORMAT_UNSPECIFIED"),
+                Self::OpenApiSpec20 => std::option::Option::Some("OPEN_API_SPEC_2_0"),
+                Self::OpenApiSpec30 => std::option::Option::Some("OPEN_API_SPEC_3_0"),
+                Self::OpenApiSpec31 => std::option::Option::Some("OPEN_API_SPEC_3_1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
-                "OPEN_API_SPEC_2_0" => std::option::Option::Some(Self::OPEN_API_SPEC_2_0),
-                "OPEN_API_SPEC_3_0" => std::option::Option::Some(Self::OPEN_API_SPEC_3_0),
-                "OPEN_API_SPEC_3_1" => std::option::Option::Some(Self::OPEN_API_SPEC_3_1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Format {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Format {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OpenApiSpec20,
+                2 => Self::OpenApiSpec30,
+                3 => Self::OpenApiSpec31,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Format {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "OPEN_API_SPEC_2_0" => Self::OpenApiSpec20,
+                "OPEN_API_SPEC_3_0" => Self::OpenApiSpec30,
+                "OPEN_API_SPEC_3_1" => Self::OpenApiSpec31,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Format {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OpenApiSpec20 => serializer.serialize_i32(1),
+                Self::OpenApiSpec30 => serializer.serialize_i32(2),
+                Self::OpenApiSpec31 => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Format {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Format>::new(
+                ".google.cloud.apihub.v1.OpenApiSpecDetails.Format",
+            ))
         }
     }
 }
@@ -5710,89 +6088,162 @@ pub mod http_operation {
     use super::*;
 
     /// Enumeration of Method types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Method(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Method {
+        /// Method unspecified.
+        Unspecified,
+        /// Get Operation type.
+        Get,
+        /// Put Operation type.
+        Put,
+        /// Post Operation type.
+        Post,
+        /// Delete Operation type.
+        Delete,
+        /// Options Operation type.
+        Options,
+        /// Head Operation type.
+        Head,
+        /// Patch Operation type.
+        Patch,
+        /// Trace Operation type.
+        Trace,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Method::value] or
+        /// [Method::name].
+        UnknownValue(method::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Method {
-        /// Method unspecified.
-        pub const METHOD_UNSPECIFIED: Method = Method::new(0);
-
-        /// Get Operation type.
-        pub const GET: Method = Method::new(1);
-
-        /// Put Operation type.
-        pub const PUT: Method = Method::new(2);
-
-        /// Post Operation type.
-        pub const POST: Method = Method::new(3);
-
-        /// Delete Operation type.
-        pub const DELETE: Method = Method::new(4);
-
-        /// Options Operation type.
-        pub const OPTIONS: Method = Method::new(5);
-
-        /// Head Operation type.
-        pub const HEAD: Method = Method::new(6);
-
-        /// Patch Operation type.
-        pub const PATCH: Method = Method::new(7);
-
-        /// Trace Operation type.
-        pub const TRACE: Method = Method::new(8);
-
-        /// Creates a new Method instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Get => std::option::Option::Some(1),
+                Self::Put => std::option::Option::Some(2),
+                Self::Post => std::option::Option::Some(3),
+                Self::Delete => std::option::Option::Some(4),
+                Self::Options => std::option::Option::Some(5),
+                Self::Head => std::option::Option::Some(6),
+                Self::Patch => std::option::Option::Some(7),
+                Self::Trace => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GET"),
-                2 => std::borrow::Cow::Borrowed("PUT"),
-                3 => std::borrow::Cow::Borrowed("POST"),
-                4 => std::borrow::Cow::Borrowed("DELETE"),
-                5 => std::borrow::Cow::Borrowed("OPTIONS"),
-                6 => std::borrow::Cow::Borrowed("HEAD"),
-                7 => std::borrow::Cow::Borrowed("PATCH"),
-                8 => std::borrow::Cow::Borrowed("TRACE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METHOD_UNSPECIFIED"),
+                Self::Get => std::option::Option::Some("GET"),
+                Self::Put => std::option::Option::Some("PUT"),
+                Self::Post => std::option::Option::Some("POST"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Options => std::option::Option::Some("OPTIONS"),
+                Self::Head => std::option::Option::Some("HEAD"),
+                Self::Patch => std::option::Option::Some("PATCH"),
+                Self::Trace => std::option::Option::Some("TRACE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
-                "GET" => std::option::Option::Some(Self::GET),
-                "PUT" => std::option::Option::Some(Self::PUT),
-                "POST" => std::option::Option::Some(Self::POST),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
-                "HEAD" => std::option::Option::Some(Self::HEAD),
-                "PATCH" => std::option::Option::Some(Self::PATCH),
-                "TRACE" => std::option::Option::Some(Self::TRACE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Method {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Method {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Method {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Method {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Get,
+                2 => Self::Put,
+                3 => Self::Post,
+                4 => Self::Delete,
+                5 => Self::Options,
+                6 => Self::Head,
+                7 => Self::Patch,
+                8 => Self::Trace,
+                _ => Self::UnknownValue(method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Method {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METHOD_UNSPECIFIED" => Self::Unspecified,
+                "GET" => Self::Get,
+                "PUT" => Self::Put,
+                "POST" => Self::Post,
+                "DELETE" => Self::Delete,
+                "OPTIONS" => Self::Options,
+                "HEAD" => Self::Head,
+                "PATCH" => Self::Patch,
+                "TRACE" => Self::Trace,
+                _ => Self::UnknownValue(method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Method {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Get => serializer.serialize_i32(1),
+                Self::Put => serializer.serialize_i32(2),
+                Self::Post => serializer.serialize_i32(3),
+                Self::Delete => serializer.serialize_i32(4),
+                Self::Options => serializer.serialize_i32(5),
+                Self::Head => serializer.serialize_i32(6),
+                Self::Patch => serializer.serialize_i32(7),
+                Self::Trace => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Method {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Method>::new(
+                ".google.cloud.apihub.v1.HttpOperation.Method",
+            ))
         }
     }
 }
@@ -6372,115 +6823,233 @@ pub mod dependency {
     use super::*;
 
     /// Possible states for a dependency.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Dependency will be in a proposed state when it is newly identified by the
         /// API hub on its own.
-        pub const PROPOSED: State = State::new(1);
-
+        Proposed,
         /// Dependency will be in a validated state when it is validated by the
         /// admin or manually created in the API hub.
-        pub const VALIDATED: State = State::new(2);
+        Validated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Proposed => std::option::Option::Some(1),
+                Self::Validated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROPOSED"),
-                2 => std::borrow::Cow::Borrowed("VALIDATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Proposed => std::option::Option::Some("PROPOSED"),
+                Self::Validated => std::option::Option::Some("VALIDATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROPOSED" => std::option::Option::Some(Self::PROPOSED),
-                "VALIDATED" => std::option::Option::Some(Self::VALIDATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Proposed,
+                2 => Self::Validated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROPOSED" => Self::Proposed,
+                "VALIDATED" => Self::Validated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Proposed => serializer.serialize_i32(1),
+                Self::Validated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apihub.v1.Dependency.State",
+            ))
         }
     }
 
     /// Possible modes of discovering the dependency.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiscoveryMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiscoveryMode {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// Manual mode of discovery when the dependency is defined by the user.
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiscoveryMode::value] or
+        /// [DiscoveryMode::name].
+        UnknownValue(discovery_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod discovery_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiscoveryMode {
-        /// Default value. This value is unused.
-        pub const DISCOVERY_MODE_UNSPECIFIED: DiscoveryMode = DiscoveryMode::new(0);
-
-        /// Manual mode of discovery when the dependency is defined by the user.
-        pub const MANUAL: DiscoveryMode = DiscoveryMode::new(1);
-
-        /// Creates a new DiscoveryMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Manual => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISCOVERY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISCOVERY_MODE_UNSPECIFIED"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISCOVERY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISCOVERY_MODE_UNSPECIFIED)
-                }
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiscoveryMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiscoveryMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiscoveryMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiscoveryMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Manual,
+                _ => Self::UnknownValue(discovery_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiscoveryMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISCOVERY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(discovery_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiscoveryMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Manual => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiscoveryMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiscoveryMode>::new(
+                ".google.cloud.apihub.v1.Dependency.DiscoveryMode",
+            ))
         }
     }
 }
@@ -6671,59 +7240,120 @@ pub mod dependency_error_detail {
     use super::*;
 
     /// Possible values representing an error in the dependency.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Error(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Error {
+        /// Default value used for no error in the dependency.
+        Unspecified,
+        /// Supplier entity has been deleted.
+        SupplierNotFound,
+        /// Supplier entity has been recreated.
+        SupplierRecreated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Error::value] or
+        /// [Error::name].
+        UnknownValue(error::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod error {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Error {
-        /// Default value used for no error in the dependency.
-        pub const ERROR_UNSPECIFIED: Error = Error::new(0);
-
-        /// Supplier entity has been deleted.
-        pub const SUPPLIER_NOT_FOUND: Error = Error::new(1);
-
-        /// Supplier entity has been recreated.
-        pub const SUPPLIER_RECREATED: Error = Error::new(2);
-
-        /// Creates a new Error instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SupplierNotFound => std::option::Option::Some(1),
+                Self::SupplierRecreated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUPPLIER_NOT_FOUND"),
-                2 => std::borrow::Cow::Borrowed("SUPPLIER_RECREATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_UNSPECIFIED"),
+                Self::SupplierNotFound => std::option::Option::Some("SUPPLIER_NOT_FOUND"),
+                Self::SupplierRecreated => std::option::Option::Some("SUPPLIER_RECREATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_UNSPECIFIED),
-                "SUPPLIER_NOT_FOUND" => std::option::Option::Some(Self::SUPPLIER_NOT_FOUND),
-                "SUPPLIER_RECREATED" => std::option::Option::Some(Self::SUPPLIER_RECREATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Error {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Error {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Error {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Error {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SupplierNotFound,
+                2 => Self::SupplierRecreated,
+                _ => Self::UnknownValue(error::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Error {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_UNSPECIFIED" => Self::Unspecified,
+                "SUPPLIER_NOT_FOUND" => Self::SupplierNotFound,
+                "SUPPLIER_RECREATED" => Self::SupplierRecreated,
+                _ => Self::UnknownValue(error::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Error {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SupplierNotFound => serializer.serialize_i32(1),
+                Self::SupplierRecreated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Error {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Error>::new(
+                ".google.cloud.apihub.v1.DependencyErrorDetail.Error",
+            ))
         }
     }
 }
@@ -7312,79 +7942,148 @@ pub mod api_hub_instance {
     }
 
     /// State of the ApiHub Instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The ApiHub instance has not been initialized or has been deleted.
+        Inactive,
+        /// The ApiHub instance is being created.
+        Creating,
+        /// The ApiHub instance has been created and is ready for use.
+        Active,
+        /// The ApiHub instance is being updated.
+        Updating,
+        /// The ApiHub instance is being deleted.
+        Deleting,
+        /// The ApiHub instance encountered an error during a state change.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The ApiHub instance has not been initialized or has been deleted.
-        pub const INACTIVE: State = State::new(1);
-
-        /// The ApiHub instance is being created.
-        pub const CREATING: State = State::new(2);
-
-        /// The ApiHub instance has been created and is ready for use.
-        pub const ACTIVE: State = State::new(3);
-
-        /// The ApiHub instance is being updated.
-        pub const UPDATING: State = State::new(4);
-
-        /// The ApiHub instance is being deleted.
-        pub const DELETING: State = State::new(5);
-
-        /// The ApiHub instance encountered an error during a state change.
-        pub const FAILED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Inactive => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Inactive,
+                2 => Self::Creating,
+                3 => Self::Active,
+                4 => Self::Updating,
+                5 => Self::Deleting,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INACTIVE" => Self::Inactive,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Inactive => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apihub.v1.ApiHubInstance.State",
+            ))
         }
     }
 }
@@ -8218,59 +8917,120 @@ pub mod plugin {
     /// Possible states a plugin can have. Note that this enum may receive new
     /// values in the future. Consumers are advised to always code against the
     /// enum values expecting new states can be added later on.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The plugin is enabled.
+        Enabled,
+        /// The plugin is disabled.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The plugin is enabled.
-        pub const ENABLED: State = State::new(1);
-
-        /// The plugin is disabled.
-        pub const DISABLED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apihub.v1.Plugin.State",
+            ))
         }
     }
 }
@@ -9024,182 +9784,369 @@ impl wkt::message::Message for RuntimeProjectAttachment {
 }
 
 /// Lint state represents success or failure for linting.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LintState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LintState {
+    /// Lint state unspecified.
+    Unspecified,
+    /// Linting was completed successfully.
+    Success,
+    /// Linting encountered errors.
+    Error,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LintState::value] or
+    /// [LintState::name].
+    UnknownValue(lint_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod lint_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LintState {
-    /// Lint state unspecified.
-    pub const LINT_STATE_UNSPECIFIED: LintState = LintState::new(0);
-
-    /// Linting was completed successfully.
-    pub const LINT_STATE_SUCCESS: LintState = LintState::new(1);
-
-    /// Linting encountered errors.
-    pub const LINT_STATE_ERROR: LintState = LintState::new(2);
-
-    /// Creates a new LintState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Success => std::option::Option::Some(1),
+            Self::Error => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LINT_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LINT_STATE_SUCCESS"),
-            2 => std::borrow::Cow::Borrowed("LINT_STATE_ERROR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LINT_STATE_UNSPECIFIED"),
+            Self::Success => std::option::Option::Some("LINT_STATE_SUCCESS"),
+            Self::Error => std::option::Option::Some("LINT_STATE_ERROR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LINT_STATE_UNSPECIFIED" => std::option::Option::Some(Self::LINT_STATE_UNSPECIFIED),
-            "LINT_STATE_SUCCESS" => std::option::Option::Some(Self::LINT_STATE_SUCCESS),
-            "LINT_STATE_ERROR" => std::option::Option::Some(Self::LINT_STATE_ERROR),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LintState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LintState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LintState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LintState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Success,
+            2 => Self::Error,
+            _ => Self::UnknownValue(lint_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LintState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LINT_STATE_UNSPECIFIED" => Self::Unspecified,
+            "LINT_STATE_SUCCESS" => Self::Success,
+            "LINT_STATE_ERROR" => Self::Error,
+            _ => Self::UnknownValue(lint_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LintState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Success => serializer.serialize_i32(1),
+            Self::Error => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LintState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LintState>::new(
+            ".google.cloud.apihub.v1.LintState",
+        ))
     }
 }
 
 /// Enumeration of linter types.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Linter(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Linter {
+    /// Linter type unspecified.
+    Unspecified,
+    /// Linter type spectral.
+    Spectral,
+    /// Linter type other.
+    Other,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Linter::value] or
+    /// [Linter::name].
+    UnknownValue(linter::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod linter {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Linter {
-    /// Linter type unspecified.
-    pub const LINTER_UNSPECIFIED: Linter = Linter::new(0);
-
-    /// Linter type spectral.
-    pub const SPECTRAL: Linter = Linter::new(1);
-
-    /// Linter type other.
-    pub const OTHER: Linter = Linter::new(2);
-
-    /// Creates a new Linter instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Spectral => std::option::Option::Some(1),
+            Self::Other => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LINTER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SPECTRAL"),
-            2 => std::borrow::Cow::Borrowed("OTHER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LINTER_UNSPECIFIED"),
+            Self::Spectral => std::option::Option::Some("SPECTRAL"),
+            Self::Other => std::option::Option::Some("OTHER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LINTER_UNSPECIFIED" => std::option::Option::Some(Self::LINTER_UNSPECIFIED),
-            "SPECTRAL" => std::option::Option::Some(Self::SPECTRAL),
-            "OTHER" => std::option::Option::Some(Self::OTHER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Linter {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Linter {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Linter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Linter {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Spectral,
+            2 => Self::Other,
+            _ => Self::UnknownValue(linter::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Linter {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LINTER_UNSPECIFIED" => Self::Unspecified,
+            "SPECTRAL" => Self::Spectral,
+            "OTHER" => Self::Other,
+            _ => Self::UnknownValue(linter::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Linter {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Spectral => serializer.serialize_i32(1),
+            Self::Other => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Linter {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Linter>::new(
+            ".google.cloud.apihub.v1.Linter",
+        ))
     }
 }
 
 /// Severity of the issue.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Severity(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Severity {
+    /// Severity unspecified.
+    Unspecified,
+    /// Severity error.
+    Error,
+    /// Severity warning.
+    Warning,
+    /// Severity info.
+    Info,
+    /// Severity hint.
+    Hint,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Severity::value] or
+    /// [Severity::name].
+    UnknownValue(severity::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod severity {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Severity {
-    /// Severity unspecified.
-    pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-    /// Severity error.
-    pub const SEVERITY_ERROR: Severity = Severity::new(1);
-
-    /// Severity warning.
-    pub const SEVERITY_WARNING: Severity = Severity::new(2);
-
-    /// Severity info.
-    pub const SEVERITY_INFO: Severity = Severity::new(3);
-
-    /// Severity hint.
-    pub const SEVERITY_HINT: Severity = Severity::new(4);
-
-    /// Creates a new Severity instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Error => std::option::Option::Some(1),
+            Self::Warning => std::option::Option::Some(2),
+            Self::Info => std::option::Option::Some(3),
+            Self::Hint => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SEVERITY_ERROR"),
-            2 => std::borrow::Cow::Borrowed("SEVERITY_WARNING"),
-            3 => std::borrow::Cow::Borrowed("SEVERITY_INFO"),
-            4 => std::borrow::Cow::Borrowed("SEVERITY_HINT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+            Self::Error => std::option::Option::Some("SEVERITY_ERROR"),
+            Self::Warning => std::option::Option::Some("SEVERITY_WARNING"),
+            Self::Info => std::option::Option::Some("SEVERITY_INFO"),
+            Self::Hint => std::option::Option::Some("SEVERITY_HINT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-            "SEVERITY_ERROR" => std::option::Option::Some(Self::SEVERITY_ERROR),
-            "SEVERITY_WARNING" => std::option::Option::Some(Self::SEVERITY_WARNING),
-            "SEVERITY_INFO" => std::option::Option::Some(Self::SEVERITY_INFO),
-            "SEVERITY_HINT" => std::option::Option::Some(Self::SEVERITY_HINT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Severity {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Severity {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Severity {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Error,
+            2 => Self::Warning,
+            3 => Self::Info,
+            4 => Self::Hint,
+            _ => Self::UnknownValue(severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Severity {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+            "SEVERITY_ERROR" => Self::Error,
+            "SEVERITY_WARNING" => Self::Warning,
+            "SEVERITY_INFO" => Self::Info,
+            "SEVERITY_HINT" => Self::Hint,
+            _ => Self::UnknownValue(severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Severity {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Error => serializer.serialize_i32(1),
+            Self::Warning => serializer.serialize_i32(2),
+            Self::Info => serializer.serialize_i32(3),
+            Self::Hint => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Severity {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+            ".google.cloud.apihub.v1.Severity",
+        ))
     }
 }

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -2471,64 +2471,127 @@ pub mod application {
     use super::*;
 
     /// Application state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// The Application is being created.
+        Creating,
+        /// The Application is ready to register Services and Workloads.
+        Active,
+        /// The Application is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Application is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The Application is ready to register Services and Workloads.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The Application is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apphub.v1.Application.State",
+            ))
         }
     }
 }
@@ -2571,59 +2634,120 @@ pub mod scope {
     use super::*;
 
     /// Scope Type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified type.
+        Unspecified,
+        /// Regional type.
+        Regional,
+        /// Global type.
+        Global,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Regional type.
-        pub const REGIONAL: Type = Type::new(1);
-
-        /// Global type.
-        pub const GLOBAL: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Regional => std::option::Option::Some(1),
+                Self::Global => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGIONAL"),
-                2 => std::borrow::Cow::Borrowed("GLOBAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::Global => std::option::Option::Some("GLOBAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Regional,
+                2 => Self::Global,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "REGIONAL" => Self::Regional,
+                "GLOBAL" => Self::Global,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Regional => serializer.serialize_i32(1),
+                Self::Global => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.apphub.v1.Scope.Type",
+            ))
         }
     }
 }
@@ -2767,69 +2891,134 @@ pub mod criticality {
     use super::*;
 
     /// Criticality Type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified type.
+        Unspecified,
+        /// Mission critical service, application or workload.
+        MissionCritical,
+        /// High impact.
+        High,
+        /// Medium impact.
+        Medium,
+        /// Low impact.
+        Low,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Mission critical service, application or workload.
-        pub const MISSION_CRITICAL: Type = Type::new(1);
-
-        /// High impact.
-        pub const HIGH: Type = Type::new(2);
-
-        /// Medium impact.
-        pub const MEDIUM: Type = Type::new(3);
-
-        /// Low impact.
-        pub const LOW: Type = Type::new(4);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MissionCritical => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::Low => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MISSION_CRITICAL"),
-                2 => std::borrow::Cow::Borrowed("HIGH"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("LOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::MissionCritical => std::option::Option::Some("MISSION_CRITICAL"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "MISSION_CRITICAL" => std::option::Option::Some(Self::MISSION_CRITICAL),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MissionCritical,
+                2 => Self::High,
+                3 => Self::Medium,
+                4 => Self::Low,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MISSION_CRITICAL" => Self::MissionCritical,
+                "HIGH" => Self::High,
+                "MEDIUM" => Self::Medium,
+                "LOW" => Self::Low,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MissionCritical => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::Low => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.apphub.v1.Criticality.Type",
+            ))
         }
     }
 }
@@ -2875,69 +3064,134 @@ pub mod environment {
     use super::*;
 
     /// Environment Type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified type.
+        Unspecified,
+        /// Production environment.
+        Production,
+        /// Staging environment.
+        Staging,
+        /// Test environment.
+        Test,
+        /// Development environment.
+        Development,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Production environment.
-        pub const PRODUCTION: Type = Type::new(1);
-
-        /// Staging environment.
-        pub const STAGING: Type = Type::new(2);
-
-        /// Test environment.
-        pub const TEST: Type = Type::new(3);
-
-        /// Development environment.
-        pub const DEVELOPMENT: Type = Type::new(4);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Production => std::option::Option::Some(1),
+                Self::Staging => std::option::Option::Some(2),
+                Self::Test => std::option::Option::Some(3),
+                Self::Development => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRODUCTION"),
-                2 => std::borrow::Cow::Borrowed("STAGING"),
-                3 => std::borrow::Cow::Borrowed("TEST"),
-                4 => std::borrow::Cow::Borrowed("DEVELOPMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Production => std::option::Option::Some("PRODUCTION"),
+                Self::Staging => std::option::Option::Some("STAGING"),
+                Self::Test => std::option::Option::Some("TEST"),
+                Self::Development => std::option::Option::Some("DEVELOPMENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PRODUCTION" => std::option::Option::Some(Self::PRODUCTION),
-                "STAGING" => std::option::Option::Some(Self::STAGING),
-                "TEST" => std::option::Option::Some(Self::TEST),
-                "DEVELOPMENT" => std::option::Option::Some(Self::DEVELOPMENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Production,
+                2 => Self::Staging,
+                3 => Self::Test,
+                4 => Self::Development,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PRODUCTION" => Self::Production,
+                "STAGING" => Self::Staging,
+                "TEST" => Self::Test,
+                "DEVELOPMENT" => Self::Development,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Production => serializer.serialize_i32(1),
+                Self::Staging => serializer.serialize_i32(2),
+                Self::Test => serializer.serialize_i32(3),
+                Self::Development => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.apphub.v1.Environment.Type",
+            ))
         }
     }
 }
@@ -3152,69 +3406,134 @@ pub mod service {
     use super::*;
 
     /// Service state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// The service is being created.
+        Creating,
+        /// The service is ready.
+        Active,
+        /// The service is being deleted.
+        Deleting,
+        /// The underlying networking resources have been deleted.
+        Detached,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The service is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The service is ready.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The service is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The underlying networking resources have been deleted.
-        pub const DETACHED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Detached => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("DETACHED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Detached => std::option::Option::Some("DETACHED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DETACHED" => std::option::Option::Some(Self::DETACHED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Detached,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "DETACHED" => Self::Detached,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Detached => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apphub.v1.Service.State",
+            ))
         }
     }
 }
@@ -3465,66 +3784,129 @@ pub mod service_project_attachment {
     use super::*;
 
     /// ServiceProjectAttachment state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The ServiceProjectAttachment is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The ServiceProjectAttachment is ready.
         /// This means Services and Workloads under the corresponding
         /// ServiceProjectAttachment is ready for registration.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The ServiceProjectAttachment is being deleted.
-        pub const DELETING: State = State::new(3);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apphub.v1.ServiceProjectAttachment.State",
+            ))
         }
     }
 }
@@ -3697,69 +4079,134 @@ pub mod workload {
     use super::*;
 
     /// Workload state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// The Workload is being created.
+        Creating,
+        /// The Workload is ready.
+        Active,
+        /// The Workload is being deleted.
+        Deleting,
+        /// The underlying compute resources have been deleted.
+        Detached,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Workload is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The Workload is ready.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The Workload is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The underlying compute resources have been deleted.
-        pub const DETACHED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Detached => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("DETACHED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Detached => std::option::Option::Some("DETACHED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DETACHED" => std::option::Option::Some(Self::DETACHED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Detached,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "DETACHED" => Self::Detached,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Detached => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.apphub.v1.Workload.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -1466,68 +1466,127 @@ pub mod partition_spec {
     /// a timestamp column, the actual partition is based on its date value
     /// (expressed in UTC. see details in
     /// <https://cloud.google.com/bigquery/docs/partitioned-tables#date_timestamp_partitioned_tables>).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PartitionKey(i32);
-
-    impl PartitionKey {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PartitionKey {
         /// Unspecified partition key. If used, it means using non-partitioned table.
-        pub const PARTITION_KEY_UNSPECIFIED: PartitionKey = PartitionKey::new(0);
-
+        Unspecified,
         /// The time when the snapshot is taken. If specified as partition key, the
         /// result table(s) is partitoned by the additional timestamp column,
         /// readTime. If [read_time] in ExportAssetsRequest is specified, the
         /// readTime column's value will be the same as it. Otherwise, its value will
         /// be the current time that is used to take the snapshot.
-        pub const READ_TIME: PartitionKey = PartitionKey::new(1);
-
+        ReadTime,
         /// The time when the request is received and started to be processed. If
         /// specified as partition key, the result table(s) is partitoned by the
         /// requestTime column, an additional timestamp column representing when the
         /// request was received.
-        pub const REQUEST_TIME: PartitionKey = PartitionKey::new(2);
+        RequestTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PartitionKey::value] or
+        /// [PartitionKey::name].
+        UnknownValue(partition_key::UnknownValue),
+    }
 
-        /// Creates a new PartitionKey instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod partition_key {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PartitionKey {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReadTime => std::option::Option::Some(1),
+                Self::RequestTime => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PARTITION_KEY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_TIME"),
-                2 => std::borrow::Cow::Borrowed("REQUEST_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PARTITION_KEY_UNSPECIFIED"),
+                Self::ReadTime => std::option::Option::Some("READ_TIME"),
+                Self::RequestTime => std::option::Option::Some("REQUEST_TIME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PARTITION_KEY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PARTITION_KEY_UNSPECIFIED)
-                }
-                "READ_TIME" => std::option::Option::Some(Self::READ_TIME),
-                "REQUEST_TIME" => std::option::Option::Some(Self::REQUEST_TIME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PartitionKey {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PartitionKey {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PartitionKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PartitionKey {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReadTime,
+                2 => Self::RequestTime,
+                _ => Self::UnknownValue(partition_key::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PartitionKey {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PARTITION_KEY_UNSPECIFIED" => Self::Unspecified,
+                "READ_TIME" => Self::ReadTime,
+                "REQUEST_TIME" => Self::RequestTime,
+                _ => Self::UnknownValue(partition_key::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PartitionKey {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReadTime => serializer.serialize_i32(1),
+                Self::RequestTime => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PartitionKey {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PartitionKey>::new(
+                ".google.cloud.asset.v1.PartitionSpec.PartitionKey",
+            ))
         }
     }
 }
@@ -3446,59 +3505,118 @@ pub mod iam_policy_analysis_output_config {
         /// Partitioning can improve query performance and reduce query cost by
         /// filtering partitions. Refer to
         /// <https://cloud.google.com/bigquery/docs/partitioned-tables> for details.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PartitionKey(i32);
-
-        impl PartitionKey {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PartitionKey {
             /// Unspecified partition key. Tables won't be partitioned using this
             /// option.
-            pub const PARTITION_KEY_UNSPECIFIED: PartitionKey = PartitionKey::new(0);
-
+            Unspecified,
             /// The time when the request is received. If specified as partition key,
             /// the result table(s) is partitoned by the RequestTime column, an
             /// additional timestamp column representing when the request was received.
-            pub const REQUEST_TIME: PartitionKey = PartitionKey::new(1);
+            RequestTime,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PartitionKey::value] or
+            /// [PartitionKey::name].
+            UnknownValue(partition_key::UnknownValue),
+        }
 
-            /// Creates a new PartitionKey instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod partition_key {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl PartitionKey {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::RequestTime => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PARTITION_KEY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("REQUEST_TIME"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PARTITION_KEY_UNSPECIFIED"),
+                    Self::RequestTime => std::option::Option::Some("REQUEST_TIME"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PARTITION_KEY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PARTITION_KEY_UNSPECIFIED)
-                    }
-                    "REQUEST_TIME" => std::option::Option::Some(Self::REQUEST_TIME),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for PartitionKey {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PartitionKey {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PartitionKey {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PartitionKey {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::RequestTime,
+                    _ => Self::UnknownValue(partition_key::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PartitionKey {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PARTITION_KEY_UNSPECIFIED" => Self::Unspecified,
+                    "REQUEST_TIME" => Self::RequestTime,
+                    _ => Self::UnknownValue(partition_key::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PartitionKey {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::RequestTime => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PartitionKey {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PartitionKey>::new(
+                    ".google.cloud.asset.v1.IamPolicyAnalysisOutputConfig.BigQueryDestination.PartitionKey"))
             }
         }
     }
@@ -4265,64 +4383,123 @@ pub mod analyze_move_request {
     use super::*;
 
     /// View enum for supporting partial analysis responses.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnalysisView(i32);
-
-    impl AnalysisView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AnalysisView {
         /// The default/unset value.
         /// The API will default to the FULL view.
-        pub const ANALYSIS_VIEW_UNSPECIFIED: AnalysisView = AnalysisView::new(0);
-
+        Unspecified,
         /// Full analysis including all level of impacts of the specified resource
         /// move.
-        pub const FULL: AnalysisView = AnalysisView::new(1);
-
+        Full,
         /// Basic analysis only including blockers which will prevent the specified
         /// resource move at runtime.
-        pub const BASIC: AnalysisView = AnalysisView::new(2);
+        Basic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AnalysisView::value] or
+        /// [AnalysisView::name].
+        UnknownValue(analysis_view::UnknownValue),
+    }
 
-        /// Creates a new AnalysisView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod analysis_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AnalysisView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Full => std::option::Option::Some(1),
+                Self::Basic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANALYSIS_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FULL"),
-                2 => std::borrow::Cow::Borrowed("BASIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANALYSIS_VIEW_UNSPECIFIED"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANALYSIS_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ANALYSIS_VIEW_UNSPECIFIED)
-                }
-                "FULL" => std::option::Option::Some(Self::FULL),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AnalysisView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AnalysisView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AnalysisView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AnalysisView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Full,
+                2 => Self::Basic,
+                _ => Self::UnknownValue(analysis_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AnalysisView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANALYSIS_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "FULL" => Self::Full,
+                "BASIC" => Self::Basic,
+                _ => Self::UnknownValue(analysis_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AnalysisView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Full => serializer.serialize_i32(1),
+                Self::Basic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AnalysisView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AnalysisView>::new(
+                ".google.cloud.asset.v1.AnalyzeMoveRequest.AnalysisView",
+            ))
         }
     }
 }
@@ -6395,64 +6572,127 @@ pub mod analyzer_org_policy_constraint {
 
         /// Specifies the default behavior in the absence of any `Policy` for the
         /// `Constraint`. This must not be `CONSTRAINT_DEFAULT_UNSPECIFIED`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ConstraintDefault(i32);
-
-        impl ConstraintDefault {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ConstraintDefault {
             /// This is only used for distinguishing unset values and should never be
             /// used.
-            pub const CONSTRAINT_DEFAULT_UNSPECIFIED: ConstraintDefault = ConstraintDefault::new(0);
-
+            Unspecified,
             /// Indicate that all values are allowed for list constraints.
             /// Indicate that enforcement is off for boolean constraints.
-            pub const ALLOW: ConstraintDefault = ConstraintDefault::new(1);
-
+            Allow,
             /// Indicate that all values are denied for list constraints.
             /// Indicate that enforcement is on for boolean constraints.
-            pub const DENY: ConstraintDefault = ConstraintDefault::new(2);
+            Deny,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ConstraintDefault::value] or
+            /// [ConstraintDefault::name].
+            UnknownValue(constraint_default::UnknownValue),
+        }
 
-            /// Creates a new ConstraintDefault instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod constraint_default {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ConstraintDefault {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Allow => std::option::Option::Some(1),
+                    Self::Deny => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONSTRAINT_DEFAULT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ALLOW"),
-                    2 => std::borrow::Cow::Borrowed("DENY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONSTRAINT_DEFAULT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONSTRAINT_DEFAULT_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("CONSTRAINT_DEFAULT_UNSPECIFIED")
                     }
-                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                    "DENY" => std::option::Option::Some(Self::DENY),
-                    _ => std::option::Option::None,
+                    Self::Allow => std::option::Option::Some("ALLOW"),
+                    Self::Deny => std::option::Option::Some("DENY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ConstraintDefault {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ConstraintDefault {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ConstraintDefault {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ConstraintDefault {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Allow,
+                    2 => Self::Deny,
+                    _ => Self::UnknownValue(constraint_default::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ConstraintDefault {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONSTRAINT_DEFAULT_UNSPECIFIED" => Self::Unspecified,
+                    "ALLOW" => Self::Allow,
+                    "DENY" => Self::Deny,
+                    _ => Self::UnknownValue(constraint_default::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ConstraintDefault {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Allow => serializer.serialize_i32(1),
+                    Self::Deny => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ConstraintDefault {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConstraintDefault>::new(
+                    ".google.cloud.asset.v1.AnalyzerOrgPolicyConstraint.Constraint.ConstraintDefault"))
             }
         }
 
@@ -6614,125 +6854,249 @@ pub mod analyzer_org_policy_constraint {
         /// If the constraint applies only when create VMs, the method_types will be
         /// "CREATE" only. If the constraint applied when create or delete VMs, the
         /// method_types will be "CREATE" and "DELETE".
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MethodType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MethodType {
+            /// Unspecified. Will results in user error.
+            Unspecified,
+            /// Constraint applied when creating the resource.
+            Create,
+            /// Constraint applied when updating the resource.
+            Update,
+            /// Constraint applied when deleting the resource.
+            Delete,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MethodType::value] or
+            /// [MethodType::name].
+            UnknownValue(method_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod method_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl MethodType {
-            /// Unspecified. Will results in user error.
-            pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
-
-            /// Constraint applied when creating the resource.
-            pub const CREATE: MethodType = MethodType::new(1);
-
-            /// Constraint applied when updating the resource.
-            pub const UPDATE: MethodType = MethodType::new(2);
-
-            /// Constraint applied when deleting the resource.
-            pub const DELETE: MethodType = MethodType::new(3);
-
-            /// Creates a new MethodType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Create => std::option::Option::Some(1),
+                    Self::Update => std::option::Option::Some(2),
+                    Self::Delete => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CREATE"),
-                    2 => std::borrow::Cow::Borrowed("UPDATE"),
-                    3 => std::borrow::Cow::Borrowed("DELETE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("METHOD_TYPE_UNSPECIFIED"),
+                    Self::Create => std::option::Option::Some("CREATE"),
+                    Self::Update => std::option::Option::Some("UPDATE"),
+                    Self::Delete => std::option::Option::Some("DELETE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "METHOD_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
-                    }
-                    "CREATE" => std::option::Option::Some(Self::CREATE),
-                    "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                    "DELETE" => std::option::Option::Some(Self::DELETE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MethodType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MethodType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MethodType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MethodType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Create,
+                    2 => Self::Update,
+                    3 => Self::Delete,
+                    _ => Self::UnknownValue(method_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MethodType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "METHOD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "CREATE" => Self::Create,
+                    "UPDATE" => Self::Update,
+                    "DELETE" => Self::Delete,
+                    _ => Self::UnknownValue(method_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MethodType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Create => serializer.serialize_i32(1),
+                    Self::Update => serializer.serialize_i32(2),
+                    Self::Delete => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MethodType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MethodType>::new(
+                    ".google.cloud.asset.v1.AnalyzerOrgPolicyConstraint.CustomConstraint.MethodType"))
             }
         }
 
         /// Allow or deny type.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ActionType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ActionType {
+            /// Unspecified. Will results in user error.
+            Unspecified,
+            /// Allowed action type.
+            Allow,
+            /// Deny action type.
+            Deny,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ActionType::value] or
+            /// [ActionType::name].
+            UnknownValue(action_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod action_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ActionType {
-            /// Unspecified. Will results in user error.
-            pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
-
-            /// Allowed action type.
-            pub const ALLOW: ActionType = ActionType::new(1);
-
-            /// Deny action type.
-            pub const DENY: ActionType = ActionType::new(2);
-
-            /// Creates a new ActionType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Allow => std::option::Option::Some(1),
+                    Self::Deny => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ALLOW"),
-                    2 => std::borrow::Cow::Borrowed("DENY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ACTION_TYPE_UNSPECIFIED"),
+                    Self::Allow => std::option::Option::Some("ALLOW"),
+                    Self::Deny => std::option::Option::Some("DENY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ACTION_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
-                    }
-                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                    "DENY" => std::option::Option::Some(Self::DENY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ActionType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ActionType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ActionType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ActionType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Allow,
+                    2 => Self::Deny,
+                    _ => Self::UnknownValue(action_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ActionType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ACTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "ALLOW" => Self::Allow,
+                    "DENY" => Self::Deny,
+                    _ => Self::UnknownValue(action_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ActionType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Allow => serializer.serialize_i32(1),
+                    Self::Deny => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ActionType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ActionType>::new(
+                    ".google.cloud.asset.v1.AnalyzerOrgPolicyConstraint.CustomConstraint.ActionType"))
             }
         }
     }
@@ -8131,71 +8495,134 @@ pub mod temporal_asset {
     use super::*;
 
     /// State of prior asset.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PriorAssetState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PriorAssetState {
+        /// prior_asset is not applicable for the current asset.
+        Unspecified,
+        /// prior_asset is populated correctly.
+        Present,
+        /// Failed to set prior_asset.
+        Invalid,
+        /// Current asset is the first known state.
+        DoesNotExist,
+        /// prior_asset is a deletion.
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PriorAssetState::value] or
+        /// [PriorAssetState::name].
+        UnknownValue(prior_asset_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod prior_asset_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PriorAssetState {
-        /// prior_asset is not applicable for the current asset.
-        pub const PRIOR_ASSET_STATE_UNSPECIFIED: PriorAssetState = PriorAssetState::new(0);
-
-        /// prior_asset is populated correctly.
-        pub const PRESENT: PriorAssetState = PriorAssetState::new(1);
-
-        /// Failed to set prior_asset.
-        pub const INVALID: PriorAssetState = PriorAssetState::new(2);
-
-        /// Current asset is the first known state.
-        pub const DOES_NOT_EXIST: PriorAssetState = PriorAssetState::new(3);
-
-        /// prior_asset is a deletion.
-        pub const DELETED: PriorAssetState = PriorAssetState::new(4);
-
-        /// Creates a new PriorAssetState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Present => std::option::Option::Some(1),
+                Self::Invalid => std::option::Option::Some(2),
+                Self::DoesNotExist => std::option::Option::Some(3),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIOR_ASSET_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRESENT"),
-                2 => std::borrow::Cow::Borrowed("INVALID"),
-                3 => std::borrow::Cow::Borrowed("DOES_NOT_EXIST"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIOR_ASSET_STATE_UNSPECIFIED"),
+                Self::Present => std::option::Option::Some("PRESENT"),
+                Self::Invalid => std::option::Option::Some("INVALID"),
+                Self::DoesNotExist => std::option::Option::Some("DOES_NOT_EXIST"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIOR_ASSET_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIOR_ASSET_STATE_UNSPECIFIED)
-                }
-                "PRESENT" => std::option::Option::Some(Self::PRESENT),
-                "INVALID" => std::option::Option::Some(Self::INVALID),
-                "DOES_NOT_EXIST" => std::option::Option::Some(Self::DOES_NOT_EXIST),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PriorAssetState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PriorAssetState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PriorAssetState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PriorAssetState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Present,
+                2 => Self::Invalid,
+                3 => Self::DoesNotExist,
+                4 => Self::Deleted,
+                _ => Self::UnknownValue(prior_asset_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PriorAssetState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIOR_ASSET_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PRESENT" => Self::Present,
+                "INVALID" => Self::Invalid,
+                "DOES_NOT_EXIST" => Self::DoesNotExist,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(prior_asset_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PriorAssetState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Present => serializer.serialize_i32(1),
+                Self::Invalid => serializer.serialize_i32(2),
+                Self::DoesNotExist => serializer.serialize_i32(3),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PriorAssetState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PriorAssetState>::new(
+                ".google.cloud.asset.v1.TemporalAsset.PriorAssetState",
+            ))
         }
     }
 }
@@ -10264,68 +10691,129 @@ pub mod condition_evaluation {
     use super::*;
 
     /// Value of this expression.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationValue(i32);
-
-    impl EvaluationValue {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EvaluationValue {
         /// Reserved for future use.
-        pub const EVALUATION_VALUE_UNSPECIFIED: EvaluationValue = EvaluationValue::new(0);
-
+        Unspecified,
         /// The evaluation result is `true`.
-        pub const TRUE: EvaluationValue = EvaluationValue::new(1);
-
+        True,
         /// The evaluation result is `false`.
-        pub const FALSE: EvaluationValue = EvaluationValue::new(2);
-
+        False,
         /// The evaluation result is `conditional` when the condition expression
         /// contains variables that are either missing input values or have not been
         /// supported by Policy Analyzer yet.
-        pub const CONDITIONAL: EvaluationValue = EvaluationValue::new(3);
+        Conditional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EvaluationValue::value] or
+        /// [EvaluationValue::name].
+        UnknownValue(evaluation_value::UnknownValue),
+    }
 
-        /// Creates a new EvaluationValue instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod evaluation_value {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EvaluationValue {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::True => std::option::Option::Some(1),
+                Self::False => std::option::Option::Some(2),
+                Self::Conditional => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVALUATION_VALUE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRUE"),
-                2 => std::borrow::Cow::Borrowed("FALSE"),
-                3 => std::borrow::Cow::Borrowed("CONDITIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVALUATION_VALUE_UNSPECIFIED"),
+                Self::True => std::option::Option::Some("TRUE"),
+                Self::False => std::option::Option::Some("FALSE"),
+                Self::Conditional => std::option::Option::Some("CONDITIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVALUATION_VALUE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVALUATION_VALUE_UNSPECIFIED)
-                }
-                "TRUE" => std::option::Option::Some(Self::TRUE),
-                "FALSE" => std::option::Option::Some(Self::FALSE),
-                "CONDITIONAL" => std::option::Option::Some(Self::CONDITIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EvaluationValue {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationValue {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EvaluationValue {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EvaluationValue {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::True,
+                2 => Self::False,
+                3 => Self::Conditional,
+                _ => Self::UnknownValue(evaluation_value::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EvaluationValue {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVALUATION_VALUE_UNSPECIFIED" => Self::Unspecified,
+                "TRUE" => Self::True,
+                "FALSE" => Self::False,
+                "CONDITIONAL" => Self::Conditional,
+                _ => Self::UnknownValue(evaluation_value::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EvaluationValue {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::True => serializer.serialize_i32(1),
+                Self::False => serializer.serialize_i32(2),
+                Self::Conditional => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EvaluationValue {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EvaluationValue>::new(
+                ".google.cloud.asset.v1.ConditionEvaluation.EvaluationValue",
+            ))
         }
     }
 }
@@ -10908,78 +11396,147 @@ pub mod iam_policy_analysis_result {
 }
 
 /// Asset content type.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContentType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ContentType {
+    /// Unspecified content type.
+    Unspecified,
+    /// Resource metadata.
+    Resource,
+    /// The actual IAM policy set on a resource.
+    IamPolicy,
+    /// The organization policy set on an asset.
+    OrgPolicy,
+    /// The Access Context Manager policy set on an asset.
+    AccessPolicy,
+    /// The runtime OS Inventory information.
+    OsInventory,
+    /// The related resources.
+    Relationship,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ContentType::value] or
+    /// [ContentType::name].
+    UnknownValue(content_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod content_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ContentType {
-    /// Unspecified content type.
-    pub const CONTENT_TYPE_UNSPECIFIED: ContentType = ContentType::new(0);
-
-    /// Resource metadata.
-    pub const RESOURCE: ContentType = ContentType::new(1);
-
-    /// The actual IAM policy set on a resource.
-    pub const IAM_POLICY: ContentType = ContentType::new(2);
-
-    /// The organization policy set on an asset.
-    pub const ORG_POLICY: ContentType = ContentType::new(4);
-
-    /// The Access Context Manager policy set on an asset.
-    pub const ACCESS_POLICY: ContentType = ContentType::new(5);
-
-    /// The runtime OS Inventory information.
-    pub const OS_INVENTORY: ContentType = ContentType::new(6);
-
-    /// The related resources.
-    pub const RELATIONSHIP: ContentType = ContentType::new(7);
-
-    /// Creates a new ContentType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Resource => std::option::Option::Some(1),
+            Self::IamPolicy => std::option::Option::Some(2),
+            Self::OrgPolicy => std::option::Option::Some(4),
+            Self::AccessPolicy => std::option::Option::Some(5),
+            Self::OsInventory => std::option::Option::Some(6),
+            Self::Relationship => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONTENT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RESOURCE"),
-            2 => std::borrow::Cow::Borrowed("IAM_POLICY"),
-            4 => std::borrow::Cow::Borrowed("ORG_POLICY"),
-            5 => std::borrow::Cow::Borrowed("ACCESS_POLICY"),
-            6 => std::borrow::Cow::Borrowed("OS_INVENTORY"),
-            7 => std::borrow::Cow::Borrowed("RELATIONSHIP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONTENT_TYPE_UNSPECIFIED"),
+            Self::Resource => std::option::Option::Some("RESOURCE"),
+            Self::IamPolicy => std::option::Option::Some("IAM_POLICY"),
+            Self::OrgPolicy => std::option::Option::Some("ORG_POLICY"),
+            Self::AccessPolicy => std::option::Option::Some("ACCESS_POLICY"),
+            Self::OsInventory => std::option::Option::Some("OS_INVENTORY"),
+            Self::Relationship => std::option::Option::Some("RELATIONSHIP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONTENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::CONTENT_TYPE_UNSPECIFIED),
-            "RESOURCE" => std::option::Option::Some(Self::RESOURCE),
-            "IAM_POLICY" => std::option::Option::Some(Self::IAM_POLICY),
-            "ORG_POLICY" => std::option::Option::Some(Self::ORG_POLICY),
-            "ACCESS_POLICY" => std::option::Option::Some(Self::ACCESS_POLICY),
-            "OS_INVENTORY" => std::option::Option::Some(Self::OS_INVENTORY),
-            "RELATIONSHIP" => std::option::Option::Some(Self::RELATIONSHIP),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ContentType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ContentType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ContentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ContentType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Resource,
+            2 => Self::IamPolicy,
+            4 => Self::OrgPolicy,
+            5 => Self::AccessPolicy,
+            6 => Self::OsInventory,
+            7 => Self::Relationship,
+            _ => Self::UnknownValue(content_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ContentType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONTENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "RESOURCE" => Self::Resource,
+            "IAM_POLICY" => Self::IamPolicy,
+            "ORG_POLICY" => Self::OrgPolicy,
+            "ACCESS_POLICY" => Self::AccessPolicy,
+            "OS_INVENTORY" => Self::OsInventory,
+            "RELATIONSHIP" => Self::Relationship,
+            _ => Self::UnknownValue(content_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ContentType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Resource => serializer.serialize_i32(1),
+            Self::IamPolicy => serializer.serialize_i32(2),
+            Self::OrgPolicy => serializer.serialize_i32(4),
+            Self::AccessPolicy => serializer.serialize_i32(5),
+            Self::OsInventory => serializer.serialize_i32(6),
+            Self::Relationship => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ContentType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentType>::new(
+            ".google.cloud.asset.v1.ContentType",
+        ))
     }
 }

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -88,7 +88,7 @@ impl super::stub::AssetService for AssetService {
             .asset_types
             .iter()
             .fold(builder, |builder, p| builder.query(&[("assetTypes", p)]));
-        let builder = builder.query(&[("contentType", &req.content_type.value())]);
+        let builder = builder.query(&[("contentType", &req.content_type)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = req.relationship_types.iter().fold(builder, |builder, p| {
@@ -120,7 +120,7 @@ impl super::stub::AssetService for AssetService {
             .asset_names
             .iter()
             .fold(builder, |builder, p| builder.query(&[("assetNames", p)]));
-        let builder = builder.query(&[("contentType", &req.content_type.value())]);
+        let builder = builder.query(&[("contentType", &req.content_type)]);
         let builder = req
             .read_time_window
             .as_ref()
@@ -402,7 +402,7 @@ impl super::stub::AssetService for AssetService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("destinationParent", &req.destination_parent)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -676,77 +676,143 @@ pub mod workload {
         use super::*;
 
         /// The type of resource.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ResourceType(i32);
-
-        impl ResourceType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ResourceType {
             /// Unknown resource type.
-            pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
-
+            Unspecified,
             /// Consumer project.
             /// AssuredWorkloads Projects are no longer supported. This field will be
             /// ignored only in CreateWorkload requests. ListWorkloads and GetWorkload
             /// will continue to provide projects information.
             /// Use CONSUMER_FOLDER instead.
-            pub const CONSUMER_PROJECT: ResourceType = ResourceType::new(1);
-
+            ConsumerProject,
             /// Consumer Folder.
-            pub const CONSUMER_FOLDER: ResourceType = ResourceType::new(4);
-
+            ConsumerFolder,
             /// Consumer project containing encryption keys.
-            pub const ENCRYPTION_KEYS_PROJECT: ResourceType = ResourceType::new(2);
-
+            EncryptionKeysProject,
             /// Keyring resource that hosts encryption keys.
-            pub const KEYRING: ResourceType = ResourceType::new(3);
+            Keyring,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ResourceType::value] or
+            /// [ResourceType::name].
+            UnknownValue(resource_type::UnknownValue),
+        }
 
-            /// Creates a new ResourceType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod resource_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ResourceType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ConsumerProject => std::option::Option::Some(1),
+                    Self::ConsumerFolder => std::option::Option::Some(4),
+                    Self::EncryptionKeysProject => std::option::Option::Some(2),
+                    Self::Keyring => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CONSUMER_PROJECT"),
-                    2 => std::borrow::Cow::Borrowed("ENCRYPTION_KEYS_PROJECT"),
-                    3 => std::borrow::Cow::Borrowed("KEYRING"),
-                    4 => std::borrow::Cow::Borrowed("CONSUMER_FOLDER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "RESOURCE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("RESOURCE_TYPE_UNSPECIFIED"),
+                    Self::ConsumerProject => std::option::Option::Some("CONSUMER_PROJECT"),
+                    Self::ConsumerFolder => std::option::Option::Some("CONSUMER_FOLDER"),
+                    Self::EncryptionKeysProject => {
+                        std::option::Option::Some("ENCRYPTION_KEYS_PROJECT")
                     }
-                    "CONSUMER_PROJECT" => std::option::Option::Some(Self::CONSUMER_PROJECT),
-                    "CONSUMER_FOLDER" => std::option::Option::Some(Self::CONSUMER_FOLDER),
-                    "ENCRYPTION_KEYS_PROJECT" => {
-                        std::option::Option::Some(Self::ENCRYPTION_KEYS_PROJECT)
-                    }
-                    "KEYRING" => std::option::Option::Some(Self::KEYRING),
-                    _ => std::option::Option::None,
+                    Self::Keyring => std::option::Option::Some("KEYRING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ResourceType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ResourceType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ResourceType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ResourceType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ConsumerProject,
+                    2 => Self::EncryptionKeysProject,
+                    3 => Self::Keyring,
+                    4 => Self::ConsumerFolder,
+                    _ => Self::UnknownValue(resource_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ResourceType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "CONSUMER_PROJECT" => Self::ConsumerProject,
+                    "CONSUMER_FOLDER" => Self::ConsumerFolder,
+                    "ENCRYPTION_KEYS_PROJECT" => Self::EncryptionKeysProject,
+                    "KEYRING" => Self::Keyring,
+                    _ => Self::UnknownValue(resource_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ResourceType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ConsumerProject => serializer.serialize_i32(1),
+                    Self::ConsumerFolder => serializer.serialize_i32(4),
+                    Self::EncryptionKeysProject => serializer.serialize_i32(2),
+                    Self::Keyring => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ResourceType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceType>::new(
+                    ".google.cloud.assuredworkloads.v1.Workload.ResourceInfo.ResourceType",
+                ))
             }
         }
     }
@@ -938,372 +1004,693 @@ pub mod workload {
         use super::*;
 
         /// Setup state of SAA enrollment.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SetupState(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SetupState {
+            /// Unspecified.
+            Unspecified,
+            /// SAA enrollment pending.
+            StatusPending,
+            /// SAA enrollment comopleted.
+            StatusComplete,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SetupState::value] or
+            /// [SetupState::name].
+            UnknownValue(setup_state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod setup_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SetupState {
-            /// Unspecified.
-            pub const SETUP_STATE_UNSPECIFIED: SetupState = SetupState::new(0);
-
-            /// SAA enrollment pending.
-            pub const STATUS_PENDING: SetupState = SetupState::new(1);
-
-            /// SAA enrollment comopleted.
-            pub const STATUS_COMPLETE: SetupState = SetupState::new(2);
-
-            /// Creates a new SetupState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::StatusPending => std::option::Option::Some(1),
+                    Self::StatusComplete => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SETUP_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("STATUS_PENDING"),
-                    2 => std::borrow::Cow::Borrowed("STATUS_COMPLETE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SETUP_STATE_UNSPECIFIED"),
+                    Self::StatusPending => std::option::Option::Some("STATUS_PENDING"),
+                    Self::StatusComplete => std::option::Option::Some("STATUS_COMPLETE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SETUP_STATE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SETUP_STATE_UNSPECIFIED)
-                    }
-                    "STATUS_PENDING" => std::option::Option::Some(Self::STATUS_PENDING),
-                    "STATUS_COMPLETE" => std::option::Option::Some(Self::STATUS_COMPLETE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SetupState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SetupState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SetupState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SetupState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::StatusPending,
+                    2 => Self::StatusComplete,
+                    _ => Self::UnknownValue(setup_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SetupState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SETUP_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "STATUS_PENDING" => Self::StatusPending,
+                    "STATUS_COMPLETE" => Self::StatusComplete,
+                    _ => Self::UnknownValue(setup_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SetupState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::StatusPending => serializer.serialize_i32(1),
+                    Self::StatusComplete => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SetupState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SetupState>::new(
+                    ".google.cloud.assuredworkloads.v1.Workload.SaaEnrollmentResponse.SetupState",
+                ))
             }
         }
 
         /// Setup error of SAA enrollment.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SetupError(i32);
-
-        impl SetupError {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SetupError {
             /// Unspecified.
-            pub const SETUP_ERROR_UNSPECIFIED: SetupError = SetupError::new(0);
-
+            Unspecified,
             /// Invalid states for all customers, to be redirected to AA UI for
             /// additional details.
-            pub const ERROR_INVALID_BASE_SETUP: SetupError = SetupError::new(1);
-
+            ErrorInvalidBaseSetup,
             /// Returned when there is not an EKM key configured.
-            pub const ERROR_MISSING_EXTERNAL_SIGNING_KEY: SetupError = SetupError::new(2);
-
+            ErrorMissingExternalSigningKey,
             /// Returned when there are no enrolled services or the customer is
             /// enrolled in CAA only for a subset of services.
-            pub const ERROR_NOT_ALL_SERVICES_ENROLLED: SetupError = SetupError::new(3);
-
+            ErrorNotAllServicesEnrolled,
             /// Returned when exception was encountered during evaluation of other
             /// criteria.
-            pub const ERROR_SETUP_CHECK_FAILED: SetupError = SetupError::new(4);
+            ErrorSetupCheckFailed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SetupError::value] or
+            /// [SetupError::name].
+            UnknownValue(setup_error::UnknownValue),
+        }
 
-            /// Creates a new SetupError instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod setup_error {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SetupError {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ErrorInvalidBaseSetup => std::option::Option::Some(1),
+                    Self::ErrorMissingExternalSigningKey => std::option::Option::Some(2),
+                    Self::ErrorNotAllServicesEnrolled => std::option::Option::Some(3),
+                    Self::ErrorSetupCheckFailed => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SETUP_ERROR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ERROR_INVALID_BASE_SETUP"),
-                    2 => std::borrow::Cow::Borrowed("ERROR_MISSING_EXTERNAL_SIGNING_KEY"),
-                    3 => std::borrow::Cow::Borrowed("ERROR_NOT_ALL_SERVICES_ENROLLED"),
-                    4 => std::borrow::Cow::Borrowed("ERROR_SETUP_CHECK_FAILED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SETUP_ERROR_UNSPECIFIED"),
+                    Self::ErrorInvalidBaseSetup => {
+                        std::option::Option::Some("ERROR_INVALID_BASE_SETUP")
+                    }
+                    Self::ErrorMissingExternalSigningKey => {
+                        std::option::Option::Some("ERROR_MISSING_EXTERNAL_SIGNING_KEY")
+                    }
+                    Self::ErrorNotAllServicesEnrolled => {
+                        std::option::Option::Some("ERROR_NOT_ALL_SERVICES_ENROLLED")
+                    }
+                    Self::ErrorSetupCheckFailed => {
+                        std::option::Option::Some("ERROR_SETUP_CHECK_FAILED")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SETUP_ERROR_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SETUP_ERROR_UNSPECIFIED)
-                    }
-                    "ERROR_INVALID_BASE_SETUP" => {
-                        std::option::Option::Some(Self::ERROR_INVALID_BASE_SETUP)
-                    }
-                    "ERROR_MISSING_EXTERNAL_SIGNING_KEY" => {
-                        std::option::Option::Some(Self::ERROR_MISSING_EXTERNAL_SIGNING_KEY)
-                    }
-                    "ERROR_NOT_ALL_SERVICES_ENROLLED" => {
-                        std::option::Option::Some(Self::ERROR_NOT_ALL_SERVICES_ENROLLED)
-                    }
-                    "ERROR_SETUP_CHECK_FAILED" => {
-                        std::option::Option::Some(Self::ERROR_SETUP_CHECK_FAILED)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SetupError {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SetupError {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SetupError {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SetupError {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ErrorInvalidBaseSetup,
+                    2 => Self::ErrorMissingExternalSigningKey,
+                    3 => Self::ErrorNotAllServicesEnrolled,
+                    4 => Self::ErrorSetupCheckFailed,
+                    _ => Self::UnknownValue(setup_error::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SetupError {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SETUP_ERROR_UNSPECIFIED" => Self::Unspecified,
+                    "ERROR_INVALID_BASE_SETUP" => Self::ErrorInvalidBaseSetup,
+                    "ERROR_MISSING_EXTERNAL_SIGNING_KEY" => Self::ErrorMissingExternalSigningKey,
+                    "ERROR_NOT_ALL_SERVICES_ENROLLED" => Self::ErrorNotAllServicesEnrolled,
+                    "ERROR_SETUP_CHECK_FAILED" => Self::ErrorSetupCheckFailed,
+                    _ => Self::UnknownValue(setup_error::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SetupError {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ErrorInvalidBaseSetup => serializer.serialize_i32(1),
+                    Self::ErrorMissingExternalSigningKey => serializer.serialize_i32(2),
+                    Self::ErrorNotAllServicesEnrolled => serializer.serialize_i32(3),
+                    Self::ErrorSetupCheckFailed => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SetupError {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SetupError>::new(
+                    ".google.cloud.assuredworkloads.v1.Workload.SaaEnrollmentResponse.SetupError",
+                ))
             }
         }
     }
 
     /// Supported Compliance Regimes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ComplianceRegime(i32);
-
-    impl ComplianceRegime {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ComplianceRegime {
         /// Unknown compliance regime.
-        pub const COMPLIANCE_REGIME_UNSPECIFIED: ComplianceRegime = ComplianceRegime::new(0);
-
+        Unspecified,
         /// Information protection as per DoD IL4 requirements.
-        pub const IL4: ComplianceRegime = ComplianceRegime::new(1);
-
+        Il4,
         /// Criminal Justice Information Services (CJIS) Security policies.
-        pub const CJIS: ComplianceRegime = ComplianceRegime::new(2);
-
+        Cjis,
         /// FedRAMP High data protection controls
-        pub const FEDRAMP_HIGH: ComplianceRegime = ComplianceRegime::new(3);
-
+        FedrampHigh,
         /// FedRAMP Moderate data protection controls
-        pub const FEDRAMP_MODERATE: ComplianceRegime = ComplianceRegime::new(4);
-
+        FedrampModerate,
         /// Assured Workloads For US Regions data protection controls
-        pub const US_REGIONAL_ACCESS: ComplianceRegime = ComplianceRegime::new(5);
-
+        UsRegionalAccess,
         /// Health Insurance Portability and Accountability Act controls
-        pub const HIPAA: ComplianceRegime = ComplianceRegime::new(6);
-
+        Hipaa,
         /// Health Information Trust Alliance controls
-        pub const HITRUST: ComplianceRegime = ComplianceRegime::new(7);
-
+        Hitrust,
         /// Assured Workloads For EU Regions and Support controls
-        pub const EU_REGIONS_AND_SUPPORT: ComplianceRegime = ComplianceRegime::new(8);
-
+        EuRegionsAndSupport,
         /// Assured Workloads For Canada Regions and Support controls
-        pub const CA_REGIONS_AND_SUPPORT: ComplianceRegime = ComplianceRegime::new(9);
-
+        CaRegionsAndSupport,
         /// International Traffic in Arms Regulations
-        pub const ITAR: ComplianceRegime = ComplianceRegime::new(10);
-
+        Itar,
         /// Assured Workloads for Australia Regions and Support controls
         /// Available for public preview consumption.
         /// Don't create production workloads.
-        pub const AU_REGIONS_AND_US_SUPPORT: ComplianceRegime = ComplianceRegime::new(11);
-
+        AuRegionsAndUsSupport,
         /// Assured Workloads for Partners
-        pub const ASSURED_WORKLOADS_FOR_PARTNERS: ComplianceRegime = ComplianceRegime::new(12);
+        AssuredWorkloadsForPartners,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ComplianceRegime::value] or
+        /// [ComplianceRegime::name].
+        UnknownValue(compliance_regime::UnknownValue),
+    }
 
-        /// Creates a new ComplianceRegime instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod compliance_regime {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ComplianceRegime {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Il4 => std::option::Option::Some(1),
+                Self::Cjis => std::option::Option::Some(2),
+                Self::FedrampHigh => std::option::Option::Some(3),
+                Self::FedrampModerate => std::option::Option::Some(4),
+                Self::UsRegionalAccess => std::option::Option::Some(5),
+                Self::Hipaa => std::option::Option::Some(6),
+                Self::Hitrust => std::option::Option::Some(7),
+                Self::EuRegionsAndSupport => std::option::Option::Some(8),
+                Self::CaRegionsAndSupport => std::option::Option::Some(9),
+                Self::Itar => std::option::Option::Some(10),
+                Self::AuRegionsAndUsSupport => std::option::Option::Some(11),
+                Self::AssuredWorkloadsForPartners => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPLIANCE_REGIME_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IL4"),
-                2 => std::borrow::Cow::Borrowed("CJIS"),
-                3 => std::borrow::Cow::Borrowed("FEDRAMP_HIGH"),
-                4 => std::borrow::Cow::Borrowed("FEDRAMP_MODERATE"),
-                5 => std::borrow::Cow::Borrowed("US_REGIONAL_ACCESS"),
-                6 => std::borrow::Cow::Borrowed("HIPAA"),
-                7 => std::borrow::Cow::Borrowed("HITRUST"),
-                8 => std::borrow::Cow::Borrowed("EU_REGIONS_AND_SUPPORT"),
-                9 => std::borrow::Cow::Borrowed("CA_REGIONS_AND_SUPPORT"),
-                10 => std::borrow::Cow::Borrowed("ITAR"),
-                11 => std::borrow::Cow::Borrowed("AU_REGIONS_AND_US_SUPPORT"),
-                12 => std::borrow::Cow::Borrowed("ASSURED_WORKLOADS_FOR_PARTNERS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPLIANCE_REGIME_UNSPECIFIED"),
+                Self::Il4 => std::option::Option::Some("IL4"),
+                Self::Cjis => std::option::Option::Some("CJIS"),
+                Self::FedrampHigh => std::option::Option::Some("FEDRAMP_HIGH"),
+                Self::FedrampModerate => std::option::Option::Some("FEDRAMP_MODERATE"),
+                Self::UsRegionalAccess => std::option::Option::Some("US_REGIONAL_ACCESS"),
+                Self::Hipaa => std::option::Option::Some("HIPAA"),
+                Self::Hitrust => std::option::Option::Some("HITRUST"),
+                Self::EuRegionsAndSupport => std::option::Option::Some("EU_REGIONS_AND_SUPPORT"),
+                Self::CaRegionsAndSupport => std::option::Option::Some("CA_REGIONS_AND_SUPPORT"),
+                Self::Itar => std::option::Option::Some("ITAR"),
+                Self::AuRegionsAndUsSupport => {
+                    std::option::Option::Some("AU_REGIONS_AND_US_SUPPORT")
+                }
+                Self::AssuredWorkloadsForPartners => {
+                    std::option::Option::Some("ASSURED_WORKLOADS_FOR_PARTNERS")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPLIANCE_REGIME_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPLIANCE_REGIME_UNSPECIFIED)
-                }
-                "IL4" => std::option::Option::Some(Self::IL4),
-                "CJIS" => std::option::Option::Some(Self::CJIS),
-                "FEDRAMP_HIGH" => std::option::Option::Some(Self::FEDRAMP_HIGH),
-                "FEDRAMP_MODERATE" => std::option::Option::Some(Self::FEDRAMP_MODERATE),
-                "US_REGIONAL_ACCESS" => std::option::Option::Some(Self::US_REGIONAL_ACCESS),
-                "HIPAA" => std::option::Option::Some(Self::HIPAA),
-                "HITRUST" => std::option::Option::Some(Self::HITRUST),
-                "EU_REGIONS_AND_SUPPORT" => std::option::Option::Some(Self::EU_REGIONS_AND_SUPPORT),
-                "CA_REGIONS_AND_SUPPORT" => std::option::Option::Some(Self::CA_REGIONS_AND_SUPPORT),
-                "ITAR" => std::option::Option::Some(Self::ITAR),
-                "AU_REGIONS_AND_US_SUPPORT" => {
-                    std::option::Option::Some(Self::AU_REGIONS_AND_US_SUPPORT)
-                }
-                "ASSURED_WORKLOADS_FOR_PARTNERS" => {
-                    std::option::Option::Some(Self::ASSURED_WORKLOADS_FOR_PARTNERS)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ComplianceRegime {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ComplianceRegime {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ComplianceRegime {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ComplianceRegime {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Il4,
+                2 => Self::Cjis,
+                3 => Self::FedrampHigh,
+                4 => Self::FedrampModerate,
+                5 => Self::UsRegionalAccess,
+                6 => Self::Hipaa,
+                7 => Self::Hitrust,
+                8 => Self::EuRegionsAndSupport,
+                9 => Self::CaRegionsAndSupport,
+                10 => Self::Itar,
+                11 => Self::AuRegionsAndUsSupport,
+                12 => Self::AssuredWorkloadsForPartners,
+                _ => Self::UnknownValue(compliance_regime::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ComplianceRegime {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPLIANCE_REGIME_UNSPECIFIED" => Self::Unspecified,
+                "IL4" => Self::Il4,
+                "CJIS" => Self::Cjis,
+                "FEDRAMP_HIGH" => Self::FedrampHigh,
+                "FEDRAMP_MODERATE" => Self::FedrampModerate,
+                "US_REGIONAL_ACCESS" => Self::UsRegionalAccess,
+                "HIPAA" => Self::Hipaa,
+                "HITRUST" => Self::Hitrust,
+                "EU_REGIONS_AND_SUPPORT" => Self::EuRegionsAndSupport,
+                "CA_REGIONS_AND_SUPPORT" => Self::CaRegionsAndSupport,
+                "ITAR" => Self::Itar,
+                "AU_REGIONS_AND_US_SUPPORT" => Self::AuRegionsAndUsSupport,
+                "ASSURED_WORKLOADS_FOR_PARTNERS" => Self::AssuredWorkloadsForPartners,
+                _ => Self::UnknownValue(compliance_regime::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ComplianceRegime {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Il4 => serializer.serialize_i32(1),
+                Self::Cjis => serializer.serialize_i32(2),
+                Self::FedrampHigh => serializer.serialize_i32(3),
+                Self::FedrampModerate => serializer.serialize_i32(4),
+                Self::UsRegionalAccess => serializer.serialize_i32(5),
+                Self::Hipaa => serializer.serialize_i32(6),
+                Self::Hitrust => serializer.serialize_i32(7),
+                Self::EuRegionsAndSupport => serializer.serialize_i32(8),
+                Self::CaRegionsAndSupport => serializer.serialize_i32(9),
+                Self::Itar => serializer.serialize_i32(10),
+                Self::AuRegionsAndUsSupport => serializer.serialize_i32(11),
+                Self::AssuredWorkloadsForPartners => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ComplianceRegime {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComplianceRegime>::new(
+                ".google.cloud.assuredworkloads.v1.Workload.ComplianceRegime",
+            ))
         }
     }
 
     /// Key Access Justifications(KAJ) Enrollment State.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KajEnrollmentState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KajEnrollmentState {
+        /// Default State for KAJ Enrollment.
+        Unspecified,
+        /// Pending State for KAJ Enrollment.
+        Pending,
+        /// Complete State for KAJ Enrollment.
+        Complete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KajEnrollmentState::value] or
+        /// [KajEnrollmentState::name].
+        UnknownValue(kaj_enrollment_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod kaj_enrollment_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl KajEnrollmentState {
-        /// Default State for KAJ Enrollment.
-        pub const KAJ_ENROLLMENT_STATE_UNSPECIFIED: KajEnrollmentState = KajEnrollmentState::new(0);
-
-        /// Pending State for KAJ Enrollment.
-        pub const KAJ_ENROLLMENT_STATE_PENDING: KajEnrollmentState = KajEnrollmentState::new(1);
-
-        /// Complete State for KAJ Enrollment.
-        pub const KAJ_ENROLLMENT_STATE_COMPLETE: KajEnrollmentState = KajEnrollmentState::new(2);
-
-        /// Creates a new KajEnrollmentState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Complete => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT_STATE_PENDING"),
-                2 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT_STATE_COMPLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KAJ_ENROLLMENT_STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("KAJ_ENROLLMENT_STATE_PENDING"),
+                Self::Complete => std::option::Option::Some("KAJ_ENROLLMENT_STATE_COMPLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KAJ_ENROLLMENT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KAJ_ENROLLMENT_STATE_UNSPECIFIED)
-                }
-                "KAJ_ENROLLMENT_STATE_PENDING" => {
-                    std::option::Option::Some(Self::KAJ_ENROLLMENT_STATE_PENDING)
-                }
-                "KAJ_ENROLLMENT_STATE_COMPLETE" => {
-                    std::option::Option::Some(Self::KAJ_ENROLLMENT_STATE_COMPLETE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for KajEnrollmentState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KajEnrollmentState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KajEnrollmentState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KajEnrollmentState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Complete,
+                _ => Self::UnknownValue(kaj_enrollment_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KajEnrollmentState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KAJ_ENROLLMENT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "KAJ_ENROLLMENT_STATE_PENDING" => Self::Pending,
+                "KAJ_ENROLLMENT_STATE_COMPLETE" => Self::Complete,
+                _ => Self::UnknownValue(kaj_enrollment_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KajEnrollmentState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Complete => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KajEnrollmentState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KajEnrollmentState>::new(
+                ".google.cloud.assuredworkloads.v1.Workload.KajEnrollmentState",
+            ))
         }
     }
 
     /// Supported Assured Workloads Partners.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Partner(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Partner {
+        /// Unknown partner regime/controls.
+        Unspecified,
+        /// S3NS regime/controls.
+        LocalControlsByS3Ns,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Partner::value] or
+        /// [Partner::name].
+        UnknownValue(partner::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod partner {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Partner {
-        /// Unknown partner regime/controls.
-        pub const PARTNER_UNSPECIFIED: Partner = Partner::new(0);
-
-        /// S3NS regime/controls.
-        pub const LOCAL_CONTROLS_BY_S3NS: Partner = Partner::new(1);
-
-        /// Creates a new Partner instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LocalControlsByS3Ns => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PARTNER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOCAL_CONTROLS_BY_S3NS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PARTNER_UNSPECIFIED"),
+                Self::LocalControlsByS3Ns => std::option::Option::Some("LOCAL_CONTROLS_BY_S3NS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PARTNER_UNSPECIFIED" => std::option::Option::Some(Self::PARTNER_UNSPECIFIED),
-                "LOCAL_CONTROLS_BY_S3NS" => std::option::Option::Some(Self::LOCAL_CONTROLS_BY_S3NS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Partner {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Partner {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Partner {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Partner {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LocalControlsByS3Ns,
+                _ => Self::UnknownValue(partner::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Partner {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PARTNER_UNSPECIFIED" => Self::Unspecified,
+                "LOCAL_CONTROLS_BY_S3NS" => Self::LocalControlsByS3Ns,
+                _ => Self::UnknownValue(partner::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Partner {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LocalControlsByS3Ns => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Partner {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Partner>::new(
+                ".google.cloud.assuredworkloads.v1.Workload.Partner",
+            ))
         }
     }
 }
@@ -1434,69 +1821,126 @@ pub mod restrict_allowed_resources_request {
     use super::*;
 
     /// The type of restriction.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestrictionType(i32);
-
-    impl RestrictionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RestrictionType {
         /// Unknown restriction type.
-        pub const RESTRICTION_TYPE_UNSPECIFIED: RestrictionType = RestrictionType::new(0);
-
+        Unspecified,
         /// Allow the use all of all gcp products, irrespective of the compliance
         /// posture. This effectively removes gcp.restrictServiceUsage OrgPolicy
         /// on the AssuredWorkloads Folder.
-        pub const ALLOW_ALL_GCP_RESOURCES: RestrictionType = RestrictionType::new(1);
-
+        AllowAllGcpResources,
         /// Based on Workload's compliance regime, allowed list changes.
         /// See - <https://cloud.google.com/assured-workloads/docs/supported-products>
         /// for the list of supported resources.
-        pub const ALLOW_COMPLIANT_RESOURCES: RestrictionType = RestrictionType::new(2);
+        AllowCompliantResources,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RestrictionType::value] or
+        /// [RestrictionType::name].
+        UnknownValue(restriction_type::UnknownValue),
+    }
 
-        /// Creates a new RestrictionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod restriction_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RestrictionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllowAllGcpResources => std::option::Option::Some(1),
+                Self::AllowCompliantResources => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESTRICTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW_ALL_GCP_RESOURCES"),
-                2 => std::borrow::Cow::Borrowed("ALLOW_COMPLIANT_RESOURCES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESTRICTION_TYPE_UNSPECIFIED"),
+                Self::AllowAllGcpResources => std::option::Option::Some("ALLOW_ALL_GCP_RESOURCES"),
+                Self::AllowCompliantResources => {
+                    std::option::Option::Some("ALLOW_COMPLIANT_RESOURCES")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESTRICTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESTRICTION_TYPE_UNSPECIFIED)
-                }
-                "ALLOW_ALL_GCP_RESOURCES" => {
-                    std::option::Option::Some(Self::ALLOW_ALL_GCP_RESOURCES)
-                }
-                "ALLOW_COMPLIANT_RESOURCES" => {
-                    std::option::Option::Some(Self::ALLOW_COMPLIANT_RESOURCES)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RestrictionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RestrictionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RestrictionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RestrictionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllowAllGcpResources,
+                2 => Self::AllowCompliantResources,
+                _ => Self::UnknownValue(restriction_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RestrictionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESTRICTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW_ALL_GCP_RESOURCES" => Self::AllowAllGcpResources,
+                "ALLOW_COMPLIANT_RESOURCES" => Self::AllowCompliantResources,
+                _ => Self::UnknownValue(restriction_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RestrictionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllowAllGcpResources => serializer.serialize_i32(1),
+                Self::AllowCompliantResources => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RestrictionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestrictionType>::new(
+                ".google.cloud.assuredworkloads.v1.RestrictAllowedResourcesRequest.RestrictionType",
+            ))
         }
     }
 }
@@ -2323,144 +2767,299 @@ pub mod violation {
         /// violation. For example, violations caused due to changes in boolean org
         /// policy requires different remediation instructions compared to violation
         /// caused due to changes in allowed values of list org policy.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RemediationType(i32);
-
-        impl RemediationType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum RemediationType {
             /// Unspecified remediation type
-            pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType = RemediationType::new(0);
-
+            Unspecified,
             /// Remediation type for boolean org policy
-            pub const REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new(1);
-
+            RemediationBooleanOrgPolicyViolation,
             /// Remediation type for list org policy which have allowed values in the
             /// monitoring rule
-            pub const REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new(2);
-
+            RemediationListAllowedValuesOrgPolicyViolation,
             /// Remediation type for list org policy which have denied values in the
             /// monitoring rule
-            pub const REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new(3);
-
+            RemediationListDeniedValuesOrgPolicyViolation,
             /// Remediation type for gcp.restrictCmekCryptoKeyProjects
-            pub const REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION:
-                RemediationType = RemediationType::new(4);
+            RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [RemediationType::value] or
+            /// [RemediationType::name].
+            UnknownValue(remediation_type::UnknownValue),
+        }
 
-            /// Creates a new RemediationType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod remediation_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl RemediationType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::RemediationBooleanOrgPolicyViolation => std::option::Option::Some(1),
+                    Self::RemediationListAllowedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(2)
+                    }
+                    Self::RemediationListDeniedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(3)
+                    }
+                    Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation => {
+                        std::option::Option::Some(4)
+                    }
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("REMEDIATION_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION"),
-                    2 => std::borrow::Cow::Borrowed(
-                        "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION",
-                    ),
-                    3 => std::borrow::Cow::Borrowed(
-                        "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION",
-                    ),
-                    4 => std::borrow::Cow::Borrowed(
-                        "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
-                    ),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("REMEDIATION_TYPE_UNSPECIFIED"),
+                    Self::RemediationBooleanOrgPolicyViolation => {
+                        std::option::Option::Some("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION")
+                    }
+                    Self::RemediationListAllowedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(
+                            "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION",
+                        )
+                    }
+                    Self::RemediationListDeniedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(
+                            "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION",
+                        )
+                    }
+                    Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation => {
+                        std::option::Option::Some(
+                            "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
+                        )
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "REMEDIATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REMEDIATION_TYPE_UNSPECIFIED),
-                    "REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for RemediationType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for RemediationType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for RemediationType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for RemediationType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::RemediationBooleanOrgPolicyViolation,
+                    2 => Self::RemediationListAllowedValuesOrgPolicyViolation,
+                    3 => Self::RemediationListDeniedValuesOrgPolicyViolation,
+                    4 => Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation,
+                    _ => Self::UnknownValue(remediation_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for RemediationType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "REMEDIATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationBooleanOrgPolicyViolation
+                    }
+                    "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationListAllowedValuesOrgPolicyViolation
+                    }
+                    "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationListDeniedValuesOrgPolicyViolation
+                    }
+                    "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation
+                    }
+                    _ => Self::UnknownValue(remediation_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for RemediationType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::RemediationBooleanOrgPolicyViolation => serializer.serialize_i32(1),
+                    Self::RemediationListAllowedValuesOrgPolicyViolation => {
+                        serializer.serialize_i32(2)
+                    }
+                    Self::RemediationListDeniedValuesOrgPolicyViolation => {
+                        serializer.serialize_i32(3)
+                    }
+                    Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation => {
+                        serializer.serialize_i32(4)
+                    }
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for RemediationType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<RemediationType>::new(
+                    ".google.cloud.assuredworkloads.v1.Violation.Remediation.RemediationType",
+                ))
             }
         }
     }
 
     /// Violation State Values
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// Violation is resolved.
+        Resolved,
+        /// Violation is Unresolved
+        Unresolved,
+        /// Violation is Exception
+        Exception,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Violation is resolved.
-        pub const RESOLVED: State = State::new(2);
-
-        /// Violation is Unresolved
-        pub const UNRESOLVED: State = State::new(3);
-
-        /// Violation is Exception
-        pub const EXCEPTION: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Resolved => std::option::Option::Some(2),
+                Self::Unresolved => std::option::Option::Some(3),
+                Self::Exception => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("RESOLVED"),
-                3 => std::borrow::Cow::Borrowed("UNRESOLVED"),
-                4 => std::borrow::Cow::Borrowed("EXCEPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Resolved => std::option::Option::Some("RESOLVED"),
+                Self::Unresolved => std::option::Option::Some("UNRESOLVED"),
+                Self::Exception => std::option::Option::Some("EXCEPTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
-                "UNRESOLVED" => std::option::Option::Some(Self::UNRESOLVED),
-                "EXCEPTION" => std::option::Option::Some(Self::EXCEPTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Resolved,
+                3 => Self::Unresolved,
+                4 => Self::Exception,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RESOLVED" => Self::Resolved,
+                "UNRESOLVED" => Self::Unresolved,
+                "EXCEPTION" => Self::Exception,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Resolved => serializer.serialize_i32(2),
+                Self::Unresolved => serializer.serialize_i32(3),
+                Self::Exception => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.assuredworkloads.v1.Violation.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -88,58 +88,115 @@ pub mod network_config {
     use super::*;
 
     /// VPC peering modes supported by Cloud BackupDR.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeeringMode(i32);
-
-    impl PeeringMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PeeringMode {
         /// Peering mode not set.
-        pub const PEERING_MODE_UNSPECIFIED: PeeringMode = PeeringMode::new(0);
-
+        Unspecified,
         /// Connect using Private Service Access to the Management Server. Private
         /// services access provides an IP address range for multiple Google Cloud
         /// services, including Cloud BackupDR.
-        pub const PRIVATE_SERVICE_ACCESS: PeeringMode = PeeringMode::new(1);
+        PrivateServiceAccess,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PeeringMode::value] or
+        /// [PeeringMode::name].
+        UnknownValue(peering_mode::UnknownValue),
+    }
 
-        /// Creates a new PeeringMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod peering_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PeeringMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PrivateServiceAccess => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PEERING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PEERING_MODE_UNSPECIFIED"),
+                Self::PrivateServiceAccess => std::option::Option::Some("PRIVATE_SERVICE_ACCESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PEERING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PEERING_MODE_UNSPECIFIED)
-                }
-                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PeeringMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PeeringMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PeeringMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PeeringMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PrivateServiceAccess,
+                _ => Self::UnknownValue(peering_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PeeringMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PEERING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "PRIVATE_SERVICE_ACCESS" => Self::PrivateServiceAccess,
+                _ => Self::UnknownValue(peering_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PeeringMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PrivateServiceAccess => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PeeringMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PeeringMode>::new(
+                ".google.cloud.backupdr.v1.NetworkConfig.PeeringMode",
+            ))
         }
     }
 }
@@ -535,143 +592,269 @@ pub mod management_server {
     use super::*;
 
     /// Type of backup service resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstanceType {
+        /// Instance type is not mentioned.
+        Unspecified,
+        /// Instance for backup and restore management (i.e., AGM).
+        BackupRestore,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstanceType::value] or
+        /// [InstanceType::name].
+        UnknownValue(instance_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod instance_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl InstanceType {
-        /// Instance type is not mentioned.
-        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType = InstanceType::new(0);
-
-        /// Instance for backup and restore management (i.e., AGM).
-        pub const BACKUP_RESTORE: InstanceType = InstanceType::new(1);
-
-        /// Creates a new InstanceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BackupRestore => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BACKUP_RESTORE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INSTANCE_TYPE_UNSPECIFIED"),
+                Self::BackupRestore => std::option::Option::Some("BACKUP_RESTORE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_TYPE_UNSPECIFIED)
-                }
-                "BACKUP_RESTORE" => std::option::Option::Some(Self::BACKUP_RESTORE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InstanceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstanceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstanceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BackupRestore,
+                _ => Self::UnknownValue(instance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstanceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BACKUP_RESTORE" => Self::BackupRestore,
+                _ => Self::UnknownValue(instance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstanceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BackupRestore => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstanceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstanceType>::new(
+                ".google.cloud.backupdr.v1.ManagementServer.InstanceType",
+            ))
         }
     }
 
     /// State of Management server instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceState(i32);
-
-    impl InstanceState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstanceState {
         /// State not set.
-        pub const INSTANCE_STATE_UNSPECIFIED: InstanceState = InstanceState::new(0);
-
+        Unspecified,
         /// The instance is being created.
-        pub const CREATING: InstanceState = InstanceState::new(1);
-
+        Creating,
         /// The instance has been created and is fully usable.
-        pub const READY: InstanceState = InstanceState::new(2);
-
+        Ready,
         /// The instance configuration is being updated. Certain kinds of updates
         /// may cause the instance to become unusable while the update is in
         /// progress.
-        pub const UPDATING: InstanceState = InstanceState::new(3);
-
+        Updating,
         /// The instance is being deleted.
-        pub const DELETING: InstanceState = InstanceState::new(4);
-
+        Deleting,
         /// The instance is being repaired and may be unstable.
-        pub const REPAIRING: InstanceState = InstanceState::new(5);
-
+        Repairing,
         /// Maintenance is being performed on this instance.
-        pub const MAINTENANCE: InstanceState = InstanceState::new(6);
-
+        Maintenance,
         /// The instance is experiencing an issue and might be unusable. You can get
         /// further details from the statusMessage field of Instance resource.
-        pub const ERROR: InstanceState = InstanceState::new(7);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstanceState::value] or
+        /// [InstanceState::name].
+        UnknownValue(instance_state::UnknownValue),
+    }
 
-        /// Creates a new InstanceState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod instance_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl InstanceState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Repairing => std::option::Option::Some(5),
+                Self::Maintenance => std::option::Option::Some(6),
+                Self::Error => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("REPAIRING"),
-                6 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                7 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INSTANCE_STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_STATE_UNSPECIFIED)
-                }
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InstanceState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstanceState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstanceState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Repairing,
+                6 => Self::Maintenance,
+                7 => Self::Error,
+                _ => Self::UnknownValue(instance_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstanceState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "REPAIRING" => Self::Repairing,
+                "MAINTENANCE" => Self::Maintenance,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(instance_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstanceState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Repairing => serializer.serialize_i32(5),
+                Self::Maintenance => serializer.serialize_i32(6),
+                Self::Error => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstanceState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstanceState>::new(
+                ".google.cloud.backupdr.v1.ManagementServer.InstanceState",
+            ))
         }
     }
 }
@@ -1441,69 +1624,134 @@ pub mod backup_plan {
     use super::*;
 
     /// `State` enumerates the possible states for a `BackupPlan`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// The resource is being created.
+        Creating,
+        /// The resource has been created and is fully usable.
+        Active,
+        /// The resource is being deleted.
+        Deleting,
+        /// The resource has been created but is not usable.
+        Inactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource has been created and is fully usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The resource has been created but is not usable.
-        pub const INACTIVE: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Inactive => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "INACTIVE" => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Inactive => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.backupdr.v1.BackupPlan.State",
+            ))
         }
     }
 }
@@ -1806,76 +2054,141 @@ pub mod standard_schedule {
     use super::*;
 
     /// `RecurrenceTypes` enumerates the applicable periodicity for the schedule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RecurrenceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RecurrenceType {
+        /// recurrence type not set
+        Unspecified,
+        /// The `BackupRule` is to be applied hourly.
+        Hourly,
+        /// The `BackupRule` is to be applied daily.
+        Daily,
+        /// The `BackupRule` is to be applied weekly.
+        Weekly,
+        /// The `BackupRule` is to be applied monthly.
+        Monthly,
+        /// The `BackupRule` is to be applied yearly.
+        Yearly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RecurrenceType::value] or
+        /// [RecurrenceType::name].
+        UnknownValue(recurrence_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod recurrence_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RecurrenceType {
-        /// recurrence type not set
-        pub const RECURRENCE_TYPE_UNSPECIFIED: RecurrenceType = RecurrenceType::new(0);
-
-        /// The `BackupRule` is to be applied hourly.
-        pub const HOURLY: RecurrenceType = RecurrenceType::new(1);
-
-        /// The `BackupRule` is to be applied daily.
-        pub const DAILY: RecurrenceType = RecurrenceType::new(2);
-
-        /// The `BackupRule` is to be applied weekly.
-        pub const WEEKLY: RecurrenceType = RecurrenceType::new(3);
-
-        /// The `BackupRule` is to be applied monthly.
-        pub const MONTHLY: RecurrenceType = RecurrenceType::new(4);
-
-        /// The `BackupRule` is to be applied yearly.
-        pub const YEARLY: RecurrenceType = RecurrenceType::new(5);
-
-        /// Creates a new RecurrenceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hourly => std::option::Option::Some(1),
+                Self::Daily => std::option::Option::Some(2),
+                Self::Weekly => std::option::Option::Some(3),
+                Self::Monthly => std::option::Option::Some(4),
+                Self::Yearly => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RECURRENCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HOURLY"),
-                2 => std::borrow::Cow::Borrowed("DAILY"),
-                3 => std::borrow::Cow::Borrowed("WEEKLY"),
-                4 => std::borrow::Cow::Borrowed("MONTHLY"),
-                5 => std::borrow::Cow::Borrowed("YEARLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RECURRENCE_TYPE_UNSPECIFIED"),
+                Self::Hourly => std::option::Option::Some("HOURLY"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Weekly => std::option::Option::Some("WEEKLY"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::Yearly => std::option::Option::Some("YEARLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RECURRENCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RECURRENCE_TYPE_UNSPECIFIED)
-                }
-                "HOURLY" => std::option::Option::Some(Self::HOURLY),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                "YEARLY" => std::option::Option::Some(Self::YEARLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RecurrenceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RecurrenceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RecurrenceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RecurrenceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hourly,
+                2 => Self::Daily,
+                3 => Self::Weekly,
+                4 => Self::Monthly,
+                5 => Self::Yearly,
+                _ => Self::UnknownValue(recurrence_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RecurrenceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RECURRENCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "HOURLY" => Self::Hourly,
+                "DAILY" => Self::Daily,
+                "WEEKLY" => Self::Weekly,
+                "MONTHLY" => Self::Monthly,
+                "YEARLY" => Self::Yearly,
+                _ => Self::UnknownValue(recurrence_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RecurrenceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hourly => serializer.serialize_i32(1),
+                Self::Daily => serializer.serialize_i32(2),
+                Self::Weekly => serializer.serialize_i32(3),
+                Self::Monthly => serializer.serialize_i32(4),
+                Self::Yearly => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RecurrenceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RecurrenceType>::new(
+                ".google.cloud.backupdr.v1.StandardSchedule.RecurrenceType",
+            ))
         }
     }
 }
@@ -1984,76 +2297,141 @@ pub mod week_day_of_month {
 
     /// `WeekOfMonth` enumerates possible weeks in the month, e.g. the first,
     /// third, or last week of the month.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WeekOfMonth(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WeekOfMonth {
+        /// The zero value. Do not use.
+        Unspecified,
+        /// The first week of the month.
+        First,
+        /// The second week of the month.
+        Second,
+        /// The third week of the month.
+        Third,
+        /// The fourth  week of the month.
+        Fourth,
+        /// The last  week of the month.
+        Last,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WeekOfMonth::value] or
+        /// [WeekOfMonth::name].
+        UnknownValue(week_of_month::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod week_of_month {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WeekOfMonth {
-        /// The zero value. Do not use.
-        pub const WEEK_OF_MONTH_UNSPECIFIED: WeekOfMonth = WeekOfMonth::new(0);
-
-        /// The first week of the month.
-        pub const FIRST: WeekOfMonth = WeekOfMonth::new(1);
-
-        /// The second week of the month.
-        pub const SECOND: WeekOfMonth = WeekOfMonth::new(2);
-
-        /// The third week of the month.
-        pub const THIRD: WeekOfMonth = WeekOfMonth::new(3);
-
-        /// The fourth  week of the month.
-        pub const FOURTH: WeekOfMonth = WeekOfMonth::new(4);
-
-        /// The last  week of the month.
-        pub const LAST: WeekOfMonth = WeekOfMonth::new(5);
-
-        /// Creates a new WeekOfMonth instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::First => std::option::Option::Some(1),
+                Self::Second => std::option::Option::Some(2),
+                Self::Third => std::option::Option::Some(3),
+                Self::Fourth => std::option::Option::Some(4),
+                Self::Last => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WEEK_OF_MONTH_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIRST"),
-                2 => std::borrow::Cow::Borrowed("SECOND"),
-                3 => std::borrow::Cow::Borrowed("THIRD"),
-                4 => std::borrow::Cow::Borrowed("FOURTH"),
-                5 => std::borrow::Cow::Borrowed("LAST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WEEK_OF_MONTH_UNSPECIFIED"),
+                Self::First => std::option::Option::Some("FIRST"),
+                Self::Second => std::option::Option::Some("SECOND"),
+                Self::Third => std::option::Option::Some("THIRD"),
+                Self::Fourth => std::option::Option::Some("FOURTH"),
+                Self::Last => std::option::Option::Some("LAST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WEEK_OF_MONTH_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WEEK_OF_MONTH_UNSPECIFIED)
-                }
-                "FIRST" => std::option::Option::Some(Self::FIRST),
-                "SECOND" => std::option::Option::Some(Self::SECOND),
-                "THIRD" => std::option::Option::Some(Self::THIRD),
-                "FOURTH" => std::option::Option::Some(Self::FOURTH),
-                "LAST" => std::option::Option::Some(Self::LAST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WeekOfMonth {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WeekOfMonth {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WeekOfMonth {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WeekOfMonth {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::First,
+                2 => Self::Second,
+                3 => Self::Third,
+                4 => Self::Fourth,
+                5 => Self::Last,
+                _ => Self::UnknownValue(week_of_month::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WeekOfMonth {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WEEK_OF_MONTH_UNSPECIFIED" => Self::Unspecified,
+                "FIRST" => Self::First,
+                "SECOND" => Self::Second,
+                "THIRD" => Self::Third,
+                "FOURTH" => Self::Fourth,
+                "LAST" => Self::Last,
+                _ => Self::UnknownValue(week_of_month::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WeekOfMonth {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::First => serializer.serialize_i32(1),
+                Self::Second => serializer.serialize_i32(2),
+                Self::Third => serializer.serialize_i32(3),
+                Self::Fourth => serializer.serialize_i32(4),
+                Self::Last => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WeekOfMonth {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WeekOfMonth>::new(
+                ".google.cloud.backupdr.v1.WeekDayOfMonth.WeekOfMonth",
+            ))
         }
     }
 }
@@ -2550,69 +2928,134 @@ pub mod backup_plan_association {
     use super::*;
 
     /// Enum for State of BackupPlan Association
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// The resource is being created.
+        Creating,
+        /// The resource has been created and is fully usable.
+        Active,
+        /// The resource is being deleted.
+        Deleting,
+        /// The resource has been created but is not usable.
+        Inactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource has been created and is fully usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The resource has been created but is not usable.
-        pub const INACTIVE: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Inactive => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "INACTIVE" => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Inactive => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.backupdr.v1.BackupPlanAssociation.State",
+            ))
         }
     }
 }
@@ -2698,72 +3141,135 @@ pub mod rule_config_info {
     use super::*;
 
     /// Enum for LastBackupState
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LastBackupState(i32);
-
-    impl LastBackupState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LastBackupState {
         /// State not set.
-        pub const LAST_BACKUP_STATE_UNSPECIFIED: LastBackupState = LastBackupState::new(0);
-
+        Unspecified,
         /// The first backup is pending.
-        pub const FIRST_BACKUP_PENDING: LastBackupState = LastBackupState::new(1);
-
+        FirstBackupPending,
         /// The most recent backup could not be run/failed because of the lack of
         /// permissions.
-        pub const PERMISSION_DENIED: LastBackupState = LastBackupState::new(2);
-
+        PermissionDenied,
         /// The last backup operation succeeded.
-        pub const SUCCEEDED: LastBackupState = LastBackupState::new(3);
-
+        Succeeded,
         /// The last backup operation failed.
-        pub const FAILED: LastBackupState = LastBackupState::new(4);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LastBackupState::value] or
+        /// [LastBackupState::name].
+        UnknownValue(last_backup_state::UnknownValue),
+    }
 
-        /// Creates a new LastBackupState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod last_backup_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LastBackupState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FirstBackupPending => std::option::Option::Some(1),
+                Self::PermissionDenied => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LAST_BACKUP_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIRST_BACKUP_PENDING"),
-                2 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LAST_BACKUP_STATE_UNSPECIFIED"),
+                Self::FirstBackupPending => std::option::Option::Some("FIRST_BACKUP_PENDING"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LAST_BACKUP_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LAST_BACKUP_STATE_UNSPECIFIED)
-                }
-                "FIRST_BACKUP_PENDING" => std::option::Option::Some(Self::FIRST_BACKUP_PENDING),
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LastBackupState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LastBackupState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LastBackupState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LastBackupState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FirstBackupPending,
+                2 => Self::PermissionDenied,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(last_backup_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LastBackupState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LAST_BACKUP_STATE_UNSPECIFIED" => Self::Unspecified,
+                "FIRST_BACKUP_PENDING" => Self::FirstBackupPending,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(last_backup_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LastBackupState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FirstBackupPending => serializer.serialize_i32(1),
+                Self::PermissionDenied => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LastBackupState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LastBackupState>::new(
+                ".google.cloud.backupdr.v1.RuleConfigInfo.LastBackupState",
+            ))
         }
     }
 }
@@ -3401,143 +3907,271 @@ pub mod backup_vault {
     use super::*;
 
     /// Holds the state of the backup vault resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// The backup vault is being created.
+        Creating,
+        /// The backup vault has been created and is fully usable.
+        Active,
+        /// The backup vault is being deleted.
+        Deleting,
+        /// The backup vault is experiencing an issue and might be unusable.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The backup vault is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The backup vault has been created and is fully usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The backup vault is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The backup vault is experiencing an issue and might be unusable.
-        pub const ERROR: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.backupdr.v1.BackupVault.State",
+            ))
         }
     }
 
     /// Holds the access restriction for the backup vault.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessRestriction(i32);
-
-    impl AccessRestriction {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AccessRestriction {
         /// Access restriction not set. If user does not provide any value or pass
         /// this value, it will be changed to WITHIN_ORGANIZATION.
-        pub const ACCESS_RESTRICTION_UNSPECIFIED: AccessRestriction = AccessRestriction::new(0);
-
+        Unspecified,
         /// Access to or from resources outside your current project will be denied.
-        pub const WITHIN_PROJECT: AccessRestriction = AccessRestriction::new(1);
-
+        WithinProject,
         /// Access to or from resources outside your current organization will be
         /// denied.
-        pub const WITHIN_ORGANIZATION: AccessRestriction = AccessRestriction::new(2);
-
+        WithinOrganization,
         /// No access restriction.
-        pub const UNRESTRICTED: AccessRestriction = AccessRestriction::new(3);
-
+        Unrestricted,
         /// Access to or from resources outside your current organization will be
         /// denied except for backup appliance.
-        pub const WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA: AccessRestriction = AccessRestriction::new(4);
+        WithinOrgButUnrestrictedForBa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AccessRestriction::value] or
+        /// [AccessRestriction::name].
+        UnknownValue(access_restriction::UnknownValue),
+    }
 
-        /// Creates a new AccessRestriction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod access_restriction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AccessRestriction {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::WithinProject => std::option::Option::Some(1),
+                Self::WithinOrganization => std::option::Option::Some(2),
+                Self::Unrestricted => std::option::Option::Some(3),
+                Self::WithinOrgButUnrestrictedForBa => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCESS_RESTRICTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WITHIN_PROJECT"),
-                2 => std::borrow::Cow::Borrowed("WITHIN_ORGANIZATION"),
-                3 => std::borrow::Cow::Borrowed("UNRESTRICTED"),
-                4 => std::borrow::Cow::Borrowed("WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCESS_RESTRICTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCESS_RESTRICTION_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCESS_RESTRICTION_UNSPECIFIED"),
+                Self::WithinProject => std::option::Option::Some("WITHIN_PROJECT"),
+                Self::WithinOrganization => std::option::Option::Some("WITHIN_ORGANIZATION"),
+                Self::Unrestricted => std::option::Option::Some("UNRESTRICTED"),
+                Self::WithinOrgButUnrestrictedForBa => {
+                    std::option::Option::Some("WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA")
                 }
-                "WITHIN_PROJECT" => std::option::Option::Some(Self::WITHIN_PROJECT),
-                "WITHIN_ORGANIZATION" => std::option::Option::Some(Self::WITHIN_ORGANIZATION),
-                "UNRESTRICTED" => std::option::Option::Some(Self::UNRESTRICTED),
-                "WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA" => {
-                    std::option::Option::Some(Self::WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for AccessRestriction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessRestriction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AccessRestriction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AccessRestriction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::WithinProject,
+                2 => Self::WithinOrganization,
+                3 => Self::Unrestricted,
+                4 => Self::WithinOrgButUnrestrictedForBa,
+                _ => Self::UnknownValue(access_restriction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AccessRestriction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCESS_RESTRICTION_UNSPECIFIED" => Self::Unspecified,
+                "WITHIN_PROJECT" => Self::WithinProject,
+                "WITHIN_ORGANIZATION" => Self::WithinOrganization,
+                "UNRESTRICTED" => Self::Unrestricted,
+                "WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA" => Self::WithinOrgButUnrestrictedForBa,
+                _ => Self::UnknownValue(access_restriction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AccessRestriction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::WithinProject => serializer.serialize_i32(1),
+                Self::WithinOrganization => serializer.serialize_i32(2),
+                Self::Unrestricted => serializer.serialize_i32(3),
+                Self::WithinOrgButUnrestrictedForBa => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AccessRestriction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessRestriction>::new(
+                ".google.cloud.backupdr.v1.BackupVault.AccessRestriction",
+            ))
         }
     }
 }
@@ -3796,69 +4430,134 @@ pub mod data_source {
     use super::*;
 
     /// Holds the state of the data source resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// The data source is being created.
+        Creating,
+        /// The data source has been created and is fully usable.
+        Active,
+        /// The data source is being deleted.
+        Deleting,
+        /// The data source is experiencing an issue and might be unusable.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The data source is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The data source has been created and is fully usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The data source is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The data source is experiencing an issue and might be unusable.
-        pub const ERROR: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.backupdr.v1.DataSource.State",
+            ))
         }
     }
 
@@ -4035,72 +4734,135 @@ pub mod backup_config_info {
 
     /// LastBackupstate tracks whether the last backup was not yet started,
     /// successful, failed, or could not be run because of the lack of permissions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LastBackupState(i32);
-
-    impl LastBackupState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LastBackupState {
         /// Status not set.
-        pub const LAST_BACKUP_STATE_UNSPECIFIED: LastBackupState = LastBackupState::new(0);
-
+        Unspecified,
         /// The first backup has not yet completed
-        pub const FIRST_BACKUP_PENDING: LastBackupState = LastBackupState::new(1);
-
+        FirstBackupPending,
         /// The most recent backup was successful
-        pub const SUCCEEDED: LastBackupState = LastBackupState::new(2);
-
+        Succeeded,
         /// The most recent backup failed
-        pub const FAILED: LastBackupState = LastBackupState::new(3);
-
+        Failed,
         /// The most recent backup could not be run/failed because of the lack of
         /// permissions
-        pub const PERMISSION_DENIED: LastBackupState = LastBackupState::new(4);
+        PermissionDenied,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LastBackupState::value] or
+        /// [LastBackupState::name].
+        UnknownValue(last_backup_state::UnknownValue),
+    }
 
-        /// Creates a new LastBackupState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod last_backup_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LastBackupState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FirstBackupPending => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::PermissionDenied => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LAST_BACKUP_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIRST_BACKUP_PENDING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LAST_BACKUP_STATE_UNSPECIFIED"),
+                Self::FirstBackupPending => std::option::Option::Some("FIRST_BACKUP_PENDING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LAST_BACKUP_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LAST_BACKUP_STATE_UNSPECIFIED)
-                }
-                "FIRST_BACKUP_PENDING" => std::option::Option::Some(Self::FIRST_BACKUP_PENDING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LastBackupState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LastBackupState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LastBackupState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LastBackupState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FirstBackupPending,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::PermissionDenied,
+                _ => Self::UnknownValue(last_backup_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LastBackupState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LAST_BACKUP_STATE_UNSPECIFIED" => Self::Unspecified,
+                "FIRST_BACKUP_PENDING" => Self::FirstBackupPending,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                _ => Self::UnknownValue(last_backup_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LastBackupState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FirstBackupPending => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::PermissionDenied => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LastBackupState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LastBackupState>::new(
+                ".google.cloud.backupdr.v1.BackupConfigInfo.LastBackupState",
+            ))
         }
     }
 
@@ -5268,128 +6030,252 @@ pub mod backup {
     }
 
     /// Holds the state of the backup resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// The backup is being created.
+        Creating,
+        /// The backup has been created and is fully usable.
+        Active,
+        /// The backup is being deleted.
+        Deleting,
+        /// The backup is experiencing an issue and might be unusable.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The backup is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The backup has been created and is fully usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The backup is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The backup is experiencing an issue and might be unusable.
-        pub const ERROR: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.backupdr.v1.Backup.State",
+            ))
         }
     }
 
     /// Type of the backup, scheduled or ondemand.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BackupType {
+        /// Backup type is unspecified.
+        Unspecified,
+        /// Scheduled backup.
+        Scheduled,
+        /// On demand backup.
+        OnDemand,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BackupType::value] or
+        /// [BackupType::name].
+        UnknownValue(backup_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod backup_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BackupType {
-        /// Backup type is unspecified.
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
-
-        /// Scheduled backup.
-        pub const SCHEDULED: BackupType = BackupType::new(1);
-
-        /// On demand backup.
-        pub const ON_DEMAND: BackupType = BackupType::new(2);
-
-        /// Creates a new BackupType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Scheduled => std::option::Option::Some(1),
+                Self::OnDemand => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCHEDULED"),
-                2 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BACKUP_TYPE_UNSPECIFIED"),
+                Self::Scheduled => std::option::Option::Some("SCHEDULED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BACKUP_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED)
-                }
-                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BackupType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BackupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Scheduled,
+                2 => Self::OnDemand,
+                _ => Self::UnknownValue(backup_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BackupType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BACKUP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCHEDULED" => Self::Scheduled,
+                "ON_DEMAND" => Self::OnDemand,
+                _ => Self::UnknownValue(backup_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BackupType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Scheduled => serializer.serialize_i32(1),
+                Self::OnDemand => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BackupType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupType>::new(
+                ".google.cloud.backupdr.v1.Backup.BackupType",
+            ))
         }
     }
 
@@ -7807,83 +8693,139 @@ pub mod compute_instance_restore_properties {
     use super::*;
 
     /// The private IPv6 google access type for the VMs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstancePrivateIpv6GoogleAccess(i32);
-
-    impl InstancePrivateIpv6GoogleAccess {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstancePrivateIpv6GoogleAccess {
         /// Default value. This value is unused.
-        pub const INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new(0);
-
+        Unspecified,
         /// Each network interface inherits PrivateIpv6GoogleAccess from its
         /// subnetwork.
-        pub const INHERIT_FROM_SUBNETWORK: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new(1);
-
+        InheritFromSubnetwork,
         /// Outbound private IPv6 access from VMs in this subnet to Google services.
         /// If specified, the subnetwork who is attached to the instance's default
         /// network interface will be assigned an internal IPv6 prefix if it doesn't
         /// have before.
-        pub const ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new(2);
-
+        EnableOutboundVmAccessToGoogle,
         /// Bidirectional private IPv6 access to/from Google services. If
         /// specified, the subnetwork who is attached to the instance's default
         /// network interface will be assigned an internal IPv6 prefix if it doesn't
         /// have before.
-        pub const ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE: InstancePrivateIpv6GoogleAccess =
-            InstancePrivateIpv6GoogleAccess::new(3);
+        EnableBidirectionalAccessToGoogle,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstancePrivateIpv6GoogleAccess::value] or
+        /// [InstancePrivateIpv6GoogleAccess::name].
+        UnknownValue(instance_private_ipv_6_google_access::UnknownValue),
+    }
 
-        /// Creates a new InstancePrivateIpv6GoogleAccess instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod instance_private_ipv_6_google_access {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl InstancePrivateIpv6GoogleAccess {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InheritFromSubnetwork => std::option::Option::Some(1),
+                Self::EnableOutboundVmAccessToGoogle => std::option::Option::Some(2),
+                Self::EnableBidirectionalAccessToGoogle => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INHERIT_FROM_SUBNETWORK"),
-                2 => std::borrow::Cow::Borrowed("ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE"),
-                3 => std::borrow::Cow::Borrowed("ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED")
+                }
+                Self::InheritFromSubnetwork => std::option::Option::Some("INHERIT_FROM_SUBNETWORK"),
+                Self::EnableOutboundVmAccessToGoogle => {
+                    std::option::Option::Some("ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE")
+                }
+                Self::EnableBidirectionalAccessToGoogle => {
+                    std::option::Option::Some("ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED)
-                }
-                "INHERIT_FROM_SUBNETWORK" => {
-                    std::option::Option::Some(Self::INHERIT_FROM_SUBNETWORK)
-                }
-                "ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE" => {
-                    std::option::Option::Some(Self::ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE)
-                }
-                "ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE" => {
-                    std::option::Option::Some(Self::ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InstancePrivateIpv6GoogleAccess {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstancePrivateIpv6GoogleAccess {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstancePrivateIpv6GoogleAccess {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstancePrivateIpv6GoogleAccess {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InheritFromSubnetwork,
+                2 => Self::EnableOutboundVmAccessToGoogle,
+                3 => Self::EnableBidirectionalAccessToGoogle,
+                _ => Self::UnknownValue(instance_private_ipv_6_google_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstancePrivateIpv6GoogleAccess {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => Self::Unspecified,
+                "INHERIT_FROM_SUBNETWORK" => Self::InheritFromSubnetwork,
+                "ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE" => Self::EnableOutboundVmAccessToGoogle,
+                "ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE" => Self::EnableBidirectionalAccessToGoogle,
+                _ => Self::UnknownValue(instance_private_ipv_6_google_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstancePrivateIpv6GoogleAccess {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InheritFromSubnetwork => serializer.serialize_i32(1),
+                Self::EnableOutboundVmAccessToGoogle => serializer.serialize_i32(2),
+                Self::EnableBidirectionalAccessToGoogle => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstancePrivateIpv6GoogleAccess {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstancePrivateIpv6GoogleAccess>::new(
+                ".google.cloud.backupdr.v1.ComputeInstanceRestoreProperties.InstancePrivateIpv6GoogleAccess"))
         }
     }
 }
@@ -8699,176 +9641,359 @@ pub mod network_interface {
     use super::*;
 
     /// Stack type for this network interface.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StackType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StackType {
+        /// Default should be STACK_TYPE_UNSPECIFIED.
+        Unspecified,
+        /// The network interface will be assigned IPv4 address.
+        Ipv4Only,
+        /// The network interface can have both IPv4 and IPv6 addresses.
+        Ipv4Ipv6,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StackType::value] or
+        /// [StackType::name].
+        UnknownValue(stack_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod stack_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StackType {
-        /// Default should be STACK_TYPE_UNSPECIFIED.
-        pub const STACK_TYPE_UNSPECIFIED: StackType = StackType::new(0);
-
-        /// The network interface will be assigned IPv4 address.
-        pub const IPV4_ONLY: StackType = StackType::new(1);
-
-        /// The network interface can have both IPv4 and IPv6 addresses.
-        pub const IPV4_IPV6: StackType = StackType::new(2);
-
-        /// Creates a new StackType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ipv4Only => std::option::Option::Some(1),
+                Self::Ipv4Ipv6 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STACK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IPV4_ONLY"),
-                2 => std::borrow::Cow::Borrowed("IPV4_IPV6"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STACK_TYPE_UNSPECIFIED"),
+                Self::Ipv4Only => std::option::Option::Some("IPV4_ONLY"),
+                Self::Ipv4Ipv6 => std::option::Option::Some("IPV4_IPV6"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STACK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STACK_TYPE_UNSPECIFIED),
-                "IPV4_ONLY" => std::option::Option::Some(Self::IPV4_ONLY),
-                "IPV4_IPV6" => std::option::Option::Some(Self::IPV4_IPV6),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StackType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StackType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StackType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StackType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ipv4Only,
+                2 => Self::Ipv4Ipv6,
+                _ => Self::UnknownValue(stack_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StackType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STACK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IPV4_ONLY" => Self::Ipv4Only,
+                "IPV4_IPV6" => Self::Ipv4Ipv6,
+                _ => Self::UnknownValue(stack_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StackType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ipv4Only => serializer.serialize_i32(1),
+                Self::Ipv4Ipv6 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StackType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StackType>::new(
+                ".google.cloud.backupdr.v1.NetworkInterface.StackType",
+            ))
         }
     }
 
     /// IPv6 access type for this network interface.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Ipv6AccessType(i32);
-
-    impl Ipv6AccessType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Ipv6AccessType {
         /// IPv6 access type not set. Means this network interface hasn't been
         /// turned on IPv6 yet.
-        pub const UNSPECIFIED_IPV6_ACCESS_TYPE: Ipv6AccessType = Ipv6AccessType::new(0);
-
+        UnspecifiedIpv6AccessType,
         /// This network interface can have internal IPv6.
-        pub const INTERNAL: Ipv6AccessType = Ipv6AccessType::new(1);
-
+        Internal,
         /// This network interface can have external IPv6.
-        pub const EXTERNAL: Ipv6AccessType = Ipv6AccessType::new(2);
+        External,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Ipv6AccessType::value] or
+        /// [Ipv6AccessType::name].
+        UnknownValue(ipv_6_access_type::UnknownValue),
+    }
 
-        /// Creates a new Ipv6AccessType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod ipv_6_access_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Ipv6AccessType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::UnspecifiedIpv6AccessType => std::option::Option::Some(0),
+                Self::Internal => std::option::Option::Some(1),
+                Self::External => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED_IPV6_ACCESS_TYPE"),
-                1 => std::borrow::Cow::Borrowed("INTERNAL"),
-                2 => std::borrow::Cow::Borrowed("EXTERNAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED_IPV6_ACCESS_TYPE" => {
-                    std::option::Option::Some(Self::UNSPECIFIED_IPV6_ACCESS_TYPE)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::UnspecifiedIpv6AccessType => {
+                    std::option::Option::Some("UNSPECIFIED_IPV6_ACCESS_TYPE")
                 }
-                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
-                "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-                _ => std::option::Option::None,
+                Self::Internal => std::option::Option::Some("INTERNAL"),
+                Self::External => std::option::Option::Some("EXTERNAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Ipv6AccessType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Ipv6AccessType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Ipv6AccessType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Ipv6AccessType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::UnspecifiedIpv6AccessType,
+                1 => Self::Internal,
+                2 => Self::External,
+                _ => Self::UnknownValue(ipv_6_access_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Ipv6AccessType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED_IPV6_ACCESS_TYPE" => Self::UnspecifiedIpv6AccessType,
+                "INTERNAL" => Self::Internal,
+                "EXTERNAL" => Self::External,
+                _ => Self::UnknownValue(ipv_6_access_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Ipv6AccessType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::UnspecifiedIpv6AccessType => serializer.serialize_i32(0),
+                Self::Internal => serializer.serialize_i32(1),
+                Self::External => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Ipv6AccessType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Ipv6AccessType>::new(
+                ".google.cloud.backupdr.v1.NetworkInterface.Ipv6AccessType",
+            ))
         }
     }
 
     /// Nic type for this network interface.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NicType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NicType {
+        /// Default should be NIC_TYPE_UNSPECIFIED.
+        Unspecified,
+        /// VIRTIO
+        VirtioNet,
+        /// GVNIC
+        Gvnic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NicType::value] or
+        /// [NicType::name].
+        UnknownValue(nic_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod nic_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl NicType {
-        /// Default should be NIC_TYPE_UNSPECIFIED.
-        pub const NIC_TYPE_UNSPECIFIED: NicType = NicType::new(0);
-
-        /// VIRTIO
-        pub const VIRTIO_NET: NicType = NicType::new(1);
-
-        /// GVNIC
-        pub const GVNIC: NicType = NicType::new(2);
-
-        /// Creates a new NicType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VirtioNet => std::option::Option::Some(1),
+                Self::Gvnic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NIC_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VIRTIO_NET"),
-                2 => std::borrow::Cow::Borrowed("GVNIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NIC_TYPE_UNSPECIFIED"),
+                Self::VirtioNet => std::option::Option::Some("VIRTIO_NET"),
+                Self::Gvnic => std::option::Option::Some("GVNIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NIC_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NIC_TYPE_UNSPECIFIED),
-                "VIRTIO_NET" => std::option::Option::Some(Self::VIRTIO_NET),
-                "GVNIC" => std::option::Option::Some(Self::GVNIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NicType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NicType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NicType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NicType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VirtioNet,
+                2 => Self::Gvnic,
+                _ => Self::UnknownValue(nic_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NicType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NIC_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "VIRTIO_NET" => Self::VirtioNet,
+                "GVNIC" => Self::Gvnic,
+                _ => Self::UnknownValue(nic_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NicType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VirtioNet => serializer.serialize_i32(1),
+                Self::Gvnic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NicType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NicType>::new(
+                ".google.cloud.backupdr.v1.NetworkInterface.NicType",
+            ))
         }
     }
 }
@@ -8917,59 +10042,120 @@ pub mod network_performance_config {
     use super::*;
 
     /// Network performance tier.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
+        /// This value is unused.
+        Unspecified,
+        /// Default network performance config.
+        Default,
+        /// Tier 1 network performance config.
+        _1,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Tier {
-        /// This value is unused.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
-        /// Default network performance config.
-        pub const DEFAULT: Tier = Tier::new(1);
-
-        /// Tier 1 network performance config.
-        pub const TIER_1: Tier = Tier::new(2);
-
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::_1 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("TIER_1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::_1 => std::option::Option::Some("TIER_1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "TIER_1" => std::option::Option::Some(Self::TIER_1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::_1,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "TIER_1" => Self::_1,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::_1 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.backupdr.v1.NetworkPerformanceConfig.Tier",
+            ))
         }
     }
 }
@@ -9119,122 +10305,240 @@ pub mod access_config {
     use super::*;
 
     /// The type of configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AccessType {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// ONE_TO_ONE_NAT
+        OneToOneNat,
+        /// Direct IPv6 access.
+        DirectIpv6,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AccessType::value] or
+        /// [AccessType::name].
+        UnknownValue(access_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod access_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AccessType {
-        /// Default value. This value is unused.
-        pub const ACCESS_TYPE_UNSPECIFIED: AccessType = AccessType::new(0);
-
-        /// ONE_TO_ONE_NAT
-        pub const ONE_TO_ONE_NAT: AccessType = AccessType::new(1);
-
-        /// Direct IPv6 access.
-        pub const DIRECT_IPV6: AccessType = AccessType::new(2);
-
-        /// Creates a new AccessType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OneToOneNat => std::option::Option::Some(1),
+                Self::DirectIpv6 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCESS_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ONE_TO_ONE_NAT"),
-                2 => std::borrow::Cow::Borrowed("DIRECT_IPV6"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCESS_TYPE_UNSPECIFIED"),
+                Self::OneToOneNat => std::option::Option::Some("ONE_TO_ONE_NAT"),
+                Self::DirectIpv6 => std::option::Option::Some("DIRECT_IPV6"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCESS_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCESS_TYPE_UNSPECIFIED)
-                }
-                "ONE_TO_ONE_NAT" => std::option::Option::Some(Self::ONE_TO_ONE_NAT),
-                "DIRECT_IPV6" => std::option::Option::Some(Self::DIRECT_IPV6),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AccessType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AccessType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AccessType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OneToOneNat,
+                2 => Self::DirectIpv6,
+                _ => Self::UnknownValue(access_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AccessType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCESS_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ONE_TO_ONE_NAT" => Self::OneToOneNat,
+                "DIRECT_IPV6" => Self::DirectIpv6,
+                _ => Self::UnknownValue(access_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AccessType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OneToOneNat => serializer.serialize_i32(1),
+                Self::DirectIpv6 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AccessType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessType>::new(
+                ".google.cloud.backupdr.v1.AccessConfig.AccessType",
+            ))
         }
     }
 
     /// Network tier property used by addresses, instances and forwarding rules.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkTier(i32);
-
-    impl NetworkTier {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NetworkTier {
         /// Default value. This value is unused.
-        pub const NETWORK_TIER_UNSPECIFIED: NetworkTier = NetworkTier::new(0);
-
+        Unspecified,
         /// High quality, Google-grade network tier, support for all networking
         /// products.
-        pub const PREMIUM: NetworkTier = NetworkTier::new(1);
-
+        Premium,
         /// Public internet quality, only limited support for other networking
         /// products.
-        pub const STANDARD: NetworkTier = NetworkTier::new(2);
+        Standard,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NetworkTier::value] or
+        /// [NetworkTier::name].
+        UnknownValue(network_tier::UnknownValue),
+    }
 
-        /// Creates a new NetworkTier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod network_tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NetworkTier {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Premium => std::option::Option::Some(1),
+                Self::Standard => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NETWORK_TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PREMIUM"),
-                2 => std::borrow::Cow::Borrowed("STANDARD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NETWORK_TIER_UNSPECIFIED"),
+                Self::Premium => std::option::Option::Some("PREMIUM"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NETWORK_TIER_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NETWORK_TIER_UNSPECIFIED)
-                }
-                "PREMIUM" => std::option::Option::Some(Self::PREMIUM),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NetworkTier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkTier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NetworkTier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NetworkTier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Premium,
+                2 => Self::Standard,
+                _ => Self::UnknownValue(network_tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NetworkTier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NETWORK_TIER_UNSPECIFIED" => Self::Unspecified,
+                "PREMIUM" => Self::Premium,
+                "STANDARD" => Self::Standard,
+                _ => Self::UnknownValue(network_tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NetworkTier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Premium => serializer.serialize_i32(1),
+                Self::Standard => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NetworkTier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NetworkTier>::new(
+                ".google.cloud.backupdr.v1.AccessConfig.NetworkTier",
+            ))
         }
     }
 }
@@ -9401,65 +10705,128 @@ pub mod allocation_affinity {
     use super::*;
 
     /// Indicates whether to consume from a reservation or not.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Default value. This value is unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Do not consume from any allocated capacity.
-        pub const NO_RESERVATION: Type = Type::new(1);
-
+        NoReservation,
         /// Consume any allocation available.
-        pub const ANY_RESERVATION: Type = Type::new(2);
-
+        AnyReservation,
         /// Must consume from a specific reservation. Must specify key value fields
         /// for specifying the reservations.
-        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+        SpecificReservation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoReservation => std::option::Option::Some(1),
+                Self::AnyReservation => std::option::Option::Some(2),
+                Self::SpecificReservation => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
-                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::NoReservation => std::option::Option::Some("NO_RESERVATION"),
+                Self::AnyReservation => std::option::Option::Some("ANY_RESERVATION"),
+                Self::SpecificReservation => std::option::Option::Some("SPECIFIC_RESERVATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
-                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
-                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoReservation,
+                2 => Self::AnyReservation,
+                3 => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NO_RESERVATION" => Self::NoReservation,
+                "ANY_RESERVATION" => Self::AnyReservation,
+                "SPECIFIC_RESERVATION" => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoReservation => serializer.serialize_i32(1),
+                Self::AnyReservation => serializer.serialize_i32(2),
+                Self::SpecificReservation => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.backupdr.v1.AllocationAffinity.Type",
+            ))
         }
     }
 }
@@ -9688,240 +11055,484 @@ pub mod scheduling {
         use super::*;
 
         /// Defines the type of node selections.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
+            /// Default value. This value is unused.
+            Unspecified,
+            /// Requires Compute Engine to seek for matched nodes.
+            In,
+            /// Requires Compute Engine to avoid certain nodes.
+            NotIn,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Operator {
-            /// Default value. This value is unused.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
-            /// Requires Compute Engine to seek for matched nodes.
-            pub const IN: Operator = Operator::new(1);
-
-            /// Requires Compute Engine to avoid certain nodes.
-            pub const NOT_IN: Operator = Operator::new(2);
-
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::In => std::option::Option::Some(1),
+                    Self::NotIn => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IN"),
-                    2 => std::borrow::Cow::Borrowed("NOT_IN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::In => std::option::Option::Some("IN"),
+                    Self::NotIn => std::option::Option::Some("NOT_IN"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "IN" => std::option::Option::Some(Self::IN),
-                    "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::In,
+                    2 => Self::NotIn,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "IN" => Self::In,
+                    "NOT_IN" => Self::NotIn,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::In => serializer.serialize_i32(1),
+                    Self::NotIn => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.cloud.backupdr.v1.Scheduling.NodeAffinity.Operator",
+                ))
             }
         }
     }
 
     /// Defines the maintenance behavior for this instance=
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OnHostMaintenance(i32);
-
-    impl OnHostMaintenance {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OnHostMaintenance {
         /// Default value. This value is unused.
-        pub const ON_HOST_MAINTENANCE_UNSPECIFIED: OnHostMaintenance = OnHostMaintenance::new(0);
-
+        Unspecified,
         /// Tells Compute Engine to terminate and (optionally) restart the instance
         /// away from the maintenance activity.
-        pub const TERMINATE: OnHostMaintenance = OnHostMaintenance::new(1);
-
+        Terminate,
         /// Default, Allows Compute Engine to automatically migrate instances
         /// out of the way of maintenance events.
-        pub const MIGRATE: OnHostMaintenance = OnHostMaintenance::new(1000);
+        Migrate,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OnHostMaintenance::value] or
+        /// [OnHostMaintenance::name].
+        UnknownValue(on_host_maintenance::UnknownValue),
+    }
 
-        /// Creates a new OnHostMaintenance instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod on_host_maintenance {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OnHostMaintenance {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Terminate => std::option::Option::Some(1),
+                Self::Migrate => std::option::Option::Some(1000),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ON_HOST_MAINTENANCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TERMINATE"),
-                1000 => std::borrow::Cow::Borrowed("MIGRATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ON_HOST_MAINTENANCE_UNSPECIFIED"),
+                Self::Terminate => std::option::Option::Some("TERMINATE"),
+                Self::Migrate => std::option::Option::Some("MIGRATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ON_HOST_MAINTENANCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ON_HOST_MAINTENANCE_UNSPECIFIED)
-                }
-                "TERMINATE" => std::option::Option::Some(Self::TERMINATE),
-                "MIGRATE" => std::option::Option::Some(Self::MIGRATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OnHostMaintenance {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OnHostMaintenance {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OnHostMaintenance {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OnHostMaintenance {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Terminate,
+                1000 => Self::Migrate,
+                _ => Self::UnknownValue(on_host_maintenance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OnHostMaintenance {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ON_HOST_MAINTENANCE_UNSPECIFIED" => Self::Unspecified,
+                "TERMINATE" => Self::Terminate,
+                "MIGRATE" => Self::Migrate,
+                _ => Self::UnknownValue(on_host_maintenance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OnHostMaintenance {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Terminate => serializer.serialize_i32(1),
+                Self::Migrate => serializer.serialize_i32(1000),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OnHostMaintenance {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OnHostMaintenance>::new(
+                ".google.cloud.backupdr.v1.Scheduling.OnHostMaintenance",
+            ))
         }
     }
 
     /// Defines the provisioning model for an instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProvisioningModel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProvisioningModel {
+        /// Default value. This value is not used.
+        Unspecified,
+        /// Standard provisioning with user controlled runtime, no discounts.
+        Standard,
+        /// Heavily discounted, no guaranteed runtime.
+        Spot,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProvisioningModel::value] or
+        /// [ProvisioningModel::name].
+        UnknownValue(provisioning_model::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod provisioning_model {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ProvisioningModel {
-        /// Default value. This value is not used.
-        pub const PROVISIONING_MODEL_UNSPECIFIED: ProvisioningModel = ProvisioningModel::new(0);
-
-        /// Standard provisioning with user controlled runtime, no discounts.
-        pub const STANDARD: ProvisioningModel = ProvisioningModel::new(1);
-
-        /// Heavily discounted, no guaranteed runtime.
-        pub const SPOT: ProvisioningModel = ProvisioningModel::new(2);
-
-        /// Creates a new ProvisioningModel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Spot => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROVISIONING_MODEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("SPOT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROVISIONING_MODEL_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Spot => std::option::Option::Some("SPOT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROVISIONING_MODEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROVISIONING_MODEL_UNSPECIFIED)
-                }
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "SPOT" => std::option::Option::Some(Self::SPOT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ProvisioningModel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProvisioningModel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProvisioningModel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProvisioningModel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Spot,
+                _ => Self::UnknownValue(provisioning_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProvisioningModel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROVISIONING_MODEL_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "SPOT" => Self::Spot,
+                _ => Self::UnknownValue(provisioning_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProvisioningModel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Spot => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProvisioningModel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProvisioningModel>::new(
+                ".google.cloud.backupdr.v1.Scheduling.ProvisioningModel",
+            ))
         }
     }
 
     /// Defines the supported termination actions for an instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceTerminationAction(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstanceTerminationAction {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// Delete the VM.
+        Delete,
+        /// Stop the VM without storing in-memory content. default action.
+        Stop,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstanceTerminationAction::value] or
+        /// [InstanceTerminationAction::name].
+        UnknownValue(instance_termination_action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod instance_termination_action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl InstanceTerminationAction {
-        /// Default value. This value is unused.
-        pub const INSTANCE_TERMINATION_ACTION_UNSPECIFIED: InstanceTerminationAction =
-            InstanceTerminationAction::new(0);
-
-        /// Delete the VM.
-        pub const DELETE: InstanceTerminationAction = InstanceTerminationAction::new(1);
-
-        /// Stop the VM without storing in-memory content. default action.
-        pub const STOP: InstanceTerminationAction = InstanceTerminationAction::new(2);
-
-        /// Creates a new InstanceTerminationAction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Delete => std::option::Option::Some(1),
+                Self::Stop => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_TERMINATION_ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DELETE"),
-                2 => std::borrow::Cow::Borrowed("STOP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_TERMINATION_ACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_TERMINATION_ACTION_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("INSTANCE_TERMINATION_ACTION_UNSPECIFIED")
                 }
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "STOP" => std::option::Option::Some(Self::STOP),
-                _ => std::option::Option::None,
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Stop => std::option::Option::Some("STOP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for InstanceTerminationAction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceTerminationAction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstanceTerminationAction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstanceTerminationAction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Delete,
+                2 => Self::Stop,
+                _ => Self::UnknownValue(instance_termination_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstanceTerminationAction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_TERMINATION_ACTION_UNSPECIFIED" => Self::Unspecified,
+                "DELETE" => Self::Delete,
+                "STOP" => Self::Stop,
+                _ => Self::UnknownValue(instance_termination_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstanceTerminationAction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Delete => serializer.serialize_i32(1),
+                Self::Stop => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstanceTerminationAction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<InstanceTerminationAction>::new(
+                    ".google.cloud.backupdr.v1.Scheduling.InstanceTerminationAction",
+                ),
+            )
         }
     }
 }
@@ -10386,249 +11997,493 @@ pub mod attached_disk {
     }
 
     /// List of the Disk Types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiskType {
+        /// Default value, which is unused.
+        Unspecified,
+        /// A scratch disk type.
+        Scratch,
+        /// A persistent disk type.
+        Persistent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiskType::value] or
+        /// [DiskType::name].
+        UnknownValue(disk_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod disk_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiskType {
-        /// Default value, which is unused.
-        pub const DISK_TYPE_UNSPECIFIED: DiskType = DiskType::new(0);
-
-        /// A scratch disk type.
-        pub const SCRATCH: DiskType = DiskType::new(1);
-
-        /// A persistent disk type.
-        pub const PERSISTENT: DiskType = DiskType::new(2);
-
-        /// Creates a new DiskType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Scratch => std::option::Option::Some(1),
+                Self::Persistent => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCRATCH"),
-                2 => std::borrow::Cow::Borrowed("PERSISTENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISK_TYPE_UNSPECIFIED"),
+                Self::Scratch => std::option::Option::Some("SCRATCH"),
+                Self::Persistent => std::option::Option::Some("PERSISTENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_TYPE_UNSPECIFIED),
-                "SCRATCH" => std::option::Option::Some(Self::SCRATCH),
-                "PERSISTENT" => std::option::Option::Some(Self::PERSISTENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiskType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiskType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiskType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Scratch,
+                2 => Self::Persistent,
+                _ => Self::UnknownValue(disk_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiskType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCRATCH" => Self::Scratch,
+                "PERSISTENT" => Self::Persistent,
+                _ => Self::UnknownValue(disk_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiskType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Scratch => serializer.serialize_i32(1),
+                Self::Persistent => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiskType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskType>::new(
+                ".google.cloud.backupdr.v1.AttachedDisk.DiskType",
+            ))
         }
     }
 
     /// List of the Disk Modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskMode(i32);
-
-    impl DiskMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiskMode {
         /// Default value, which is unused.
-        pub const DISK_MODE_UNSPECIFIED: DiskMode = DiskMode::new(0);
-
+        Unspecified,
         /// Attaches this disk in read-write mode. Only one
         /// virtual machine at a time can be attached to a disk in read-write mode.
-        pub const READ_WRITE: DiskMode = DiskMode::new(1);
-
+        ReadWrite,
         /// Attaches this disk in read-only mode. Multiple virtual machines can use
         /// a disk in read-only mode at a time.
-        pub const READ_ONLY: DiskMode = DiskMode::new(2);
-
+        ReadOnly,
         /// The disk is locked for administrative reasons. Nobody else
         /// can use the disk. This mode is used (for example) when taking
         /// a snapshot of a disk to prevent mounting the disk while it is
         /// being snapshotted.
-        pub const LOCKED: DiskMode = DiskMode::new(3);
+        Locked,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiskMode::value] or
+        /// [DiskMode::name].
+        UnknownValue(disk_mode::UnknownValue),
+    }
 
-        /// Creates a new DiskMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod disk_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DiskMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReadWrite => std::option::Option::Some(1),
+                Self::ReadOnly => std::option::Option::Some(2),
+                Self::Locked => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISK_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                2 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                3 => std::borrow::Cow::Borrowed("LOCKED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISK_MODE_UNSPECIFIED"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                Self::Locked => std::option::Option::Some("LOCKED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISK_MODE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_MODE_UNSPECIFIED),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                "LOCKED" => std::option::Option::Some(Self::LOCKED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiskMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiskMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiskMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReadWrite,
+                2 => Self::ReadOnly,
+                3 => Self::Locked,
+                _ => Self::UnknownValue(disk_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiskMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISK_MODE_UNSPECIFIED" => Self::Unspecified,
+                "READ_WRITE" => Self::ReadWrite,
+                "READ_ONLY" => Self::ReadOnly,
+                "LOCKED" => Self::Locked,
+                _ => Self::UnknownValue(disk_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiskMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReadWrite => serializer.serialize_i32(1),
+                Self::ReadOnly => serializer.serialize_i32(2),
+                Self::Locked => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiskMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskMode>::new(
+                ".google.cloud.backupdr.v1.AttachedDisk.DiskMode",
+            ))
         }
     }
 
     /// List of the Disk Interfaces.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskInterface(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiskInterface {
+        /// Default value, which is unused.
+        Unspecified,
+        /// SCSI Disk Interface.
+        Scsi,
+        /// NVME Disk Interface.
+        Nvme,
+        /// NVDIMM Disk Interface.
+        Nvdimm,
+        /// ISCSI Disk Interface.
+        Iscsi,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiskInterface::value] or
+        /// [DiskInterface::name].
+        UnknownValue(disk_interface::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod disk_interface {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiskInterface {
-        /// Default value, which is unused.
-        pub const DISK_INTERFACE_UNSPECIFIED: DiskInterface = DiskInterface::new(0);
-
-        /// SCSI Disk Interface.
-        pub const SCSI: DiskInterface = DiskInterface::new(1);
-
-        /// NVME Disk Interface.
-        pub const NVME: DiskInterface = DiskInterface::new(2);
-
-        /// NVDIMM Disk Interface.
-        pub const NVDIMM: DiskInterface = DiskInterface::new(3);
-
-        /// ISCSI Disk Interface.
-        pub const ISCSI: DiskInterface = DiskInterface::new(4);
-
-        /// Creates a new DiskInterface instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Scsi => std::option::Option::Some(1),
+                Self::Nvme => std::option::Option::Some(2),
+                Self::Nvdimm => std::option::Option::Some(3),
+                Self::Iscsi => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISK_INTERFACE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCSI"),
-                2 => std::borrow::Cow::Borrowed("NVME"),
-                3 => std::borrow::Cow::Borrowed("NVDIMM"),
-                4 => std::borrow::Cow::Borrowed("ISCSI"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISK_INTERFACE_UNSPECIFIED"),
+                Self::Scsi => std::option::Option::Some("SCSI"),
+                Self::Nvme => std::option::Option::Some("NVME"),
+                Self::Nvdimm => std::option::Option::Some("NVDIMM"),
+                Self::Iscsi => std::option::Option::Some("ISCSI"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISK_INTERFACE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISK_INTERFACE_UNSPECIFIED)
-                }
-                "SCSI" => std::option::Option::Some(Self::SCSI),
-                "NVME" => std::option::Option::Some(Self::NVME),
-                "NVDIMM" => std::option::Option::Some(Self::NVDIMM),
-                "ISCSI" => std::option::Option::Some(Self::ISCSI),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiskInterface {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskInterface {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiskInterface {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiskInterface {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Scsi,
+                2 => Self::Nvme,
+                3 => Self::Nvdimm,
+                4 => Self::Iscsi,
+                _ => Self::UnknownValue(disk_interface::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiskInterface {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISK_INTERFACE_UNSPECIFIED" => Self::Unspecified,
+                "SCSI" => Self::Scsi,
+                "NVME" => Self::Nvme,
+                "NVDIMM" => Self::Nvdimm,
+                "ISCSI" => Self::Iscsi,
+                _ => Self::UnknownValue(disk_interface::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiskInterface {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Scsi => serializer.serialize_i32(1),
+                Self::Nvme => serializer.serialize_i32(2),
+                Self::Nvdimm => serializer.serialize_i32(3),
+                Self::Iscsi => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiskInterface {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskInterface>::new(
+                ".google.cloud.backupdr.v1.AttachedDisk.DiskInterface",
+            ))
         }
     }
 
     /// List of the states of the Disk.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskSavedState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiskSavedState {
+        /// Default Disk state has not been preserved.
+        Unspecified,
+        /// Disk state has been preserved.
+        Preserved,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiskSavedState::value] or
+        /// [DiskSavedState::name].
+        UnknownValue(disk_saved_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod disk_saved_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiskSavedState {
-        /// Default Disk state has not been preserved.
-        pub const DISK_SAVED_STATE_UNSPECIFIED: DiskSavedState = DiskSavedState::new(0);
-
-        /// Disk state has been preserved.
-        pub const PRESERVED: DiskSavedState = DiskSavedState::new(1);
-
-        /// Creates a new DiskSavedState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Preserved => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISK_SAVED_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRESERVED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISK_SAVED_STATE_UNSPECIFIED"),
+                Self::Preserved => std::option::Option::Some("PRESERVED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISK_SAVED_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISK_SAVED_STATE_UNSPECIFIED)
-                }
-                "PRESERVED" => std::option::Option::Some(Self::PRESERVED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiskSavedState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskSavedState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiskSavedState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiskSavedState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Preserved,
+                _ => Self::UnknownValue(disk_saved_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiskSavedState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISK_SAVED_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PRESERVED" => Self::Preserved,
+                _ => Self::UnknownValue(disk_saved_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiskSavedState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Preserved => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiskSavedState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskSavedState>::new(
+                ".google.cloud.backupdr.v1.AttachedDisk.DiskSavedState",
+            ))
         }
     }
 }
@@ -10677,366 +12532,688 @@ pub mod guest_os_feature {
     use super::*;
 
     /// List of the Feature Types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FeatureType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FeatureType {
+        /// Default value, which is unused.
+        Unspecified,
+        /// VIRTIO_SCSI_MULTIQUEUE feature type.
+        VirtioScsiMultiqueue,
+        /// WINDOWS feature type.
+        Windows,
+        /// MULTI_IP_SUBNET feature type.
+        MultiIpSubnet,
+        /// UEFI_COMPATIBLE feature type.
+        UefiCompatible,
+        /// SECURE_BOOT feature type.
+        SecureBoot,
+        /// GVNIC feature type.
+        Gvnic,
+        /// SEV_CAPABLE feature type.
+        SevCapable,
+        /// BARE_METAL_LINUX_COMPATIBLE feature type.
+        BareMetalLinuxCompatible,
+        /// SUSPEND_RESUME_COMPATIBLE feature type.
+        SuspendResumeCompatible,
+        /// SEV_LIVE_MIGRATABLE feature type.
+        SevLiveMigratable,
+        /// SEV_SNP_CAPABLE feature type.
+        SevSnpCapable,
+        /// TDX_CAPABLE feature type.
+        TdxCapable,
+        /// IDPF feature type.
+        Idpf,
+        /// SEV_LIVE_MIGRATABLE_V2 feature type.
+        SevLiveMigratableV2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FeatureType::value] or
+        /// [FeatureType::name].
+        UnknownValue(feature_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod feature_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FeatureType {
-        /// Default value, which is unused.
-        pub const FEATURE_TYPE_UNSPECIFIED: FeatureType = FeatureType::new(0);
-
-        /// VIRTIO_SCSI_MULTIQUEUE feature type.
-        pub const VIRTIO_SCSI_MULTIQUEUE: FeatureType = FeatureType::new(1);
-
-        /// WINDOWS feature type.
-        pub const WINDOWS: FeatureType = FeatureType::new(2);
-
-        /// MULTI_IP_SUBNET feature type.
-        pub const MULTI_IP_SUBNET: FeatureType = FeatureType::new(3);
-
-        /// UEFI_COMPATIBLE feature type.
-        pub const UEFI_COMPATIBLE: FeatureType = FeatureType::new(4);
-
-        /// SECURE_BOOT feature type.
-        pub const SECURE_BOOT: FeatureType = FeatureType::new(5);
-
-        /// GVNIC feature type.
-        pub const GVNIC: FeatureType = FeatureType::new(6);
-
-        /// SEV_CAPABLE feature type.
-        pub const SEV_CAPABLE: FeatureType = FeatureType::new(7);
-
-        /// BARE_METAL_LINUX_COMPATIBLE feature type.
-        pub const BARE_METAL_LINUX_COMPATIBLE: FeatureType = FeatureType::new(8);
-
-        /// SUSPEND_RESUME_COMPATIBLE feature type.
-        pub const SUSPEND_RESUME_COMPATIBLE: FeatureType = FeatureType::new(9);
-
-        /// SEV_LIVE_MIGRATABLE feature type.
-        pub const SEV_LIVE_MIGRATABLE: FeatureType = FeatureType::new(10);
-
-        /// SEV_SNP_CAPABLE feature type.
-        pub const SEV_SNP_CAPABLE: FeatureType = FeatureType::new(11);
-
-        /// TDX_CAPABLE feature type.
-        pub const TDX_CAPABLE: FeatureType = FeatureType::new(12);
-
-        /// IDPF feature type.
-        pub const IDPF: FeatureType = FeatureType::new(13);
-
-        /// SEV_LIVE_MIGRATABLE_V2 feature type.
-        pub const SEV_LIVE_MIGRATABLE_V2: FeatureType = FeatureType::new(14);
-
-        /// Creates a new FeatureType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VirtioScsiMultiqueue => std::option::Option::Some(1),
+                Self::Windows => std::option::Option::Some(2),
+                Self::MultiIpSubnet => std::option::Option::Some(3),
+                Self::UefiCompatible => std::option::Option::Some(4),
+                Self::SecureBoot => std::option::Option::Some(5),
+                Self::Gvnic => std::option::Option::Some(6),
+                Self::SevCapable => std::option::Option::Some(7),
+                Self::BareMetalLinuxCompatible => std::option::Option::Some(8),
+                Self::SuspendResumeCompatible => std::option::Option::Some(9),
+                Self::SevLiveMigratable => std::option::Option::Some(10),
+                Self::SevSnpCapable => std::option::Option::Some(11),
+                Self::TdxCapable => std::option::Option::Some(12),
+                Self::Idpf => std::option::Option::Some(13),
+                Self::SevLiveMigratableV2 => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FEATURE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VIRTIO_SCSI_MULTIQUEUE"),
-                2 => std::borrow::Cow::Borrowed("WINDOWS"),
-                3 => std::borrow::Cow::Borrowed("MULTI_IP_SUBNET"),
-                4 => std::borrow::Cow::Borrowed("UEFI_COMPATIBLE"),
-                5 => std::borrow::Cow::Borrowed("SECURE_BOOT"),
-                6 => std::borrow::Cow::Borrowed("GVNIC"),
-                7 => std::borrow::Cow::Borrowed("SEV_CAPABLE"),
-                8 => std::borrow::Cow::Borrowed("BARE_METAL_LINUX_COMPATIBLE"),
-                9 => std::borrow::Cow::Borrowed("SUSPEND_RESUME_COMPATIBLE"),
-                10 => std::borrow::Cow::Borrowed("SEV_LIVE_MIGRATABLE"),
-                11 => std::borrow::Cow::Borrowed("SEV_SNP_CAPABLE"),
-                12 => std::borrow::Cow::Borrowed("TDX_CAPABLE"),
-                13 => std::borrow::Cow::Borrowed("IDPF"),
-                14 => std::borrow::Cow::Borrowed("SEV_LIVE_MIGRATABLE_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FEATURE_TYPE_UNSPECIFIED"),
+                Self::VirtioScsiMultiqueue => std::option::Option::Some("VIRTIO_SCSI_MULTIQUEUE"),
+                Self::Windows => std::option::Option::Some("WINDOWS"),
+                Self::MultiIpSubnet => std::option::Option::Some("MULTI_IP_SUBNET"),
+                Self::UefiCompatible => std::option::Option::Some("UEFI_COMPATIBLE"),
+                Self::SecureBoot => std::option::Option::Some("SECURE_BOOT"),
+                Self::Gvnic => std::option::Option::Some("GVNIC"),
+                Self::SevCapable => std::option::Option::Some("SEV_CAPABLE"),
+                Self::BareMetalLinuxCompatible => {
+                    std::option::Option::Some("BARE_METAL_LINUX_COMPATIBLE")
+                }
+                Self::SuspendResumeCompatible => {
+                    std::option::Option::Some("SUSPEND_RESUME_COMPATIBLE")
+                }
+                Self::SevLiveMigratable => std::option::Option::Some("SEV_LIVE_MIGRATABLE"),
+                Self::SevSnpCapable => std::option::Option::Some("SEV_SNP_CAPABLE"),
+                Self::TdxCapable => std::option::Option::Some("TDX_CAPABLE"),
+                Self::Idpf => std::option::Option::Some("IDPF"),
+                Self::SevLiveMigratableV2 => std::option::Option::Some("SEV_LIVE_MIGRATABLE_V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FEATURE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FEATURE_TYPE_UNSPECIFIED)
-                }
-                "VIRTIO_SCSI_MULTIQUEUE" => std::option::Option::Some(Self::VIRTIO_SCSI_MULTIQUEUE),
-                "WINDOWS" => std::option::Option::Some(Self::WINDOWS),
-                "MULTI_IP_SUBNET" => std::option::Option::Some(Self::MULTI_IP_SUBNET),
-                "UEFI_COMPATIBLE" => std::option::Option::Some(Self::UEFI_COMPATIBLE),
-                "SECURE_BOOT" => std::option::Option::Some(Self::SECURE_BOOT),
-                "GVNIC" => std::option::Option::Some(Self::GVNIC),
-                "SEV_CAPABLE" => std::option::Option::Some(Self::SEV_CAPABLE),
-                "BARE_METAL_LINUX_COMPATIBLE" => {
-                    std::option::Option::Some(Self::BARE_METAL_LINUX_COMPATIBLE)
-                }
-                "SUSPEND_RESUME_COMPATIBLE" => {
-                    std::option::Option::Some(Self::SUSPEND_RESUME_COMPATIBLE)
-                }
-                "SEV_LIVE_MIGRATABLE" => std::option::Option::Some(Self::SEV_LIVE_MIGRATABLE),
-                "SEV_SNP_CAPABLE" => std::option::Option::Some(Self::SEV_SNP_CAPABLE),
-                "TDX_CAPABLE" => std::option::Option::Some(Self::TDX_CAPABLE),
-                "IDPF" => std::option::Option::Some(Self::IDPF),
-                "SEV_LIVE_MIGRATABLE_V2" => std::option::Option::Some(Self::SEV_LIVE_MIGRATABLE_V2),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FeatureType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FeatureType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FeatureType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FeatureType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VirtioScsiMultiqueue,
+                2 => Self::Windows,
+                3 => Self::MultiIpSubnet,
+                4 => Self::UefiCompatible,
+                5 => Self::SecureBoot,
+                6 => Self::Gvnic,
+                7 => Self::SevCapable,
+                8 => Self::BareMetalLinuxCompatible,
+                9 => Self::SuspendResumeCompatible,
+                10 => Self::SevLiveMigratable,
+                11 => Self::SevSnpCapable,
+                12 => Self::TdxCapable,
+                13 => Self::Idpf,
+                14 => Self::SevLiveMigratableV2,
+                _ => Self::UnknownValue(feature_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FeatureType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FEATURE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "VIRTIO_SCSI_MULTIQUEUE" => Self::VirtioScsiMultiqueue,
+                "WINDOWS" => Self::Windows,
+                "MULTI_IP_SUBNET" => Self::MultiIpSubnet,
+                "UEFI_COMPATIBLE" => Self::UefiCompatible,
+                "SECURE_BOOT" => Self::SecureBoot,
+                "GVNIC" => Self::Gvnic,
+                "SEV_CAPABLE" => Self::SevCapable,
+                "BARE_METAL_LINUX_COMPATIBLE" => Self::BareMetalLinuxCompatible,
+                "SUSPEND_RESUME_COMPATIBLE" => Self::SuspendResumeCompatible,
+                "SEV_LIVE_MIGRATABLE" => Self::SevLiveMigratable,
+                "SEV_SNP_CAPABLE" => Self::SevSnpCapable,
+                "TDX_CAPABLE" => Self::TdxCapable,
+                "IDPF" => Self::Idpf,
+                "SEV_LIVE_MIGRATABLE_V2" => Self::SevLiveMigratableV2,
+                _ => Self::UnknownValue(feature_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FeatureType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VirtioScsiMultiqueue => serializer.serialize_i32(1),
+                Self::Windows => serializer.serialize_i32(2),
+                Self::MultiIpSubnet => serializer.serialize_i32(3),
+                Self::UefiCompatible => serializer.serialize_i32(4),
+                Self::SecureBoot => serializer.serialize_i32(5),
+                Self::Gvnic => serializer.serialize_i32(6),
+                Self::SevCapable => serializer.serialize_i32(7),
+                Self::BareMetalLinuxCompatible => serializer.serialize_i32(8),
+                Self::SuspendResumeCompatible => serializer.serialize_i32(9),
+                Self::SevLiveMigratable => serializer.serialize_i32(10),
+                Self::SevSnpCapable => serializer.serialize_i32(11),
+                Self::TdxCapable => serializer.serialize_i32(12),
+                Self::Idpf => serializer.serialize_i32(13),
+                Self::SevLiveMigratableV2 => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FeatureType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FeatureType>::new(
+                ".google.cloud.backupdr.v1.GuestOsFeature.FeatureType",
+            ))
         }
     }
 }
 
 /// Backup configuration state. Is the resource configured for backup?
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackupConfigState(i32);
-
-impl BackupConfigState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BackupConfigState {
     /// The possible states of backup configuration.
     /// Status not set.
-    pub const BACKUP_CONFIG_STATE_UNSPECIFIED: BackupConfigState = BackupConfigState::new(0);
-
+    Unspecified,
     /// The data source is actively protected (i.e. there is a
     /// BackupPlanAssociation or Appliance SLA pointing to it)
-    pub const ACTIVE: BackupConfigState = BackupConfigState::new(1);
-
+    Active,
     /// The data source is no longer protected (but may have backups under it)
-    pub const PASSIVE: BackupConfigState = BackupConfigState::new(2);
+    Passive,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BackupConfigState::value] or
+    /// [BackupConfigState::name].
+    UnknownValue(backup_config_state::UnknownValue),
+}
 
-    /// Creates a new BackupConfigState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod backup_config_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BackupConfigState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Active => std::option::Option::Some(1),
+            Self::Passive => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BACKUP_CONFIG_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVE"),
-            2 => std::borrow::Cow::Borrowed("PASSIVE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BACKUP_CONFIG_STATE_UNSPECIFIED"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::Passive => std::option::Option::Some("PASSIVE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BACKUP_CONFIG_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::BACKUP_CONFIG_STATE_UNSPECIFIED)
-            }
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "PASSIVE" => std::option::Option::Some(Self::PASSIVE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BackupConfigState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BackupConfigState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BackupConfigState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BackupConfigState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Active,
+            2 => Self::Passive,
+            _ => Self::UnknownValue(backup_config_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BackupConfigState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BACKUP_CONFIG_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVE" => Self::Active,
+            "PASSIVE" => Self::Passive,
+            _ => Self::UnknownValue(backup_config_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BackupConfigState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Active => serializer.serialize_i32(1),
+            Self::Passive => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BackupConfigState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupConfigState>::new(
+            ".google.cloud.backupdr.v1.BackupConfigState",
+        ))
     }
 }
 
 /// BackupView contains enum options for Partial and Full view.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackupView(i32);
-
-impl BackupView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BackupView {
     /// If the value is not set, the default 'FULL' view is used.
-    pub const BACKUP_VIEW_UNSPECIFIED: BackupView = BackupView::new(0);
-
+    Unspecified,
     /// Includes basic data about the Backup, but not the full contents.
-    pub const BACKUP_VIEW_BASIC: BackupView = BackupView::new(1);
-
+    Basic,
     /// Includes all data about the Backup.
     /// This is the default value (for both ListBackups and GetBackup).
-    pub const BACKUP_VIEW_FULL: BackupView = BackupView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BackupView::value] or
+    /// [BackupView::name].
+    UnknownValue(backup_view::UnknownValue),
+}
 
-    /// Creates a new BackupView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod backup_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BackupView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BACKUP_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BACKUP_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("BACKUP_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BACKUP_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BACKUP_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("BACKUP_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BACKUP_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::BACKUP_VIEW_UNSPECIFIED),
-            "BACKUP_VIEW_BASIC" => std::option::Option::Some(Self::BACKUP_VIEW_BASIC),
-            "BACKUP_VIEW_FULL" => std::option::Option::Some(Self::BACKUP_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BackupView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BackupView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BackupView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BackupView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(backup_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BackupView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BACKUP_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BACKUP_VIEW_BASIC" => Self::Basic,
+            "BACKUP_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(backup_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BackupView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BackupView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupView>::new(
+            ".google.cloud.backupdr.v1.BackupView",
+        ))
     }
 }
 
 /// BackupVaultView contains enum options for Partial and Full view.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackupVaultView(i32);
-
-impl BackupVaultView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BackupVaultView {
     /// If the value is not set, the default 'FULL' view is used.
-    pub const BACKUP_VAULT_VIEW_UNSPECIFIED: BackupVaultView = BackupVaultView::new(0);
-
+    Unspecified,
     /// Includes basic data about the Backup Vault, but not the full contents.
-    pub const BACKUP_VAULT_VIEW_BASIC: BackupVaultView = BackupVaultView::new(1);
-
+    Basic,
     /// Includes all data about the Backup Vault.
     /// This is the default value (for both ListBackupVaults and GetBackupVault).
-    pub const BACKUP_VAULT_VIEW_FULL: BackupVaultView = BackupVaultView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BackupVaultView::value] or
+    /// [BackupVaultView::name].
+    UnknownValue(backup_vault_view::UnknownValue),
+}
 
-    /// Creates a new BackupVaultView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod backup_vault_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BackupVaultView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BACKUP_VAULT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BACKUP_VAULT_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("BACKUP_VAULT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BACKUP_VAULT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BACKUP_VAULT_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("BACKUP_VAULT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BACKUP_VAULT_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::BACKUP_VAULT_VIEW_UNSPECIFIED)
-            }
-            "BACKUP_VAULT_VIEW_BASIC" => std::option::Option::Some(Self::BACKUP_VAULT_VIEW_BASIC),
-            "BACKUP_VAULT_VIEW_FULL" => std::option::Option::Some(Self::BACKUP_VAULT_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BackupVaultView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BackupVaultView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BackupVaultView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BackupVaultView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(backup_vault_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BackupVaultView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BACKUP_VAULT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BACKUP_VAULT_VIEW_BASIC" => Self::Basic,
+            "BACKUP_VAULT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(backup_vault_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BackupVaultView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BackupVaultView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupVaultView>::new(
+            ".google.cloud.backupdr.v1.BackupVaultView",
+        ))
     }
 }
 
 /// Specifies whether the virtual machine instance will be shut down on key
 /// revocation. It is currently used in instance, instance properties and GMI
 /// protos
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct KeyRevocationActionType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum KeyRevocationActionType {
+    /// Default value. This value is unused.
+    Unspecified,
+    /// Indicates user chose no operation.
+    None,
+    /// Indicates user chose to opt for VM shutdown on key revocation.
+    Stop,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [KeyRevocationActionType::value] or
+    /// [KeyRevocationActionType::name].
+    UnknownValue(key_revocation_action_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod key_revocation_action_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl KeyRevocationActionType {
-    /// Default value. This value is unused.
-    pub const KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED: KeyRevocationActionType =
-        KeyRevocationActionType::new(0);
-
-    /// Indicates user chose no operation.
-    pub const NONE: KeyRevocationActionType = KeyRevocationActionType::new(1);
-
-    /// Indicates user chose to opt for VM shutdown on key revocation.
-    pub const STOP: KeyRevocationActionType = KeyRevocationActionType::new(2);
-
-    /// Creates a new KeyRevocationActionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::None => std::option::Option::Some(1),
+            Self::Stop => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NONE"),
-            2 => std::borrow::Cow::Borrowed("STOP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED")
             }
-            "NONE" => std::option::Option::Some(Self::NONE),
-            "STOP" => std::option::Option::Some(Self::STOP),
-            _ => std::option::Option::None,
+            Self::None => std::option::Option::Some("NONE"),
+            Self::Stop => std::option::Option::Some("STOP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for KeyRevocationActionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for KeyRevocationActionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for KeyRevocationActionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for KeyRevocationActionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::None,
+            2 => Self::Stop,
+            _ => Self::UnknownValue(key_revocation_action_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for KeyRevocationActionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "KEY_REVOCATION_ACTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "NONE" => Self::None,
+            "STOP" => Self::Stop,
+            _ => Self::UnknownValue(key_revocation_action_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for KeyRevocationActionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::None => serializer.serialize_i32(1),
+            Self::Stop => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for KeyRevocationActionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<KeyRevocationActionType>::new(
+            ".google.cloud.backupdr.v1.KeyRevocationActionType",
+        ))
     }
 }

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -181,7 +181,7 @@ impl super::stub::BackupDR for BackupDR {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -227,7 +227,7 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -397,7 +397,7 @@ impl super::stub::BackupDR for BackupDR {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -417,7 +417,7 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -439,84 +439,155 @@ pub mod instance {
     use super::*;
 
     /// The possible states for this server.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The server is in an unknown state.
+        Unspecified,
+        /// The server is being provisioned.
+        Provisioning,
+        /// The server is running.
+        Running,
+        /// The server has been deleted.
+        Deleted,
+        /// The server is being updated.
+        Updating,
+        /// The server is starting.
+        Starting,
+        /// The server is stopping.
+        Stopping,
+        /// The server is shutdown.
+        Shutdown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The server is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The server is being provisioned.
-        pub const PROVISIONING: State = State::new(1);
-
-        /// The server is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The server has been deleted.
-        pub const DELETED: State = State::new(3);
-
-        /// The server is being updated.
-        pub const UPDATING: State = State::new(4);
-
-        /// The server is starting.
-        pub const STARTING: State = State::new(5);
-
-        /// The server is stopping.
-        pub const STOPPING: State = State::new(6);
-
-        /// The server is shutdown.
-        pub const SHUTDOWN: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::Starting => std::option::Option::Some(5),
+                Self::Stopping => std::option::Option::Some(6),
+                Self::Shutdown => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DELETED"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("STARTING"),
-                6 => std::borrow::Cow::Borrowed("STOPPING"),
-                7 => std::borrow::Cow::Borrowed("SHUTDOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Shutdown => std::option::Option::Some("SHUTDOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "SHUTDOWN" => std::option::Option::Some(Self::SHUTDOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Deleted,
+                4 => Self::Updating,
+                5 => Self::Starting,
+                6 => Self::Stopping,
+                7 => Self::Shutdown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "DELETED" => Self::Deleted,
+                "UPDATING" => Self::Updating,
+                "STARTING" => Self::Starting,
+                "STOPPING" => Self::Stopping,
+                "SHUTDOWN" => Self::Shutdown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::Starting => serializer.serialize_i32(5),
+                Self::Stopping => serializer.serialize_i32(6),
+                Self::Shutdown => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.Instance.State",
+            ))
         }
     }
 }
@@ -1230,61 +1301,122 @@ pub mod server_network_template {
         use super::*;
 
         /// Interface type.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct InterfaceType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum InterfaceType {
+            /// Unspecified value.
+            Unspecified,
+            /// Bond interface type.
+            Bond,
+            /// NIC interface type.
+            Nic,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [InterfaceType::value] or
+            /// [InterfaceType::name].
+            UnknownValue(interface_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod interface_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl InterfaceType {
-            /// Unspecified value.
-            pub const INTERFACE_TYPE_UNSPECIFIED: InterfaceType = InterfaceType::new(0);
-
-            /// Bond interface type.
-            pub const BOND: InterfaceType = InterfaceType::new(1);
-
-            /// NIC interface type.
-            pub const NIC: InterfaceType = InterfaceType::new(2);
-
-            /// Creates a new InterfaceType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Bond => std::option::Option::Some(1),
+                    Self::Nic => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("INTERFACE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("BOND"),
-                    2 => std::borrow::Cow::Borrowed("NIC"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("INTERFACE_TYPE_UNSPECIFIED"),
+                    Self::Bond => std::option::Option::Some("BOND"),
+                    Self::Nic => std::option::Option::Some("NIC"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "INTERFACE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::INTERFACE_TYPE_UNSPECIFIED)
-                    }
-                    "BOND" => std::option::Option::Some(Self::BOND),
-                    "NIC" => std::option::Option::Some(Self::NIC),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for InterfaceType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for InterfaceType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for InterfaceType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for InterfaceType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Bond,
+                    2 => Self::Nic,
+                    _ => Self::UnknownValue(interface_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for InterfaceType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "INTERFACE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "BOND" => Self::Bond,
+                    "NIC" => Self::Nic,
+                    _ => Self::UnknownValue(interface_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for InterfaceType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Bond => serializer.serialize_i32(1),
+                    Self::Nic => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for InterfaceType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterfaceType>::new(
+                    ".google.cloud.baremetalsolution.v2.ServerNetworkTemplate.LogicalInterface.InterfaceType"))
             }
         }
     }
@@ -1452,187 +1584,370 @@ pub mod lun {
     use super::*;
 
     /// The possible states for the LUN.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The LUN is in an unknown state.
+        Unspecified,
+        /// The LUN is being created.
+        Creating,
+        /// The LUN is being updated.
+        Updating,
+        /// The LUN is ready for use.
+        Ready,
+        /// The LUN has been requested to be deleted.
+        Deleting,
+        /// The LUN is in cool off state. It will be deleted after `expire_time`.
+        CoolOff,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The LUN is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The LUN is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The LUN is being updated.
-        pub const UPDATING: State = State::new(2);
-
-        /// The LUN is ready for use.
-        pub const READY: State = State::new(3);
-
-        /// The LUN has been requested to be deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// The LUN is in cool off state. It will be deleted after `expire_time`.
-        pub const COOL_OFF: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::Ready => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::CoolOff => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                3 => std::borrow::Cow::Borrowed("READY"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("COOL_OFF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::CoolOff => std::option::Option::Some("COOL_OFF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "COOL_OFF" => std::option::Option::Some(Self::COOL_OFF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Updating,
+                3 => Self::Ready,
+                4 => Self::Deleting,
+                5 => Self::CoolOff,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "COOL_OFF" => Self::CoolOff,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::Ready => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::CoolOff => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.Lun.State",
+            ))
         }
     }
 
     /// Display the operating systems present for the LUN multiprotocol type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MultiprotocolType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MultiprotocolType {
+        /// Server has no OS specified.
+        Unspecified,
+        /// Server with Linux OS.
+        Linux,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MultiprotocolType::value] or
+        /// [MultiprotocolType::name].
+        UnknownValue(multiprotocol_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod multiprotocol_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MultiprotocolType {
-        /// Server has no OS specified.
-        pub const MULTIPROTOCOL_TYPE_UNSPECIFIED: MultiprotocolType = MultiprotocolType::new(0);
-
-        /// Server with Linux OS.
-        pub const LINUX: MultiprotocolType = MultiprotocolType::new(1);
-
-        /// Creates a new MultiprotocolType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Linux => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MULTIPROTOCOL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LINUX"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MULTIPROTOCOL_TYPE_UNSPECIFIED"),
+                Self::Linux => std::option::Option::Some("LINUX"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MULTIPROTOCOL_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MULTIPROTOCOL_TYPE_UNSPECIFIED)
-                }
-                "LINUX" => std::option::Option::Some(Self::LINUX),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MultiprotocolType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MultiprotocolType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MultiprotocolType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MultiprotocolType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Linux,
+                _ => Self::UnknownValue(multiprotocol_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MultiprotocolType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MULTIPROTOCOL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LINUX" => Self::Linux,
+                _ => Self::UnknownValue(multiprotocol_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MultiprotocolType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Linux => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MultiprotocolType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MultiprotocolType>::new(
+                ".google.cloud.baremetalsolution.v2.Lun.MultiprotocolType",
+            ))
         }
     }
 
     /// The storage types for a LUN.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StorageType {
+        /// The storage type for this LUN is unknown.
+        Unspecified,
+        /// This storage type for this LUN is SSD.
+        Ssd,
+        /// This storage type for this LUN is HDD.
+        Hdd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StorageType::value] or
+        /// [StorageType::name].
+        UnknownValue(storage_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod storage_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StorageType {
-        /// The storage type for this LUN is unknown.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
-
-        /// This storage type for this LUN is SSD.
-        pub const SSD: StorageType = StorageType::new(1);
-
-        /// This storage type for this LUN is HDD.
-        pub const HDD: StorageType = StorageType::new(2);
-
-        /// Creates a new StorageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ssd => std::option::Option::Some(1),
+                Self::Hdd => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SSD"),
-                2 => std::borrow::Cow::Borrowed("HDD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STORAGE_TYPE_UNSPECIFIED"),
+                Self::Ssd => std::option::Option::Some("SSD"),
+                Self::Hdd => std::option::Option::Some("HDD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STORAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
-                }
-                "SSD" => std::option::Option::Some(Self::SSD),
-                "HDD" => std::option::Option::Some(Self::HDD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StorageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StorageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ssd,
+                2 => Self::Hdd,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StorageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STORAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SSD" => Self::Ssd,
+                "HDD" => Self::Hdd,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StorageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ssd => serializer.serialize_i32(1),
+                Self::Hdd => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StorageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageType>::new(
+                ".google.cloud.baremetalsolution.v2.Lun.StorageType",
+            ))
         }
     }
 }
@@ -2047,126 +2362,252 @@ pub mod network {
     use super::*;
 
     /// Network type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified value.
+        Unspecified,
+        /// Client network, a network peered to a Google Cloud VPC.
+        Client,
+        /// Private network, a network local to the Bare Metal Solution environment.
+        Private,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Client network, a network peered to a Google Cloud VPC.
-        pub const CLIENT: Type = Type::new(1);
-
-        /// Private network, a network local to the Bare Metal Solution environment.
-        pub const PRIVATE: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Client => std::option::Option::Some(1),
+                Self::Private => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLIENT"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Client => std::option::Option::Some("CLIENT"),
+                Self::Private => std::option::Option::Some("PRIVATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CLIENT" => std::option::Option::Some(Self::CLIENT),
-                "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Client,
+                2 => Self::Private,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CLIENT" => Self::Client,
+                "PRIVATE" => Self::Private,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Client => serializer.serialize_i32(1),
+                Self::Private => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.baremetalsolution.v2.Network.Type",
+            ))
         }
     }
 
     /// The possible states for this Network.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The Network is in an unknown state.
+        Unspecified,
+        /// The Network is provisioning.
+        Provisioning,
+        /// The Network has been provisioned.
+        Provisioned,
+        /// The Network is being deprovisioned.
+        Deprovisioning,
+        /// The Network is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The Network is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Network is provisioning.
-        pub const PROVISIONING: State = State::new(1);
-
-        /// The Network has been provisioned.
-        pub const PROVISIONED: State = State::new(2);
-
-        /// The Network is being deprovisioned.
-        pub const DEPROVISIONING: State = State::new(3);
-
-        /// The Network is being updated.
-        pub const UPDATING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Provisioned => std::option::Option::Some(2),
+                Self::Deprovisioning => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("PROVISIONED"),
-                3 => std::borrow::Cow::Borrowed("DEPROVISIONING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Provisioned => std::option::Option::Some("PROVISIONED"),
+                Self::Deprovisioning => std::option::Option::Some("DEPROVISIONING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
-                "DEPROVISIONING" => std::option::Option::Some(Self::DEPROVISIONING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Provisioned,
+                3 => Self::Deprovisioning,
+                4 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "PROVISIONED" => Self::Provisioned,
+                "DEPROVISIONING" => Self::Deprovisioning,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Provisioned => serializer.serialize_i32(2),
+                Self::Deprovisioning => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.Network.State",
+            ))
         }
     }
 }
@@ -2442,59 +2883,120 @@ pub mod vrf {
     }
 
     /// The possible states for this VRF.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The unspecified state.
+        Unspecified,
+        /// The vrf is provisioning.
+        Provisioning,
+        /// The vrf is provisioned.
+        Provisioned,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The vrf is provisioning.
-        pub const PROVISIONING: State = State::new(1);
-
-        /// The vrf is provisioned.
-        pub const PROVISIONED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Provisioned => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("PROVISIONED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Provisioned => std::option::Option::Some("PROVISIONED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Provisioned,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "PROVISIONED" => Self::Provisioned,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Provisioned => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.VRF.State",
+            ))
         }
     }
 }
@@ -3345,187 +3847,370 @@ pub mod nfs_share {
     }
 
     /// The possible states for this NFS share.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The share is in an unknown state.
+        Unspecified,
+        /// The share has been provisioned.
+        Provisioned,
+        /// The NFS Share is being created.
+        Creating,
+        /// The NFS Share is being updated.
+        Updating,
+        /// The NFS Share has been requested to be deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The share is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The share has been provisioned.
-        pub const PROVISIONED: State = State::new(1);
-
-        /// The NFS Share is being created.
-        pub const CREATING: State = State::new(2);
-
-        /// The NFS Share is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The NFS Share has been requested to be deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioned => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONED"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioned => std::option::Option::Some("PROVISIONED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioned,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONED" => Self::Provisioned,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioned => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.NfsShare.State",
+            ))
         }
     }
 
     /// The possible mount permissions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MountPermissions(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MountPermissions {
+        /// Permissions were not specified.
+        Unspecified,
+        /// NFS share can be mount with read-only permissions.
+        Read,
+        /// NFS share can be mount with read-write permissions.
+        ReadWrite,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MountPermissions::value] or
+        /// [MountPermissions::name].
+        UnknownValue(mount_permissions::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mount_permissions {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MountPermissions {
-        /// Permissions were not specified.
-        pub const MOUNT_PERMISSIONS_UNSPECIFIED: MountPermissions = MountPermissions::new(0);
-
-        /// NFS share can be mount with read-only permissions.
-        pub const READ: MountPermissions = MountPermissions::new(1);
-
-        /// NFS share can be mount with read-write permissions.
-        pub const READ_WRITE: MountPermissions = MountPermissions::new(2);
-
-        /// Creates a new MountPermissions instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Read => std::option::Option::Some(1),
+                Self::ReadWrite => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MOUNT_PERMISSIONS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ"),
-                2 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MOUNT_PERMISSIONS_UNSPECIFIED"),
+                Self::Read => std::option::Option::Some("READ"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MOUNT_PERMISSIONS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MOUNT_PERMISSIONS_UNSPECIFIED)
-                }
-                "READ" => std::option::Option::Some(Self::READ),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MountPermissions {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MountPermissions {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MountPermissions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MountPermissions {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Read,
+                2 => Self::ReadWrite,
+                _ => Self::UnknownValue(mount_permissions::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MountPermissions {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MOUNT_PERMISSIONS_UNSPECIFIED" => Self::Unspecified,
+                "READ" => Self::Read,
+                "READ_WRITE" => Self::ReadWrite,
+                _ => Self::UnknownValue(mount_permissions::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MountPermissions {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Read => serializer.serialize_i32(1),
+                Self::ReadWrite => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MountPermissions {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MountPermissions>::new(
+                ".google.cloud.baremetalsolution.v2.NfsShare.MountPermissions",
+            ))
         }
     }
 
     /// The storage type for a volume.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StorageType {
+        /// The storage type for this volume is unknown.
+        Unspecified,
+        /// The storage type for this volume is SSD.
+        Ssd,
+        /// This storage type for this volume is HDD.
+        Hdd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StorageType::value] or
+        /// [StorageType::name].
+        UnknownValue(storage_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod storage_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StorageType {
-        /// The storage type for this volume is unknown.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
-
-        /// The storage type for this volume is SSD.
-        pub const SSD: StorageType = StorageType::new(1);
-
-        /// This storage type for this volume is HDD.
-        pub const HDD: StorageType = StorageType::new(2);
-
-        /// Creates a new StorageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ssd => std::option::Option::Some(1),
+                Self::Hdd => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SSD"),
-                2 => std::borrow::Cow::Borrowed("HDD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STORAGE_TYPE_UNSPECIFIED"),
+                Self::Ssd => std::option::Option::Some("SSD"),
+                Self::Hdd => std::option::Option::Some("HDD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STORAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
-                }
-                "SSD" => std::option::Option::Some(Self::SSD),
-                "HDD" => std::option::Option::Some(Self::HDD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StorageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StorageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ssd,
+                2 => Self::Hdd,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StorageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STORAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SSD" => Self::Ssd,
+                "HDD" => Self::Hdd,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StorageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ssd => serializer.serialize_i32(1),
+                Self::Hdd => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StorageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageType>::new(
+                ".google.cloud.baremetalsolution.v2.NfsShare.StorageType",
+            ))
         }
     }
 }
@@ -4274,87 +4959,158 @@ pub mod provisioning_config {
     use super::*;
 
     /// The possible states for this ProvisioningConfig.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State wasn't specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// ProvisioningConfig is a draft and can be freely modified.
-        pub const DRAFT: State = State::new(1);
-
+        Draft,
         /// ProvisioningConfig was already submitted and cannot be modified.
-        pub const SUBMITTED: State = State::new(2);
-
+        Submitted,
         /// ProvisioningConfig was in the provisioning state.  Initially this state
         /// comes from the work order table in big query when SNOW is used.  Later
         /// this field can be set by the work order API.
-        pub const PROVISIONING: State = State::new(3);
-
+        Provisioning,
         /// ProvisioningConfig was provisioned, meaning the resources exist.
-        pub const PROVISIONED: State = State::new(4);
-
+        Provisioned,
         /// ProvisioningConfig was validated.  A validation tool will be run to
         /// set this state.
-        pub const VALIDATED: State = State::new(5);
-
+        Validated,
         /// ProvisioningConfig was canceled.
-        pub const CANCELLED: State = State::new(6);
-
+        Cancelled,
         /// The request is submitted for provisioning, with error return.
-        pub const FAILED: State = State::new(7);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Submitted => std::option::Option::Some(2),
+                Self::Provisioning => std::option::Option::Some(3),
+                Self::Provisioned => std::option::Option::Some(4),
+                Self::Validated => std::option::Option::Some(5),
+                Self::Cancelled => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("SUBMITTED"),
-                3 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                4 => std::borrow::Cow::Borrowed("PROVISIONED"),
-                5 => std::borrow::Cow::Borrowed("VALIDATED"),
-                6 => std::borrow::Cow::Borrowed("CANCELLED"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Submitted => std::option::Option::Some("SUBMITTED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Provisioned => std::option::Option::Some("PROVISIONED"),
+                Self::Validated => std::option::Option::Some("VALIDATED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "SUBMITTED" => std::option::Option::Some(Self::SUBMITTED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
-                "VALIDATED" => std::option::Option::Some(Self::VALIDATED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Submitted,
+                3 => Self::Provisioning,
+                4 => Self::Provisioned,
+                5 => Self::Validated,
+                6 => Self::Cancelled,
+                7 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "SUBMITTED" => Self::Submitted,
+                "PROVISIONING" => Self::Provisioning,
+                "PROVISIONED" => Self::Provisioned,
+                "VALIDATED" => Self::Validated,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Submitted => serializer.serialize_i32(2),
+                Self::Provisioning => serializer.serialize_i32(3),
+                Self::Provisioned => serializer.serialize_i32(4),
+                Self::Validated => serializer.serialize_i32(5),
+                Self::Cancelled => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.ProvisioningConfig.State",
+            ))
         }
     }
 }
@@ -4678,64 +5434,127 @@ pub mod provisioning_quota {
     use super::*;
 
     /// The available asset types for intake.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AssetType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AssetType {
+        /// The unspecified type.
+        Unspecified,
+        /// The server asset type.
+        Server,
+        /// The storage asset type.
+        Storage,
+        /// The network asset type.
+        Network,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AssetType::value] or
+        /// [AssetType::name].
+        UnknownValue(asset_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod asset_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AssetType {
-        /// The unspecified type.
-        pub const ASSET_TYPE_UNSPECIFIED: AssetType = AssetType::new(0);
-
-        /// The server asset type.
-        pub const ASSET_TYPE_SERVER: AssetType = AssetType::new(1);
-
-        /// The storage asset type.
-        pub const ASSET_TYPE_STORAGE: AssetType = AssetType::new(2);
-
-        /// The network asset type.
-        pub const ASSET_TYPE_NETWORK: AssetType = AssetType::new(3);
-
-        /// Creates a new AssetType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Server => std::option::Option::Some(1),
+                Self::Storage => std::option::Option::Some(2),
+                Self::Network => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ASSET_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ASSET_TYPE_SERVER"),
-                2 => std::borrow::Cow::Borrowed("ASSET_TYPE_STORAGE"),
-                3 => std::borrow::Cow::Borrowed("ASSET_TYPE_NETWORK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ASSET_TYPE_UNSPECIFIED"),
+                Self::Server => std::option::Option::Some("ASSET_TYPE_SERVER"),
+                Self::Storage => std::option::Option::Some("ASSET_TYPE_STORAGE"),
+                Self::Network => std::option::Option::Some("ASSET_TYPE_NETWORK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ASSET_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ASSET_TYPE_UNSPECIFIED),
-                "ASSET_TYPE_SERVER" => std::option::Option::Some(Self::ASSET_TYPE_SERVER),
-                "ASSET_TYPE_STORAGE" => std::option::Option::Some(Self::ASSET_TYPE_STORAGE),
-                "ASSET_TYPE_NETWORK" => std::option::Option::Some(Self::ASSET_TYPE_NETWORK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AssetType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AssetType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AssetType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AssetType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Server,
+                2 => Self::Storage,
+                3 => Self::Network,
+                _ => Self::UnknownValue(asset_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AssetType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ASSET_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ASSET_TYPE_SERVER" => Self::Server,
+                "ASSET_TYPE_STORAGE" => Self::Storage,
+                "ASSET_TYPE_NETWORK" => Self::Network,
+                _ => Self::UnknownValue(asset_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AssetType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Server => serializer.serialize_i32(1),
+                Self::Storage => serializer.serialize_i32(2),
+                Self::Network => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AssetType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AssetType>::new(
+                ".google.cloud.baremetalsolution.v2.ProvisioningQuota.AssetType",
+            ))
         }
     }
 
@@ -5129,62 +5948,123 @@ pub mod instance_config {
     }
 
     /// The network configuration of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkConfig(i32);
-
-    impl NetworkConfig {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NetworkConfig {
         /// The unspecified network configuration.
-        pub const NETWORKCONFIG_UNSPECIFIED: NetworkConfig = NetworkConfig::new(0);
-
+        NetworkconfigUnspecified,
         /// Instance part of single client network and single private network.
-        pub const SINGLE_VLAN: NetworkConfig = NetworkConfig::new(1);
-
+        SingleVlan,
         /// Instance part of multiple (or single) client networks and private
         /// networks.
-        pub const MULTI_VLAN: NetworkConfig = NetworkConfig::new(2);
+        MultiVlan,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NetworkConfig::value] or
+        /// [NetworkConfig::name].
+        UnknownValue(network_config::UnknownValue),
+    }
 
-        /// Creates a new NetworkConfig instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod network_config {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NetworkConfig {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NetworkconfigUnspecified => std::option::Option::Some(0),
+                Self::SingleVlan => std::option::Option::Some(1),
+                Self::MultiVlan => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NETWORKCONFIG_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SINGLE_VLAN"),
-                2 => std::borrow::Cow::Borrowed("MULTI_VLAN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NETWORKCONFIG_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NETWORKCONFIG_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NetworkconfigUnspecified => {
+                    std::option::Option::Some("NETWORKCONFIG_UNSPECIFIED")
                 }
-                "SINGLE_VLAN" => std::option::Option::Some(Self::SINGLE_VLAN),
-                "MULTI_VLAN" => std::option::Option::Some(Self::MULTI_VLAN),
-                _ => std::option::Option::None,
+                Self::SingleVlan => std::option::Option::Some("SINGLE_VLAN"),
+                Self::MultiVlan => std::option::Option::Some("MULTI_VLAN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for NetworkConfig {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkConfig {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NetworkConfig {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NetworkConfig {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NetworkconfigUnspecified,
+                1 => Self::SingleVlan,
+                2 => Self::MultiVlan,
+                _ => Self::UnknownValue(network_config::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NetworkConfig {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NETWORKCONFIG_UNSPECIFIED" => Self::NetworkconfigUnspecified,
+                "SINGLE_VLAN" => Self::SingleVlan,
+                "MULTI_VLAN" => Self::MultiVlan,
+                _ => Self::UnknownValue(network_config::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NetworkConfig {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NetworkconfigUnspecified => serializer.serialize_i32(0),
+                Self::SingleVlan => serializer.serialize_i32(1),
+                Self::MultiVlan => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NetworkConfig {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NetworkConfig>::new(
+                ".google.cloud.baremetalsolution.v2.InstanceConfig.NetworkConfig",
+            ))
         }
     }
 }
@@ -5559,61 +6439,123 @@ pub mod volume_config {
         use super::*;
 
         /// Permissions that can granted for an export.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Permissions(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Permissions {
+            /// Unspecified value.
+            Unspecified,
+            /// Read-only permission.
+            ReadOnly,
+            /// Read-write permission.
+            ReadWrite,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Permissions::value] or
+            /// [Permissions::name].
+            UnknownValue(permissions::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod permissions {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Permissions {
-            /// Unspecified value.
-            pub const PERMISSIONS_UNSPECIFIED: Permissions = Permissions::new(0);
-
-            /// Read-only permission.
-            pub const READ_ONLY: Permissions = Permissions::new(1);
-
-            /// Read-write permission.
-            pub const READ_WRITE: Permissions = Permissions::new(2);
-
-            /// Creates a new Permissions instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ReadOnly => std::option::Option::Some(1),
+                    Self::ReadWrite => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PERMISSIONS_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                    2 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PERMISSIONS_UNSPECIFIED"),
+                    Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                    Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PERMISSIONS_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PERMISSIONS_UNSPECIFIED)
-                    }
-                    "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                    "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Permissions {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Permissions {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Permissions {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Permissions {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ReadOnly,
+                    2 => Self::ReadWrite,
+                    _ => Self::UnknownValue(permissions::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Permissions {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PERMISSIONS_UNSPECIFIED" => Self::Unspecified,
+                    "READ_ONLY" => Self::ReadOnly,
+                    "READ_WRITE" => Self::ReadWrite,
+                    _ => Self::UnknownValue(permissions::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Permissions {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ReadOnly => serializer.serialize_i32(1),
+                    Self::ReadWrite => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Permissions {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Permissions>::new(
+                    ".google.cloud.baremetalsolution.v2.VolumeConfig.NfsExport.Permissions",
+                ))
             }
         }
 
@@ -5631,116 +6573,238 @@ pub mod volume_config {
     }
 
     /// The types of Volumes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// The unspecified type.
+        Unspecified,
+        /// This Volume is on flash.
+        Flash,
+        /// This Volume is on disk.
+        Disk,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// The unspecified type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// This Volume is on flash.
-        pub const FLASH: Type = Type::new(1);
-
-        /// This Volume is on disk.
-        pub const DISK: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Flash => std::option::Option::Some(1),
+                Self::Disk => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FLASH"),
-                2 => std::borrow::Cow::Borrowed("DISK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Flash => std::option::Option::Some("FLASH"),
+                Self::Disk => std::option::Option::Some("DISK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "FLASH" => std::option::Option::Some(Self::FLASH),
-                "DISK" => std::option::Option::Some(Self::DISK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Flash,
+                2 => Self::Disk,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FLASH" => Self::Flash,
+                "DISK" => Self::Disk,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Flash => serializer.serialize_i32(1),
+                Self::Disk => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.baremetalsolution.v2.VolumeConfig.Type",
+            ))
         }
     }
 
     /// The protocol used to access the volume.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Protocol {
+        /// Unspecified value.
+        Unspecified,
+        /// Fibre channel.
+        Fc,
+        /// Network file system.
+        Nfs,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Protocol::value] or
+        /// [Protocol::name].
+        UnknownValue(protocol::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Protocol {
-        /// Unspecified value.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
-
-        /// Fibre channel.
-        pub const PROTOCOL_FC: Protocol = Protocol::new(1);
-
-        /// Network file system.
-        pub const PROTOCOL_NFS: Protocol = Protocol::new(2);
-
-        /// Creates a new Protocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Fc => std::option::Option::Some(1),
+                Self::Nfs => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROTOCOL_FC"),
-                2 => std::borrow::Cow::Borrowed("PROTOCOL_NFS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROTOCOL_UNSPECIFIED"),
+                Self::Fc => std::option::Option::Some("PROTOCOL_FC"),
+                Self::Nfs => std::option::Option::Some("PROTOCOL_NFS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
-                "PROTOCOL_FC" => std::option::Option::Some(Self::PROTOCOL_FC),
-                "PROTOCOL_NFS" => std::option::Option::Some(Self::PROTOCOL_NFS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Protocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Protocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Fc,
+                2 => Self::Nfs,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Protocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "PROTOCOL_FC" => Self::Fc,
+                "PROTOCOL_NFS" => Self::Nfs,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Protocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Fc => serializer.serialize_i32(1),
+                Self::Nfs => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Protocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Protocol>::new(
+                ".google.cloud.baremetalsolution.v2.VolumeConfig.Protocol",
+            ))
         }
     }
 }
@@ -5941,195 +7005,384 @@ pub mod network_config {
     }
 
     /// Network type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified value.
+        Unspecified,
+        /// Client network, that is a network peered to a GCP VPC.
+        Client,
+        /// Private network, that is a network local to the BMS POD.
+        Private,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Client network, that is a network peered to a GCP VPC.
-        pub const CLIENT: Type = Type::new(1);
-
-        /// Private network, that is a network local to the BMS POD.
-        pub const PRIVATE: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Client => std::option::Option::Some(1),
+                Self::Private => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLIENT"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Client => std::option::Option::Some("CLIENT"),
+                Self::Private => std::option::Option::Some("PRIVATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CLIENT" => std::option::Option::Some(Self::CLIENT),
-                "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Client,
+                2 => Self::Private,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CLIENT" => Self::Client,
+                "PRIVATE" => Self::Private,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Client => serializer.serialize_i32(1),
+                Self::Private => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.baremetalsolution.v2.NetworkConfig.Type",
+            ))
         }
     }
 
     /// Interconnect bandwidth.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Bandwidth(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Bandwidth {
+        /// Unspecified value.
+        Unspecified,
+        /// 1 Gbps.
+        Bw1Gbps,
+        /// 2 Gbps.
+        Bw2Gbps,
+        /// 5 Gbps.
+        Bw5Gbps,
+        /// 10 Gbps.
+        Bw10Gbps,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Bandwidth::value] or
+        /// [Bandwidth::name].
+        UnknownValue(bandwidth::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod bandwidth {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Bandwidth {
-        /// Unspecified value.
-        pub const BANDWIDTH_UNSPECIFIED: Bandwidth = Bandwidth::new(0);
-
-        /// 1 Gbps.
-        pub const BW_1_GBPS: Bandwidth = Bandwidth::new(1);
-
-        /// 2 Gbps.
-        pub const BW_2_GBPS: Bandwidth = Bandwidth::new(2);
-
-        /// 5 Gbps.
-        pub const BW_5_GBPS: Bandwidth = Bandwidth::new(3);
-
-        /// 10 Gbps.
-        pub const BW_10_GBPS: Bandwidth = Bandwidth::new(4);
-
-        /// Creates a new Bandwidth instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bw1Gbps => std::option::Option::Some(1),
+                Self::Bw2Gbps => std::option::Option::Some(2),
+                Self::Bw5Gbps => std::option::Option::Some(3),
+                Self::Bw10Gbps => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BANDWIDTH_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BW_1_GBPS"),
-                2 => std::borrow::Cow::Borrowed("BW_2_GBPS"),
-                3 => std::borrow::Cow::Borrowed("BW_5_GBPS"),
-                4 => std::borrow::Cow::Borrowed("BW_10_GBPS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BANDWIDTH_UNSPECIFIED"),
+                Self::Bw1Gbps => std::option::Option::Some("BW_1_GBPS"),
+                Self::Bw2Gbps => std::option::Option::Some("BW_2_GBPS"),
+                Self::Bw5Gbps => std::option::Option::Some("BW_5_GBPS"),
+                Self::Bw10Gbps => std::option::Option::Some("BW_10_GBPS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BANDWIDTH_UNSPECIFIED" => std::option::Option::Some(Self::BANDWIDTH_UNSPECIFIED),
-                "BW_1_GBPS" => std::option::Option::Some(Self::BW_1_GBPS),
-                "BW_2_GBPS" => std::option::Option::Some(Self::BW_2_GBPS),
-                "BW_5_GBPS" => std::option::Option::Some(Self::BW_5_GBPS),
-                "BW_10_GBPS" => std::option::Option::Some(Self::BW_10_GBPS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Bandwidth {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Bandwidth {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Bandwidth {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Bandwidth {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bw1Gbps,
+                2 => Self::Bw2Gbps,
+                3 => Self::Bw5Gbps,
+                4 => Self::Bw10Gbps,
+                _ => Self::UnknownValue(bandwidth::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Bandwidth {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BANDWIDTH_UNSPECIFIED" => Self::Unspecified,
+                "BW_1_GBPS" => Self::Bw1Gbps,
+                "BW_2_GBPS" => Self::Bw2Gbps,
+                "BW_5_GBPS" => Self::Bw5Gbps,
+                "BW_10_GBPS" => Self::Bw10Gbps,
+                _ => Self::UnknownValue(bandwidth::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Bandwidth {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bw1Gbps => serializer.serialize_i32(1),
+                Self::Bw2Gbps => serializer.serialize_i32(2),
+                Self::Bw5Gbps => serializer.serialize_i32(3),
+                Self::Bw10Gbps => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Bandwidth {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Bandwidth>::new(
+                ".google.cloud.baremetalsolution.v2.NetworkConfig.Bandwidth",
+            ))
         }
     }
 
     /// Service network block.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServiceCidr(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ServiceCidr {
+        /// Unspecified value.
+        Unspecified,
+        /// Services are disabled for the given network.
+        Disabled,
+        /// Use the highest /26 block of the network to host services.
+        High26,
+        /// Use the highest /27 block of the network to host services.
+        High27,
+        /// Use the highest /28 block of the network to host services.
+        High28,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ServiceCidr::value] or
+        /// [ServiceCidr::name].
+        UnknownValue(service_cidr::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod service_cidr {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ServiceCidr {
-        /// Unspecified value.
-        pub const SERVICE_CIDR_UNSPECIFIED: ServiceCidr = ServiceCidr::new(0);
-
-        /// Services are disabled for the given network.
-        pub const DISABLED: ServiceCidr = ServiceCidr::new(1);
-
-        /// Use the highest /26 block of the network to host services.
-        pub const HIGH_26: ServiceCidr = ServiceCidr::new(2);
-
-        /// Use the highest /27 block of the network to host services.
-        pub const HIGH_27: ServiceCidr = ServiceCidr::new(3);
-
-        /// Use the highest /28 block of the network to host services.
-        pub const HIGH_28: ServiceCidr = ServiceCidr::new(4);
-
-        /// Creates a new ServiceCidr instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::High26 => std::option::Option::Some(2),
+                Self::High27 => std::option::Option::Some(3),
+                Self::High28 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SERVICE_CIDR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("HIGH_26"),
-                3 => std::borrow::Cow::Borrowed("HIGH_27"),
-                4 => std::borrow::Cow::Borrowed("HIGH_28"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SERVICE_CIDR_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::High26 => std::option::Option::Some("HIGH_26"),
+                Self::High27 => std::option::Option::Some("HIGH_27"),
+                Self::High28 => std::option::Option::Some("HIGH_28"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SERVICE_CIDR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SERVICE_CIDR_UNSPECIFIED)
-                }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "HIGH_26" => std::option::Option::Some(Self::HIGH_26),
-                "HIGH_27" => std::option::Option::Some(Self::HIGH_27),
-                "HIGH_28" => std::option::Option::Some(Self::HIGH_28),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ServiceCidr {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ServiceCidr {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ServiceCidr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ServiceCidr {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::High26,
+                3 => Self::High27,
+                4 => Self::High28,
+                _ => Self::UnknownValue(service_cidr::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ServiceCidr {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SERVICE_CIDR_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "HIGH_26" => Self::High26,
+                "HIGH_27" => Self::High27,
+                "HIGH_28" => Self::High28,
+                _ => Self::UnknownValue(service_cidr::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ServiceCidr {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::High26 => serializer.serialize_i32(2),
+                Self::High27 => serializer.serialize_i32(3),
+                Self::High28 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ServiceCidr {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceCidr>::new(
+                ".google.cloud.baremetalsolution.v2.NetworkConfig.ServiceCidr",
+            ))
         }
     }
 }
@@ -7007,318 +8260,628 @@ pub mod volume {
     }
 
     /// The storage type for a volume.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StorageType {
+        /// The storage type for this volume is unknown.
+        Unspecified,
+        /// The storage type for this volume is SSD.
+        Ssd,
+        /// This storage type for this volume is HDD.
+        Hdd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StorageType::value] or
+        /// [StorageType::name].
+        UnknownValue(storage_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod storage_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StorageType {
-        /// The storage type for this volume is unknown.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
-
-        /// The storage type for this volume is SSD.
-        pub const SSD: StorageType = StorageType::new(1);
-
-        /// This storage type for this volume is HDD.
-        pub const HDD: StorageType = StorageType::new(2);
-
-        /// Creates a new StorageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ssd => std::option::Option::Some(1),
+                Self::Hdd => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SSD"),
-                2 => std::borrow::Cow::Borrowed("HDD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STORAGE_TYPE_UNSPECIFIED"),
+                Self::Ssd => std::option::Option::Some("SSD"),
+                Self::Hdd => std::option::Option::Some("HDD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STORAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
-                }
-                "SSD" => std::option::Option::Some(Self::SSD),
-                "HDD" => std::option::Option::Some(Self::HDD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StorageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StorageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ssd,
+                2 => Self::Hdd,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StorageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STORAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SSD" => Self::Ssd,
+                "HDD" => Self::Hdd,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StorageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ssd => serializer.serialize_i32(1),
+                Self::Hdd => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StorageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageType>::new(
+                ".google.cloud.baremetalsolution.v2.Volume.StorageType",
+            ))
         }
     }
 
     /// The possible states for a storage volume.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The storage volume is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The storage volume is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The storage volume is ready for use.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The storage volume has been requested to be deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// The storage volume is being updated.
-        pub const UPDATING: State = State::new(4);
-
+        Updating,
         /// The storage volume is in cool off state. It will be deleted after
         /// `expire_time`.
-        pub const COOL_OFF: State = State::new(5);
+        CoolOff,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::CoolOff => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("COOL_OFF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::CoolOff => std::option::Option::Some("COOL_OFF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "COOL_OFF" => std::option::Option::Some(Self::COOL_OFF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                4 => Self::Updating,
+                5 => Self::CoolOff,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "COOL_OFF" => Self::CoolOff,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::CoolOff => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.baremetalsolution.v2.Volume.State",
+            ))
         }
     }
 
     /// The kinds of auto delete behavior to use when snapshot reserved space is
     /// full.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SnapshotAutoDeleteBehavior(i32);
-
-    impl SnapshotAutoDeleteBehavior {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SnapshotAutoDeleteBehavior {
         /// The unspecified behavior.
-        pub const SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED: SnapshotAutoDeleteBehavior =
-            SnapshotAutoDeleteBehavior::new(0);
-
+        Unspecified,
         /// Don't delete any snapshots. This disables new snapshot creation, as
         /// long as the snapshot reserved space is full.
-        pub const DISABLED: SnapshotAutoDeleteBehavior = SnapshotAutoDeleteBehavior::new(1);
-
+        Disabled,
         /// Delete the oldest snapshots first.
-        pub const OLDEST_FIRST: SnapshotAutoDeleteBehavior = SnapshotAutoDeleteBehavior::new(2);
-
+        OldestFirst,
         /// Delete the newest snapshots first.
-        pub const NEWEST_FIRST: SnapshotAutoDeleteBehavior = SnapshotAutoDeleteBehavior::new(3);
+        NewestFirst,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SnapshotAutoDeleteBehavior::value] or
+        /// [SnapshotAutoDeleteBehavior::name].
+        UnknownValue(snapshot_auto_delete_behavior::UnknownValue),
+    }
 
-        /// Creates a new SnapshotAutoDeleteBehavior instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod snapshot_auto_delete_behavior {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SnapshotAutoDeleteBehavior {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::OldestFirst => std::option::Option::Some(2),
+                Self::NewestFirst => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("OLDEST_FIRST"),
-                3 => std::borrow::Cow::Borrowed("NEWEST_FIRST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED")
                 }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "OLDEST_FIRST" => std::option::Option::Some(Self::OLDEST_FIRST),
-                "NEWEST_FIRST" => std::option::Option::Some(Self::NEWEST_FIRST),
-                _ => std::option::Option::None,
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::OldestFirst => std::option::Option::Some("OLDEST_FIRST"),
+                Self::NewestFirst => std::option::Option::Some("NEWEST_FIRST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SnapshotAutoDeleteBehavior {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SnapshotAutoDeleteBehavior {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SnapshotAutoDeleteBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SnapshotAutoDeleteBehavior {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::OldestFirst,
+                3 => Self::NewestFirst,
+                _ => Self::UnknownValue(snapshot_auto_delete_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SnapshotAutoDeleteBehavior {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SNAPSHOT_AUTO_DELETE_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "OLDEST_FIRST" => Self::OldestFirst,
+                "NEWEST_FIRST" => Self::NewestFirst,
+                _ => Self::UnknownValue(snapshot_auto_delete_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SnapshotAutoDeleteBehavior {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::OldestFirst => serializer.serialize_i32(2),
+                Self::NewestFirst => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SnapshotAutoDeleteBehavior {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<SnapshotAutoDeleteBehavior>::new(
+                    ".google.cloud.baremetalsolution.v2.Volume.SnapshotAutoDeleteBehavior",
+                ),
+            )
         }
     }
 
     /// Storage protocol.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(i32);
-
-    impl Protocol {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Protocol {
         /// Value is not specified.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
-
+        Unspecified,
         /// Fibre Channel protocol.
-        pub const FIBRE_CHANNEL: Protocol = Protocol::new(1);
-
+        FibreChannel,
         /// NFS protocol means Volume is a NFS Share volume.
         /// Such volumes cannot be manipulated via Volumes API.
-        pub const NFS: Protocol = Protocol::new(2);
+        Nfs,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Protocol::value] or
+        /// [Protocol::name].
+        UnknownValue(protocol::UnknownValue),
+    }
 
-        /// Creates a new Protocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Protocol {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FibreChannel => std::option::Option::Some(1),
+                Self::Nfs => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIBRE_CHANNEL"),
-                2 => std::borrow::Cow::Borrowed("NFS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROTOCOL_UNSPECIFIED"),
+                Self::FibreChannel => std::option::Option::Some("FIBRE_CHANNEL"),
+                Self::Nfs => std::option::Option::Some("NFS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
-                "FIBRE_CHANNEL" => std::option::Option::Some(Self::FIBRE_CHANNEL),
-                "NFS" => std::option::Option::Some(Self::NFS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Protocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Protocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FibreChannel,
+                2 => Self::Nfs,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Protocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "FIBRE_CHANNEL" => Self::FibreChannel,
+                "NFS" => Self::Nfs,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Protocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FibreChannel => serializer.serialize_i32(1),
+                Self::Nfs => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Protocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Protocol>::new(
+                ".google.cloud.baremetalsolution.v2.Volume.Protocol",
+            ))
         }
     }
 
     /// The possible values for a workload profile.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WorkloadProfile(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WorkloadProfile {
+        /// The workload profile is in an unknown state.
+        Unspecified,
+        /// The workload profile is generic.
+        Generic,
+        /// The workload profile is hana.
+        Hana,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WorkloadProfile::value] or
+        /// [WorkloadProfile::name].
+        UnknownValue(workload_profile::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod workload_profile {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WorkloadProfile {
-        /// The workload profile is in an unknown state.
-        pub const WORKLOAD_PROFILE_UNSPECIFIED: WorkloadProfile = WorkloadProfile::new(0);
-
-        /// The workload profile is generic.
-        pub const GENERIC: WorkloadProfile = WorkloadProfile::new(1);
-
-        /// The workload profile is hana.
-        pub const HANA: WorkloadProfile = WorkloadProfile::new(2);
-
-        /// Creates a new WorkloadProfile instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Generic => std::option::Option::Some(1),
+                Self::Hana => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GENERIC"),
-                2 => std::borrow::Cow::Borrowed("HANA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WORKLOAD_PROFILE_UNSPECIFIED"),
+                Self::Generic => std::option::Option::Some("GENERIC"),
+                Self::Hana => std::option::Option::Some("HANA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WORKLOAD_PROFILE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WORKLOAD_PROFILE_UNSPECIFIED)
-                }
-                "GENERIC" => std::option::Option::Some(Self::GENERIC),
-                "HANA" => std::option::Option::Some(Self::HANA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WorkloadProfile {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WorkloadProfile {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WorkloadProfile {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WorkloadProfile {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Generic,
+                2 => Self::Hana,
+                _ => Self::UnknownValue(workload_profile::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WorkloadProfile {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WORKLOAD_PROFILE_UNSPECIFIED" => Self::Unspecified,
+                "GENERIC" => Self::Generic,
+                "HANA" => Self::Hana,
+                _ => Self::UnknownValue(workload_profile::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WorkloadProfile {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Generic => serializer.serialize_i32(1),
+                Self::Hana => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WorkloadProfile {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WorkloadProfile>::new(
+                ".google.cloud.baremetalsolution.v2.Volume.WorkloadProfile",
+            ))
         }
     }
 }
@@ -7760,61 +9323,120 @@ pub mod volume_snapshot {
     use super::*;
 
     /// Represents the type of a snapshot.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SnapshotType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SnapshotType {
+        /// Type is not specified.
+        Unspecified,
+        /// Snapshot was taken manually by user.
+        AdHoc,
+        /// Snapshot was taken automatically as a part of a snapshot schedule.
+        Scheduled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SnapshotType::value] or
+        /// [SnapshotType::name].
+        UnknownValue(snapshot_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod snapshot_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SnapshotType {
-        /// Type is not specified.
-        pub const SNAPSHOT_TYPE_UNSPECIFIED: SnapshotType = SnapshotType::new(0);
-
-        /// Snapshot was taken manually by user.
-        pub const AD_HOC: SnapshotType = SnapshotType::new(1);
-
-        /// Snapshot was taken automatically as a part of a snapshot schedule.
-        pub const SCHEDULED: SnapshotType = SnapshotType::new(2);
-
-        /// Creates a new SnapshotType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AdHoc => std::option::Option::Some(1),
+                Self::Scheduled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SNAPSHOT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AD_HOC"),
-                2 => std::borrow::Cow::Borrowed("SCHEDULED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SNAPSHOT_TYPE_UNSPECIFIED"),
+                Self::AdHoc => std::option::Option::Some("AD_HOC"),
+                Self::Scheduled => std::option::Option::Some("SCHEDULED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SNAPSHOT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SNAPSHOT_TYPE_UNSPECIFIED)
-                }
-                "AD_HOC" => std::option::Option::Some(Self::AD_HOC),
-                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SnapshotType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SnapshotType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SnapshotType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SnapshotType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AdHoc,
+                2 => Self::Scheduled,
+                _ => Self::UnknownValue(snapshot_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SnapshotType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SNAPSHOT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AD_HOC" => Self::AdHoc,
+                "SCHEDULED" => Self::Scheduled,
+                _ => Self::UnknownValue(snapshot_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SnapshotType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AdHoc => serializer.serialize_i32(1),
+                Self::Scheduled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SnapshotType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SnapshotType>::new(
+                ".google.cloud.baremetalsolution.v2.VolumeSnapshot.SnapshotType",
+            ))
         }
     }
 }
@@ -8093,132 +9715,244 @@ impl wkt::message::Message for RestoreVolumeSnapshotRequest {
 }
 
 /// Performance tier of the Volume.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct VolumePerformanceTier(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum VolumePerformanceTier {
+    /// Value is not specified.
+    Unspecified,
+    /// Regular volumes, shared aggregates.
+    Shared,
+    /// Assigned aggregates.
+    Assigned,
+    /// High throughput aggregates.
+    Ht,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [VolumePerformanceTier::value] or
+    /// [VolumePerformanceTier::name].
+    UnknownValue(volume_performance_tier::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod volume_performance_tier {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl VolumePerformanceTier {
-    /// Value is not specified.
-    pub const VOLUME_PERFORMANCE_TIER_UNSPECIFIED: VolumePerformanceTier =
-        VolumePerformanceTier::new(0);
-
-    /// Regular volumes, shared aggregates.
-    pub const VOLUME_PERFORMANCE_TIER_SHARED: VolumePerformanceTier = VolumePerformanceTier::new(1);
-
-    /// Assigned aggregates.
-    pub const VOLUME_PERFORMANCE_TIER_ASSIGNED: VolumePerformanceTier =
-        VolumePerformanceTier::new(2);
-
-    /// High throughput aggregates.
-    pub const VOLUME_PERFORMANCE_TIER_HT: VolumePerformanceTier = VolumePerformanceTier::new(3);
-
-    /// Creates a new VolumePerformanceTier instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Shared => std::option::Option::Some(1),
+            Self::Assigned => std::option::Option::Some(2),
+            Self::Ht => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_SHARED"),
-            2 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_ASSIGNED"),
-            3 => std::borrow::Cow::Borrowed("VOLUME_PERFORMANCE_TIER_HT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VOLUME_PERFORMANCE_TIER_UNSPECIFIED"),
+            Self::Shared => std::option::Option::Some("VOLUME_PERFORMANCE_TIER_SHARED"),
+            Self::Assigned => std::option::Option::Some("VOLUME_PERFORMANCE_TIER_ASSIGNED"),
+            Self::Ht => std::option::Option::Some("VOLUME_PERFORMANCE_TIER_HT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VOLUME_PERFORMANCE_TIER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_UNSPECIFIED)
-            }
-            "VOLUME_PERFORMANCE_TIER_SHARED" => {
-                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_SHARED)
-            }
-            "VOLUME_PERFORMANCE_TIER_ASSIGNED" => {
-                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_ASSIGNED)
-            }
-            "VOLUME_PERFORMANCE_TIER_HT" => {
-                std::option::Option::Some(Self::VOLUME_PERFORMANCE_TIER_HT)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for VolumePerformanceTier {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for VolumePerformanceTier {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for VolumePerformanceTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for VolumePerformanceTier {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Shared,
+            2 => Self::Assigned,
+            3 => Self::Ht,
+            _ => Self::UnknownValue(volume_performance_tier::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for VolumePerformanceTier {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VOLUME_PERFORMANCE_TIER_UNSPECIFIED" => Self::Unspecified,
+            "VOLUME_PERFORMANCE_TIER_SHARED" => Self::Shared,
+            "VOLUME_PERFORMANCE_TIER_ASSIGNED" => Self::Assigned,
+            "VOLUME_PERFORMANCE_TIER_HT" => Self::Ht,
+            _ => Self::UnknownValue(volume_performance_tier::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for VolumePerformanceTier {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Shared => serializer.serialize_i32(1),
+            Self::Assigned => serializer.serialize_i32(2),
+            Self::Ht => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for VolumePerformanceTier {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<VolumePerformanceTier>::new(
+            ".google.cloud.baremetalsolution.v2.VolumePerformanceTier",
+        ))
     }
 }
 
 /// The possible values for a workload profile.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct WorkloadProfile(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum WorkloadProfile {
+    /// The workload profile is in an unknown state.
+    Unspecified,
+    /// The workload profile is generic.
+    Generic,
+    /// The workload profile is hana.
+    Hana,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [WorkloadProfile::value] or
+    /// [WorkloadProfile::name].
+    UnknownValue(workload_profile::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod workload_profile {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl WorkloadProfile {
-    /// The workload profile is in an unknown state.
-    pub const WORKLOAD_PROFILE_UNSPECIFIED: WorkloadProfile = WorkloadProfile::new(0);
-
-    /// The workload profile is generic.
-    pub const WORKLOAD_PROFILE_GENERIC: WorkloadProfile = WorkloadProfile::new(1);
-
-    /// The workload profile is hana.
-    pub const WORKLOAD_PROFILE_HANA: WorkloadProfile = WorkloadProfile::new(2);
-
-    /// Creates a new WorkloadProfile instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Generic => std::option::Option::Some(1),
+            Self::Hana => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_GENERIC"),
-            2 => std::borrow::Cow::Borrowed("WORKLOAD_PROFILE_HANA"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("WORKLOAD_PROFILE_UNSPECIFIED"),
+            Self::Generic => std::option::Option::Some("WORKLOAD_PROFILE_GENERIC"),
+            Self::Hana => std::option::Option::Some("WORKLOAD_PROFILE_HANA"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "WORKLOAD_PROFILE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::WORKLOAD_PROFILE_UNSPECIFIED)
-            }
-            "WORKLOAD_PROFILE_GENERIC" => std::option::Option::Some(Self::WORKLOAD_PROFILE_GENERIC),
-            "WORKLOAD_PROFILE_HANA" => std::option::Option::Some(Self::WORKLOAD_PROFILE_HANA),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for WorkloadProfile {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for WorkloadProfile {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for WorkloadProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for WorkloadProfile {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Generic,
+            2 => Self::Hana,
+            _ => Self::UnknownValue(workload_profile::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for WorkloadProfile {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "WORKLOAD_PROFILE_UNSPECIFIED" => Self::Unspecified,
+            "WORKLOAD_PROFILE_GENERIC" => Self::Generic,
+            "WORKLOAD_PROFILE_HANA" => Self::Hana,
+            _ => Self::UnknownValue(workload_profile::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for WorkloadProfile {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Generic => serializer.serialize_i32(1),
+            Self::Hana => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for WorkloadProfile {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<WorkloadProfile>::new(
+            ".google.cloud.baremetalsolution.v2.WorkloadProfile",
+        ))
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -996,182 +996,370 @@ pub mod app_connection {
         use super::*;
 
         /// Enum listing possible gateway hosting options.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Default value. This value is unused.
+            Unspecified,
+            /// Gateway hosted in a GCP regional managed instance group.
+            GcpRegionalMig,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Default value. This value is unused.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// Gateway hosted in a GCP regional managed instance group.
-            pub const GCP_REGIONAL_MIG: Type = Type::new(1);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::GcpRegionalMig => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("GCP_REGIONAL_MIG"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::GcpRegionalMig => std::option::Option::Some("GCP_REGIONAL_MIG"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "GCP_REGIONAL_MIG" => std::option::Option::Some(Self::GCP_REGIONAL_MIG),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::GcpRegionalMig,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "GCP_REGIONAL_MIG" => Self::GcpRegionalMig,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::GcpRegionalMig => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.beyondcorp.appconnections.v1.AppConnection.Gateway.Type",
+                ))
             }
         }
     }
 
     /// Enum containing list of all possible network connectivity options
     /// supported by BeyondCorp AppConnection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Default value. This value is unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// TCP Proxy based BeyondCorp AppConnection. API will default to this if
         /// unset.
-        pub const TCP_PROXY: Type = Type::new(1);
+        TcpProxy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TcpProxy => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TCP_PROXY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::TcpProxy => std::option::Option::Some("TCP_PROXY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TCP_PROXY" => std::option::Option::Some(Self::TCP_PROXY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TcpProxy,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TCP_PROXY" => Self::TcpProxy,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TcpProxy => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.beyondcorp.appconnections.v1.AppConnection.Type",
+            ))
         }
     }
 
     /// Represents the different states of a AppConnection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// AppConnection is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// AppConnection has been created.
-        pub const CREATED: State = State::new(2);
-
+        Created,
         /// AppConnection's configuration is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// AppConnection is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// AppConnection is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new(5);
+        Down,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Created => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Down => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("CREATED"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("DOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Down => std::option::Option::Some("DOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DOWN" => std::option::Option::Some(Self::DOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Created,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Down,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "CREATED" => Self::Created,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "DOWN" => Self::Down,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Created => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Down => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.beyondcorp.appconnections.v1.AppConnection.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -1084,75 +1084,142 @@ pub mod app_connector {
     }
 
     /// Represents the different states of a AppConnector.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// AppConnector is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// AppConnector has been created.
-        pub const CREATED: State = State::new(2);
-
+        Created,
         /// AppConnector's configuration is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// AppConnector is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// AppConnector is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new(5);
+        Down,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Created => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Down => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("CREATED"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("DOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Down => std::option::Option::Some("DOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DOWN" => std::option::Option::Some(Self::DOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Created,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Down,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "CREATED" => Self::Created,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "DOWN" => Self::Down,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Created => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Down => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.beyondcorp.appconnectors.v1.AppConnector.State",
+            ))
         }
     }
 }
@@ -1356,70 +1423,133 @@ impl wkt::message::Message for ResourceInfo {
 }
 
 /// HealthStatus represents the health status.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HealthStatus(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HealthStatus {
+    /// Health status is unknown: not initialized or failed to retrieve.
+    Unspecified,
+    /// The resource is healthy.
+    Healthy,
+    /// The resource is unhealthy.
+    Unhealthy,
+    /// The resource is unresponsive.
+    Unresponsive,
+    /// Some sub-resources are UNHEALTHY.
+    Degraded,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HealthStatus::value] or
+    /// [HealthStatus::name].
+    UnknownValue(health_status::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod health_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl HealthStatus {
-    /// Health status is unknown: not initialized or failed to retrieve.
-    pub const HEALTH_STATUS_UNSPECIFIED: HealthStatus = HealthStatus::new(0);
-
-    /// The resource is healthy.
-    pub const HEALTHY: HealthStatus = HealthStatus::new(1);
-
-    /// The resource is unhealthy.
-    pub const UNHEALTHY: HealthStatus = HealthStatus::new(2);
-
-    /// The resource is unresponsive.
-    pub const UNRESPONSIVE: HealthStatus = HealthStatus::new(3);
-
-    /// Some sub-resources are UNHEALTHY.
-    pub const DEGRADED: HealthStatus = HealthStatus::new(4);
-
-    /// Creates a new HealthStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Healthy => std::option::Option::Some(1),
+            Self::Unhealthy => std::option::Option::Some(2),
+            Self::Unresponsive => std::option::Option::Some(3),
+            Self::Degraded => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HEALTH_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HEALTHY"),
-            2 => std::borrow::Cow::Borrowed("UNHEALTHY"),
-            3 => std::borrow::Cow::Borrowed("UNRESPONSIVE"),
-            4 => std::borrow::Cow::Borrowed("DEGRADED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HEALTH_STATUS_UNSPECIFIED"),
+            Self::Healthy => std::option::Option::Some("HEALTHY"),
+            Self::Unhealthy => std::option::Option::Some("UNHEALTHY"),
+            Self::Unresponsive => std::option::Option::Some("UNRESPONSIVE"),
+            Self::Degraded => std::option::Option::Some("DEGRADED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HEALTH_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HEALTH_STATUS_UNSPECIFIED)
-            }
-            "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
-            "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
-            "UNRESPONSIVE" => std::option::Option::Some(Self::UNRESPONSIVE),
-            "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HealthStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HealthStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HealthStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Healthy,
+            2 => Self::Unhealthy,
+            3 => Self::Unresponsive,
+            4 => Self::Degraded,
+            _ => Self::UnknownValue(health_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HealthStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HEALTH_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "HEALTHY" => Self::Healthy,
+            "UNHEALTHY" => Self::Unhealthy,
+            "UNRESPONSIVE" => Self::Unresponsive,
+            "DEGRADED" => Self::Degraded,
+            _ => Self::UnknownValue(health_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HealthStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Healthy => serializer.serialize_i32(1),
+            Self::Unhealthy => serializer.serialize_i32(2),
+            Self::Unresponsive => serializer.serialize_i32(3),
+            Self::Degraded => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HealthStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HealthStatus>::new(
+            ".google.cloud.beyondcorp.appconnectors.v1.HealthStatus",
+        ))
     }
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -596,180 +596,365 @@ pub mod app_gateway {
 
     /// Enum containing list of all possible network connectivity options
     /// supported by BeyondCorp AppGateway.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// TCP Proxy based BeyondCorp Connection. API will default to this if unset.
+        TcpProxy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Default value. This value is unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// TCP Proxy based BeyondCorp Connection. API will default to this if unset.
-        pub const TCP_PROXY: Type = Type::new(1);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TcpProxy => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TCP_PROXY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::TcpProxy => std::option::Option::Some("TCP_PROXY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TCP_PROXY" => std::option::Option::Some(Self::TCP_PROXY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TcpProxy,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TCP_PROXY" => Self::TcpProxy,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TcpProxy => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.beyondcorp.appgateways.v1.AppGateway.Type",
+            ))
         }
     }
 
     /// Represents the different states of an AppGateway.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// AppGateway is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// AppGateway has been created.
-        pub const CREATED: State = State::new(2);
-
+        Created,
         /// AppGateway's configuration is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// AppGateway is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// AppGateway is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new(5);
+        Down,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Created => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Down => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("CREATED"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("DOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Down => std::option::Option::Some("DOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DOWN" => std::option::Option::Some(Self::DOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Created,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Down,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "CREATED" => Self::Created,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "DOWN" => Self::Down,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Created => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Down => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.beyondcorp.appgateways.v1.AppGateway.State",
+            ))
         }
     }
 
     /// Enum containing list of all possible host types supported by BeyondCorp
     /// Connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HostType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HostType {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// AppGateway hosted in a GCP regional managed instance group.
+        GcpRegionalMig,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HostType::value] or
+        /// [HostType::name].
+        UnknownValue(host_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod host_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HostType {
-        /// Default value. This value is unused.
-        pub const HOST_TYPE_UNSPECIFIED: HostType = HostType::new(0);
-
-        /// AppGateway hosted in a GCP regional managed instance group.
-        pub const GCP_REGIONAL_MIG: HostType = HostType::new(1);
-
-        /// Creates a new HostType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GcpRegionalMig => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HOST_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCP_REGIONAL_MIG"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HOST_TYPE_UNSPECIFIED"),
+                Self::GcpRegionalMig => std::option::Option::Some("GCP_REGIONAL_MIG"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HOST_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::HOST_TYPE_UNSPECIFIED),
-                "GCP_REGIONAL_MIG" => std::option::Option::Some(Self::GCP_REGIONAL_MIG),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HostType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HostType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HostType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HostType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GcpRegionalMig,
+                _ => Self::UnknownValue(host_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HostType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HOST_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GCP_REGIONAL_MIG" => Self::GcpRegionalMig,
+                _ => Self::UnknownValue(host_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HostType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GcpRegionalMig => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HostType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HostType>::new(
+                ".google.cloud.beyondcorp.appgateways.v1.AppGateway.HostType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -357,57 +357,117 @@ pub mod client_connector_service {
             }
 
             /// The protocol used to connect to the server.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct TransportProtocol(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum TransportProtocol {
+                /// Default value. This value is unused.
+                Unspecified,
+                /// TCP protocol.
+                Tcp,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [TransportProtocol::value] or
+                /// [TransportProtocol::name].
+                UnknownValue(transport_protocol::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod transport_protocol {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl TransportProtocol {
-                /// Default value. This value is unused.
-                pub const TRANSPORT_PROTOCOL_UNSPECIFIED: TransportProtocol =
-                    TransportProtocol::new(0);
-
-                /// TCP protocol.
-                pub const TCP: TransportProtocol = TransportProtocol::new(1);
-
-                /// Creates a new TransportProtocol instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Tcp => std::option::Option::Some(1),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("TRANSPORT_PROTOCOL_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("TCP"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "TRANSPORT_PROTOCOL_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::TRANSPORT_PROTOCOL_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("TRANSPORT_PROTOCOL_UNSPECIFIED")
                         }
-                        "TCP" => std::option::Option::Some(Self::TCP),
-                        _ => std::option::Option::None,
+                        Self::Tcp => std::option::Option::Some("TCP"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for TransportProtocol {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for TransportProtocol {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for TransportProtocol {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for TransportProtocol {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Tcp,
+                        _ => Self::UnknownValue(transport_protocol::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for TransportProtocol {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "TRANSPORT_PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                        "TCP" => Self::Tcp,
+                        _ => Self::UnknownValue(transport_protocol::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for TransportProtocol {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Tcp => serializer.serialize_i32(1),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for TransportProtocol {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransportProtocol>::new(
+                        ".google.cloud.beyondcorp.clientconnectorservices.v1.ClientConnectorService.Ingress.Config.TransportProtocol"))
                 }
             }
         }
@@ -553,81 +613,150 @@ pub mod client_connector_service {
     }
 
     /// Represents the different states of a ClientConnectorService.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// ClientConnectorService is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// ClientConnectorService is being updated.
-        pub const UPDATING: State = State::new(2);
-
+        Updating,
         /// ClientConnectorService is being deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// ClientConnectorService is running.
-        pub const RUNNING: State = State::new(4);
-
+        Running,
         /// ClientConnectorService is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new(5);
-
+        Down,
         /// ClientConnectorService encountered an error and is in an indeterministic
         /// state.
-        pub const ERROR: State = State::new(6);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Running => std::option::Option::Some(4),
+                Self::Down => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("RUNNING"),
-                5 => std::borrow::Cow::Borrowed("DOWN"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Down => std::option::Option::Some("DOWN"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DOWN" => std::option::Option::Some(Self::DOWN),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Updating,
+                3 => Self::Deleting,
+                4 => Self::Running,
+                5 => Self::Down,
+                6 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "RUNNING" => Self::Running,
+                "DOWN" => Self::Down,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Running => serializer.serialize_i32(4),
+                Self::Down => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.beyondcorp.clientconnectorservices.v1.ClientConnectorService.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -135,80 +135,149 @@ pub mod client_gateway {
     use super::*;
 
     /// Represents the different states of a gateway.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Gateway is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Gateway is being updated.
-        pub const UPDATING: State = State::new(2);
-
+        Updating,
         /// Gateway is being deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// Gateway is running.
-        pub const RUNNING: State = State::new(4);
-
+        Running,
         /// Gateway is down and may be restored in the future.
         /// This happens when CCFE sends ProjectState = OFF.
-        pub const DOWN: State = State::new(5);
-
+        Down,
         /// ClientGateway encountered an error and is in indeterministic state.
-        pub const ERROR: State = State::new(6);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Running => std::option::Option::Some(4),
+                Self::Down => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("RUNNING"),
-                5 => std::borrow::Cow::Borrowed("DOWN"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Down => std::option::Option::Some("DOWN"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DOWN" => std::option::Option::Some(Self::DOWN),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Updating,
+                3 => Self::Deleting,
+                4 => Self::Running,
+                5 => Self::Down,
+                6 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "RUNNING" => Self::Running,
+                "DOWN" => Self::Down,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Running => serializer.serialize_i32(4),
+                Self::Down => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.beyondcorp.clientgateways.v1.ClientGateway.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -1312,189 +1312,341 @@ pub mod listing {
     }
 
     /// State of the listing.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Subscribable state. Users with dataexchange.listings.subscribe permission
         /// can subscribe to this listing.
-        pub const ACTIVE: State = State::new(1);
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.analyticshub.v1.Listing.State",
+            ))
         }
     }
 
     /// Listing categories.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Category {
+        Unspecified,
+        Others,
+        AdvertisingAndMarketing,
+        Commerce,
+        ClimateAndEnvironment,
+        Demographics,
+        Economics,
+        Education,
+        Energy,
+        Financial,
+        Gaming,
+        Geospatial,
+        HealthcareAndLifeScience,
+        Media,
+        PublicSector,
+        Retail,
+        Sports,
+        ScienceAndResearch,
+        TransportationAndLogistics,
+        TravelAndTourism,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Category::value] or
+        /// [Category::name].
+        UnknownValue(category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Category {
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
-
-        pub const CATEGORY_OTHERS: Category = Category::new(1);
-
-        pub const CATEGORY_ADVERTISING_AND_MARKETING: Category = Category::new(2);
-
-        pub const CATEGORY_COMMERCE: Category = Category::new(3);
-
-        pub const CATEGORY_CLIMATE_AND_ENVIRONMENT: Category = Category::new(4);
-
-        pub const CATEGORY_DEMOGRAPHICS: Category = Category::new(5);
-
-        pub const CATEGORY_ECONOMICS: Category = Category::new(6);
-
-        pub const CATEGORY_EDUCATION: Category = Category::new(7);
-
-        pub const CATEGORY_ENERGY: Category = Category::new(8);
-
-        pub const CATEGORY_FINANCIAL: Category = Category::new(9);
-
-        pub const CATEGORY_GAMING: Category = Category::new(10);
-
-        pub const CATEGORY_GEOSPATIAL: Category = Category::new(11);
-
-        pub const CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE: Category = Category::new(12);
-
-        pub const CATEGORY_MEDIA: Category = Category::new(13);
-
-        pub const CATEGORY_PUBLIC_SECTOR: Category = Category::new(14);
-
-        pub const CATEGORY_RETAIL: Category = Category::new(15);
-
-        pub const CATEGORY_SPORTS: Category = Category::new(16);
-
-        pub const CATEGORY_SCIENCE_AND_RESEARCH: Category = Category::new(17);
-
-        pub const CATEGORY_TRANSPORTATION_AND_LOGISTICS: Category = Category::new(18);
-
-        pub const CATEGORY_TRAVEL_AND_TOURISM: Category = Category::new(19);
-
-        /// Creates a new Category instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Others => std::option::Option::Some(1),
+                Self::AdvertisingAndMarketing => std::option::Option::Some(2),
+                Self::Commerce => std::option::Option::Some(3),
+                Self::ClimateAndEnvironment => std::option::Option::Some(4),
+                Self::Demographics => std::option::Option::Some(5),
+                Self::Economics => std::option::Option::Some(6),
+                Self::Education => std::option::Option::Some(7),
+                Self::Energy => std::option::Option::Some(8),
+                Self::Financial => std::option::Option::Some(9),
+                Self::Gaming => std::option::Option::Some(10),
+                Self::Geospatial => std::option::Option::Some(11),
+                Self::HealthcareAndLifeScience => std::option::Option::Some(12),
+                Self::Media => std::option::Option::Some(13),
+                Self::PublicSector => std::option::Option::Some(14),
+                Self::Retail => std::option::Option::Some(15),
+                Self::Sports => std::option::Option::Some(16),
+                Self::ScienceAndResearch => std::option::Option::Some(17),
+                Self::TransportationAndLogistics => std::option::Option::Some(18),
+                Self::TravelAndTourism => std::option::Option::Some(19),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CATEGORY_OTHERS"),
-                2 => std::borrow::Cow::Borrowed("CATEGORY_ADVERTISING_AND_MARKETING"),
-                3 => std::borrow::Cow::Borrowed("CATEGORY_COMMERCE"),
-                4 => std::borrow::Cow::Borrowed("CATEGORY_CLIMATE_AND_ENVIRONMENT"),
-                5 => std::borrow::Cow::Borrowed("CATEGORY_DEMOGRAPHICS"),
-                6 => std::borrow::Cow::Borrowed("CATEGORY_ECONOMICS"),
-                7 => std::borrow::Cow::Borrowed("CATEGORY_EDUCATION"),
-                8 => std::borrow::Cow::Borrowed("CATEGORY_ENERGY"),
-                9 => std::borrow::Cow::Borrowed("CATEGORY_FINANCIAL"),
-                10 => std::borrow::Cow::Borrowed("CATEGORY_GAMING"),
-                11 => std::borrow::Cow::Borrowed("CATEGORY_GEOSPATIAL"),
-                12 => std::borrow::Cow::Borrowed("CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE"),
-                13 => std::borrow::Cow::Borrowed("CATEGORY_MEDIA"),
-                14 => std::borrow::Cow::Borrowed("CATEGORY_PUBLIC_SECTOR"),
-                15 => std::borrow::Cow::Borrowed("CATEGORY_RETAIL"),
-                16 => std::borrow::Cow::Borrowed("CATEGORY_SPORTS"),
-                17 => std::borrow::Cow::Borrowed("CATEGORY_SCIENCE_AND_RESEARCH"),
-                18 => std::borrow::Cow::Borrowed("CATEGORY_TRANSPORTATION_AND_LOGISTICS"),
-                19 => std::borrow::Cow::Borrowed("CATEGORY_TRAVEL_AND_TOURISM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CATEGORY_UNSPECIFIED"),
+                Self::Others => std::option::Option::Some("CATEGORY_OTHERS"),
+                Self::AdvertisingAndMarketing => {
+                    std::option::Option::Some("CATEGORY_ADVERTISING_AND_MARKETING")
+                }
+                Self::Commerce => std::option::Option::Some("CATEGORY_COMMERCE"),
+                Self::ClimateAndEnvironment => {
+                    std::option::Option::Some("CATEGORY_CLIMATE_AND_ENVIRONMENT")
+                }
+                Self::Demographics => std::option::Option::Some("CATEGORY_DEMOGRAPHICS"),
+                Self::Economics => std::option::Option::Some("CATEGORY_ECONOMICS"),
+                Self::Education => std::option::Option::Some("CATEGORY_EDUCATION"),
+                Self::Energy => std::option::Option::Some("CATEGORY_ENERGY"),
+                Self::Financial => std::option::Option::Some("CATEGORY_FINANCIAL"),
+                Self::Gaming => std::option::Option::Some("CATEGORY_GAMING"),
+                Self::Geospatial => std::option::Option::Some("CATEGORY_GEOSPATIAL"),
+                Self::HealthcareAndLifeScience => {
+                    std::option::Option::Some("CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE")
+                }
+                Self::Media => std::option::Option::Some("CATEGORY_MEDIA"),
+                Self::PublicSector => std::option::Option::Some("CATEGORY_PUBLIC_SECTOR"),
+                Self::Retail => std::option::Option::Some("CATEGORY_RETAIL"),
+                Self::Sports => std::option::Option::Some("CATEGORY_SPORTS"),
+                Self::ScienceAndResearch => {
+                    std::option::Option::Some("CATEGORY_SCIENCE_AND_RESEARCH")
+                }
+                Self::TransportationAndLogistics => {
+                    std::option::Option::Some("CATEGORY_TRANSPORTATION_AND_LOGISTICS")
+                }
+                Self::TravelAndTourism => std::option::Option::Some("CATEGORY_TRAVEL_AND_TOURISM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
-                "CATEGORY_OTHERS" => std::option::Option::Some(Self::CATEGORY_OTHERS),
-                "CATEGORY_ADVERTISING_AND_MARKETING" => {
-                    std::option::Option::Some(Self::CATEGORY_ADVERTISING_AND_MARKETING)
-                }
-                "CATEGORY_COMMERCE" => std::option::Option::Some(Self::CATEGORY_COMMERCE),
-                "CATEGORY_CLIMATE_AND_ENVIRONMENT" => {
-                    std::option::Option::Some(Self::CATEGORY_CLIMATE_AND_ENVIRONMENT)
-                }
-                "CATEGORY_DEMOGRAPHICS" => std::option::Option::Some(Self::CATEGORY_DEMOGRAPHICS),
-                "CATEGORY_ECONOMICS" => std::option::Option::Some(Self::CATEGORY_ECONOMICS),
-                "CATEGORY_EDUCATION" => std::option::Option::Some(Self::CATEGORY_EDUCATION),
-                "CATEGORY_ENERGY" => std::option::Option::Some(Self::CATEGORY_ENERGY),
-                "CATEGORY_FINANCIAL" => std::option::Option::Some(Self::CATEGORY_FINANCIAL),
-                "CATEGORY_GAMING" => std::option::Option::Some(Self::CATEGORY_GAMING),
-                "CATEGORY_GEOSPATIAL" => std::option::Option::Some(Self::CATEGORY_GEOSPATIAL),
-                "CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE" => {
-                    std::option::Option::Some(Self::CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE)
-                }
-                "CATEGORY_MEDIA" => std::option::Option::Some(Self::CATEGORY_MEDIA),
-                "CATEGORY_PUBLIC_SECTOR" => std::option::Option::Some(Self::CATEGORY_PUBLIC_SECTOR),
-                "CATEGORY_RETAIL" => std::option::Option::Some(Self::CATEGORY_RETAIL),
-                "CATEGORY_SPORTS" => std::option::Option::Some(Self::CATEGORY_SPORTS),
-                "CATEGORY_SCIENCE_AND_RESEARCH" => {
-                    std::option::Option::Some(Self::CATEGORY_SCIENCE_AND_RESEARCH)
-                }
-                "CATEGORY_TRANSPORTATION_AND_LOGISTICS" => {
-                    std::option::Option::Some(Self::CATEGORY_TRANSPORTATION_AND_LOGISTICS)
-                }
-                "CATEGORY_TRAVEL_AND_TOURISM" => {
-                    std::option::Option::Some(Self::CATEGORY_TRAVEL_AND_TOURISM)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Category {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Category {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Others,
+                2 => Self::AdvertisingAndMarketing,
+                3 => Self::Commerce,
+                4 => Self::ClimateAndEnvironment,
+                5 => Self::Demographics,
+                6 => Self::Economics,
+                7 => Self::Education,
+                8 => Self::Energy,
+                9 => Self::Financial,
+                10 => Self::Gaming,
+                11 => Self::Geospatial,
+                12 => Self::HealthcareAndLifeScience,
+                13 => Self::Media,
+                14 => Self::PublicSector,
+                15 => Self::Retail,
+                16 => Self::Sports,
+                17 => Self::ScienceAndResearch,
+                18 => Self::TransportationAndLogistics,
+                19 => Self::TravelAndTourism,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Category {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "CATEGORY_OTHERS" => Self::Others,
+                "CATEGORY_ADVERTISING_AND_MARKETING" => Self::AdvertisingAndMarketing,
+                "CATEGORY_COMMERCE" => Self::Commerce,
+                "CATEGORY_CLIMATE_AND_ENVIRONMENT" => Self::ClimateAndEnvironment,
+                "CATEGORY_DEMOGRAPHICS" => Self::Demographics,
+                "CATEGORY_ECONOMICS" => Self::Economics,
+                "CATEGORY_EDUCATION" => Self::Education,
+                "CATEGORY_ENERGY" => Self::Energy,
+                "CATEGORY_FINANCIAL" => Self::Financial,
+                "CATEGORY_GAMING" => Self::Gaming,
+                "CATEGORY_GEOSPATIAL" => Self::Geospatial,
+                "CATEGORY_HEALTHCARE_AND_LIFE_SCIENCE" => Self::HealthcareAndLifeScience,
+                "CATEGORY_MEDIA" => Self::Media,
+                "CATEGORY_PUBLIC_SECTOR" => Self::PublicSector,
+                "CATEGORY_RETAIL" => Self::Retail,
+                "CATEGORY_SPORTS" => Self::Sports,
+                "CATEGORY_SCIENCE_AND_RESEARCH" => Self::ScienceAndResearch,
+                "CATEGORY_TRANSPORTATION_AND_LOGISTICS" => Self::TransportationAndLogistics,
+                "CATEGORY_TRAVEL_AND_TOURISM" => Self::TravelAndTourism,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Category {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Others => serializer.serialize_i32(1),
+                Self::AdvertisingAndMarketing => serializer.serialize_i32(2),
+                Self::Commerce => serializer.serialize_i32(3),
+                Self::ClimateAndEnvironment => serializer.serialize_i32(4),
+                Self::Demographics => serializer.serialize_i32(5),
+                Self::Economics => serializer.serialize_i32(6),
+                Self::Education => serializer.serialize_i32(7),
+                Self::Energy => serializer.serialize_i32(8),
+                Self::Financial => serializer.serialize_i32(9),
+                Self::Gaming => serializer.serialize_i32(10),
+                Self::Geospatial => serializer.serialize_i32(11),
+                Self::HealthcareAndLifeScience => serializer.serialize_i32(12),
+                Self::Media => serializer.serialize_i32(13),
+                Self::PublicSector => serializer.serialize_i32(14),
+                Self::Retail => serializer.serialize_i32(15),
+                Self::Sports => serializer.serialize_i32(16),
+                Self::ScienceAndResearch => serializer.serialize_i32(17),
+                Self::TransportationAndLogistics => serializer.serialize_i32(18),
+                Self::TravelAndTourism => serializer.serialize_i32(19),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Category {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Category>::new(
+                ".google.cloud.bigquery.analyticshub.v1.Listing.Category",
+            ))
         }
     }
 
@@ -1882,66 +2034,129 @@ pub mod subscription {
     }
 
     /// State of the subscription.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// This subscription is active and the data is accessible.
-        pub const STATE_ACTIVE: State = State::new(1);
-
+        Active,
         /// The data referenced by this subscription is out of date and should be
         /// refreshed. This can happen when a data provider adds or removes datasets.
-        pub const STATE_STALE: State = State::new(2);
-
+        Stale,
         /// This subscription has been cancelled or revoked and the data is no longer
         /// accessible.
-        pub const STATE_INACTIVE: State = State::new(3);
+        Inactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Stale => std::option::Option::Some(2),
+                Self::Inactive => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATE_ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("STATE_STALE"),
-                3 => std::borrow::Cow::Borrowed("STATE_INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("STATE_ACTIVE"),
+                Self::Stale => std::option::Option::Some("STATE_STALE"),
+                Self::Inactive => std::option::Option::Some("STATE_INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STATE_ACTIVE" => std::option::Option::Some(Self::STATE_ACTIVE),
-                "STATE_STALE" => std::option::Option::Some(Self::STATE_STALE),
-                "STATE_INACTIVE" => std::option::Option::Some(Self::STATE_INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Stale,
+                3 => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STATE_ACTIVE" => Self::Active,
+                "STATE_STALE" => Self::Stale,
+                "STATE_INACTIVE" => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Stale => serializer.serialize_i32(2),
+                Self::Inactive => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.analyticshub.v1.Subscription.State",
+            ))
         }
     }
 
@@ -4943,121 +5158,239 @@ impl wkt::message::Message for JavaScriptUDF {
 /// Specifies the type of discovery on the discovery page. Note that
 /// this does not control the visibility of the exchange/listing which is
 /// defined by IAM permission.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DiscoveryType(i32);
-
-impl DiscoveryType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DiscoveryType {
     /// Unspecified. Defaults to DISCOVERY_TYPE_PRIVATE.
-    pub const DISCOVERY_TYPE_UNSPECIFIED: DiscoveryType = DiscoveryType::new(0);
-
+    Unspecified,
     /// The Data exchange/listing can be discovered in the 'Private' results
     /// list.
-    pub const DISCOVERY_TYPE_PRIVATE: DiscoveryType = DiscoveryType::new(1);
-
+    Private,
     /// The Data exchange/listing can be discovered in the 'Public' results
     /// list.
-    pub const DISCOVERY_TYPE_PUBLIC: DiscoveryType = DiscoveryType::new(2);
+    Public,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DiscoveryType::value] or
+    /// [DiscoveryType::name].
+    UnknownValue(discovery_type::UnknownValue),
+}
 
-    /// Creates a new DiscoveryType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod discovery_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DiscoveryType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Private => std::option::Option::Some(1),
+            Self::Public => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DISCOVERY_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DISCOVERY_TYPE_PRIVATE"),
-            2 => std::borrow::Cow::Borrowed("DISCOVERY_TYPE_PUBLIC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DISCOVERY_TYPE_UNSPECIFIED"),
+            Self::Private => std::option::Option::Some("DISCOVERY_TYPE_PRIVATE"),
+            Self::Public => std::option::Option::Some("DISCOVERY_TYPE_PUBLIC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DISCOVERY_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DISCOVERY_TYPE_UNSPECIFIED)
-            }
-            "DISCOVERY_TYPE_PRIVATE" => std::option::Option::Some(Self::DISCOVERY_TYPE_PRIVATE),
-            "DISCOVERY_TYPE_PUBLIC" => std::option::Option::Some(Self::DISCOVERY_TYPE_PUBLIC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DiscoveryType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DiscoveryType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DiscoveryType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DiscoveryType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Private,
+            2 => Self::Public,
+            _ => Self::UnknownValue(discovery_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DiscoveryType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DISCOVERY_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "DISCOVERY_TYPE_PRIVATE" => Self::Private,
+            "DISCOVERY_TYPE_PUBLIC" => Self::Public,
+            _ => Self::UnknownValue(discovery_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DiscoveryType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Private => serializer.serialize_i32(1),
+            Self::Public => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DiscoveryType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiscoveryType>::new(
+            ".google.cloud.bigquery.analyticshub.v1.DiscoveryType",
+        ))
     }
 }
 
 /// The underlying shared asset type shared in a listing by a publisher.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SharedResourceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SharedResourceType {
+    /// Not specified.
+    Unspecified,
+    /// BigQuery Dataset Asset.
+    BigqueryDataset,
+    /// Pub/Sub Topic Asset.
+    PubsubTopic,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SharedResourceType::value] or
+    /// [SharedResourceType::name].
+    UnknownValue(shared_resource_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod shared_resource_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SharedResourceType {
-    /// Not specified.
-    pub const SHARED_RESOURCE_TYPE_UNSPECIFIED: SharedResourceType = SharedResourceType::new(0);
-
-    /// BigQuery Dataset Asset.
-    pub const BIGQUERY_DATASET: SharedResourceType = SharedResourceType::new(1);
-
-    /// Pub/Sub Topic Asset.
-    pub const PUBSUB_TOPIC: SharedResourceType = SharedResourceType::new(2);
-
-    /// Creates a new SharedResourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::BigqueryDataset => std::option::Option::Some(1),
+            Self::PubsubTopic => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SHARED_RESOURCE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BIGQUERY_DATASET"),
-            2 => std::borrow::Cow::Borrowed("PUBSUB_TOPIC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SHARED_RESOURCE_TYPE_UNSPECIFIED"),
+            Self::BigqueryDataset => std::option::Option::Some("BIGQUERY_DATASET"),
+            Self::PubsubTopic => std::option::Option::Some("PUBSUB_TOPIC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SHARED_RESOURCE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SHARED_RESOURCE_TYPE_UNSPECIFIED)
-            }
-            "BIGQUERY_DATASET" => std::option::Option::Some(Self::BIGQUERY_DATASET),
-            "PUBSUB_TOPIC" => std::option::Option::Some(Self::PUBSUB_TOPIC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SharedResourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SharedResourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SharedResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SharedResourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::BigqueryDataset,
+            2 => Self::PubsubTopic,
+            _ => Self::UnknownValue(shared_resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SharedResourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SHARED_RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BIGQUERY_DATASET" => Self::BigqueryDataset,
+            "PUBSUB_TOPIC" => Self::PubsubTopic,
+            _ => Self::UnknownValue(shared_resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SharedResourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::BigqueryDataset => serializer.serialize_i32(1),
+            Self::PubsubTopic => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SharedResourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SharedResourceType>::new(
+            ".google.cloud.bigquery.analyticshub.v1.SharedResourceType",
+        ))
     }
 }

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -763,61 +763,120 @@ pub mod cloud_sql_properties {
     use super::*;
 
     /// Supported Cloud SQL database types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseType {
+        /// Unspecified database type.
+        Unspecified,
+        /// Cloud SQL for PostgreSQL.
+        Postgres,
+        /// Cloud SQL for MySQL.
+        Mysql,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseType::value] or
+        /// [DatabaseType::name].
+        UnknownValue(database_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseType {
-        /// Unspecified database type.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
-
-        /// Cloud SQL for PostgreSQL.
-        pub const POSTGRES: DatabaseType = DatabaseType::new(1);
-
-        /// Cloud SQL for MySQL.
-        pub const MYSQL: DatabaseType = DatabaseType::new(2);
-
-        /// Creates a new DatabaseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Postgres => std::option::Option::Some(1),
+                Self::Mysql => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("POSTGRES"),
-                2 => std::borrow::Cow::Borrowed("MYSQL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_TYPE_UNSPECIFIED"),
+                Self::Postgres => std::option::Option::Some("POSTGRES"),
+                Self::Mysql => std::option::Option::Some("MYSQL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
-                }
-                "POSTGRES" => std::option::Option::Some(Self::POSTGRES),
-                "MYSQL" => std::option::Option::Some(Self::MYSQL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Postgres,
+                2 => Self::Mysql,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "POSTGRES" => Self::Postgres,
+                "MYSQL" => Self::Mysql,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Postgres => serializer.serialize_i32(1),
+                Self::Mysql => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseType>::new(
+                ".google.cloud.bigquery.connection.v1.CloudSqlProperties.DatabaseType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -535,64 +535,123 @@ pub mod data_policy {
     use super::*;
 
     /// A list of supported data policy types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataPolicyType(i32);
-
-    impl DataPolicyType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataPolicyType {
         /// Default value for the data policy type. This should not be used.
-        pub const DATA_POLICY_TYPE_UNSPECIFIED: DataPolicyType = DataPolicyType::new(0);
-
+        Unspecified,
         /// Used to create a data policy for column-level security, without data
         /// masking.
-        pub const COLUMN_LEVEL_SECURITY_POLICY: DataPolicyType = DataPolicyType::new(3);
-
+        ColumnLevelSecurityPolicy,
         /// Used to create a data policy for data masking.
-        pub const DATA_MASKING_POLICY: DataPolicyType = DataPolicyType::new(2);
+        DataMaskingPolicy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataPolicyType::value] or
+        /// [DataPolicyType::name].
+        UnknownValue(data_policy_type::UnknownValue),
+    }
 
-        /// Creates a new DataPolicyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_policy_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataPolicyType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ColumnLevelSecurityPolicy => std::option::Option::Some(3),
+                Self::DataMaskingPolicy => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_POLICY_TYPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("DATA_MASKING_POLICY"),
-                3 => std::borrow::Cow::Borrowed("COLUMN_LEVEL_SECURITY_POLICY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_POLICY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_POLICY_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_POLICY_TYPE_UNSPECIFIED"),
+                Self::ColumnLevelSecurityPolicy => {
+                    std::option::Option::Some("COLUMN_LEVEL_SECURITY_POLICY")
                 }
-                "COLUMN_LEVEL_SECURITY_POLICY" => {
-                    std::option::Option::Some(Self::COLUMN_LEVEL_SECURITY_POLICY)
-                }
-                "DATA_MASKING_POLICY" => std::option::Option::Some(Self::DATA_MASKING_POLICY),
-                _ => std::option::Option::None,
+                Self::DataMaskingPolicy => std::option::Option::Some("DATA_MASKING_POLICY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DataPolicyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataPolicyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataPolicyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataPolicyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::DataMaskingPolicy,
+                3 => Self::ColumnLevelSecurityPolicy,
+                _ => Self::UnknownValue(data_policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataPolicyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_POLICY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "COLUMN_LEVEL_SECURITY_POLICY" => Self::ColumnLevelSecurityPolicy,
+                "DATA_MASKING_POLICY" => Self::DataMaskingPolicy,
+                _ => Self::UnknownValue(data_policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataPolicyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ColumnLevelSecurityPolicy => serializer.serialize_i32(3),
+                Self::DataMaskingPolicy => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataPolicyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataPolicyType>::new(
+                ".google.cloud.bigquery.datapolicies.v1.DataPolicy.DataPolicyType",
+            ))
         }
     }
 
@@ -723,21 +782,16 @@ pub mod data_masking_policy {
 
     /// The available masking rules. Learn more here:
     /// <https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PredefinedExpression(i32);
-
-    impl PredefinedExpression {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PredefinedExpression {
         /// Default, unspecified predefined expression. No masking will take place
         /// since no expression is specified.
-        pub const PREDEFINED_EXPRESSION_UNSPECIFIED: PredefinedExpression =
-            PredefinedExpression::new(0);
-
+        Unspecified,
         /// Masking expression to replace data with SHA-256 hash.
-        pub const SHA256: PredefinedExpression = PredefinedExpression::new(3);
-
+        Sha256,
         /// Masking expression to replace data with NULLs.
-        pub const ALWAYS_NULL: PredefinedExpression = PredefinedExpression::new(5);
-
+        AlwaysNull,
         /// Masking expression to replace data with their default masking values.
         /// The default masking values for each type listed as below:
         ///
@@ -756,24 +810,21 @@ pub mod data_masking_policy {
         /// * ARRAY: []
         /// * STRUCT: NOT_APPLICABLE
         /// * JSON: NULL
-        pub const DEFAULT_MASKING_VALUE: PredefinedExpression = PredefinedExpression::new(7);
-
+        DefaultMaskingValue,
         /// Masking expression shows the last four characters of text.
         /// The masking behavior is as follows:
         ///
         /// * If text length > 4 characters: Replace text with XXXXX, append last
         ///   four characters of original text.
         /// * If text length <= 4 characters: Apply SHA-256 hash.
-        pub const LAST_FOUR_CHARACTERS: PredefinedExpression = PredefinedExpression::new(9);
-
+        LastFourCharacters,
         /// Masking expression shows the first four characters of text.
         /// The masking behavior is as follows:
         ///
         /// * If text length > 4 characters: Replace text with XXXXX, prepend first
         ///   four characters of original text.
         /// * If text length <= 4 characters: Apply SHA-256 hash.
-        pub const FIRST_FOUR_CHARACTERS: PredefinedExpression = PredefinedExpression::new(10);
-
+        FirstFourCharacters,
         /// Masking expression for email addresses.
         /// The masking behavior is as follows:
         ///
@@ -783,8 +834,7 @@ pub mod data_masking_policy {
         ///
         /// For more information, see [Email
         /// mask](https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options).
-        pub const EMAIL_MASK: PredefinedExpression = PredefinedExpression::new(12);
-
+        EmailMask,
         /// Masking expression to only show the year of `Date`,
         /// `DateTime` and `TimeStamp`. For example, with the
         /// year 2076:
@@ -798,60 +848,137 @@ pub mod data_masking_policy {
         /// For more information, see the <a
         /// href="https://cloud.google.com/bigquery/docs/reference/system-variables">System
         /// variables reference</a>.
-        pub const DATE_YEAR_MASK: PredefinedExpression = PredefinedExpression::new(13);
+        DateYearMask,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PredefinedExpression::value] or
+        /// [PredefinedExpression::name].
+        UnknownValue(predefined_expression::UnknownValue),
+    }
 
-        /// Creates a new PredefinedExpression instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod predefined_expression {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PredefinedExpression {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Sha256 => std::option::Option::Some(3),
+                Self::AlwaysNull => std::option::Option::Some(5),
+                Self::DefaultMaskingValue => std::option::Option::Some(7),
+                Self::LastFourCharacters => std::option::Option::Some(9),
+                Self::FirstFourCharacters => std::option::Option::Some(10),
+                Self::EmailMask => std::option::Option::Some(12),
+                Self::DateYearMask => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PREDEFINED_EXPRESSION_UNSPECIFIED"),
-                3 => std::borrow::Cow::Borrowed("SHA256"),
-                5 => std::borrow::Cow::Borrowed("ALWAYS_NULL"),
-                7 => std::borrow::Cow::Borrowed("DEFAULT_MASKING_VALUE"),
-                9 => std::borrow::Cow::Borrowed("LAST_FOUR_CHARACTERS"),
-                10 => std::borrow::Cow::Borrowed("FIRST_FOUR_CHARACTERS"),
-                12 => std::borrow::Cow::Borrowed("EMAIL_MASK"),
-                13 => std::borrow::Cow::Borrowed("DATE_YEAR_MASK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PREDEFINED_EXPRESSION_UNSPECIFIED"),
+                Self::Sha256 => std::option::Option::Some("SHA256"),
+                Self::AlwaysNull => std::option::Option::Some("ALWAYS_NULL"),
+                Self::DefaultMaskingValue => std::option::Option::Some("DEFAULT_MASKING_VALUE"),
+                Self::LastFourCharacters => std::option::Option::Some("LAST_FOUR_CHARACTERS"),
+                Self::FirstFourCharacters => std::option::Option::Some("FIRST_FOUR_CHARACTERS"),
+                Self::EmailMask => std::option::Option::Some("EMAIL_MASK"),
+                Self::DateYearMask => std::option::Option::Some("DATE_YEAR_MASK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PREDEFINED_EXPRESSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PREDEFINED_EXPRESSION_UNSPECIFIED)
-                }
-                "SHA256" => std::option::Option::Some(Self::SHA256),
-                "ALWAYS_NULL" => std::option::Option::Some(Self::ALWAYS_NULL),
-                "DEFAULT_MASKING_VALUE" => std::option::Option::Some(Self::DEFAULT_MASKING_VALUE),
-                "LAST_FOUR_CHARACTERS" => std::option::Option::Some(Self::LAST_FOUR_CHARACTERS),
-                "FIRST_FOUR_CHARACTERS" => std::option::Option::Some(Self::FIRST_FOUR_CHARACTERS),
-                "EMAIL_MASK" => std::option::Option::Some(Self::EMAIL_MASK),
-                "DATE_YEAR_MASK" => std::option::Option::Some(Self::DATE_YEAR_MASK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PredefinedExpression {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PredefinedExpression {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PredefinedExpression {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PredefinedExpression {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                3 => Self::Sha256,
+                5 => Self::AlwaysNull,
+                7 => Self::DefaultMaskingValue,
+                9 => Self::LastFourCharacters,
+                10 => Self::FirstFourCharacters,
+                12 => Self::EmailMask,
+                13 => Self::DateYearMask,
+                _ => Self::UnknownValue(predefined_expression::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PredefinedExpression {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PREDEFINED_EXPRESSION_UNSPECIFIED" => Self::Unspecified,
+                "SHA256" => Self::Sha256,
+                "ALWAYS_NULL" => Self::AlwaysNull,
+                "DEFAULT_MASKING_VALUE" => Self::DefaultMaskingValue,
+                "LAST_FOUR_CHARACTERS" => Self::LastFourCharacters,
+                "FIRST_FOUR_CHARACTERS" => Self::FirstFourCharacters,
+                "EMAIL_MASK" => Self::EmailMask,
+                "DATE_YEAR_MASK" => Self::DateYearMask,
+                _ => Self::UnknownValue(predefined_expression::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PredefinedExpression {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Sha256 => serializer.serialize_i32(3),
+                Self::AlwaysNull => serializer.serialize_i32(5),
+                Self::DefaultMaskingValue => serializer.serialize_i32(7),
+                Self::LastFourCharacters => serializer.serialize_i32(9),
+                Self::FirstFourCharacters => serializer.serialize_i32(10),
+                Self::EmailMask => serializer.serialize_i32(12),
+                Self::DateYearMask => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PredefinedExpression {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PredefinedExpression>::new(
+                ".google.cloud.bigquery.datapolicies.v1.DataMaskingPolicy.PredefinedExpression",
+            ))
         }
     }
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -250,85 +250,156 @@ pub mod data_source_parameter {
     use super::*;
 
     /// Parameter type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Type unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// String parameter.
-        pub const STRING: Type = Type::new(1);
-
+        String,
         /// Integer parameter (64-bits).
         /// Will be serialized to json as string.
-        pub const INTEGER: Type = Type::new(2);
-
+        Integer,
         /// Double precision floating point parameter.
-        pub const DOUBLE: Type = Type::new(3);
-
+        Double,
         /// Boolean parameter.
-        pub const BOOLEAN: Type = Type::new(4);
-
+        Boolean,
         /// Deprecated. This field has no effect.
-        pub const RECORD: Type = Type::new(5);
-
+        Record,
         /// Page ID for a Google+ Page.
-        pub const PLUS_PAGE: Type = Type::new(6);
-
+        PlusPage,
         /// List of strings parameter.
-        pub const LIST: Type = Type::new(7);
+        List,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::String => std::option::Option::Some(1),
+                Self::Integer => std::option::Option::Some(2),
+                Self::Double => std::option::Option::Some(3),
+                Self::Boolean => std::option::Option::Some(4),
+                Self::Record => std::option::Option::Some(5),
+                Self::PlusPage => std::option::Option::Some(6),
+                Self::List => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STRING"),
-                2 => std::borrow::Cow::Borrowed("INTEGER"),
-                3 => std::borrow::Cow::Borrowed("DOUBLE"),
-                4 => std::borrow::Cow::Borrowed("BOOLEAN"),
-                5 => std::borrow::Cow::Borrowed("RECORD"),
-                6 => std::borrow::Cow::Borrowed("PLUS_PAGE"),
-                7 => std::borrow::Cow::Borrowed("LIST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Integer => std::option::Option::Some("INTEGER"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::Boolean => std::option::Option::Some("BOOLEAN"),
+                Self::Record => std::option::Option::Some("RECORD"),
+                Self::PlusPage => std::option::Option::Some("PLUS_PAGE"),
+                Self::List => std::option::Option::Some("LIST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "INTEGER" => std::option::Option::Some(Self::INTEGER),
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
-                "RECORD" => std::option::Option::Some(Self::RECORD),
-                "PLUS_PAGE" => std::option::Option::Some(Self::PLUS_PAGE),
-                "LIST" => std::option::Option::Some(Self::LIST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::String,
+                2 => Self::Integer,
+                3 => Self::Double,
+                4 => Self::Boolean,
+                5 => Self::Record,
+                6 => Self::PlusPage,
+                7 => Self::List,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STRING" => Self::String,
+                "INTEGER" => Self::Integer,
+                "DOUBLE" => Self::Double,
+                "BOOLEAN" => Self::Boolean,
+                "RECORD" => Self::Record,
+                "PLUS_PAGE" => Self::PlusPage,
+                "LIST" => Self::List,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::String => serializer.serialize_i32(1),
+                Self::Integer => serializer.serialize_i32(2),
+                Self::Double => serializer.serialize_i32(3),
+                Self::Boolean => serializer.serialize_i32(4),
+                Self::Record => serializer.serialize_i32(5),
+                Self::PlusPage => serializer.serialize_i32(6),
+                Self::List => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.bigquery.datatransfer.v1.DataSourceParameter.Type",
+            ))
         }
     }
 }
@@ -586,133 +657,253 @@ pub mod data_source {
     use super::*;
 
     /// The type of authorization needed for this data source.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthorizationType(i32);
-
-    impl AuthorizationType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AuthorizationType {
         /// Type unspecified.
-        pub const AUTHORIZATION_TYPE_UNSPECIFIED: AuthorizationType = AuthorizationType::new(0);
-
+        Unspecified,
         /// Use OAuth 2 authorization codes that can be exchanged
         /// for a refresh token on the backend.
-        pub const AUTHORIZATION_CODE: AuthorizationType = AuthorizationType::new(1);
-
+        AuthorizationCode,
         /// Return an authorization code for a given Google+ page that can then be
         /// exchanged for a refresh token on the backend.
-        pub const GOOGLE_PLUS_AUTHORIZATION_CODE: AuthorizationType = AuthorizationType::new(2);
-
+        GooglePlusAuthorizationCode,
         /// Use First Party OAuth.
-        pub const FIRST_PARTY_OAUTH: AuthorizationType = AuthorizationType::new(3);
+        FirstPartyOauth,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AuthorizationType::value] or
+        /// [AuthorizationType::name].
+        UnknownValue(authorization_type::UnknownValue),
+    }
 
-        /// Creates a new AuthorizationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod authorization_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AuthorizationType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AuthorizationCode => std::option::Option::Some(1),
+                Self::GooglePlusAuthorizationCode => std::option::Option::Some(2),
+                Self::FirstPartyOauth => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTHORIZATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTHORIZATION_CODE"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_PLUS_AUTHORIZATION_CODE"),
-                3 => std::borrow::Cow::Borrowed("FIRST_PARTY_OAUTH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTHORIZATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTHORIZATION_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTHORIZATION_TYPE_UNSPECIFIED"),
+                Self::AuthorizationCode => std::option::Option::Some("AUTHORIZATION_CODE"),
+                Self::GooglePlusAuthorizationCode => {
+                    std::option::Option::Some("GOOGLE_PLUS_AUTHORIZATION_CODE")
                 }
-                "AUTHORIZATION_CODE" => std::option::Option::Some(Self::AUTHORIZATION_CODE),
-                "GOOGLE_PLUS_AUTHORIZATION_CODE" => {
-                    std::option::Option::Some(Self::GOOGLE_PLUS_AUTHORIZATION_CODE)
-                }
-                "FIRST_PARTY_OAUTH" => std::option::Option::Some(Self::FIRST_PARTY_OAUTH),
-                _ => std::option::Option::None,
+                Self::FirstPartyOauth => std::option::Option::Some("FIRST_PARTY_OAUTH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for AuthorizationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthorizationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AuthorizationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AuthorizationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AuthorizationCode,
+                2 => Self::GooglePlusAuthorizationCode,
+                3 => Self::FirstPartyOauth,
+                _ => Self::UnknownValue(authorization_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AuthorizationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTHORIZATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AUTHORIZATION_CODE" => Self::AuthorizationCode,
+                "GOOGLE_PLUS_AUTHORIZATION_CODE" => Self::GooglePlusAuthorizationCode,
+                "FIRST_PARTY_OAUTH" => Self::FirstPartyOauth,
+                _ => Self::UnknownValue(authorization_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AuthorizationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AuthorizationCode => serializer.serialize_i32(1),
+                Self::GooglePlusAuthorizationCode => serializer.serialize_i32(2),
+                Self::FirstPartyOauth => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AuthorizationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthorizationType>::new(
+                ".google.cloud.bigquery.datatransfer.v1.DataSource.AuthorizationType",
+            ))
         }
     }
 
     /// Represents how the data source supports data auto refresh.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataRefreshType(i32);
-
-    impl DataRefreshType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataRefreshType {
         /// The data source won't support data auto refresh, which is default value.
-        pub const DATA_REFRESH_TYPE_UNSPECIFIED: DataRefreshType = DataRefreshType::new(0);
-
+        Unspecified,
         /// The data source supports data auto refresh, and runs will be scheduled
         /// for the past few days. Does not allow custom values to be set for each
         /// transfer config.
-        pub const SLIDING_WINDOW: DataRefreshType = DataRefreshType::new(1);
-
+        SlidingWindow,
         /// The data source supports data auto refresh, and runs will be scheduled
         /// for the past few days. Allows custom values to be set for each transfer
         /// config.
-        pub const CUSTOM_SLIDING_WINDOW: DataRefreshType = DataRefreshType::new(2);
+        CustomSlidingWindow,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataRefreshType::value] or
+        /// [DataRefreshType::name].
+        UnknownValue(data_refresh_type::UnknownValue),
+    }
 
-        /// Creates a new DataRefreshType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_refresh_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataRefreshType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SlidingWindow => std::option::Option::Some(1),
+                Self::CustomSlidingWindow => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_REFRESH_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SLIDING_WINDOW"),
-                2 => std::borrow::Cow::Borrowed("CUSTOM_SLIDING_WINDOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_REFRESH_TYPE_UNSPECIFIED"),
+                Self::SlidingWindow => std::option::Option::Some("SLIDING_WINDOW"),
+                Self::CustomSlidingWindow => std::option::Option::Some("CUSTOM_SLIDING_WINDOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_REFRESH_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_REFRESH_TYPE_UNSPECIFIED)
-                }
-                "SLIDING_WINDOW" => std::option::Option::Some(Self::SLIDING_WINDOW),
-                "CUSTOM_SLIDING_WINDOW" => std::option::Option::Some(Self::CUSTOM_SLIDING_WINDOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataRefreshType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataRefreshType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataRefreshType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataRefreshType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SlidingWindow,
+                2 => Self::CustomSlidingWindow,
+                _ => Self::UnknownValue(data_refresh_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataRefreshType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_REFRESH_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SLIDING_WINDOW" => Self::SlidingWindow,
+                "CUSTOM_SLIDING_WINDOW" => Self::CustomSlidingWindow,
+                _ => Self::UnknownValue(data_refresh_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataRefreshType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SlidingWindow => serializer.serialize_i32(1),
+                Self::CustomSlidingWindow => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataRefreshType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataRefreshType>::new(
+                ".google.cloud.bigquery.datatransfer.v1.DataSource.DataRefreshType",
+            ))
         }
     }
 }
@@ -1502,56 +1693,113 @@ pub mod list_transfer_runs_request {
     use super::*;
 
     /// Represents which runs should be pulled.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RunAttempt(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RunAttempt {
+        /// All runs should be returned.
+        Unspecified,
+        /// Only latest run per day should be returned.
+        Latest,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RunAttempt::value] or
+        /// [RunAttempt::name].
+        UnknownValue(run_attempt::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod run_attempt {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RunAttempt {
-        /// All runs should be returned.
-        pub const RUN_ATTEMPT_UNSPECIFIED: RunAttempt = RunAttempt::new(0);
-
-        /// Only latest run per day should be returned.
-        pub const LATEST: RunAttempt = RunAttempt::new(1);
-
-        /// Creates a new RunAttempt instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Latest => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RUN_ATTEMPT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LATEST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RUN_ATTEMPT_UNSPECIFIED"),
+                Self::Latest => std::option::Option::Some("LATEST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RUN_ATTEMPT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RUN_ATTEMPT_UNSPECIFIED)
-                }
-                "LATEST" => std::option::Option::Some(Self::LATEST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RunAttempt {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RunAttempt {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RunAttempt {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RunAttempt {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Latest,
+                _ => Self::UnknownValue(run_attempt::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RunAttempt {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RUN_ATTEMPT_UNSPECIFIED" => Self::Unspecified,
+                "LATEST" => Self::Latest,
+                _ => Self::UnknownValue(run_attempt::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RunAttempt {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Latest => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RunAttempt {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RunAttempt>::new(
+                ".google.cloud.bigquery.datatransfer.v1.ListTransferRunsRequest.RunAttempt",
+            ))
         }
     }
 }
@@ -3428,201 +3676,386 @@ pub mod transfer_message {
     use super::*;
 
     /// Represents data transfer user facing message severity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageSeverity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MessageSeverity {
+        /// No severity specified.
+        Unspecified,
+        /// Informational message.
+        Info,
+        /// Warning message.
+        Warning,
+        /// Error message.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MessageSeverity::value] or
+        /// [MessageSeverity::name].
+        UnknownValue(message_severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod message_severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MessageSeverity {
-        /// No severity specified.
-        pub const MESSAGE_SEVERITY_UNSPECIFIED: MessageSeverity = MessageSeverity::new(0);
-
-        /// Informational message.
-        pub const INFO: MessageSeverity = MessageSeverity::new(1);
-
-        /// Warning message.
-        pub const WARNING: MessageSeverity = MessageSeverity::new(2);
-
-        /// Error message.
-        pub const ERROR: MessageSeverity = MessageSeverity::new(3);
-
-        /// Creates a new MessageSeverity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Info => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MESSAGE_SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INFO"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MESSAGE_SEVERITY_UNSPECIFIED"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MESSAGE_SEVERITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MESSAGE_SEVERITY_UNSPECIFIED)
-                }
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MessageSeverity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageSeverity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MessageSeverity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MessageSeverity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Info,
+                2 => Self::Warning,
+                3 => Self::Error,
+                _ => Self::UnknownValue(message_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MessageSeverity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MESSAGE_SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "INFO" => Self::Info,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(message_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MessageSeverity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Info => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MessageSeverity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MessageSeverity>::new(
+                ".google.cloud.bigquery.datatransfer.v1.TransferMessage.MessageSeverity",
+            ))
         }
     }
 }
 
 /// DEPRECATED. Represents data transfer type.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferType(i32);
-
-impl TransferType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransferType {
     /// Invalid or Unknown transfer type placeholder.
-    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType = TransferType::new(0);
-
+    Unspecified,
     /// Batch data transfer.
-    pub const BATCH: TransferType = TransferType::new(1);
-
+    Batch,
     /// Streaming data transfer. Streaming data source currently doesn't
     /// support multiple transfer configs per project.
-    pub const STREAMING: TransferType = TransferType::new(2);
+    Streaming,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransferType::value] or
+    /// [TransferType::name].
+    UnknownValue(transfer_type::UnknownValue),
+}
 
-    /// Creates a new TransferType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod transfer_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl TransferType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Batch => std::option::Option::Some(1),
+            Self::Streaming => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFER_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BATCH"),
-            2 => std::borrow::Cow::Borrowed("STREAMING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFER_TYPE_UNSPECIFIED"),
+            Self::Batch => std::option::Option::Some("BATCH"),
+            Self::Streaming => std::option::Option::Some("STREAMING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFER_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFER_TYPE_UNSPECIFIED)
-            }
-            "BATCH" => std::option::Option::Some(Self::BATCH),
-            "STREAMING" => std::option::Option::Some(Self::STREAMING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransferType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransferType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransferType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Batch,
+            2 => Self::Streaming,
+            _ => Self::UnknownValue(transfer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransferType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFER_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BATCH" => Self::Batch,
+            "STREAMING" => Self::Streaming,
+            _ => Self::UnknownValue(transfer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransferType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Batch => serializer.serialize_i32(1),
+            Self::Streaming => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransferType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransferType>::new(
+            ".google.cloud.bigquery.datatransfer.v1.TransferType",
+        ))
     }
 }
 
 /// Represents data transfer run state.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferState(i32);
-
-impl TransferState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransferState {
     /// State placeholder (0).
-    pub const TRANSFER_STATE_UNSPECIFIED: TransferState = TransferState::new(0);
-
+    Unspecified,
     /// Data transfer is scheduled and is waiting to be picked up by
     /// data transfer backend (2).
-    pub const PENDING: TransferState = TransferState::new(2);
-
+    Pending,
     /// Data transfer is in progress (3).
-    pub const RUNNING: TransferState = TransferState::new(3);
-
+    Running,
     /// Data transfer completed successfully (4).
-    pub const SUCCEEDED: TransferState = TransferState::new(4);
-
+    Succeeded,
     /// Data transfer failed (5).
-    pub const FAILED: TransferState = TransferState::new(5);
-
+    Failed,
     /// Data transfer is cancelled (6).
-    pub const CANCELLED: TransferState = TransferState::new(6);
+    Cancelled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransferState::value] or
+    /// [TransferState::name].
+    UnknownValue(transfer_state::UnknownValue),
+}
 
-    /// Creates a new TransferState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod transfer_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl TransferState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Pending => std::option::Option::Some(2),
+            Self::Running => std::option::Option::Some(3),
+            Self::Succeeded => std::option::Option::Some(4),
+            Self::Failed => std::option::Option::Some(5),
+            Self::Cancelled => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFER_STATE_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("PENDING"),
-            3 => std::borrow::Cow::Borrowed("RUNNING"),
-            4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-            5 => std::borrow::Cow::Borrowed("FAILED"),
-            6 => std::borrow::Cow::Borrowed("CANCELLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFER_STATE_UNSPECIFIED"),
+            Self::Pending => std::option::Option::Some("PENDING"),
+            Self::Running => std::option::Option::Some("RUNNING"),
+            Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::Cancelled => std::option::Option::Some("CANCELLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFER_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFER_STATE_UNSPECIFIED)
-            }
-            "PENDING" => std::option::Option::Some(Self::PENDING),
-            "RUNNING" => std::option::Option::Some(Self::RUNNING),
-            "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransferState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransferState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransferState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::Pending,
+            3 => Self::Running,
+            4 => Self::Succeeded,
+            5 => Self::Failed,
+            6 => Self::Cancelled,
+            _ => Self::UnknownValue(transfer_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransferState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFER_STATE_UNSPECIFIED" => Self::Unspecified,
+            "PENDING" => Self::Pending,
+            "RUNNING" => Self::Running,
+            "SUCCEEDED" => Self::Succeeded,
+            "FAILED" => Self::Failed,
+            "CANCELLED" => Self::Cancelled,
+            _ => Self::UnknownValue(transfer_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransferState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Pending => serializer.serialize_i32(2),
+            Self::Running => serializer.serialize_i32(3),
+            Self::Succeeded => serializer.serialize_i32(4),
+            Self::Failed => serializer.serialize_i32(5),
+            Self::Cancelled => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransferState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransferState>::new(
+            ".google.cloud.bigquery.datatransfer.v1.TransferState",
+        ))
     }
 }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -311,12 +311,13 @@ impl super::stub::DataTransferService for DataTransferService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = req.states.iter().fold(builder, |builder, p| {
-            builder.query(&[("states", p.value())])
-        });
+        let builder = req
+            .states
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("states", p)]));
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("runAttempt", &req.run_attempt.value())]);
+        let builder = builder.query(&[("runAttempt", &req.run_attempt)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -341,9 +342,10 @@ impl super::stub::DataTransferService for DataTransferService {
             );
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = req.message_types.iter().fold(builder, |builder, p| {
-            builder.query(&[("messageTypes", p.value())])
-        });
+        let builder = req
+            .message_types
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("messageTypes", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -141,73 +141,138 @@ pub mod migration_workflow {
     use super::*;
 
     /// Possible migration workflow states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Workflow state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Workflow is in draft status, i.e. tasks are not yet eligible for
         /// execution.
-        pub const DRAFT: State = State::new(1);
-
+        Draft,
         /// Workflow is running (i.e. tasks are eligible for execution).
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// Workflow is paused. Tasks currently in progress may continue, but no
         /// further tasks will be scheduled.
-        pub const PAUSED: State = State::new(3);
-
+        Paused,
         /// Workflow is complete. There should not be any task in a non-terminal
         /// state, but if they are (e.g. forced termination), they will not be
         /// scheduled.
-        pub const COMPLETED: State = State::new(4);
+        Completed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Paused => std::option::Option::Some(3),
+                Self::Completed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("PAUSED"),
-                4 => std::borrow::Cow::Borrowed("COMPLETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Running,
+                3 => Self::Paused,
+                4 => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "RUNNING" => Self::Running,
+                "PAUSED" => Self::Paused,
+                "COMPLETED" => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Paused => serializer.serialize_i32(3),
+                Self::Completed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.migration.v2.MigrationWorkflow.State",
+            ))
         }
     }
 }
@@ -485,80 +550,149 @@ pub mod migration_task {
     use super::*;
 
     /// Possible states of a migration task.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The task is waiting for orchestration.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The task is assigned to an orchestrator.
-        pub const ORCHESTRATING: State = State::new(2);
-
+        Orchestrating,
         /// The task is running, i.e. its subtasks are ready for execution.
-        pub const RUNNING: State = State::new(3);
-
+        Running,
         /// Tha task is paused. Assigned subtasks can continue, but no new subtasks
         /// will be scheduled.
-        pub const PAUSED: State = State::new(4);
-
+        Paused,
         /// The task finished successfully.
-        pub const SUCCEEDED: State = State::new(5);
-
+        Succeeded,
         /// The task finished unsuccessfully.
-        pub const FAILED: State = State::new(6);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Orchestrating => std::option::Option::Some(2),
+                Self::Running => std::option::Option::Some(3),
+                Self::Paused => std::option::Option::Some(4),
+                Self::Succeeded => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("ORCHESTRATING"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                4 => std::borrow::Cow::Borrowed("PAUSED"),
-                5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Orchestrating => std::option::Option::Some("ORCHESTRATING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ORCHESTRATING" => std::option::Option::Some(Self::ORCHESTRATING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Orchestrating,
+                3 => Self::Running,
+                4 => Self::Paused,
+                5 => Self::Succeeded,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "ORCHESTRATING" => Self::Orchestrating,
+                "RUNNING" => Self::Running,
+                "PAUSED" => Self::Paused,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Orchestrating => serializer.serialize_i32(2),
+                Self::Running => serializer.serialize_i32(3),
+                Self::Paused => serializer.serialize_i32(4),
+                Self::Succeeded => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.migration.v2.MigrationTask.State",
+            ))
         }
     }
 
@@ -740,81 +874,150 @@ pub mod migration_subtask {
     use super::*;
 
     /// Possible states of a migration subtask.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The subtask is ready, i.e. it is ready for execution.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The subtask is running, i.e. it is assigned to a worker for execution.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The subtask finished successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The subtask finished unsuccessfully.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// The subtask is paused, i.e., it will not be scheduled. If it was already
         /// assigned,it might still finish but no new lease renewals will be granted.
-        pub const PAUSED: State = State::new(5);
-
+        Paused,
         /// The subtask is pending a dependency. It will be scheduled once its
         /// dependencies are done.
-        pub const PENDING_DEPENDENCY: State = State::new(6);
+        PendingDependency,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Paused => std::option::Option::Some(5),
+                Self::PendingDependency => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("PAUSED"),
-                6 => std::borrow::Cow::Borrowed("PENDING_DEPENDENCY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::PendingDependency => std::option::Option::Some("PENDING_DEPENDENCY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "PENDING_DEPENDENCY" => std::option::Option::Some(Self::PENDING_DEPENDENCY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Paused,
+                6 => Self::PendingDependency,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "PAUSED" => Self::Paused,
+                "PENDING_DEPENDENCY" => Self::PendingDependency,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Paused => serializer.serialize_i32(5),
+                Self::PendingDependency => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.migration.v2.MigrationSubtask.State",
+            ))
         }
     }
 }
@@ -2946,59 +3149,120 @@ pub mod teradata_dialect {
     use super::*;
 
     /// The sub-dialect options for Teradata.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Unspecified mode.
+        Unspecified,
+        /// Teradata SQL mode.
+        Sql,
+        /// BTEQ mode (which includes SQL).
+        Bteq,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Unspecified mode.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// Teradata SQL mode.
-        pub const SQL: Mode = Mode::new(1);
-
-        /// BTEQ mode (which includes SQL).
-        pub const BTEQ: Mode = Mode::new(2);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Sql => std::option::Option::Some(1),
+                Self::Bteq => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SQL"),
-                2 => std::borrow::Cow::Borrowed("BTEQ"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Sql => std::option::Option::Some("SQL"),
+                Self::Bteq => std::option::Option::Some("BTEQ"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "SQL" => std::option::Option::Some(Self::SQL),
-                "BTEQ" => std::option::Option::Some(Self::BTEQ),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Sql,
+                2 => Self::Bteq,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "SQL" => Self::Sql,
+                "BTEQ" => Self::Bteq,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Sql => serializer.serialize_i32(1),
+                Self::Bteq => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.bigquery.migration.v2.TeradataDialect.Mode",
+            ))
         }
     }
 }
@@ -3463,84 +3727,155 @@ pub mod name_mapping_key {
     use super::*;
 
     /// The type of the object that is being mapped.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified name mapping type.
+        Unspecified,
+        /// The object being mapped is a database.
+        Database,
+        /// The object being mapped is a schema.
+        Schema,
+        /// The object being mapped is a relation.
+        Relation,
+        /// The object being mapped is an attribute.
+        Attribute,
+        /// The object being mapped is a relation alias.
+        RelationAlias,
+        /// The object being mapped is a an attribute alias.
+        AttributeAlias,
+        /// The object being mapped is a function.
+        Function,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified name mapping type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// The object being mapped is a database.
-        pub const DATABASE: Type = Type::new(1);
-
-        /// The object being mapped is a schema.
-        pub const SCHEMA: Type = Type::new(2);
-
-        /// The object being mapped is a relation.
-        pub const RELATION: Type = Type::new(3);
-
-        /// The object being mapped is an attribute.
-        pub const ATTRIBUTE: Type = Type::new(4);
-
-        /// The object being mapped is a relation alias.
-        pub const RELATION_ALIAS: Type = Type::new(5);
-
-        /// The object being mapped is a an attribute alias.
-        pub const ATTRIBUTE_ALIAS: Type = Type::new(6);
-
-        /// The object being mapped is a function.
-        pub const FUNCTION: Type = Type::new(7);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Database => std::option::Option::Some(1),
+                Self::Schema => std::option::Option::Some(2),
+                Self::Relation => std::option::Option::Some(3),
+                Self::Attribute => std::option::Option::Some(4),
+                Self::RelationAlias => std::option::Option::Some(5),
+                Self::AttributeAlias => std::option::Option::Some(6),
+                Self::Function => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATABASE"),
-                2 => std::borrow::Cow::Borrowed("SCHEMA"),
-                3 => std::borrow::Cow::Borrowed("RELATION"),
-                4 => std::borrow::Cow::Borrowed("ATTRIBUTE"),
-                5 => std::borrow::Cow::Borrowed("RELATION_ALIAS"),
-                6 => std::borrow::Cow::Borrowed("ATTRIBUTE_ALIAS"),
-                7 => std::borrow::Cow::Borrowed("FUNCTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Database => std::option::Option::Some("DATABASE"),
+                Self::Schema => std::option::Option::Some("SCHEMA"),
+                Self::Relation => std::option::Option::Some("RELATION"),
+                Self::Attribute => std::option::Option::Some("ATTRIBUTE"),
+                Self::RelationAlias => std::option::Option::Some("RELATION_ALIAS"),
+                Self::AttributeAlias => std::option::Option::Some("ATTRIBUTE_ALIAS"),
+                Self::Function => std::option::Option::Some("FUNCTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "DATABASE" => std::option::Option::Some(Self::DATABASE),
-                "SCHEMA" => std::option::Option::Some(Self::SCHEMA),
-                "RELATION" => std::option::Option::Some(Self::RELATION),
-                "ATTRIBUTE" => std::option::Option::Some(Self::ATTRIBUTE),
-                "RELATION_ALIAS" => std::option::Option::Some(Self::RELATION_ALIAS),
-                "ATTRIBUTE_ALIAS" => std::option::Option::Some(Self::ATTRIBUTE_ALIAS),
-                "FUNCTION" => std::option::Option::Some(Self::FUNCTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Database,
+                2 => Self::Schema,
+                3 => Self::Relation,
+                4 => Self::Attribute,
+                5 => Self::RelationAlias,
+                6 => Self::AttributeAlias,
+                7 => Self::Function,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DATABASE" => Self::Database,
+                "SCHEMA" => Self::Schema,
+                "RELATION" => Self::Relation,
+                "ATTRIBUTE" => Self::Attribute,
+                "RELATION_ALIAS" => Self::RelationAlias,
+                "ATTRIBUTE_ALIAS" => Self::AttributeAlias,
+                "FUNCTION" => Self::Function,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Database => serializer.serialize_i32(1),
+                Self::Schema => serializer.serialize_i32(2),
+                Self::Relation => serializer.serialize_i32(3),
+                Self::Attribute => serializer.serialize_i32(4),
+                Self::RelationAlias => serializer.serialize_i32(5),
+                Self::AttributeAlias => serializer.serialize_i32(6),
+                Self::Function => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.bigquery.migration.v2.NameMappingKey.Type",
+            ))
         }
     }
 }
@@ -4240,65 +4575,128 @@ pub mod translation_report_record {
     use super::*;
 
     /// The severity type of the record.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
-
-    impl Severity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
         /// SeverityType not specified.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
+        Unspecified,
         /// INFO type.
-        pub const INFO: Severity = Severity::new(1);
-
+        Info,
         /// WARNING type. The translated query may still provide useful information
         /// if all the report records are WARNING.
-        pub const WARNING: Severity = Severity::new(2);
-
+        Warning,
         /// ERROR type. Translation failed.
-        pub const ERROR: Severity = Severity::new(3);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
 
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Severity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Info => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INFO"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Info,
+                2 => Self::Warning,
+                3 => Self::Error,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "INFO" => Self::Info,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Info => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.bigquery.migration.v2.TranslationReportRecord.Severity",
+            ))
         }
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -568,181 +568,317 @@ pub mod capacity_commitment {
 
     /// Commitment plan defines the current committed period. Capacity commitment
     /// cannot be deleted during it's committed period.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommitmentPlan(i32);
-
-    impl CommitmentPlan {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CommitmentPlan {
         /// Invalid plan value. Requests with this value will be rejected with
         /// error code `google.rpc.Code.INVALID_ARGUMENT`.
-        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
-
+        Unspecified,
         /// Flex commitments have committed period of 1 minute after becoming ACTIVE.
         /// After that, they are not in a committed period anymore and can be removed
         /// any time.
-        pub const FLEX: CommitmentPlan = CommitmentPlan::new(3);
-
+        Flex,
         /// Same as FLEX, should only be used if flat-rate commitments are still
         /// available.
-        pub const FLEX_FLAT_RATE: CommitmentPlan = CommitmentPlan::new(7);
-
+        FlexFlatRate,
         /// Trial commitments have a committed period of 182 days after becoming
         /// ACTIVE. After that, they are converted to a new commitment based on the
         /// `renewal_plan`. Default `renewal_plan` for Trial commitment is Flex so
         /// that it can be deleted right after committed period ends.
-        pub const TRIAL: CommitmentPlan = CommitmentPlan::new(5);
-
+        Trial,
         /// Monthly commitments have a committed period of 30 days after becoming
         /// ACTIVE. After that, they are not in a committed period anymore and can be
         /// removed any time.
-        pub const MONTHLY: CommitmentPlan = CommitmentPlan::new(2);
-
+        Monthly,
         /// Same as MONTHLY, should only be used if flat-rate commitments are still
         /// available.
-        pub const MONTHLY_FLAT_RATE: CommitmentPlan = CommitmentPlan::new(8);
-
+        MonthlyFlatRate,
         /// Annual commitments have a committed period of 365 days after becoming
         /// ACTIVE. After that they are converted to a new commitment based on the
         /// renewal_plan.
-        pub const ANNUAL: CommitmentPlan = CommitmentPlan::new(4);
-
+        Annual,
         /// Same as ANNUAL, should only be used if flat-rate commitments are still
         /// available.
-        pub const ANNUAL_FLAT_RATE: CommitmentPlan = CommitmentPlan::new(9);
-
+        AnnualFlatRate,
         /// 3-year commitments have a committed period of 1095(3 * 365) days after
         /// becoming ACTIVE. After that they are converted to a new commitment based
         /// on the renewal_plan.
-        pub const THREE_YEAR: CommitmentPlan = CommitmentPlan::new(10);
-
+        ThreeYear,
         /// Should only be used for `renewal_plan` and is only meaningful if
         /// edition is specified to values other than EDITION_UNSPECIFIED. Otherwise
         /// CreateCapacityCommitmentRequest or UpdateCapacityCommitmentRequest will
         /// be rejected with error code `google.rpc.Code.INVALID_ARGUMENT`. If the
         /// renewal_plan is NONE, capacity commitment will be removed at the end of
         /// its commitment period.
-        pub const NONE: CommitmentPlan = CommitmentPlan::new(6);
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CommitmentPlan::value] or
+        /// [CommitmentPlan::name].
+        UnknownValue(commitment_plan::UnknownValue),
+    }
 
-        /// Creates a new CommitmentPlan instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod commitment_plan {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CommitmentPlan {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Flex => std::option::Option::Some(3),
+                Self::FlexFlatRate => std::option::Option::Some(7),
+                Self::Trial => std::option::Option::Some(5),
+                Self::Monthly => std::option::Option::Some(2),
+                Self::MonthlyFlatRate => std::option::Option::Some(8),
+                Self::Annual => std::option::Option::Some(4),
+                Self::AnnualFlatRate => std::option::Option::Some(9),
+                Self::ThreeYear => std::option::Option::Some(10),
+                Self::None => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("MONTHLY"),
-                3 => std::borrow::Cow::Borrowed("FLEX"),
-                4 => std::borrow::Cow::Borrowed("ANNUAL"),
-                5 => std::borrow::Cow::Borrowed("TRIAL"),
-                6 => std::borrow::Cow::Borrowed("NONE"),
-                7 => std::borrow::Cow::Borrowed("FLEX_FLAT_RATE"),
-                8 => std::borrow::Cow::Borrowed("MONTHLY_FLAT_RATE"),
-                9 => std::borrow::Cow::Borrowed("ANNUAL_FLAT_RATE"),
-                10 => std::borrow::Cow::Borrowed("THREE_YEAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMMITMENT_PLAN_UNSPECIFIED"),
+                Self::Flex => std::option::Option::Some("FLEX"),
+                Self::FlexFlatRate => std::option::Option::Some("FLEX_FLAT_RATE"),
+                Self::Trial => std::option::Option::Some("TRIAL"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::MonthlyFlatRate => std::option::Option::Some("MONTHLY_FLAT_RATE"),
+                Self::Annual => std::option::Option::Some("ANNUAL"),
+                Self::AnnualFlatRate => std::option::Option::Some("ANNUAL_FLAT_RATE"),
+                Self::ThreeYear => std::option::Option::Some("THREE_YEAR"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMMITMENT_PLAN_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
-                }
-                "FLEX" => std::option::Option::Some(Self::FLEX),
-                "FLEX_FLAT_RATE" => std::option::Option::Some(Self::FLEX_FLAT_RATE),
-                "TRIAL" => std::option::Option::Some(Self::TRIAL),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                "MONTHLY_FLAT_RATE" => std::option::Option::Some(Self::MONTHLY_FLAT_RATE),
-                "ANNUAL" => std::option::Option::Some(Self::ANNUAL),
-                "ANNUAL_FLAT_RATE" => std::option::Option::Some(Self::ANNUAL_FLAT_RATE),
-                "THREE_YEAR" => std::option::Option::Some(Self::THREE_YEAR),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CommitmentPlan {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CommitmentPlan {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CommitmentPlan {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CommitmentPlan {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Monthly,
+                3 => Self::Flex,
+                4 => Self::Annual,
+                5 => Self::Trial,
+                6 => Self::None,
+                7 => Self::FlexFlatRate,
+                8 => Self::MonthlyFlatRate,
+                9 => Self::AnnualFlatRate,
+                10 => Self::ThreeYear,
+                _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CommitmentPlan {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMMITMENT_PLAN_UNSPECIFIED" => Self::Unspecified,
+                "FLEX" => Self::Flex,
+                "FLEX_FLAT_RATE" => Self::FlexFlatRate,
+                "TRIAL" => Self::Trial,
+                "MONTHLY" => Self::Monthly,
+                "MONTHLY_FLAT_RATE" => Self::MonthlyFlatRate,
+                "ANNUAL" => Self::Annual,
+                "ANNUAL_FLAT_RATE" => Self::AnnualFlatRate,
+                "THREE_YEAR" => Self::ThreeYear,
+                "NONE" => Self::None,
+                _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CommitmentPlan {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Flex => serializer.serialize_i32(3),
+                Self::FlexFlatRate => serializer.serialize_i32(7),
+                Self::Trial => serializer.serialize_i32(5),
+                Self::Monthly => serializer.serialize_i32(2),
+                Self::MonthlyFlatRate => serializer.serialize_i32(8),
+                Self::Annual => serializer.serialize_i32(4),
+                Self::AnnualFlatRate => serializer.serialize_i32(9),
+                Self::ThreeYear => serializer.serialize_i32(10),
+                Self::None => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CommitmentPlan {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommitmentPlan>::new(
+                ".google.cloud.bigquery.reservation.v1.CapacityCommitment.CommitmentPlan",
+            ))
         }
     }
 
     /// Capacity commitment can either become ACTIVE right away or transition
     /// from PENDING to ACTIVE or FAILED.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid state value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Capacity commitment is pending provisioning. Pending capacity commitment
         /// does not contribute to the project's slot_capacity.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// Once slots are provisioned, capacity commitment becomes active.
         /// slot_count is added to the project's slot_capacity.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// Capacity commitment is failed to be activated by the backend.
-        pub const FAILED: State = State::new(3);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Active,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.reservation.v1.CapacityCommitment.State",
+            ))
         }
     }
 }
@@ -1680,137 +1816,265 @@ pub mod assignment {
     use super::*;
 
     /// Types of job, which could be specified when using the reservation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobType(i32);
-
-    impl JobType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JobType {
         /// Invalid type. Requests with this value will be rejected with
         /// error code `google.rpc.Code.INVALID_ARGUMENT`.
-        pub const JOB_TYPE_UNSPECIFIED: JobType = JobType::new(0);
-
+        Unspecified,
         /// Pipeline (load/export) jobs from the project will use the reservation.
-        pub const PIPELINE: JobType = JobType::new(1);
-
+        Pipeline,
         /// Query jobs from the project will use the reservation.
-        pub const QUERY: JobType = JobType::new(2);
-
+        Query,
         /// BigQuery ML jobs that use services external to BigQuery for model
         /// training. These jobs will not utilize idle slots from other reservations.
-        pub const ML_EXTERNAL: JobType = JobType::new(3);
-
+        MlExternal,
         /// Background jobs that BigQuery runs for the customers in the background.
-        pub const BACKGROUND: JobType = JobType::new(4);
-
+        Background,
         /// Continuous SQL jobs will use this reservation. Reservations with
         /// continuous assignments cannot be mixed with non-continuous assignments.
-        pub const CONTINUOUS: JobType = JobType::new(6);
+        Continuous,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JobType::value] or
+        /// [JobType::name].
+        UnknownValue(job_type::UnknownValue),
+    }
 
-        /// Creates a new JobType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod job_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl JobType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pipeline => std::option::Option::Some(1),
+                Self::Query => std::option::Option::Some(2),
+                Self::MlExternal => std::option::Option::Some(3),
+                Self::Background => std::option::Option::Some(4),
+                Self::Continuous => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JOB_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PIPELINE"),
-                2 => std::borrow::Cow::Borrowed("QUERY"),
-                3 => std::borrow::Cow::Borrowed("ML_EXTERNAL"),
-                4 => std::borrow::Cow::Borrowed("BACKGROUND"),
-                6 => std::borrow::Cow::Borrowed("CONTINUOUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("JOB_TYPE_UNSPECIFIED"),
+                Self::Pipeline => std::option::Option::Some("PIPELINE"),
+                Self::Query => std::option::Option::Some("QUERY"),
+                Self::MlExternal => std::option::Option::Some("ML_EXTERNAL"),
+                Self::Background => std::option::Option::Some("BACKGROUND"),
+                Self::Continuous => std::option::Option::Some("CONTINUOUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JOB_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::JOB_TYPE_UNSPECIFIED),
-                "PIPELINE" => std::option::Option::Some(Self::PIPELINE),
-                "QUERY" => std::option::Option::Some(Self::QUERY),
-                "ML_EXTERNAL" => std::option::Option::Some(Self::ML_EXTERNAL),
-                "BACKGROUND" => std::option::Option::Some(Self::BACKGROUND),
-                "CONTINUOUS" => std::option::Option::Some(Self::CONTINUOUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JobType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JobType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JobType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JobType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pipeline,
+                2 => Self::Query,
+                3 => Self::MlExternal,
+                4 => Self::Background,
+                6 => Self::Continuous,
+                _ => Self::UnknownValue(job_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JobType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JOB_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PIPELINE" => Self::Pipeline,
+                "QUERY" => Self::Query,
+                "ML_EXTERNAL" => Self::MlExternal,
+                "BACKGROUND" => Self::Background,
+                "CONTINUOUS" => Self::Continuous,
+                _ => Self::UnknownValue(job_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JobType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pipeline => serializer.serialize_i32(1),
+                Self::Query => serializer.serialize_i32(2),
+                Self::MlExternal => serializer.serialize_i32(3),
+                Self::Background => serializer.serialize_i32(4),
+                Self::Continuous => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JobType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobType>::new(
+                ".google.cloud.bigquery.reservation.v1.Assignment.JobType",
+            ))
         }
     }
 
     /// Assignment will remain in PENDING state if no active capacity commitment is
     /// present. It will become ACTIVE when some capacity commitment becomes
     /// active.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid state value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Queries from assignee will be executed as on-demand, if related
         /// assignment is pending.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// Assignment is ready.
-        pub const ACTIVE: State = State::new(2);
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.bigquery.reservation.v1.Assignment.State",
+            ))
         }
     }
 }
@@ -2655,63 +2919,126 @@ impl wkt::message::Message for UpdateBiReservationRequest {
 /// The type of editions.
 /// Different features and behaviors are provided to different editions
 /// Capacity commitments and reservations are linked to editions.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Edition(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Edition {
+    /// Default value, which will be treated as ENTERPRISE.
+    Unspecified,
+    /// Standard edition.
+    Standard,
+    /// Enterprise edition.
+    Enterprise,
+    /// Enterprise Plus edition.
+    EnterprisePlus,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Edition::value] or
+    /// [Edition::name].
+    UnknownValue(edition::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod edition {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Edition {
-    /// Default value, which will be treated as ENTERPRISE.
-    pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
-
-    /// Standard edition.
-    pub const STANDARD: Edition = Edition::new(1);
-
-    /// Enterprise edition.
-    pub const ENTERPRISE: Edition = Edition::new(2);
-
-    /// Enterprise Plus edition.
-    pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
-
-    /// Creates a new Edition instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Standard => std::option::Option::Some(1),
+            Self::Enterprise => std::option::Option::Some(2),
+            Self::EnterprisePlus => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("STANDARD"),
-            2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-            3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EDITION_UNSPECIFIED"),
+            Self::Standard => std::option::Option::Some("STANDARD"),
+            Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+            Self::EnterprisePlus => std::option::Option::Some("ENTERPRISE_PLUS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
-            "STANDARD" => std::option::Option::Some(Self::STANDARD),
-            "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-            "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Edition {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Edition {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Edition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Edition {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Standard,
+            2 => Self::Enterprise,
+            3 => Self::EnterprisePlus,
+            _ => Self::UnknownValue(edition::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Edition {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EDITION_UNSPECIFIED" => Self::Unspecified,
+            "STANDARD" => Self::Standard,
+            "ENTERPRISE" => Self::Enterprise,
+            "ENTERPRISE_PLUS" => Self::EnterprisePlus,
+            _ => Self::UnknownValue(edition::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Edition {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Standard => serializer.serialize_i32(1),
+            Self::Enterprise => serializer.serialize_i32(2),
+            Self::EnterprisePlus => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Edition {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Edition>::new(
+            ".google.cloud.bigquery.reservation.v1.Edition",
+        ))
     }
 }

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -113,110 +113,224 @@ pub mod big_lake_configuration {
     use super::*;
 
     /// Supported file formats for BigQuery tables for Apache Iceberg.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FileFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FileFormat {
+        /// Default Value.
+        Unspecified,
+        /// Apache Parquet format.
+        Parquet,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FileFormat::value] or
+        /// [FileFormat::name].
+        UnknownValue(file_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod file_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FileFormat {
-        /// Default Value.
-        pub const FILE_FORMAT_UNSPECIFIED: FileFormat = FileFormat::new(0);
-
-        /// Apache Parquet format.
-        pub const PARQUET: FileFormat = FileFormat::new(1);
-
-        /// Creates a new FileFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Parquet => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FILE_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PARQUET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FILE_FORMAT_UNSPECIFIED"),
+                Self::Parquet => std::option::Option::Some("PARQUET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FILE_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FILE_FORMAT_UNSPECIFIED)
-                }
-                "PARQUET" => std::option::Option::Some(Self::PARQUET),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FileFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FileFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FileFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FileFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Parquet,
+                _ => Self::UnknownValue(file_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FileFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FILE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "PARQUET" => Self::Parquet,
+                _ => Self::UnknownValue(file_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FileFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Parquet => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FileFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileFormat>::new(
+                ".google.cloud.bigquery.v2.BigLakeConfiguration.FileFormat",
+            ))
         }
     }
 
     /// Supported table formats for BigQuery tables for Apache Iceberg.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TableFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TableFormat {
+        /// Default Value.
+        Unspecified,
+        /// Apache Iceberg format.
+        Iceberg,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TableFormat::value] or
+        /// [TableFormat::name].
+        UnknownValue(table_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod table_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TableFormat {
-        /// Default Value.
-        pub const TABLE_FORMAT_UNSPECIFIED: TableFormat = TableFormat::new(0);
-
-        /// Apache Iceberg format.
-        pub const ICEBERG: TableFormat = TableFormat::new(1);
-
-        /// Creates a new TableFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Iceberg => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TABLE_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ICEBERG"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TABLE_FORMAT_UNSPECIFIED"),
+                Self::Iceberg => std::option::Option::Some("ICEBERG"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TABLE_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TABLE_FORMAT_UNSPECIFIED)
-                }
-                "ICEBERG" => std::option::Option::Some(Self::ICEBERG),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TableFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TableFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TableFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TableFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Iceberg,
+                _ => Self::UnknownValue(table_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TableFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TABLE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "ICEBERG" => Self::Iceberg,
+                _ => Self::UnknownValue(table_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TableFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Iceberg => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TableFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableFormat>::new(
+                ".google.cloud.bigquery.v2.BigLakeConfiguration.TableFormat",
+            ))
         }
     }
 }
@@ -331,61 +445,120 @@ pub mod dataset_access_entry {
     use super::*;
 
     /// Indicates the type of resources in a dataset that the entry applies to.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TargetType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TargetType {
+        /// Do not use. You must set a target type explicitly.
+        Unspecified,
+        /// This entry applies to views in the dataset.
+        Views,
+        /// This entry applies to routines in the dataset.
+        Routines,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TargetType::value] or
+        /// [TargetType::name].
+        UnknownValue(target_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod target_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TargetType {
-        /// Do not use. You must set a target type explicitly.
-        pub const TARGET_TYPE_UNSPECIFIED: TargetType = TargetType::new(0);
-
-        /// This entry applies to views in the dataset.
-        pub const VIEWS: TargetType = TargetType::new(1);
-
-        /// This entry applies to routines in the dataset.
-        pub const ROUTINES: TargetType = TargetType::new(2);
-
-        /// Creates a new TargetType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Views => std::option::Option::Some(1),
+                Self::Routines => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TARGET_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VIEWS"),
-                2 => std::borrow::Cow::Borrowed("ROUTINES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TARGET_TYPE_UNSPECIFIED"),
+                Self::Views => std::option::Option::Some("VIEWS"),
+                Self::Routines => std::option::Option::Some("ROUTINES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TARGET_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TARGET_TYPE_UNSPECIFIED)
-                }
-                "VIEWS" => std::option::Option::Some(Self::VIEWS),
-                "ROUTINES" => std::option::Option::Some(Self::ROUTINES),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TargetType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TargetType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TargetType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TargetType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Views,
+                2 => Self::Routines,
+                _ => Self::UnknownValue(target_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TargetType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TARGET_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "VIEWS" => Self::Views,
+                "ROUTINES" => Self::Routines,
+                _ => Self::UnknownValue(target_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TargetType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Views => serializer.serialize_i32(1),
+                Self::Routines => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TargetType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TargetType>::new(
+                ".google.cloud.bigquery.v2.DatasetAccessEntry.TargetType",
+            ))
         }
     }
 }
@@ -1093,62 +1266,120 @@ pub mod dataset {
     use super::*;
 
     /// Indicates the billing model that will be applied to the dataset.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageBillingModel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StorageBillingModel {
+        /// Value not set.
+        Unspecified,
+        /// Billing for logical bytes.
+        Logical,
+        /// Billing for physical bytes.
+        Physical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StorageBillingModel::value] or
+        /// [StorageBillingModel::name].
+        UnknownValue(storage_billing_model::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod storage_billing_model {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StorageBillingModel {
-        /// Value not set.
-        pub const STORAGE_BILLING_MODEL_UNSPECIFIED: StorageBillingModel =
-            StorageBillingModel::new(0);
-
-        /// Billing for logical bytes.
-        pub const LOGICAL: StorageBillingModel = StorageBillingModel::new(1);
-
-        /// Billing for physical bytes.
-        pub const PHYSICAL: StorageBillingModel = StorageBillingModel::new(2);
-
-        /// Creates a new StorageBillingModel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Logical => std::option::Option::Some(1),
+                Self::Physical => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STORAGE_BILLING_MODEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOGICAL"),
-                2 => std::borrow::Cow::Borrowed("PHYSICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STORAGE_BILLING_MODEL_UNSPECIFIED"),
+                Self::Logical => std::option::Option::Some("LOGICAL"),
+                Self::Physical => std::option::Option::Some("PHYSICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STORAGE_BILLING_MODEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STORAGE_BILLING_MODEL_UNSPECIFIED)
-                }
-                "LOGICAL" => std::option::Option::Some(Self::LOGICAL),
-                "PHYSICAL" => std::option::Option::Some(Self::PHYSICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StorageBillingModel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageBillingModel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StorageBillingModel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StorageBillingModel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Logical,
+                2 => Self::Physical,
+                _ => Self::UnknownValue(storage_billing_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StorageBillingModel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STORAGE_BILLING_MODEL_UNSPECIFIED" => Self::Unspecified,
+                "LOGICAL" => Self::Logical,
+                "PHYSICAL" => Self::Physical,
+                _ => Self::UnknownValue(storage_billing_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StorageBillingModel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Logical => serializer.serialize_i32(1),
+                Self::Physical => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StorageBillingModel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageBillingModel>::new(
+                ".google.cloud.bigquery.v2.Dataset.StorageBillingModel",
+            ))
         }
     }
 }
@@ -1277,61 +1508,122 @@ pub mod linked_dataset_metadata {
     use super::*;
 
     /// Specifies whether Linked Dataset is currently in a linked state or not.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LinkState(i32);
-
-    impl LinkState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LinkState {
         /// The default value.
         /// Default to the LINKED state.
-        pub const LINK_STATE_UNSPECIFIED: LinkState = LinkState::new(0);
-
+        Unspecified,
         /// Normal Linked Dataset state. Data is queryable via the Linked Dataset.
-        pub const LINKED: LinkState = LinkState::new(1);
-
+        Linked,
         /// Data publisher or owner has unlinked this Linked Dataset. It means you
         /// can no longer query or see the data in the Linked Dataset.
-        pub const UNLINKED: LinkState = LinkState::new(2);
+        Unlinked,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LinkState::value] or
+        /// [LinkState::name].
+        UnknownValue(link_state::UnknownValue),
+    }
 
-        /// Creates a new LinkState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod link_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LinkState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Linked => std::option::Option::Some(1),
+                Self::Unlinked => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LINK_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LINKED"),
-                2 => std::borrow::Cow::Borrowed("UNLINKED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LINK_STATE_UNSPECIFIED"),
+                Self::Linked => std::option::Option::Some("LINKED"),
+                Self::Unlinked => std::option::Option::Some("UNLINKED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LINK_STATE_UNSPECIFIED" => std::option::Option::Some(Self::LINK_STATE_UNSPECIFIED),
-                "LINKED" => std::option::Option::Some(Self::LINKED),
-                "UNLINKED" => std::option::Option::Some(Self::UNLINKED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LinkState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LinkState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LinkState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LinkState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Linked,
+                2 => Self::Unlinked,
+                _ => Self::UnknownValue(link_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LinkState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LINK_STATE_UNSPECIFIED" => Self::Unspecified,
+                "LINKED" => Self::Linked,
+                "UNLINKED" => Self::Unlinked,
+                _ => Self::UnknownValue(link_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LinkState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Linked => serializer.serialize_i32(1),
+                Self::Unlinked => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LinkState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LinkState>::new(
+                ".google.cloud.bigquery.v2.LinkedDatasetMetadata.LinkState",
+            ))
         }
     }
 }
@@ -1434,69 +1726,130 @@ pub mod get_dataset_request {
     use super::*;
 
     /// DatasetView specifies which dataset information is returned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatasetView(i32);
-
-    impl DatasetView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatasetView {
         /// The default value.
         /// Default to the FULL view.
-        pub const DATASET_VIEW_UNSPECIFIED: DatasetView = DatasetView::new(0);
-
+        Unspecified,
         /// Updates metadata information for the dataset, such as friendlyName,
         /// description, labels, etc.
-        pub const METADATA: DatasetView = DatasetView::new(1);
-
+        Metadata,
         /// Updates ACL information for the dataset, which defines dataset access
         /// for one or more entities.
-        pub const ACL: DatasetView = DatasetView::new(2);
-
+        Acl,
         /// Updates both dataset metadata and ACL information.
-        pub const FULL: DatasetView = DatasetView::new(3);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatasetView::value] or
+        /// [DatasetView::name].
+        UnknownValue(dataset_view::UnknownValue),
+    }
 
-        /// Creates a new DatasetView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod dataset_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DatasetView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Metadata => std::option::Option::Some(1),
+                Self::Acl => std::option::Option::Some(2),
+                Self::Full => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATASET_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("METADATA"),
-                2 => std::borrow::Cow::Borrowed("ACL"),
-                3 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATASET_VIEW_UNSPECIFIED"),
+                Self::Metadata => std::option::Option::Some("METADATA"),
+                Self::Acl => std::option::Option::Some("ACL"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATASET_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATASET_VIEW_UNSPECIFIED)
-                }
-                "METADATA" => std::option::Option::Some(Self::METADATA),
-                "ACL" => std::option::Option::Some(Self::ACL),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatasetView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatasetView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatasetView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatasetView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Metadata,
+                2 => Self::Acl,
+                3 => Self::Full,
+                _ => Self::UnknownValue(dataset_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatasetView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATASET_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "METADATA" => Self::Metadata,
+                "ACL" => Self::Acl,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(dataset_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatasetView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Metadata => serializer.serialize_i32(1),
+                Self::Acl => serializer.serialize_i32(2),
+                Self::Full => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatasetView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatasetView>::new(
+                ".google.cloud.bigquery.v2.GetDatasetRequest.DatasetView",
+            ))
         }
     }
 }
@@ -1684,69 +2037,130 @@ pub mod update_or_patch_dataset_request {
     use super::*;
 
     /// UpdateMode specifies which dataset fields is updated.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UpdateMode(i32);
-
-    impl UpdateMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UpdateMode {
         /// The default value.
         /// Default to the UPDATE_FULL.
-        pub const UPDATE_MODE_UNSPECIFIED: UpdateMode = UpdateMode::new(0);
-
+        Unspecified,
         /// Includes metadata information for the dataset, such as friendlyName,
         /// description, labels, etc.
-        pub const UPDATE_METADATA: UpdateMode = UpdateMode::new(1);
-
+        UpdateMetadata,
         /// Includes ACL information for the dataset, which defines dataset access
         /// for one or more entities.
-        pub const UPDATE_ACL: UpdateMode = UpdateMode::new(2);
-
+        UpdateAcl,
         /// Includes both dataset metadata and ACL information.
-        pub const UPDATE_FULL: UpdateMode = UpdateMode::new(3);
+        UpdateFull,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UpdateMode::value] or
+        /// [UpdateMode::name].
+        UnknownValue(update_mode::UnknownValue),
+    }
 
-        /// Creates a new UpdateMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod update_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl UpdateMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UpdateMetadata => std::option::Option::Some(1),
+                Self::UpdateAcl => std::option::Option::Some(2),
+                Self::UpdateFull => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UPDATE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UPDATE_METADATA"),
-                2 => std::borrow::Cow::Borrowed("UPDATE_ACL"),
-                3 => std::borrow::Cow::Borrowed("UPDATE_FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UPDATE_MODE_UNSPECIFIED"),
+                Self::UpdateMetadata => std::option::Option::Some("UPDATE_METADATA"),
+                Self::UpdateAcl => std::option::Option::Some("UPDATE_ACL"),
+                Self::UpdateFull => std::option::Option::Some("UPDATE_FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UPDATE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::UPDATE_MODE_UNSPECIFIED)
-                }
-                "UPDATE_METADATA" => std::option::Option::Some(Self::UPDATE_METADATA),
-                "UPDATE_ACL" => std::option::Option::Some(Self::UPDATE_ACL),
-                "UPDATE_FULL" => std::option::Option::Some(Self::UPDATE_FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UpdateMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UpdateMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UpdateMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UpdateMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UpdateMetadata,
+                2 => Self::UpdateAcl,
+                3 => Self::UpdateFull,
+                _ => Self::UnknownValue(update_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UpdateMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UPDATE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "UPDATE_METADATA" => Self::UpdateMetadata,
+                "UPDATE_ACL" => Self::UpdateAcl,
+                "UPDATE_FULL" => Self::UpdateFull,
+                _ => Self::UnknownValue(update_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UpdateMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UpdateMetadata => serializer.serialize_i32(1),
+                Self::UpdateAcl => serializer.serialize_i32(2),
+                Self::UpdateFull => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UpdateMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UpdateMode>::new(
+                ".google.cloud.bigquery.v2.UpdateOrPatchDatasetRequest.UpdateMode",
+            ))
         }
     }
 }
@@ -3768,125 +4182,243 @@ pub mod external_data_configuration {
     use super::*;
 
     /// Supported Object Metadata Types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ObjectMetadata(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ObjectMetadata {
+        /// Unspecified by default.
+        Unspecified,
+        /// A synonym for `SIMPLE`.
+        Directory,
+        /// Directory listing of objects.
+        Simple,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ObjectMetadata::value] or
+        /// [ObjectMetadata::name].
+        UnknownValue(object_metadata::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod object_metadata {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ObjectMetadata {
-        /// Unspecified by default.
-        pub const OBJECT_METADATA_UNSPECIFIED: ObjectMetadata = ObjectMetadata::new(0);
-
-        /// A synonym for `SIMPLE`.
-        pub const DIRECTORY: ObjectMetadata = ObjectMetadata::new(1);
-
-        /// Directory listing of objects.
-        pub const SIMPLE: ObjectMetadata = ObjectMetadata::new(2);
-
-        /// Creates a new ObjectMetadata instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Directory => std::option::Option::Some(1),
+                Self::Simple => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OBJECT_METADATA_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIRECTORY"),
-                2 => std::borrow::Cow::Borrowed("SIMPLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OBJECT_METADATA_UNSPECIFIED"),
+                Self::Directory => std::option::Option::Some("DIRECTORY"),
+                Self::Simple => std::option::Option::Some("SIMPLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OBJECT_METADATA_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OBJECT_METADATA_UNSPECIFIED)
-                }
-                "DIRECTORY" => std::option::Option::Some(Self::DIRECTORY),
-                "SIMPLE" => std::option::Option::Some(Self::SIMPLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ObjectMetadata {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ObjectMetadata {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ObjectMetadata {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ObjectMetadata {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Directory,
+                2 => Self::Simple,
+                _ => Self::UnknownValue(object_metadata::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ObjectMetadata {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OBJECT_METADATA_UNSPECIFIED" => Self::Unspecified,
+                "DIRECTORY" => Self::Directory,
+                "SIMPLE" => Self::Simple,
+                _ => Self::UnknownValue(object_metadata::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ObjectMetadata {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Directory => serializer.serialize_i32(1),
+                Self::Simple => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ObjectMetadata {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ObjectMetadata>::new(
+                ".google.cloud.bigquery.v2.ExternalDataConfiguration.ObjectMetadata",
+            ))
         }
     }
 
     /// MetadataCacheMode identifies if the table should use metadata caching for
     /// files from external source (eg Google Cloud Storage).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetadataCacheMode(i32);
-
-    impl MetadataCacheMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MetadataCacheMode {
         /// Unspecified metadata cache mode.
-        pub const METADATA_CACHE_MODE_UNSPECIFIED: MetadataCacheMode = MetadataCacheMode::new(0);
-
+        Unspecified,
         /// Set this mode to trigger automatic background refresh of metadata cache
         /// from the external source. Queries will use the latest available cache
         /// version within the table's maxStaleness interval.
-        pub const AUTOMATIC: MetadataCacheMode = MetadataCacheMode::new(1);
-
+        Automatic,
         /// Set this mode to enable triggering manual refresh of the metadata cache
         /// from external source. Queries will use the latest manually triggered
         /// cache version within the table's maxStaleness interval.
-        pub const MANUAL: MetadataCacheMode = MetadataCacheMode::new(2);
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MetadataCacheMode::value] or
+        /// [MetadataCacheMode::name].
+        UnknownValue(metadata_cache_mode::UnknownValue),
+    }
 
-        /// Creates a new MetadataCacheMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod metadata_cache_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MetadataCacheMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METADATA_CACHE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METADATA_CACHE_MODE_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METADATA_CACHE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METADATA_CACHE_MODE_UNSPECIFIED)
-                }
-                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MetadataCacheMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MetadataCacheMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MetadataCacheMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MetadataCacheMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(metadata_cache_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MetadataCacheMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METADATA_CACHE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC" => Self::Automatic,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(metadata_cache_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MetadataCacheMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MetadataCacheMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetadataCacheMode>::new(
+                ".google.cloud.bigquery.v2.ExternalDataConfiguration.MetadataCacheMode",
+            ))
         }
     }
 }
@@ -4258,79 +4790,142 @@ pub mod remote_model_info {
     use super::*;
 
     /// Supported service type for remote model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RemoteServiceType(i32);
-
-    impl RemoteServiceType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RemoteServiceType {
         /// Unspecified remote service type.
-        pub const REMOTE_SERVICE_TYPE_UNSPECIFIED: RemoteServiceType = RemoteServiceType::new(0);
-
+        Unspecified,
         /// V3 Cloud AI Translation API. See more details at [Cloud Translation API]
         /// (<https://cloud.google.com/translate/docs/reference/rest>).
-        pub const CLOUD_AI_TRANSLATE_V3: RemoteServiceType = RemoteServiceType::new(1);
-
+        CloudAiTranslateV3,
         /// V1 Cloud AI Vision API See more details at [Cloud Vision API]
         /// (<https://cloud.google.com/vision/docs/reference/rest>).
-        pub const CLOUD_AI_VISION_V1: RemoteServiceType = RemoteServiceType::new(2);
-
+        CloudAiVisionV1,
         /// V1 Cloud AI Natural Language API. See more details at [REST Resource:
         /// documents](https://cloud.google.com/natural-language/docs/reference/rest/v1/documents).
-        pub const CLOUD_AI_NATURAL_LANGUAGE_V1: RemoteServiceType = RemoteServiceType::new(3);
-
+        CloudAiNaturalLanguageV1,
         /// V2 Speech-to-Text API. See more details at [Google Cloud Speech-to-Text
         /// V2 API](https://cloud.google.com/speech-to-text/v2/docs)
-        pub const CLOUD_AI_SPEECH_TO_TEXT_V2: RemoteServiceType = RemoteServiceType::new(7);
+        CloudAiSpeechToTextV2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RemoteServiceType::value] or
+        /// [RemoteServiceType::name].
+        UnknownValue(remote_service_type::UnknownValue),
+    }
 
-        /// Creates a new RemoteServiceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod remote_service_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RemoteServiceType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudAiTranslateV3 => std::option::Option::Some(1),
+                Self::CloudAiVisionV1 => std::option::Option::Some(2),
+                Self::CloudAiNaturalLanguageV1 => std::option::Option::Some(3),
+                Self::CloudAiSpeechToTextV2 => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REMOTE_SERVICE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_AI_TRANSLATE_V3"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_AI_VISION_V1"),
-                3 => std::borrow::Cow::Borrowed("CLOUD_AI_NATURAL_LANGUAGE_V1"),
-                7 => std::borrow::Cow::Borrowed("CLOUD_AI_SPEECH_TO_TEXT_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REMOTE_SERVICE_TYPE_UNSPECIFIED"),
+                Self::CloudAiTranslateV3 => std::option::Option::Some("CLOUD_AI_TRANSLATE_V3"),
+                Self::CloudAiVisionV1 => std::option::Option::Some("CLOUD_AI_VISION_V1"),
+                Self::CloudAiNaturalLanguageV1 => {
+                    std::option::Option::Some("CLOUD_AI_NATURAL_LANGUAGE_V1")
+                }
+                Self::CloudAiSpeechToTextV2 => {
+                    std::option::Option::Some("CLOUD_AI_SPEECH_TO_TEXT_V2")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REMOTE_SERVICE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REMOTE_SERVICE_TYPE_UNSPECIFIED)
-                }
-                "CLOUD_AI_TRANSLATE_V3" => std::option::Option::Some(Self::CLOUD_AI_TRANSLATE_V3),
-                "CLOUD_AI_VISION_V1" => std::option::Option::Some(Self::CLOUD_AI_VISION_V1),
-                "CLOUD_AI_NATURAL_LANGUAGE_V1" => {
-                    std::option::Option::Some(Self::CLOUD_AI_NATURAL_LANGUAGE_V1)
-                }
-                "CLOUD_AI_SPEECH_TO_TEXT_V2" => {
-                    std::option::Option::Some(Self::CLOUD_AI_SPEECH_TO_TEXT_V2)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RemoteServiceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RemoteServiceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RemoteServiceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RemoteServiceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudAiTranslateV3,
+                2 => Self::CloudAiVisionV1,
+                3 => Self::CloudAiNaturalLanguageV1,
+                7 => Self::CloudAiSpeechToTextV2,
+                _ => Self::UnknownValue(remote_service_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RemoteServiceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REMOTE_SERVICE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_AI_TRANSLATE_V3" => Self::CloudAiTranslateV3,
+                "CLOUD_AI_VISION_V1" => Self::CloudAiVisionV1,
+                "CLOUD_AI_NATURAL_LANGUAGE_V1" => Self::CloudAiNaturalLanguageV1,
+                "CLOUD_AI_SPEECH_TO_TEXT_V2" => Self::CloudAiSpeechToTextV2,
+                _ => Self::UnknownValue(remote_service_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RemoteServiceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudAiTranslateV3 => serializer.serialize_i32(1),
+                Self::CloudAiVisionV1 => serializer.serialize_i32(2),
+                Self::CloudAiNaturalLanguageV1 => serializer.serialize_i32(3),
+                Self::CloudAiSpeechToTextV2 => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RemoteServiceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RemoteServiceType>::new(
+                ".google.cloud.bigquery.v2.RemoteModelInfo.RemoteServiceType",
+            ))
         }
     }
 
@@ -4755,82 +5350,153 @@ pub mod model {
         use super::*;
 
         /// Seasonal period type.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SeasonalPeriodType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SeasonalPeriodType {
+            /// Unspecified seasonal period.
+            Unspecified,
+            /// No seasonality
+            NoSeasonality,
+            /// Daily period, 24 hours.
+            Daily,
+            /// Weekly period, 7 days.
+            Weekly,
+            /// Monthly period, 30 days or irregular.
+            Monthly,
+            /// Quarterly period, 90 days or irregular.
+            Quarterly,
+            /// Yearly period, 365 days or irregular.
+            Yearly,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SeasonalPeriodType::value] or
+            /// [SeasonalPeriodType::name].
+            UnknownValue(seasonal_period_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod seasonal_period_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SeasonalPeriodType {
-            /// Unspecified seasonal period.
-            pub const SEASONAL_PERIOD_TYPE_UNSPECIFIED: SeasonalPeriodType =
-                SeasonalPeriodType::new(0);
-
-            /// No seasonality
-            pub const NO_SEASONALITY: SeasonalPeriodType = SeasonalPeriodType::new(1);
-
-            /// Daily period, 24 hours.
-            pub const DAILY: SeasonalPeriodType = SeasonalPeriodType::new(2);
-
-            /// Weekly period, 7 days.
-            pub const WEEKLY: SeasonalPeriodType = SeasonalPeriodType::new(3);
-
-            /// Monthly period, 30 days or irregular.
-            pub const MONTHLY: SeasonalPeriodType = SeasonalPeriodType::new(4);
-
-            /// Quarterly period, 90 days or irregular.
-            pub const QUARTERLY: SeasonalPeriodType = SeasonalPeriodType::new(5);
-
-            /// Yearly period, 365 days or irregular.
-            pub const YEARLY: SeasonalPeriodType = SeasonalPeriodType::new(6);
-
-            /// Creates a new SeasonalPeriodType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::NoSeasonality => std::option::Option::Some(1),
+                    Self::Daily => std::option::Option::Some(2),
+                    Self::Weekly => std::option::Option::Some(3),
+                    Self::Monthly => std::option::Option::Some(4),
+                    Self::Quarterly => std::option::Option::Some(5),
+                    Self::Yearly => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SEASONAL_PERIOD_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NO_SEASONALITY"),
-                    2 => std::borrow::Cow::Borrowed("DAILY"),
-                    3 => std::borrow::Cow::Borrowed("WEEKLY"),
-                    4 => std::borrow::Cow::Borrowed("MONTHLY"),
-                    5 => std::borrow::Cow::Borrowed("QUARTERLY"),
-                    6 => std::borrow::Cow::Borrowed("YEARLY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SEASONAL_PERIOD_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SEASONAL_PERIOD_TYPE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SEASONAL_PERIOD_TYPE_UNSPECIFIED")
                     }
-                    "NO_SEASONALITY" => std::option::Option::Some(Self::NO_SEASONALITY),
-                    "DAILY" => std::option::Option::Some(Self::DAILY),
-                    "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                    "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                    "QUARTERLY" => std::option::Option::Some(Self::QUARTERLY),
-                    "YEARLY" => std::option::Option::Some(Self::YEARLY),
-                    _ => std::option::Option::None,
+                    Self::NoSeasonality => std::option::Option::Some("NO_SEASONALITY"),
+                    Self::Daily => std::option::Option::Some("DAILY"),
+                    Self::Weekly => std::option::Option::Some("WEEKLY"),
+                    Self::Monthly => std::option::Option::Some("MONTHLY"),
+                    Self::Quarterly => std::option::Option::Some("QUARTERLY"),
+                    Self::Yearly => std::option::Option::Some("YEARLY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for SeasonalPeriodType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SeasonalPeriodType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SeasonalPeriodType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SeasonalPeriodType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::NoSeasonality,
+                    2 => Self::Daily,
+                    3 => Self::Weekly,
+                    4 => Self::Monthly,
+                    5 => Self::Quarterly,
+                    6 => Self::Yearly,
+                    _ => Self::UnknownValue(seasonal_period_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SeasonalPeriodType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SEASONAL_PERIOD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "NO_SEASONALITY" => Self::NoSeasonality,
+                    "DAILY" => Self::Daily,
+                    "WEEKLY" => Self::Weekly,
+                    "MONTHLY" => Self::Monthly,
+                    "QUARTERLY" => Self::Quarterly,
+                    "YEARLY" => Self::Yearly,
+                    _ => Self::UnknownValue(seasonal_period_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SeasonalPeriodType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::NoSeasonality => serializer.serialize_i32(1),
+                    Self::Daily => serializer.serialize_i32(2),
+                    Self::Weekly => serializer.serialize_i32(3),
+                    Self::Monthly => serializer.serialize_i32(4),
+                    Self::Quarterly => serializer.serialize_i32(5),
+                    Self::Yearly => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SeasonalPeriodType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SeasonalPeriodType>::new(
+                    ".google.cloud.bigquery.v2.Model.SeasonalPeriod.SeasonalPeriodType",
+                ))
             }
         }
     }
@@ -4864,69 +5530,135 @@ pub mod model {
 
         /// Indicates the method used to initialize the centroids for KMeans
         /// clustering algorithm.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct KmeansInitializationMethod(i32);
-
-        impl KmeansInitializationMethod {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum KmeansInitializationMethod {
             /// Unspecified initialization method.
-            pub const KMEANS_INITIALIZATION_METHOD_UNSPECIFIED: KmeansInitializationMethod =
-                KmeansInitializationMethod::new(0);
-
+            Unspecified,
             /// Initializes the centroids randomly.
-            pub const RANDOM: KmeansInitializationMethod = KmeansInitializationMethod::new(1);
-
+            Random,
             /// Initializes the centroids using data specified in
             /// kmeans_initialization_column.
-            pub const CUSTOM: KmeansInitializationMethod = KmeansInitializationMethod::new(2);
-
+            Custom,
             /// Initializes with kmeans++.
-            pub const KMEANS_PLUS_PLUS: KmeansInitializationMethod =
-                KmeansInitializationMethod::new(3);
+            KmeansPlusPlus,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [KmeansInitializationMethod::value] or
+            /// [KmeansInitializationMethod::name].
+            UnknownValue(kmeans_initialization_method::UnknownValue),
+        }
 
-            /// Creates a new KmeansInitializationMethod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod kmeans_initialization_method {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl KmeansInitializationMethod {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Random => std::option::Option::Some(1),
+                    Self::Custom => std::option::Option::Some(2),
+                    Self::KmeansPlusPlus => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("KMEANS_INITIALIZATION_METHOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RANDOM"),
-                    2 => std::borrow::Cow::Borrowed("CUSTOM"),
-                    3 => std::borrow::Cow::Borrowed("KMEANS_PLUS_PLUS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "KMEANS_INITIALIZATION_METHOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::KMEANS_INITIALIZATION_METHOD_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("KMEANS_INITIALIZATION_METHOD_UNSPECIFIED")
                     }
-                    "RANDOM" => std::option::Option::Some(Self::RANDOM),
-                    "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                    "KMEANS_PLUS_PLUS" => std::option::Option::Some(Self::KMEANS_PLUS_PLUS),
-                    _ => std::option::Option::None,
+                    Self::Random => std::option::Option::Some("RANDOM"),
+                    Self::Custom => std::option::Option::Some("CUSTOM"),
+                    Self::KmeansPlusPlus => std::option::Option::Some("KMEANS_PLUS_PLUS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for KmeansInitializationMethod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for KmeansInitializationMethod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for KmeansInitializationMethod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for KmeansInitializationMethod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Random,
+                    2 => Self::Custom,
+                    3 => Self::KmeansPlusPlus,
+                    _ => Self::UnknownValue(kmeans_initialization_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for KmeansInitializationMethod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "KMEANS_INITIALIZATION_METHOD_UNSPECIFIED" => Self::Unspecified,
+                    "RANDOM" => Self::Random,
+                    "CUSTOM" => Self::Custom,
+                    "KMEANS_PLUS_PLUS" => Self::KmeansPlusPlus,
+                    _ => Self::UnknownValue(kmeans_initialization_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for KmeansInitializationMethod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Random => serializer.serialize_i32(1),
+                    Self::Custom => serializer.serialize_i32(2),
+                    Self::KmeansPlusPlus => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for KmeansInitializationMethod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(
+                    wkt::internal::EnumVisitor::<KmeansInitializationMethod>::new(
+                        ".google.cloud.bigquery.v2.Model.KmeansEnums.KmeansInitializationMethod",
+                    ),
+                )
             }
         }
     }
@@ -4959,193 +5691,384 @@ pub mod model {
         use super::*;
 
         /// Booster types supported. Refer to booster parameter in XGBoost.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BoosterType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum BoosterType {
+            /// Unspecified booster type.
+            Unspecified,
+            /// Gbtree booster.
+            Gbtree,
+            /// Dart booster.
+            Dart,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [BoosterType::value] or
+            /// [BoosterType::name].
+            UnknownValue(booster_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod booster_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl BoosterType {
-            /// Unspecified booster type.
-            pub const BOOSTER_TYPE_UNSPECIFIED: BoosterType = BoosterType::new(0);
-
-            /// Gbtree booster.
-            pub const GBTREE: BoosterType = BoosterType::new(1);
-
-            /// Dart booster.
-            pub const DART: BoosterType = BoosterType::new(2);
-
-            /// Creates a new BoosterType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Gbtree => std::option::Option::Some(1),
+                    Self::Dart => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("BOOSTER_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("GBTREE"),
-                    2 => std::borrow::Cow::Borrowed("DART"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("BOOSTER_TYPE_UNSPECIFIED"),
+                    Self::Gbtree => std::option::Option::Some("GBTREE"),
+                    Self::Dart => std::option::Option::Some("DART"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "BOOSTER_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::BOOSTER_TYPE_UNSPECIFIED)
-                    }
-                    "GBTREE" => std::option::Option::Some(Self::GBTREE),
-                    "DART" => std::option::Option::Some(Self::DART),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for BoosterType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for BoosterType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for BoosterType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for BoosterType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Gbtree,
+                    2 => Self::Dart,
+                    _ => Self::UnknownValue(booster_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for BoosterType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "BOOSTER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "GBTREE" => Self::Gbtree,
+                    "DART" => Self::Dart,
+                    _ => Self::UnknownValue(booster_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for BoosterType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Gbtree => serializer.serialize_i32(1),
+                    Self::Dart => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for BoosterType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<BoosterType>::new(
+                    ".google.cloud.bigquery.v2.Model.BoostedTreeOptionEnums.BoosterType",
+                ))
             }
         }
 
         /// Type of normalization algorithm for boosted tree models using dart
         /// booster. Refer to normalize_type in XGBoost.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DartNormalizeType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DartNormalizeType {
+            /// Unspecified dart normalize type.
+            Unspecified,
+            /// New trees have the same weight of each of dropped trees.
+            Tree,
+            /// New trees have the same weight of sum of dropped trees.
+            Forest,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DartNormalizeType::value] or
+            /// [DartNormalizeType::name].
+            UnknownValue(dart_normalize_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod dart_normalize_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl DartNormalizeType {
-            /// Unspecified dart normalize type.
-            pub const DART_NORMALIZE_TYPE_UNSPECIFIED: DartNormalizeType =
-                DartNormalizeType::new(0);
-
-            /// New trees have the same weight of each of dropped trees.
-            pub const TREE: DartNormalizeType = DartNormalizeType::new(1);
-
-            /// New trees have the same weight of sum of dropped trees.
-            pub const FOREST: DartNormalizeType = DartNormalizeType::new(2);
-
-            /// Creates a new DartNormalizeType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Tree => std::option::Option::Some(1),
+                    Self::Forest => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DART_NORMALIZE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TREE"),
-                    2 => std::borrow::Cow::Borrowed("FOREST"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DART_NORMALIZE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DART_NORMALIZE_TYPE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("DART_NORMALIZE_TYPE_UNSPECIFIED")
                     }
-                    "TREE" => std::option::Option::Some(Self::TREE),
-                    "FOREST" => std::option::Option::Some(Self::FOREST),
-                    _ => std::option::Option::None,
+                    Self::Tree => std::option::Option::Some("TREE"),
+                    Self::Forest => std::option::Option::Some("FOREST"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for DartNormalizeType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for DartNormalizeType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for DartNormalizeType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for DartNormalizeType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Tree,
+                    2 => Self::Forest,
+                    _ => Self::UnknownValue(dart_normalize_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for DartNormalizeType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DART_NORMALIZE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "TREE" => Self::Tree,
+                    "FOREST" => Self::Forest,
+                    _ => Self::UnknownValue(dart_normalize_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for DartNormalizeType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Tree => serializer.serialize_i32(1),
+                    Self::Forest => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for DartNormalizeType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DartNormalizeType>::new(
+                    ".google.cloud.bigquery.v2.Model.BoostedTreeOptionEnums.DartNormalizeType",
+                ))
             }
         }
 
         /// Tree construction algorithm used in boosted tree models.
         /// Refer to tree_method in XGBoost.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TreeMethod(i32);
-
-        impl TreeMethod {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TreeMethod {
             /// Unspecified tree method.
-            pub const TREE_METHOD_UNSPECIFIED: TreeMethod = TreeMethod::new(0);
-
+            Unspecified,
             /// Use heuristic to choose the fastest method.
-            pub const AUTO: TreeMethod = TreeMethod::new(1);
-
+            Auto,
             /// Exact greedy algorithm.
-            pub const EXACT: TreeMethod = TreeMethod::new(2);
-
+            Exact,
             /// Approximate greedy algorithm using quantile sketch and gradient
             /// histogram.
-            pub const APPROX: TreeMethod = TreeMethod::new(3);
-
+            Approx,
             /// Fast histogram optimized approximate greedy algorithm.
-            pub const HIST: TreeMethod = TreeMethod::new(4);
+            Hist,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TreeMethod::value] or
+            /// [TreeMethod::name].
+            UnknownValue(tree_method::UnknownValue),
+        }
 
-            /// Creates a new TreeMethod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod tree_method {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl TreeMethod {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Auto => std::option::Option::Some(1),
+                    Self::Exact => std::option::Option::Some(2),
+                    Self::Approx => std::option::Option::Some(3),
+                    Self::Hist => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TREE_METHOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AUTO"),
-                    2 => std::borrow::Cow::Borrowed("EXACT"),
-                    3 => std::borrow::Cow::Borrowed("APPROX"),
-                    4 => std::borrow::Cow::Borrowed("HIST"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TREE_METHOD_UNSPECIFIED"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::Exact => std::option::Option::Some("EXACT"),
+                    Self::Approx => std::option::Option::Some("APPROX"),
+                    Self::Hist => std::option::Option::Some("HIST"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TREE_METHOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::TREE_METHOD_UNSPECIFIED)
-                    }
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    "EXACT" => std::option::Option::Some(Self::EXACT),
-                    "APPROX" => std::option::Option::Some(Self::APPROX),
-                    "HIST" => std::option::Option::Some(Self::HIST),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for TreeMethod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TreeMethod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TreeMethod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TreeMethod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Auto,
+                    2 => Self::Exact,
+                    3 => Self::Approx,
+                    4 => Self::Hist,
+                    _ => Self::UnknownValue(tree_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TreeMethod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TREE_METHOD_UNSPECIFIED" => Self::Unspecified,
+                    "AUTO" => Self::Auto,
+                    "EXACT" => Self::Exact,
+                    "APPROX" => Self::Approx,
+                    "HIST" => Self::Hist,
+                    _ => Self::UnknownValue(tree_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TreeMethod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Auto => serializer.serialize_i32(1),
+                    Self::Exact => serializer.serialize_i32(2),
+                    Self::Approx => serializer.serialize_i32(3),
+                    Self::Hist => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TreeMethod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TreeMethod>::new(
+                    ".google.cloud.bigquery.v2.Model.BoostedTreeOptionEnums.TreeMethod",
+                ))
             }
         }
     }
@@ -5178,154 +6101,245 @@ pub mod model {
         use super::*;
 
         /// Available evaluation metrics used as hyperparameter tuning objectives.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct HparamTuningObjective(i32);
-
-        impl HparamTuningObjective {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum HparamTuningObjective {
             /// Unspecified evaluation metric.
-            pub const HPARAM_TUNING_OBJECTIVE_UNSPECIFIED: HparamTuningObjective =
-                HparamTuningObjective::new(0);
-
+            Unspecified,
             /// Mean absolute error.
             /// mean_absolute_error = AVG(ABS(label - predicted))
-            pub const MEAN_ABSOLUTE_ERROR: HparamTuningObjective = HparamTuningObjective::new(1);
-
+            MeanAbsoluteError,
             /// Mean squared error.
             /// mean_squared_error = AVG(POW(label - predicted, 2))
-            pub const MEAN_SQUARED_ERROR: HparamTuningObjective = HparamTuningObjective::new(2);
-
+            MeanSquaredError,
             /// Mean squared log error.
             /// mean_squared_log_error = AVG(POW(LN(1 + label) - LN(1 + predicted), 2))
-            pub const MEAN_SQUARED_LOG_ERROR: HparamTuningObjective = HparamTuningObjective::new(3);
-
+            MeanSquaredLogError,
             /// Mean absolute error.
             /// median_absolute_error = APPROX_QUANTILES(absolute_error, 2)[OFFSET(1)]
-            pub const MEDIAN_ABSOLUTE_ERROR: HparamTuningObjective = HparamTuningObjective::new(4);
-
+            MedianAbsoluteError,
             /// R^2 score. This corresponds to r2_score in ML.EVALUATE.
             /// r_squared = 1 - SUM(squared_error)/(COUNT(label)*VAR_POP(label))
-            pub const R_SQUARED: HparamTuningObjective = HparamTuningObjective::new(5);
-
+            RSquared,
             /// Explained variance.
             /// explained_variance = 1 - VAR_POP(label_error)/VAR_POP(label)
-            pub const EXPLAINED_VARIANCE: HparamTuningObjective = HparamTuningObjective::new(6);
-
+            ExplainedVariance,
             /// Precision is the fraction of actual positive predictions that had
             /// positive actual labels. For multiclass this is a macro-averaged metric
             /// treating each class as a binary classifier.
-            pub const PRECISION: HparamTuningObjective = HparamTuningObjective::new(7);
-
+            Precision,
             /// Recall is the fraction of actual positive labels that were given a
             /// positive prediction. For multiclass this is a macro-averaged metric.
-            pub const RECALL: HparamTuningObjective = HparamTuningObjective::new(8);
-
+            Recall,
             /// Accuracy is the fraction of predictions given the correct label. For
             /// multiclass this is a globally micro-averaged metric.
-            pub const ACCURACY: HparamTuningObjective = HparamTuningObjective::new(9);
-
+            Accuracy,
             /// The F1 score is an average of recall and precision. For multiclass this
             /// is a macro-averaged metric.
-            pub const F1_SCORE: HparamTuningObjective = HparamTuningObjective::new(10);
-
+            F1Score,
             /// Logarithmic Loss. For multiclass this is a macro-averaged metric.
-            pub const LOG_LOSS: HparamTuningObjective = HparamTuningObjective::new(11);
-
+            LogLoss,
             /// Area Under an ROC Curve. For multiclass this is a macro-averaged
             /// metric.
-            pub const ROC_AUC: HparamTuningObjective = HparamTuningObjective::new(12);
-
+            RocAuc,
             /// Davies-Bouldin Index.
-            pub const DAVIES_BOULDIN_INDEX: HparamTuningObjective = HparamTuningObjective::new(13);
-
+            DaviesBouldinIndex,
             /// Mean Average Precision.
-            pub const MEAN_AVERAGE_PRECISION: HparamTuningObjective =
-                HparamTuningObjective::new(14);
-
+            MeanAveragePrecision,
             /// Normalized Discounted Cumulative Gain.
-            pub const NORMALIZED_DISCOUNTED_CUMULATIVE_GAIN: HparamTuningObjective =
-                HparamTuningObjective::new(15);
-
+            NormalizedDiscountedCumulativeGain,
             /// Average Rank.
-            pub const AVERAGE_RANK: HparamTuningObjective = HparamTuningObjective::new(16);
+            AverageRank,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [HparamTuningObjective::value] or
+            /// [HparamTuningObjective::name].
+            UnknownValue(hparam_tuning_objective::UnknownValue),
+        }
 
-            /// Creates a new HparamTuningObjective instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod hparam_tuning_objective {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl HparamTuningObjective {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::MeanAbsoluteError => std::option::Option::Some(1),
+                    Self::MeanSquaredError => std::option::Option::Some(2),
+                    Self::MeanSquaredLogError => std::option::Option::Some(3),
+                    Self::MedianAbsoluteError => std::option::Option::Some(4),
+                    Self::RSquared => std::option::Option::Some(5),
+                    Self::ExplainedVariance => std::option::Option::Some(6),
+                    Self::Precision => std::option::Option::Some(7),
+                    Self::Recall => std::option::Option::Some(8),
+                    Self::Accuracy => std::option::Option::Some(9),
+                    Self::F1Score => std::option::Option::Some(10),
+                    Self::LogLoss => std::option::Option::Some(11),
+                    Self::RocAuc => std::option::Option::Some(12),
+                    Self::DaviesBouldinIndex => std::option::Option::Some(13),
+                    Self::MeanAveragePrecision => std::option::Option::Some(14),
+                    Self::NormalizedDiscountedCumulativeGain => std::option::Option::Some(15),
+                    Self::AverageRank => std::option::Option::Some(16),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("HPARAM_TUNING_OBJECTIVE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MEAN_ABSOLUTE_ERROR"),
-                    2 => std::borrow::Cow::Borrowed("MEAN_SQUARED_ERROR"),
-                    3 => std::borrow::Cow::Borrowed("MEAN_SQUARED_LOG_ERROR"),
-                    4 => std::borrow::Cow::Borrowed("MEDIAN_ABSOLUTE_ERROR"),
-                    5 => std::borrow::Cow::Borrowed("R_SQUARED"),
-                    6 => std::borrow::Cow::Borrowed("EXPLAINED_VARIANCE"),
-                    7 => std::borrow::Cow::Borrowed("PRECISION"),
-                    8 => std::borrow::Cow::Borrowed("RECALL"),
-                    9 => std::borrow::Cow::Borrowed("ACCURACY"),
-                    10 => std::borrow::Cow::Borrowed("F1_SCORE"),
-                    11 => std::borrow::Cow::Borrowed("LOG_LOSS"),
-                    12 => std::borrow::Cow::Borrowed("ROC_AUC"),
-                    13 => std::borrow::Cow::Borrowed("DAVIES_BOULDIN_INDEX"),
-                    14 => std::borrow::Cow::Borrowed("MEAN_AVERAGE_PRECISION"),
-                    15 => std::borrow::Cow::Borrowed("NORMALIZED_DISCOUNTED_CUMULATIVE_GAIN"),
-                    16 => std::borrow::Cow::Borrowed("AVERAGE_RANK"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("HPARAM_TUNING_OBJECTIVE_UNSPECIFIED")
+                    }
+                    Self::MeanAbsoluteError => std::option::Option::Some("MEAN_ABSOLUTE_ERROR"),
+                    Self::MeanSquaredError => std::option::Option::Some("MEAN_SQUARED_ERROR"),
+                    Self::MeanSquaredLogError => {
+                        std::option::Option::Some("MEAN_SQUARED_LOG_ERROR")
+                    }
+                    Self::MedianAbsoluteError => std::option::Option::Some("MEDIAN_ABSOLUTE_ERROR"),
+                    Self::RSquared => std::option::Option::Some("R_SQUARED"),
+                    Self::ExplainedVariance => std::option::Option::Some("EXPLAINED_VARIANCE"),
+                    Self::Precision => std::option::Option::Some("PRECISION"),
+                    Self::Recall => std::option::Option::Some("RECALL"),
+                    Self::Accuracy => std::option::Option::Some("ACCURACY"),
+                    Self::F1Score => std::option::Option::Some("F1_SCORE"),
+                    Self::LogLoss => std::option::Option::Some("LOG_LOSS"),
+                    Self::RocAuc => std::option::Option::Some("ROC_AUC"),
+                    Self::DaviesBouldinIndex => std::option::Option::Some("DAVIES_BOULDIN_INDEX"),
+                    Self::MeanAveragePrecision => {
+                        std::option::Option::Some("MEAN_AVERAGE_PRECISION")
+                    }
+                    Self::NormalizedDiscountedCumulativeGain => {
+                        std::option::Option::Some("NORMALIZED_DISCOUNTED_CUMULATIVE_GAIN")
+                    }
+                    Self::AverageRank => std::option::Option::Some("AVERAGE_RANK"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "HPARAM_TUNING_OBJECTIVE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::HPARAM_TUNING_OBJECTIVE_UNSPECIFIED)
-                    }
-                    "MEAN_ABSOLUTE_ERROR" => std::option::Option::Some(Self::MEAN_ABSOLUTE_ERROR),
-                    "MEAN_SQUARED_ERROR" => std::option::Option::Some(Self::MEAN_SQUARED_ERROR),
-                    "MEAN_SQUARED_LOG_ERROR" => {
-                        std::option::Option::Some(Self::MEAN_SQUARED_LOG_ERROR)
-                    }
-                    "MEDIAN_ABSOLUTE_ERROR" => {
-                        std::option::Option::Some(Self::MEDIAN_ABSOLUTE_ERROR)
-                    }
-                    "R_SQUARED" => std::option::Option::Some(Self::R_SQUARED),
-                    "EXPLAINED_VARIANCE" => std::option::Option::Some(Self::EXPLAINED_VARIANCE),
-                    "PRECISION" => std::option::Option::Some(Self::PRECISION),
-                    "RECALL" => std::option::Option::Some(Self::RECALL),
-                    "ACCURACY" => std::option::Option::Some(Self::ACCURACY),
-                    "F1_SCORE" => std::option::Option::Some(Self::F1_SCORE),
-                    "LOG_LOSS" => std::option::Option::Some(Self::LOG_LOSS),
-                    "ROC_AUC" => std::option::Option::Some(Self::ROC_AUC),
-                    "DAVIES_BOULDIN_INDEX" => std::option::Option::Some(Self::DAVIES_BOULDIN_INDEX),
-                    "MEAN_AVERAGE_PRECISION" => {
-                        std::option::Option::Some(Self::MEAN_AVERAGE_PRECISION)
-                    }
-                    "NORMALIZED_DISCOUNTED_CUMULATIVE_GAIN" => {
-                        std::option::Option::Some(Self::NORMALIZED_DISCOUNTED_CUMULATIVE_GAIN)
-                    }
-                    "AVERAGE_RANK" => std::option::Option::Some(Self::AVERAGE_RANK),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for HparamTuningObjective {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for HparamTuningObjective {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for HparamTuningObjective {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for HparamTuningObjective {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::MeanAbsoluteError,
+                    2 => Self::MeanSquaredError,
+                    3 => Self::MeanSquaredLogError,
+                    4 => Self::MedianAbsoluteError,
+                    5 => Self::RSquared,
+                    6 => Self::ExplainedVariance,
+                    7 => Self::Precision,
+                    8 => Self::Recall,
+                    9 => Self::Accuracy,
+                    10 => Self::F1Score,
+                    11 => Self::LogLoss,
+                    12 => Self::RocAuc,
+                    13 => Self::DaviesBouldinIndex,
+                    14 => Self::MeanAveragePrecision,
+                    15 => Self::NormalizedDiscountedCumulativeGain,
+                    16 => Self::AverageRank,
+                    _ => Self::UnknownValue(hparam_tuning_objective::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for HparamTuningObjective {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "HPARAM_TUNING_OBJECTIVE_UNSPECIFIED" => Self::Unspecified,
+                    "MEAN_ABSOLUTE_ERROR" => Self::MeanAbsoluteError,
+                    "MEAN_SQUARED_ERROR" => Self::MeanSquaredError,
+                    "MEAN_SQUARED_LOG_ERROR" => Self::MeanSquaredLogError,
+                    "MEDIAN_ABSOLUTE_ERROR" => Self::MedianAbsoluteError,
+                    "R_SQUARED" => Self::RSquared,
+                    "EXPLAINED_VARIANCE" => Self::ExplainedVariance,
+                    "PRECISION" => Self::Precision,
+                    "RECALL" => Self::Recall,
+                    "ACCURACY" => Self::Accuracy,
+                    "F1_SCORE" => Self::F1Score,
+                    "LOG_LOSS" => Self::LogLoss,
+                    "ROC_AUC" => Self::RocAuc,
+                    "DAVIES_BOULDIN_INDEX" => Self::DaviesBouldinIndex,
+                    "MEAN_AVERAGE_PRECISION" => Self::MeanAveragePrecision,
+                    "NORMALIZED_DISCOUNTED_CUMULATIVE_GAIN" => {
+                        Self::NormalizedDiscountedCumulativeGain
+                    }
+                    "AVERAGE_RANK" => Self::AverageRank,
+                    _ => Self::UnknownValue(hparam_tuning_objective::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for HparamTuningObjective {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::MeanAbsoluteError => serializer.serialize_i32(1),
+                    Self::MeanSquaredError => serializer.serialize_i32(2),
+                    Self::MeanSquaredLogError => serializer.serialize_i32(3),
+                    Self::MedianAbsoluteError => serializer.serialize_i32(4),
+                    Self::RSquared => serializer.serialize_i32(5),
+                    Self::ExplainedVariance => serializer.serialize_i32(6),
+                    Self::Precision => serializer.serialize_i32(7),
+                    Self::Recall => serializer.serialize_i32(8),
+                    Self::Accuracy => serializer.serialize_i32(9),
+                    Self::F1Score => serializer.serialize_i32(10),
+                    Self::LogLoss => serializer.serialize_i32(11),
+                    Self::RocAuc => serializer.serialize_i32(12),
+                    Self::DaviesBouldinIndex => serializer.serialize_i32(13),
+                    Self::MeanAveragePrecision => serializer.serialize_i32(14),
+                    Self::NormalizedDiscountedCumulativeGain => serializer.serialize_i32(15),
+                    Self::AverageRank => serializer.serialize_i32(16),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for HparamTuningObjective {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(
+                    wkt::internal::EnumVisitor::<HparamTuningObjective>::new(
+                        ".google.cloud.bigquery.v2.Model.HparamTuningEnums.HparamTuningObjective",
+                    ),
+                )
             }
         }
     }
@@ -7381,66 +8395,130 @@ pub mod model {
         use super::*;
 
         /// Supported encoding methods for categorical features.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EncodingMethod(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EncodingMethod {
+            /// Unspecified encoding method.
+            Unspecified,
+            /// Applies one-hot encoding.
+            OneHotEncoding,
+            /// Applies label encoding.
+            LabelEncoding,
+            /// Applies dummy encoding.
+            DummyEncoding,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EncodingMethod::value] or
+            /// [EncodingMethod::name].
+            UnknownValue(encoding_method::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod encoding_method {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl EncodingMethod {
-            /// Unspecified encoding method.
-            pub const ENCODING_METHOD_UNSPECIFIED: EncodingMethod = EncodingMethod::new(0);
-
-            /// Applies one-hot encoding.
-            pub const ONE_HOT_ENCODING: EncodingMethod = EncodingMethod::new(1);
-
-            /// Applies label encoding.
-            pub const LABEL_ENCODING: EncodingMethod = EncodingMethod::new(2);
-
-            /// Applies dummy encoding.
-            pub const DUMMY_ENCODING: EncodingMethod = EncodingMethod::new(3);
-
-            /// Creates a new EncodingMethod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::OneHotEncoding => std::option::Option::Some(1),
+                    Self::LabelEncoding => std::option::Option::Some(2),
+                    Self::DummyEncoding => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENCODING_METHOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ONE_HOT_ENCODING"),
-                    2 => std::borrow::Cow::Borrowed("LABEL_ENCODING"),
-                    3 => std::borrow::Cow::Borrowed("DUMMY_ENCODING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENCODING_METHOD_UNSPECIFIED"),
+                    Self::OneHotEncoding => std::option::Option::Some("ONE_HOT_ENCODING"),
+                    Self::LabelEncoding => std::option::Option::Some("LABEL_ENCODING"),
+                    Self::DummyEncoding => std::option::Option::Some("DUMMY_ENCODING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENCODING_METHOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ENCODING_METHOD_UNSPECIFIED)
-                    }
-                    "ONE_HOT_ENCODING" => std::option::Option::Some(Self::ONE_HOT_ENCODING),
-                    "LABEL_ENCODING" => std::option::Option::Some(Self::LABEL_ENCODING),
-                    "DUMMY_ENCODING" => std::option::Option::Some(Self::DUMMY_ENCODING),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EncodingMethod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EncodingMethod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EncodingMethod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EncodingMethod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::OneHotEncoding,
+                    2 => Self::LabelEncoding,
+                    3 => Self::DummyEncoding,
+                    _ => Self::UnknownValue(encoding_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EncodingMethod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENCODING_METHOD_UNSPECIFIED" => Self::Unspecified,
+                    "ONE_HOT_ENCODING" => Self::OneHotEncoding,
+                    "LABEL_ENCODING" => Self::LabelEncoding,
+                    "DUMMY_ENCODING" => Self::DummyEncoding,
+                    _ => Self::UnknownValue(encoding_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EncodingMethod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::OneHotEncoding => serializer.serialize_i32(1),
+                    Self::LabelEncoding => serializer.serialize_i32(2),
+                    Self::DummyEncoding => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EncodingMethod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncodingMethod>::new(
+                    ".google.cloud.bigquery.v2.Model.CategoryEncodingMethod.EncodingMethod",
+                ))
             }
         }
     }
@@ -7473,64 +8551,130 @@ pub mod model {
         use super::*;
 
         /// Enums for supported PCA solvers.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PcaSolver(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PcaSolver {
+            /// Default value.
+            Unspecified,
+            /// Full eigen-decoposition.
+            Full,
+            /// Randomized SVD.
+            Randomized,
+            /// Auto.
+            Auto,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PcaSolver::value] or
+            /// [PcaSolver::name].
+            UnknownValue(pca_solver::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod pca_solver {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PcaSolver {
-            /// Default value.
-            pub const UNSPECIFIED: PcaSolver = PcaSolver::new(0);
-
-            /// Full eigen-decoposition.
-            pub const FULL: PcaSolver = PcaSolver::new(1);
-
-            /// Randomized SVD.
-            pub const RANDOMIZED: PcaSolver = PcaSolver::new(2);
-
-            /// Auto.
-            pub const AUTO: PcaSolver = PcaSolver::new(3);
-
-            /// Creates a new PcaSolver instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Full => std::option::Option::Some(1),
+                    Self::Randomized => std::option::Option::Some(2),
+                    Self::Auto => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("FULL"),
-                    2 => std::borrow::Cow::Borrowed("RANDOMIZED"),
-                    3 => std::borrow::Cow::Borrowed("AUTO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                    Self::Full => std::option::Option::Some("FULL"),
+                    Self::Randomized => std::option::Option::Some("RANDOMIZED"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                    "FULL" => std::option::Option::Some(Self::FULL),
-                    "RANDOMIZED" => std::option::Option::Some(Self::RANDOMIZED),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for PcaSolver {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PcaSolver {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PcaSolver {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PcaSolver {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Full,
+                    2 => Self::Randomized,
+                    3 => Self::Auto,
+                    _ => Self::UnknownValue(pca_solver::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PcaSolver {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNSPECIFIED" => Self::Unspecified,
+                    "FULL" => Self::Full,
+                    "RANDOMIZED" => Self::Randomized,
+                    "AUTO" => Self::Auto,
+                    _ => Self::UnknownValue(pca_solver::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PcaSolver {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Full => serializer.serialize_i32(1),
+                    Self::Randomized => serializer.serialize_i32(2),
+                    Self::Auto => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PcaSolver {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PcaSolver>::new(
+                    ".google.cloud.bigquery.v2.Model.PcaSolverOptionEnums.PcaSolver",
+                ))
             }
         }
     }
@@ -7563,56 +8707,116 @@ pub mod model {
         use super::*;
 
         /// Enums for supported model registries.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ModelRegistry(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ModelRegistry {
+            /// Default value.
+            Unspecified,
+            /// Vertex AI.
+            VertexAi,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ModelRegistry::value] or
+            /// [ModelRegistry::name].
+            UnknownValue(model_registry::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod model_registry {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ModelRegistry {
-            /// Default value.
-            pub const MODEL_REGISTRY_UNSPECIFIED: ModelRegistry = ModelRegistry::new(0);
-
-            /// Vertex AI.
-            pub const VERTEX_AI: ModelRegistry = ModelRegistry::new(1);
-
-            /// Creates a new ModelRegistry instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::VertexAi => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODEL_REGISTRY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("VERTEX_AI"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODEL_REGISTRY_UNSPECIFIED"),
+                    Self::VertexAi => std::option::Option::Some("VERTEX_AI"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODEL_REGISTRY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::MODEL_REGISTRY_UNSPECIFIED)
-                    }
-                    "VERTEX_AI" => std::option::Option::Some(Self::VERTEX_AI),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ModelRegistry {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ModelRegistry {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ModelRegistry {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ModelRegistry {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::VertexAi,
+                    _ => Self::UnknownValue(model_registry::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ModelRegistry {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODEL_REGISTRY_UNSPECIFIED" => Self::Unspecified,
+                    "VERTEX_AI" => Self::VertexAi,
+                    _ => Self::UnknownValue(model_registry::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ModelRegistry {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::VertexAi => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ModelRegistry {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelRegistry>::new(
+                    ".google.cloud.bigquery.v2.Model.ModelRegistryOptionEnums.ModelRegistry",
+                ))
             }
         }
     }
@@ -10828,1189 +12032,2050 @@ pub mod model {
         use super::*;
 
         /// Current status of the trial.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TrialStatus(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TrialStatus {
+            /// Default value.
+            Unspecified,
+            /// Scheduled but not started.
+            NotStarted,
+            /// Running state.
+            Running,
+            /// The trial succeeded.
+            Succeeded,
+            /// The trial failed.
+            Failed,
+            /// The trial is infeasible due to the invalid params.
+            Infeasible,
+            /// Trial stopped early because it's not promising.
+            StoppedEarly,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TrialStatus::value] or
+            /// [TrialStatus::name].
+            UnknownValue(trial_status::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod trial_status {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl TrialStatus {
-            /// Default value.
-            pub const TRIAL_STATUS_UNSPECIFIED: TrialStatus = TrialStatus::new(0);
-
-            /// Scheduled but not started.
-            pub const NOT_STARTED: TrialStatus = TrialStatus::new(1);
-
-            /// Running state.
-            pub const RUNNING: TrialStatus = TrialStatus::new(2);
-
-            /// The trial succeeded.
-            pub const SUCCEEDED: TrialStatus = TrialStatus::new(3);
-
-            /// The trial failed.
-            pub const FAILED: TrialStatus = TrialStatus::new(4);
-
-            /// The trial is infeasible due to the invalid params.
-            pub const INFEASIBLE: TrialStatus = TrialStatus::new(5);
-
-            /// Trial stopped early because it's not promising.
-            pub const STOPPED_EARLY: TrialStatus = TrialStatus::new(6);
-
-            /// Creates a new TrialStatus instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::NotStarted => std::option::Option::Some(1),
+                    Self::Running => std::option::Option::Some(2),
+                    Self::Succeeded => std::option::Option::Some(3),
+                    Self::Failed => std::option::Option::Some(4),
+                    Self::Infeasible => std::option::Option::Some(5),
+                    Self::StoppedEarly => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TRIAL_STATUS_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
-                    2 => std::borrow::Cow::Borrowed("RUNNING"),
-                    3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                    4 => std::borrow::Cow::Borrowed("FAILED"),
-                    5 => std::borrow::Cow::Borrowed("INFEASIBLE"),
-                    6 => std::borrow::Cow::Borrowed("STOPPED_EARLY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TRIAL_STATUS_UNSPECIFIED"),
+                    Self::NotStarted => std::option::Option::Some("NOT_STARTED"),
+                    Self::Running => std::option::Option::Some("RUNNING"),
+                    Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::Infeasible => std::option::Option::Some("INFEASIBLE"),
+                    Self::StoppedEarly => std::option::Option::Some("STOPPED_EARLY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TRIAL_STATUS_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::TRIAL_STATUS_UNSPECIFIED)
-                    }
-                    "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
-                    "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "INFEASIBLE" => std::option::Option::Some(Self::INFEASIBLE),
-                    "STOPPED_EARLY" => std::option::Option::Some(Self::STOPPED_EARLY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for TrialStatus {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TrialStatus {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TrialStatus {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TrialStatus {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::NotStarted,
+                    2 => Self::Running,
+                    3 => Self::Succeeded,
+                    4 => Self::Failed,
+                    5 => Self::Infeasible,
+                    6 => Self::StoppedEarly,
+                    _ => Self::UnknownValue(trial_status::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TrialStatus {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TRIAL_STATUS_UNSPECIFIED" => Self::Unspecified,
+                    "NOT_STARTED" => Self::NotStarted,
+                    "RUNNING" => Self::Running,
+                    "SUCCEEDED" => Self::Succeeded,
+                    "FAILED" => Self::Failed,
+                    "INFEASIBLE" => Self::Infeasible,
+                    "STOPPED_EARLY" => Self::StoppedEarly,
+                    _ => Self::UnknownValue(trial_status::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TrialStatus {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::NotStarted => serializer.serialize_i32(1),
+                    Self::Running => serializer.serialize_i32(2),
+                    Self::Succeeded => serializer.serialize_i32(3),
+                    Self::Failed => serializer.serialize_i32(4),
+                    Self::Infeasible => serializer.serialize_i32(5),
+                    Self::StoppedEarly => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TrialStatus {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TrialStatus>::new(
+                    ".google.cloud.bigquery.v2.Model.HparamTuningTrial.TrialStatus",
+                ))
             }
         }
     }
 
     /// Indicates the type of the Model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(i32);
-
-    impl ModelType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelType {
         /// Default value.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
-
+        Unspecified,
         /// Linear regression model.
-        pub const LINEAR_REGRESSION: ModelType = ModelType::new(1);
-
+        LinearRegression,
         /// Logistic regression based classification model.
-        pub const LOGISTIC_REGRESSION: ModelType = ModelType::new(2);
-
+        LogisticRegression,
         /// K-means clustering model.
-        pub const KMEANS: ModelType = ModelType::new(3);
-
+        Kmeans,
         /// Matrix factorization model.
-        pub const MATRIX_FACTORIZATION: ModelType = ModelType::new(4);
-
+        MatrixFactorization,
         /// DNN classifier model.
-        pub const DNN_CLASSIFIER: ModelType = ModelType::new(5);
-
+        DnnClassifier,
         /// An imported TensorFlow model.
-        pub const TENSORFLOW: ModelType = ModelType::new(6);
-
+        Tensorflow,
         /// DNN regressor model.
-        pub const DNN_REGRESSOR: ModelType = ModelType::new(7);
-
+        DnnRegressor,
         /// An imported XGBoost model.
-        pub const XGBOOST: ModelType = ModelType::new(8);
-
+        Xgboost,
         /// Boosted tree regressor model.
-        pub const BOOSTED_TREE_REGRESSOR: ModelType = ModelType::new(9);
-
+        BoostedTreeRegressor,
         /// Boosted tree classifier model.
-        pub const BOOSTED_TREE_CLASSIFIER: ModelType = ModelType::new(10);
-
+        BoostedTreeClassifier,
         /// ARIMA model.
-        pub const ARIMA: ModelType = ModelType::new(11);
-
+        Arima,
         /// AutoML Tables regression model.
-        pub const AUTOML_REGRESSOR: ModelType = ModelType::new(12);
-
+        AutomlRegressor,
         /// AutoML Tables classification model.
-        pub const AUTOML_CLASSIFIER: ModelType = ModelType::new(13);
-
+        AutomlClassifier,
         /// Prinpical Component Analysis model.
-        pub const PCA: ModelType = ModelType::new(14);
-
+        Pca,
         /// Wide-and-deep classifier model.
-        pub const DNN_LINEAR_COMBINED_CLASSIFIER: ModelType = ModelType::new(16);
-
+        DnnLinearCombinedClassifier,
         /// Wide-and-deep regressor model.
-        pub const DNN_LINEAR_COMBINED_REGRESSOR: ModelType = ModelType::new(17);
-
+        DnnLinearCombinedRegressor,
         /// Autoencoder model.
-        pub const AUTOENCODER: ModelType = ModelType::new(18);
-
+        Autoencoder,
         /// New name for the ARIMA model.
-        pub const ARIMA_PLUS: ModelType = ModelType::new(19);
-
+        ArimaPlus,
         /// ARIMA with external regressors.
-        pub const ARIMA_PLUS_XREG: ModelType = ModelType::new(23);
-
+        ArimaPlusXreg,
         /// Random forest regressor model.
-        pub const RANDOM_FOREST_REGRESSOR: ModelType = ModelType::new(24);
-
+        RandomForestRegressor,
         /// Random forest classifier model.
-        pub const RANDOM_FOREST_CLASSIFIER: ModelType = ModelType::new(25);
-
+        RandomForestClassifier,
         /// An imported TensorFlow Lite model.
-        pub const TENSORFLOW_LITE: ModelType = ModelType::new(26);
-
+        TensorflowLite,
         /// An imported ONNX model.
-        pub const ONNX: ModelType = ModelType::new(28);
-
+        Onnx,
         /// Model to capture the columns and logic in the TRANSFORM clause along with
         /// statistics useful for ML analytic functions.
-        pub const TRANSFORM_ONLY: ModelType = ModelType::new(29);
-
+        TransformOnly,
         /// The contribution analysis model.
-        pub const CONTRIBUTION_ANALYSIS: ModelType = ModelType::new(37);
+        ContributionAnalysis,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelType::value] or
+        /// [ModelType::name].
+        UnknownValue(model_type::UnknownValue),
+    }
 
-        /// Creates a new ModelType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod model_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ModelType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LinearRegression => std::option::Option::Some(1),
+                Self::LogisticRegression => std::option::Option::Some(2),
+                Self::Kmeans => std::option::Option::Some(3),
+                Self::MatrixFactorization => std::option::Option::Some(4),
+                Self::DnnClassifier => std::option::Option::Some(5),
+                Self::Tensorflow => std::option::Option::Some(6),
+                Self::DnnRegressor => std::option::Option::Some(7),
+                Self::Xgboost => std::option::Option::Some(8),
+                Self::BoostedTreeRegressor => std::option::Option::Some(9),
+                Self::BoostedTreeClassifier => std::option::Option::Some(10),
+                Self::Arima => std::option::Option::Some(11),
+                Self::AutomlRegressor => std::option::Option::Some(12),
+                Self::AutomlClassifier => std::option::Option::Some(13),
+                Self::Pca => std::option::Option::Some(14),
+                Self::DnnLinearCombinedClassifier => std::option::Option::Some(16),
+                Self::DnnLinearCombinedRegressor => std::option::Option::Some(17),
+                Self::Autoencoder => std::option::Option::Some(18),
+                Self::ArimaPlus => std::option::Option::Some(19),
+                Self::ArimaPlusXreg => std::option::Option::Some(23),
+                Self::RandomForestRegressor => std::option::Option::Some(24),
+                Self::RandomForestClassifier => std::option::Option::Some(25),
+                Self::TensorflowLite => std::option::Option::Some(26),
+                Self::Onnx => std::option::Option::Some(28),
+                Self::TransformOnly => std::option::Option::Some(29),
+                Self::ContributionAnalysis => std::option::Option::Some(37),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LINEAR_REGRESSION"),
-                2 => std::borrow::Cow::Borrowed("LOGISTIC_REGRESSION"),
-                3 => std::borrow::Cow::Borrowed("KMEANS"),
-                4 => std::borrow::Cow::Borrowed("MATRIX_FACTORIZATION"),
-                5 => std::borrow::Cow::Borrowed("DNN_CLASSIFIER"),
-                6 => std::borrow::Cow::Borrowed("TENSORFLOW"),
-                7 => std::borrow::Cow::Borrowed("DNN_REGRESSOR"),
-                8 => std::borrow::Cow::Borrowed("XGBOOST"),
-                9 => std::borrow::Cow::Borrowed("BOOSTED_TREE_REGRESSOR"),
-                10 => std::borrow::Cow::Borrowed("BOOSTED_TREE_CLASSIFIER"),
-                11 => std::borrow::Cow::Borrowed("ARIMA"),
-                12 => std::borrow::Cow::Borrowed("AUTOML_REGRESSOR"),
-                13 => std::borrow::Cow::Borrowed("AUTOML_CLASSIFIER"),
-                14 => std::borrow::Cow::Borrowed("PCA"),
-                16 => std::borrow::Cow::Borrowed("DNN_LINEAR_COMBINED_CLASSIFIER"),
-                17 => std::borrow::Cow::Borrowed("DNN_LINEAR_COMBINED_REGRESSOR"),
-                18 => std::borrow::Cow::Borrowed("AUTOENCODER"),
-                19 => std::borrow::Cow::Borrowed("ARIMA_PLUS"),
-                23 => std::borrow::Cow::Borrowed("ARIMA_PLUS_XREG"),
-                24 => std::borrow::Cow::Borrowed("RANDOM_FOREST_REGRESSOR"),
-                25 => std::borrow::Cow::Borrowed("RANDOM_FOREST_CLASSIFIER"),
-                26 => std::borrow::Cow::Borrowed("TENSORFLOW_LITE"),
-                28 => std::borrow::Cow::Borrowed("ONNX"),
-                29 => std::borrow::Cow::Borrowed("TRANSFORM_ONLY"),
-                37 => std::borrow::Cow::Borrowed("CONTRIBUTION_ANALYSIS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_TYPE_UNSPECIFIED"),
+                Self::LinearRegression => std::option::Option::Some("LINEAR_REGRESSION"),
+                Self::LogisticRegression => std::option::Option::Some("LOGISTIC_REGRESSION"),
+                Self::Kmeans => std::option::Option::Some("KMEANS"),
+                Self::MatrixFactorization => std::option::Option::Some("MATRIX_FACTORIZATION"),
+                Self::DnnClassifier => std::option::Option::Some("DNN_CLASSIFIER"),
+                Self::Tensorflow => std::option::Option::Some("TENSORFLOW"),
+                Self::DnnRegressor => std::option::Option::Some("DNN_REGRESSOR"),
+                Self::Xgboost => std::option::Option::Some("XGBOOST"),
+                Self::BoostedTreeRegressor => std::option::Option::Some("BOOSTED_TREE_REGRESSOR"),
+                Self::BoostedTreeClassifier => std::option::Option::Some("BOOSTED_TREE_CLASSIFIER"),
+                Self::Arima => std::option::Option::Some("ARIMA"),
+                Self::AutomlRegressor => std::option::Option::Some("AUTOML_REGRESSOR"),
+                Self::AutomlClassifier => std::option::Option::Some("AUTOML_CLASSIFIER"),
+                Self::Pca => std::option::Option::Some("PCA"),
+                Self::DnnLinearCombinedClassifier => {
+                    std::option::Option::Some("DNN_LINEAR_COMBINED_CLASSIFIER")
+                }
+                Self::DnnLinearCombinedRegressor => {
+                    std::option::Option::Some("DNN_LINEAR_COMBINED_REGRESSOR")
+                }
+                Self::Autoencoder => std::option::Option::Some("AUTOENCODER"),
+                Self::ArimaPlus => std::option::Option::Some("ARIMA_PLUS"),
+                Self::ArimaPlusXreg => std::option::Option::Some("ARIMA_PLUS_XREG"),
+                Self::RandomForestRegressor => std::option::Option::Some("RANDOM_FOREST_REGRESSOR"),
+                Self::RandomForestClassifier => {
+                    std::option::Option::Some("RANDOM_FOREST_CLASSIFIER")
+                }
+                Self::TensorflowLite => std::option::Option::Some("TENSORFLOW_LITE"),
+                Self::Onnx => std::option::Option::Some("ONNX"),
+                Self::TransformOnly => std::option::Option::Some("TRANSFORM_ONLY"),
+                Self::ContributionAnalysis => std::option::Option::Some("CONTRIBUTION_ANALYSIS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
-                "LINEAR_REGRESSION" => std::option::Option::Some(Self::LINEAR_REGRESSION),
-                "LOGISTIC_REGRESSION" => std::option::Option::Some(Self::LOGISTIC_REGRESSION),
-                "KMEANS" => std::option::Option::Some(Self::KMEANS),
-                "MATRIX_FACTORIZATION" => std::option::Option::Some(Self::MATRIX_FACTORIZATION),
-                "DNN_CLASSIFIER" => std::option::Option::Some(Self::DNN_CLASSIFIER),
-                "TENSORFLOW" => std::option::Option::Some(Self::TENSORFLOW),
-                "DNN_REGRESSOR" => std::option::Option::Some(Self::DNN_REGRESSOR),
-                "XGBOOST" => std::option::Option::Some(Self::XGBOOST),
-                "BOOSTED_TREE_REGRESSOR" => std::option::Option::Some(Self::BOOSTED_TREE_REGRESSOR),
-                "BOOSTED_TREE_CLASSIFIER" => {
-                    std::option::Option::Some(Self::BOOSTED_TREE_CLASSIFIER)
-                }
-                "ARIMA" => std::option::Option::Some(Self::ARIMA),
-                "AUTOML_REGRESSOR" => std::option::Option::Some(Self::AUTOML_REGRESSOR),
-                "AUTOML_CLASSIFIER" => std::option::Option::Some(Self::AUTOML_CLASSIFIER),
-                "PCA" => std::option::Option::Some(Self::PCA),
-                "DNN_LINEAR_COMBINED_CLASSIFIER" => {
-                    std::option::Option::Some(Self::DNN_LINEAR_COMBINED_CLASSIFIER)
-                }
-                "DNN_LINEAR_COMBINED_REGRESSOR" => {
-                    std::option::Option::Some(Self::DNN_LINEAR_COMBINED_REGRESSOR)
-                }
-                "AUTOENCODER" => std::option::Option::Some(Self::AUTOENCODER),
-                "ARIMA_PLUS" => std::option::Option::Some(Self::ARIMA_PLUS),
-                "ARIMA_PLUS_XREG" => std::option::Option::Some(Self::ARIMA_PLUS_XREG),
-                "RANDOM_FOREST_REGRESSOR" => {
-                    std::option::Option::Some(Self::RANDOM_FOREST_REGRESSOR)
-                }
-                "RANDOM_FOREST_CLASSIFIER" => {
-                    std::option::Option::Some(Self::RANDOM_FOREST_CLASSIFIER)
-                }
-                "TENSORFLOW_LITE" => std::option::Option::Some(Self::TENSORFLOW_LITE),
-                "ONNX" => std::option::Option::Some(Self::ONNX),
-                "TRANSFORM_ONLY" => std::option::Option::Some(Self::TRANSFORM_ONLY),
-                "CONTRIBUTION_ANALYSIS" => std::option::Option::Some(Self::CONTRIBUTION_ANALYSIS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LinearRegression,
+                2 => Self::LogisticRegression,
+                3 => Self::Kmeans,
+                4 => Self::MatrixFactorization,
+                5 => Self::DnnClassifier,
+                6 => Self::Tensorflow,
+                7 => Self::DnnRegressor,
+                8 => Self::Xgboost,
+                9 => Self::BoostedTreeRegressor,
+                10 => Self::BoostedTreeClassifier,
+                11 => Self::Arima,
+                12 => Self::AutomlRegressor,
+                13 => Self::AutomlClassifier,
+                14 => Self::Pca,
+                16 => Self::DnnLinearCombinedClassifier,
+                17 => Self::DnnLinearCombinedRegressor,
+                18 => Self::Autoencoder,
+                19 => Self::ArimaPlus,
+                23 => Self::ArimaPlusXreg,
+                24 => Self::RandomForestRegressor,
+                25 => Self::RandomForestClassifier,
+                26 => Self::TensorflowLite,
+                28 => Self::Onnx,
+                29 => Self::TransformOnly,
+                37 => Self::ContributionAnalysis,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LINEAR_REGRESSION" => Self::LinearRegression,
+                "LOGISTIC_REGRESSION" => Self::LogisticRegression,
+                "KMEANS" => Self::Kmeans,
+                "MATRIX_FACTORIZATION" => Self::MatrixFactorization,
+                "DNN_CLASSIFIER" => Self::DnnClassifier,
+                "TENSORFLOW" => Self::Tensorflow,
+                "DNN_REGRESSOR" => Self::DnnRegressor,
+                "XGBOOST" => Self::Xgboost,
+                "BOOSTED_TREE_REGRESSOR" => Self::BoostedTreeRegressor,
+                "BOOSTED_TREE_CLASSIFIER" => Self::BoostedTreeClassifier,
+                "ARIMA" => Self::Arima,
+                "AUTOML_REGRESSOR" => Self::AutomlRegressor,
+                "AUTOML_CLASSIFIER" => Self::AutomlClassifier,
+                "PCA" => Self::Pca,
+                "DNN_LINEAR_COMBINED_CLASSIFIER" => Self::DnnLinearCombinedClassifier,
+                "DNN_LINEAR_COMBINED_REGRESSOR" => Self::DnnLinearCombinedRegressor,
+                "AUTOENCODER" => Self::Autoencoder,
+                "ARIMA_PLUS" => Self::ArimaPlus,
+                "ARIMA_PLUS_XREG" => Self::ArimaPlusXreg,
+                "RANDOM_FOREST_REGRESSOR" => Self::RandomForestRegressor,
+                "RANDOM_FOREST_CLASSIFIER" => Self::RandomForestClassifier,
+                "TENSORFLOW_LITE" => Self::TensorflowLite,
+                "ONNX" => Self::Onnx,
+                "TRANSFORM_ONLY" => Self::TransformOnly,
+                "CONTRIBUTION_ANALYSIS" => Self::ContributionAnalysis,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LinearRegression => serializer.serialize_i32(1),
+                Self::LogisticRegression => serializer.serialize_i32(2),
+                Self::Kmeans => serializer.serialize_i32(3),
+                Self::MatrixFactorization => serializer.serialize_i32(4),
+                Self::DnnClassifier => serializer.serialize_i32(5),
+                Self::Tensorflow => serializer.serialize_i32(6),
+                Self::DnnRegressor => serializer.serialize_i32(7),
+                Self::Xgboost => serializer.serialize_i32(8),
+                Self::BoostedTreeRegressor => serializer.serialize_i32(9),
+                Self::BoostedTreeClassifier => serializer.serialize_i32(10),
+                Self::Arima => serializer.serialize_i32(11),
+                Self::AutomlRegressor => serializer.serialize_i32(12),
+                Self::AutomlClassifier => serializer.serialize_i32(13),
+                Self::Pca => serializer.serialize_i32(14),
+                Self::DnnLinearCombinedClassifier => serializer.serialize_i32(16),
+                Self::DnnLinearCombinedRegressor => serializer.serialize_i32(17),
+                Self::Autoencoder => serializer.serialize_i32(18),
+                Self::ArimaPlus => serializer.serialize_i32(19),
+                Self::ArimaPlusXreg => serializer.serialize_i32(23),
+                Self::RandomForestRegressor => serializer.serialize_i32(24),
+                Self::RandomForestClassifier => serializer.serialize_i32(25),
+                Self::TensorflowLite => serializer.serialize_i32(26),
+                Self::Onnx => serializer.serialize_i32(28),
+                Self::TransformOnly => serializer.serialize_i32(29),
+                Self::ContributionAnalysis => serializer.serialize_i32(37),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelType>::new(
+                ".google.cloud.bigquery.v2.Model.ModelType",
+            ))
         }
     }
 
     /// Loss metric to evaluate model training performance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LossType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LossType {
+        /// Default value.
+        Unspecified,
+        /// Mean squared loss, used for linear regression.
+        MeanSquaredLoss,
+        /// Mean log loss, used for logistic regression.
+        MeanLogLoss,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LossType::value] or
+        /// [LossType::name].
+        UnknownValue(loss_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod loss_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LossType {
-        /// Default value.
-        pub const LOSS_TYPE_UNSPECIFIED: LossType = LossType::new(0);
-
-        /// Mean squared loss, used for linear regression.
-        pub const MEAN_SQUARED_LOSS: LossType = LossType::new(1);
-
-        /// Mean log loss, used for logistic regression.
-        pub const MEAN_LOG_LOSS: LossType = LossType::new(2);
-
-        /// Creates a new LossType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MeanSquaredLoss => std::option::Option::Some(1),
+                Self::MeanLogLoss => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOSS_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MEAN_SQUARED_LOSS"),
-                2 => std::borrow::Cow::Borrowed("MEAN_LOG_LOSS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOSS_TYPE_UNSPECIFIED"),
+                Self::MeanSquaredLoss => std::option::Option::Some("MEAN_SQUARED_LOSS"),
+                Self::MeanLogLoss => std::option::Option::Some("MEAN_LOG_LOSS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOSS_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LOSS_TYPE_UNSPECIFIED),
-                "MEAN_SQUARED_LOSS" => std::option::Option::Some(Self::MEAN_SQUARED_LOSS),
-                "MEAN_LOG_LOSS" => std::option::Option::Some(Self::MEAN_LOG_LOSS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LossType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LossType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LossType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LossType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MeanSquaredLoss,
+                2 => Self::MeanLogLoss,
+                _ => Self::UnknownValue(loss_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LossType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOSS_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MEAN_SQUARED_LOSS" => Self::MeanSquaredLoss,
+                "MEAN_LOG_LOSS" => Self::MeanLogLoss,
+                _ => Self::UnknownValue(loss_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LossType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MeanSquaredLoss => serializer.serialize_i32(1),
+                Self::MeanLogLoss => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LossType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LossType>::new(
+                ".google.cloud.bigquery.v2.Model.LossType",
+            ))
         }
     }
 
     /// Distance metric used to compute the distance between two points.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DistanceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DistanceType {
+        /// Default value.
+        Unspecified,
+        /// Eculidean distance.
+        Euclidean,
+        /// Cosine distance.
+        Cosine,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DistanceType::value] or
+        /// [DistanceType::name].
+        UnknownValue(distance_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod distance_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DistanceType {
-        /// Default value.
-        pub const DISTANCE_TYPE_UNSPECIFIED: DistanceType = DistanceType::new(0);
-
-        /// Eculidean distance.
-        pub const EUCLIDEAN: DistanceType = DistanceType::new(1);
-
-        /// Cosine distance.
-        pub const COSINE: DistanceType = DistanceType::new(2);
-
-        /// Creates a new DistanceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Euclidean => std::option::Option::Some(1),
+                Self::Cosine => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISTANCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EUCLIDEAN"),
-                2 => std::borrow::Cow::Borrowed("COSINE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISTANCE_TYPE_UNSPECIFIED"),
+                Self::Euclidean => std::option::Option::Some("EUCLIDEAN"),
+                Self::Cosine => std::option::Option::Some("COSINE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISTANCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISTANCE_TYPE_UNSPECIFIED)
-                }
-                "EUCLIDEAN" => std::option::Option::Some(Self::EUCLIDEAN),
-                "COSINE" => std::option::Option::Some(Self::COSINE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DistanceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DistanceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DistanceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DistanceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Euclidean,
+                2 => Self::Cosine,
+                _ => Self::UnknownValue(distance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DistanceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISTANCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "EUCLIDEAN" => Self::Euclidean,
+                "COSINE" => Self::Cosine,
+                _ => Self::UnknownValue(distance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DistanceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Euclidean => serializer.serialize_i32(1),
+                Self::Cosine => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DistanceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DistanceType>::new(
+                ".google.cloud.bigquery.v2.Model.DistanceType",
+            ))
         }
     }
 
     /// Indicates the method to split input data into multiple tables.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataSplitMethod(i32);
-
-    impl DataSplitMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataSplitMethod {
         /// Default value.
-        pub const DATA_SPLIT_METHOD_UNSPECIFIED: DataSplitMethod = DataSplitMethod::new(0);
-
+        Unspecified,
         /// Splits data randomly.
-        pub const RANDOM: DataSplitMethod = DataSplitMethod::new(1);
-
+        Random,
         /// Splits data with the user provided tags.
-        pub const CUSTOM: DataSplitMethod = DataSplitMethod::new(2);
-
+        Custom,
         /// Splits data sequentially.
-        pub const SEQUENTIAL: DataSplitMethod = DataSplitMethod::new(3);
-
+        Sequential,
         /// Data split will be skipped.
-        pub const NO_SPLIT: DataSplitMethod = DataSplitMethod::new(4);
-
+        NoSplit,
         /// Splits data automatically: Uses NO_SPLIT if the data size is small.
         /// Otherwise uses RANDOM.
-        pub const AUTO_SPLIT: DataSplitMethod = DataSplitMethod::new(5);
+        AutoSplit,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataSplitMethod::value] or
+        /// [DataSplitMethod::name].
+        UnknownValue(data_split_method::UnknownValue),
+    }
 
-        /// Creates a new DataSplitMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_split_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataSplitMethod {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Random => std::option::Option::Some(1),
+                Self::Custom => std::option::Option::Some(2),
+                Self::Sequential => std::option::Option::Some(3),
+                Self::NoSplit => std::option::Option::Some(4),
+                Self::AutoSplit => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_SPLIT_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RANDOM"),
-                2 => std::borrow::Cow::Borrowed("CUSTOM"),
-                3 => std::borrow::Cow::Borrowed("SEQUENTIAL"),
-                4 => std::borrow::Cow::Borrowed("NO_SPLIT"),
-                5 => std::borrow::Cow::Borrowed("AUTO_SPLIT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_SPLIT_METHOD_UNSPECIFIED"),
+                Self::Random => std::option::Option::Some("RANDOM"),
+                Self::Custom => std::option::Option::Some("CUSTOM"),
+                Self::Sequential => std::option::Option::Some("SEQUENTIAL"),
+                Self::NoSplit => std::option::Option::Some("NO_SPLIT"),
+                Self::AutoSplit => std::option::Option::Some("AUTO_SPLIT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_SPLIT_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_SPLIT_METHOD_UNSPECIFIED)
-                }
-                "RANDOM" => std::option::Option::Some(Self::RANDOM),
-                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                "SEQUENTIAL" => std::option::Option::Some(Self::SEQUENTIAL),
-                "NO_SPLIT" => std::option::Option::Some(Self::NO_SPLIT),
-                "AUTO_SPLIT" => std::option::Option::Some(Self::AUTO_SPLIT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataSplitMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataSplitMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataSplitMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataSplitMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Random,
+                2 => Self::Custom,
+                3 => Self::Sequential,
+                4 => Self::NoSplit,
+                5 => Self::AutoSplit,
+                _ => Self::UnknownValue(data_split_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataSplitMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_SPLIT_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "RANDOM" => Self::Random,
+                "CUSTOM" => Self::Custom,
+                "SEQUENTIAL" => Self::Sequential,
+                "NO_SPLIT" => Self::NoSplit,
+                "AUTO_SPLIT" => Self::AutoSplit,
+                _ => Self::UnknownValue(data_split_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataSplitMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Random => serializer.serialize_i32(1),
+                Self::Custom => serializer.serialize_i32(2),
+                Self::Sequential => serializer.serialize_i32(3),
+                Self::NoSplit => serializer.serialize_i32(4),
+                Self::AutoSplit => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataSplitMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataSplitMethod>::new(
+                ".google.cloud.bigquery.v2.Model.DataSplitMethod",
+            ))
         }
     }
 
     /// Type of supported data frequency for time series forecasting models.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFrequency(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataFrequency {
+        /// Default value.
+        Unspecified,
+        /// Automatically inferred from timestamps.
+        AutoFrequency,
+        /// Yearly data.
+        Yearly,
+        /// Quarterly data.
+        Quarterly,
+        /// Monthly data.
+        Monthly,
+        /// Weekly data.
+        Weekly,
+        /// Daily data.
+        Daily,
+        /// Hourly data.
+        Hourly,
+        /// Per-minute data.
+        PerMinute,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataFrequency::value] or
+        /// [DataFrequency::name].
+        UnknownValue(data_frequency::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_frequency {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataFrequency {
-        /// Default value.
-        pub const DATA_FREQUENCY_UNSPECIFIED: DataFrequency = DataFrequency::new(0);
-
-        /// Automatically inferred from timestamps.
-        pub const AUTO_FREQUENCY: DataFrequency = DataFrequency::new(1);
-
-        /// Yearly data.
-        pub const YEARLY: DataFrequency = DataFrequency::new(2);
-
-        /// Quarterly data.
-        pub const QUARTERLY: DataFrequency = DataFrequency::new(3);
-
-        /// Monthly data.
-        pub const MONTHLY: DataFrequency = DataFrequency::new(4);
-
-        /// Weekly data.
-        pub const WEEKLY: DataFrequency = DataFrequency::new(5);
-
-        /// Daily data.
-        pub const DAILY: DataFrequency = DataFrequency::new(6);
-
-        /// Hourly data.
-        pub const HOURLY: DataFrequency = DataFrequency::new(7);
-
-        /// Per-minute data.
-        pub const PER_MINUTE: DataFrequency = DataFrequency::new(8);
-
-        /// Creates a new DataFrequency instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AutoFrequency => std::option::Option::Some(1),
+                Self::Yearly => std::option::Option::Some(2),
+                Self::Quarterly => std::option::Option::Some(3),
+                Self::Monthly => std::option::Option::Some(4),
+                Self::Weekly => std::option::Option::Some(5),
+                Self::Daily => std::option::Option::Some(6),
+                Self::Hourly => std::option::Option::Some(7),
+                Self::PerMinute => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_FREQUENCY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTO_FREQUENCY"),
-                2 => std::borrow::Cow::Borrowed("YEARLY"),
-                3 => std::borrow::Cow::Borrowed("QUARTERLY"),
-                4 => std::borrow::Cow::Borrowed("MONTHLY"),
-                5 => std::borrow::Cow::Borrowed("WEEKLY"),
-                6 => std::borrow::Cow::Borrowed("DAILY"),
-                7 => std::borrow::Cow::Borrowed("HOURLY"),
-                8 => std::borrow::Cow::Borrowed("PER_MINUTE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_FREQUENCY_UNSPECIFIED"),
+                Self::AutoFrequency => std::option::Option::Some("AUTO_FREQUENCY"),
+                Self::Yearly => std::option::Option::Some("YEARLY"),
+                Self::Quarterly => std::option::Option::Some("QUARTERLY"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::Weekly => std::option::Option::Some("WEEKLY"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Hourly => std::option::Option::Some("HOURLY"),
+                Self::PerMinute => std::option::Option::Some("PER_MINUTE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_FREQUENCY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_FREQUENCY_UNSPECIFIED)
-                }
-                "AUTO_FREQUENCY" => std::option::Option::Some(Self::AUTO_FREQUENCY),
-                "YEARLY" => std::option::Option::Some(Self::YEARLY),
-                "QUARTERLY" => std::option::Option::Some(Self::QUARTERLY),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "HOURLY" => std::option::Option::Some(Self::HOURLY),
-                "PER_MINUTE" => std::option::Option::Some(Self::PER_MINUTE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataFrequency {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFrequency {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataFrequency {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataFrequency {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AutoFrequency,
+                2 => Self::Yearly,
+                3 => Self::Quarterly,
+                4 => Self::Monthly,
+                5 => Self::Weekly,
+                6 => Self::Daily,
+                7 => Self::Hourly,
+                8 => Self::PerMinute,
+                _ => Self::UnknownValue(data_frequency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataFrequency {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_FREQUENCY_UNSPECIFIED" => Self::Unspecified,
+                "AUTO_FREQUENCY" => Self::AutoFrequency,
+                "YEARLY" => Self::Yearly,
+                "QUARTERLY" => Self::Quarterly,
+                "MONTHLY" => Self::Monthly,
+                "WEEKLY" => Self::Weekly,
+                "DAILY" => Self::Daily,
+                "HOURLY" => Self::Hourly,
+                "PER_MINUTE" => Self::PerMinute,
+                _ => Self::UnknownValue(data_frequency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataFrequency {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AutoFrequency => serializer.serialize_i32(1),
+                Self::Yearly => serializer.serialize_i32(2),
+                Self::Quarterly => serializer.serialize_i32(3),
+                Self::Monthly => serializer.serialize_i32(4),
+                Self::Weekly => serializer.serialize_i32(5),
+                Self::Daily => serializer.serialize_i32(6),
+                Self::Hourly => serializer.serialize_i32(7),
+                Self::PerMinute => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataFrequency {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFrequency>::new(
+                ".google.cloud.bigquery.v2.Model.DataFrequency",
+            ))
         }
     }
 
     /// Type of supported holiday regions for time series forecasting models.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HolidayRegion(i32);
-
-    impl HolidayRegion {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HolidayRegion {
         /// Holiday region unspecified.
-        pub const HOLIDAY_REGION_UNSPECIFIED: HolidayRegion = HolidayRegion::new(0);
-
+        Unspecified,
         /// Global.
-        pub const GLOBAL: HolidayRegion = HolidayRegion::new(1);
-
+        Global,
         /// North America.
-        pub const NA: HolidayRegion = HolidayRegion::new(2);
-
+        Na,
         /// Japan and Asia Pacific: Korea, Greater China, India, Australia, and New
         /// Zealand.
-        pub const JAPAC: HolidayRegion = HolidayRegion::new(3);
-
+        Japac,
         /// Europe, the Middle East and Africa.
-        pub const EMEA: HolidayRegion = HolidayRegion::new(4);
-
+        Emea,
         /// Latin America and the Caribbean.
-        pub const LAC: HolidayRegion = HolidayRegion::new(5);
-
+        Lac,
         /// United Arab Emirates
-        pub const AE: HolidayRegion = HolidayRegion::new(6);
-
+        Ae,
         /// Argentina
-        pub const AR: HolidayRegion = HolidayRegion::new(7);
-
+        Ar,
         /// Austria
-        pub const AT: HolidayRegion = HolidayRegion::new(8);
-
+        At,
         /// Australia
-        pub const AU: HolidayRegion = HolidayRegion::new(9);
-
+        Au,
         /// Belgium
-        pub const BE: HolidayRegion = HolidayRegion::new(10);
-
+        Be,
         /// Brazil
-        pub const BR: HolidayRegion = HolidayRegion::new(11);
-
+        Br,
         /// Canada
-        pub const CA: HolidayRegion = HolidayRegion::new(12);
-
+        Ca,
         /// Switzerland
-        pub const CH: HolidayRegion = HolidayRegion::new(13);
-
+        Ch,
         /// Chile
-        pub const CL: HolidayRegion = HolidayRegion::new(14);
-
+        Cl,
         /// China
-        pub const CN: HolidayRegion = HolidayRegion::new(15);
-
+        Cn,
         /// Colombia
-        pub const CO: HolidayRegion = HolidayRegion::new(16);
-
+        Co,
         /// Czechoslovakia
-        pub const CS: HolidayRegion = HolidayRegion::new(17);
-
+        Cs,
         /// Czech Republic
-        pub const CZ: HolidayRegion = HolidayRegion::new(18);
-
+        Cz,
         /// Germany
-        pub const DE: HolidayRegion = HolidayRegion::new(19);
-
+        De,
         /// Denmark
-        pub const DK: HolidayRegion = HolidayRegion::new(20);
-
+        Dk,
         /// Algeria
-        pub const DZ: HolidayRegion = HolidayRegion::new(21);
-
+        Dz,
         /// Ecuador
-        pub const EC: HolidayRegion = HolidayRegion::new(22);
-
+        Ec,
         /// Estonia
-        pub const EE: HolidayRegion = HolidayRegion::new(23);
-
+        Ee,
         /// Egypt
-        pub const EG: HolidayRegion = HolidayRegion::new(24);
-
+        Eg,
         /// Spain
-        pub const ES: HolidayRegion = HolidayRegion::new(25);
-
+        Es,
         /// Finland
-        pub const FI: HolidayRegion = HolidayRegion::new(26);
-
+        Fi,
         /// France
-        pub const FR: HolidayRegion = HolidayRegion::new(27);
-
+        Fr,
         /// Great Britain (United Kingdom)
-        pub const GB: HolidayRegion = HolidayRegion::new(28);
-
+        Gb,
         /// Greece
-        pub const GR: HolidayRegion = HolidayRegion::new(29);
-
+        Gr,
         /// Hong Kong
-        pub const HK: HolidayRegion = HolidayRegion::new(30);
-
+        Hk,
         /// Hungary
-        pub const HU: HolidayRegion = HolidayRegion::new(31);
-
+        Hu,
         /// Indonesia
-        pub const ID: HolidayRegion = HolidayRegion::new(32);
-
+        Id,
         /// Ireland
-        pub const IE: HolidayRegion = HolidayRegion::new(33);
-
+        Ie,
         /// Israel
-        pub const IL: HolidayRegion = HolidayRegion::new(34);
-
+        Il,
         /// India
-        pub const IN: HolidayRegion = HolidayRegion::new(35);
-
+        In,
         /// Iran
-        pub const IR: HolidayRegion = HolidayRegion::new(36);
-
+        Ir,
         /// Italy
-        pub const IT: HolidayRegion = HolidayRegion::new(37);
-
+        It,
         /// Japan
-        pub const JP: HolidayRegion = HolidayRegion::new(38);
-
+        Jp,
         /// Korea (South)
-        pub const KR: HolidayRegion = HolidayRegion::new(39);
-
+        Kr,
         /// Latvia
-        pub const LV: HolidayRegion = HolidayRegion::new(40);
-
+        Lv,
         /// Morocco
-        pub const MA: HolidayRegion = HolidayRegion::new(41);
-
+        Ma,
         /// Mexico
-        pub const MX: HolidayRegion = HolidayRegion::new(42);
-
+        Mx,
         /// Malaysia
-        pub const MY: HolidayRegion = HolidayRegion::new(43);
-
+        My,
         /// Nigeria
-        pub const NG: HolidayRegion = HolidayRegion::new(44);
-
+        Ng,
         /// Netherlands
-        pub const NL: HolidayRegion = HolidayRegion::new(45);
-
+        Nl,
         /// Norway
-        pub const NO: HolidayRegion = HolidayRegion::new(46);
-
+        No,
         /// New Zealand
-        pub const NZ: HolidayRegion = HolidayRegion::new(47);
-
+        Nz,
         /// Peru
-        pub const PE: HolidayRegion = HolidayRegion::new(48);
-
+        Pe,
         /// Philippines
-        pub const PH: HolidayRegion = HolidayRegion::new(49);
-
+        Ph,
         /// Pakistan
-        pub const PK: HolidayRegion = HolidayRegion::new(50);
-
+        Pk,
         /// Poland
-        pub const PL: HolidayRegion = HolidayRegion::new(51);
-
+        Pl,
         /// Portugal
-        pub const PT: HolidayRegion = HolidayRegion::new(52);
-
+        Pt,
         /// Romania
-        pub const RO: HolidayRegion = HolidayRegion::new(53);
-
+        Ro,
         /// Serbia
-        pub const RS: HolidayRegion = HolidayRegion::new(54);
-
+        Rs,
         /// Russian Federation
-        pub const RU: HolidayRegion = HolidayRegion::new(55);
-
+        Ru,
         /// Saudi Arabia
-        pub const SA: HolidayRegion = HolidayRegion::new(56);
-
+        Sa,
         /// Sweden
-        pub const SE: HolidayRegion = HolidayRegion::new(57);
-
+        Se,
         /// Singapore
-        pub const SG: HolidayRegion = HolidayRegion::new(58);
-
+        Sg,
         /// Slovenia
-        pub const SI: HolidayRegion = HolidayRegion::new(59);
-
+        Si,
         /// Slovakia
-        pub const SK: HolidayRegion = HolidayRegion::new(60);
-
+        Sk,
         /// Thailand
-        pub const TH: HolidayRegion = HolidayRegion::new(61);
-
+        Th,
         /// Turkey
-        pub const TR: HolidayRegion = HolidayRegion::new(62);
-
+        Tr,
         /// Taiwan
-        pub const TW: HolidayRegion = HolidayRegion::new(63);
-
+        Tw,
         /// Ukraine
-        pub const UA: HolidayRegion = HolidayRegion::new(64);
-
+        Ua,
         /// United States
-        pub const US: HolidayRegion = HolidayRegion::new(65);
-
+        Us,
         /// Venezuela
-        pub const VE: HolidayRegion = HolidayRegion::new(66);
-
+        Ve,
         /// Vietnam
-        pub const VN: HolidayRegion = HolidayRegion::new(67);
-
+        Vn,
         /// South Africa
-        pub const ZA: HolidayRegion = HolidayRegion::new(68);
+        Za,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HolidayRegion::value] or
+        /// [HolidayRegion::name].
+        UnknownValue(holiday_region::UnknownValue),
+    }
 
-        /// Creates a new HolidayRegion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod holiday_region {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl HolidayRegion {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Global => std::option::Option::Some(1),
+                Self::Na => std::option::Option::Some(2),
+                Self::Japac => std::option::Option::Some(3),
+                Self::Emea => std::option::Option::Some(4),
+                Self::Lac => std::option::Option::Some(5),
+                Self::Ae => std::option::Option::Some(6),
+                Self::Ar => std::option::Option::Some(7),
+                Self::At => std::option::Option::Some(8),
+                Self::Au => std::option::Option::Some(9),
+                Self::Be => std::option::Option::Some(10),
+                Self::Br => std::option::Option::Some(11),
+                Self::Ca => std::option::Option::Some(12),
+                Self::Ch => std::option::Option::Some(13),
+                Self::Cl => std::option::Option::Some(14),
+                Self::Cn => std::option::Option::Some(15),
+                Self::Co => std::option::Option::Some(16),
+                Self::Cs => std::option::Option::Some(17),
+                Self::Cz => std::option::Option::Some(18),
+                Self::De => std::option::Option::Some(19),
+                Self::Dk => std::option::Option::Some(20),
+                Self::Dz => std::option::Option::Some(21),
+                Self::Ec => std::option::Option::Some(22),
+                Self::Ee => std::option::Option::Some(23),
+                Self::Eg => std::option::Option::Some(24),
+                Self::Es => std::option::Option::Some(25),
+                Self::Fi => std::option::Option::Some(26),
+                Self::Fr => std::option::Option::Some(27),
+                Self::Gb => std::option::Option::Some(28),
+                Self::Gr => std::option::Option::Some(29),
+                Self::Hk => std::option::Option::Some(30),
+                Self::Hu => std::option::Option::Some(31),
+                Self::Id => std::option::Option::Some(32),
+                Self::Ie => std::option::Option::Some(33),
+                Self::Il => std::option::Option::Some(34),
+                Self::In => std::option::Option::Some(35),
+                Self::Ir => std::option::Option::Some(36),
+                Self::It => std::option::Option::Some(37),
+                Self::Jp => std::option::Option::Some(38),
+                Self::Kr => std::option::Option::Some(39),
+                Self::Lv => std::option::Option::Some(40),
+                Self::Ma => std::option::Option::Some(41),
+                Self::Mx => std::option::Option::Some(42),
+                Self::My => std::option::Option::Some(43),
+                Self::Ng => std::option::Option::Some(44),
+                Self::Nl => std::option::Option::Some(45),
+                Self::No => std::option::Option::Some(46),
+                Self::Nz => std::option::Option::Some(47),
+                Self::Pe => std::option::Option::Some(48),
+                Self::Ph => std::option::Option::Some(49),
+                Self::Pk => std::option::Option::Some(50),
+                Self::Pl => std::option::Option::Some(51),
+                Self::Pt => std::option::Option::Some(52),
+                Self::Ro => std::option::Option::Some(53),
+                Self::Rs => std::option::Option::Some(54),
+                Self::Ru => std::option::Option::Some(55),
+                Self::Sa => std::option::Option::Some(56),
+                Self::Se => std::option::Option::Some(57),
+                Self::Sg => std::option::Option::Some(58),
+                Self::Si => std::option::Option::Some(59),
+                Self::Sk => std::option::Option::Some(60),
+                Self::Th => std::option::Option::Some(61),
+                Self::Tr => std::option::Option::Some(62),
+                Self::Tw => std::option::Option::Some(63),
+                Self::Ua => std::option::Option::Some(64),
+                Self::Us => std::option::Option::Some(65),
+                Self::Ve => std::option::Option::Some(66),
+                Self::Vn => std::option::Option::Some(67),
+                Self::Za => std::option::Option::Some(68),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HOLIDAY_REGION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GLOBAL"),
-                2 => std::borrow::Cow::Borrowed("NA"),
-                3 => std::borrow::Cow::Borrowed("JAPAC"),
-                4 => std::borrow::Cow::Borrowed("EMEA"),
-                5 => std::borrow::Cow::Borrowed("LAC"),
-                6 => std::borrow::Cow::Borrowed("AE"),
-                7 => std::borrow::Cow::Borrowed("AR"),
-                8 => std::borrow::Cow::Borrowed("AT"),
-                9 => std::borrow::Cow::Borrowed("AU"),
-                10 => std::borrow::Cow::Borrowed("BE"),
-                11 => std::borrow::Cow::Borrowed("BR"),
-                12 => std::borrow::Cow::Borrowed("CA"),
-                13 => std::borrow::Cow::Borrowed("CH"),
-                14 => std::borrow::Cow::Borrowed("CL"),
-                15 => std::borrow::Cow::Borrowed("CN"),
-                16 => std::borrow::Cow::Borrowed("CO"),
-                17 => std::borrow::Cow::Borrowed("CS"),
-                18 => std::borrow::Cow::Borrowed("CZ"),
-                19 => std::borrow::Cow::Borrowed("DE"),
-                20 => std::borrow::Cow::Borrowed("DK"),
-                21 => std::borrow::Cow::Borrowed("DZ"),
-                22 => std::borrow::Cow::Borrowed("EC"),
-                23 => std::borrow::Cow::Borrowed("EE"),
-                24 => std::borrow::Cow::Borrowed("EG"),
-                25 => std::borrow::Cow::Borrowed("ES"),
-                26 => std::borrow::Cow::Borrowed("FI"),
-                27 => std::borrow::Cow::Borrowed("FR"),
-                28 => std::borrow::Cow::Borrowed("GB"),
-                29 => std::borrow::Cow::Borrowed("GR"),
-                30 => std::borrow::Cow::Borrowed("HK"),
-                31 => std::borrow::Cow::Borrowed("HU"),
-                32 => std::borrow::Cow::Borrowed("ID"),
-                33 => std::borrow::Cow::Borrowed("IE"),
-                34 => std::borrow::Cow::Borrowed("IL"),
-                35 => std::borrow::Cow::Borrowed("IN"),
-                36 => std::borrow::Cow::Borrowed("IR"),
-                37 => std::borrow::Cow::Borrowed("IT"),
-                38 => std::borrow::Cow::Borrowed("JP"),
-                39 => std::borrow::Cow::Borrowed("KR"),
-                40 => std::borrow::Cow::Borrowed("LV"),
-                41 => std::borrow::Cow::Borrowed("MA"),
-                42 => std::borrow::Cow::Borrowed("MX"),
-                43 => std::borrow::Cow::Borrowed("MY"),
-                44 => std::borrow::Cow::Borrowed("NG"),
-                45 => std::borrow::Cow::Borrowed("NL"),
-                46 => std::borrow::Cow::Borrowed("NO"),
-                47 => std::borrow::Cow::Borrowed("NZ"),
-                48 => std::borrow::Cow::Borrowed("PE"),
-                49 => std::borrow::Cow::Borrowed("PH"),
-                50 => std::borrow::Cow::Borrowed("PK"),
-                51 => std::borrow::Cow::Borrowed("PL"),
-                52 => std::borrow::Cow::Borrowed("PT"),
-                53 => std::borrow::Cow::Borrowed("RO"),
-                54 => std::borrow::Cow::Borrowed("RS"),
-                55 => std::borrow::Cow::Borrowed("RU"),
-                56 => std::borrow::Cow::Borrowed("SA"),
-                57 => std::borrow::Cow::Borrowed("SE"),
-                58 => std::borrow::Cow::Borrowed("SG"),
-                59 => std::borrow::Cow::Borrowed("SI"),
-                60 => std::borrow::Cow::Borrowed("SK"),
-                61 => std::borrow::Cow::Borrowed("TH"),
-                62 => std::borrow::Cow::Borrowed("TR"),
-                63 => std::borrow::Cow::Borrowed("TW"),
-                64 => std::borrow::Cow::Borrowed("UA"),
-                65 => std::borrow::Cow::Borrowed("US"),
-                66 => std::borrow::Cow::Borrowed("VE"),
-                67 => std::borrow::Cow::Borrowed("VN"),
-                68 => std::borrow::Cow::Borrowed("ZA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HOLIDAY_REGION_UNSPECIFIED"),
+                Self::Global => std::option::Option::Some("GLOBAL"),
+                Self::Na => std::option::Option::Some("NA"),
+                Self::Japac => std::option::Option::Some("JAPAC"),
+                Self::Emea => std::option::Option::Some("EMEA"),
+                Self::Lac => std::option::Option::Some("LAC"),
+                Self::Ae => std::option::Option::Some("AE"),
+                Self::Ar => std::option::Option::Some("AR"),
+                Self::At => std::option::Option::Some("AT"),
+                Self::Au => std::option::Option::Some("AU"),
+                Self::Be => std::option::Option::Some("BE"),
+                Self::Br => std::option::Option::Some("BR"),
+                Self::Ca => std::option::Option::Some("CA"),
+                Self::Ch => std::option::Option::Some("CH"),
+                Self::Cl => std::option::Option::Some("CL"),
+                Self::Cn => std::option::Option::Some("CN"),
+                Self::Co => std::option::Option::Some("CO"),
+                Self::Cs => std::option::Option::Some("CS"),
+                Self::Cz => std::option::Option::Some("CZ"),
+                Self::De => std::option::Option::Some("DE"),
+                Self::Dk => std::option::Option::Some("DK"),
+                Self::Dz => std::option::Option::Some("DZ"),
+                Self::Ec => std::option::Option::Some("EC"),
+                Self::Ee => std::option::Option::Some("EE"),
+                Self::Eg => std::option::Option::Some("EG"),
+                Self::Es => std::option::Option::Some("ES"),
+                Self::Fi => std::option::Option::Some("FI"),
+                Self::Fr => std::option::Option::Some("FR"),
+                Self::Gb => std::option::Option::Some("GB"),
+                Self::Gr => std::option::Option::Some("GR"),
+                Self::Hk => std::option::Option::Some("HK"),
+                Self::Hu => std::option::Option::Some("HU"),
+                Self::Id => std::option::Option::Some("ID"),
+                Self::Ie => std::option::Option::Some("IE"),
+                Self::Il => std::option::Option::Some("IL"),
+                Self::In => std::option::Option::Some("IN"),
+                Self::Ir => std::option::Option::Some("IR"),
+                Self::It => std::option::Option::Some("IT"),
+                Self::Jp => std::option::Option::Some("JP"),
+                Self::Kr => std::option::Option::Some("KR"),
+                Self::Lv => std::option::Option::Some("LV"),
+                Self::Ma => std::option::Option::Some("MA"),
+                Self::Mx => std::option::Option::Some("MX"),
+                Self::My => std::option::Option::Some("MY"),
+                Self::Ng => std::option::Option::Some("NG"),
+                Self::Nl => std::option::Option::Some("NL"),
+                Self::No => std::option::Option::Some("NO"),
+                Self::Nz => std::option::Option::Some("NZ"),
+                Self::Pe => std::option::Option::Some("PE"),
+                Self::Ph => std::option::Option::Some("PH"),
+                Self::Pk => std::option::Option::Some("PK"),
+                Self::Pl => std::option::Option::Some("PL"),
+                Self::Pt => std::option::Option::Some("PT"),
+                Self::Ro => std::option::Option::Some("RO"),
+                Self::Rs => std::option::Option::Some("RS"),
+                Self::Ru => std::option::Option::Some("RU"),
+                Self::Sa => std::option::Option::Some("SA"),
+                Self::Se => std::option::Option::Some("SE"),
+                Self::Sg => std::option::Option::Some("SG"),
+                Self::Si => std::option::Option::Some("SI"),
+                Self::Sk => std::option::Option::Some("SK"),
+                Self::Th => std::option::Option::Some("TH"),
+                Self::Tr => std::option::Option::Some("TR"),
+                Self::Tw => std::option::Option::Some("TW"),
+                Self::Ua => std::option::Option::Some("UA"),
+                Self::Us => std::option::Option::Some("US"),
+                Self::Ve => std::option::Option::Some("VE"),
+                Self::Vn => std::option::Option::Some("VN"),
+                Self::Za => std::option::Option::Some("ZA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HOLIDAY_REGION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HOLIDAY_REGION_UNSPECIFIED)
-                }
-                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
-                "NA" => std::option::Option::Some(Self::NA),
-                "JAPAC" => std::option::Option::Some(Self::JAPAC),
-                "EMEA" => std::option::Option::Some(Self::EMEA),
-                "LAC" => std::option::Option::Some(Self::LAC),
-                "AE" => std::option::Option::Some(Self::AE),
-                "AR" => std::option::Option::Some(Self::AR),
-                "AT" => std::option::Option::Some(Self::AT),
-                "AU" => std::option::Option::Some(Self::AU),
-                "BE" => std::option::Option::Some(Self::BE),
-                "BR" => std::option::Option::Some(Self::BR),
-                "CA" => std::option::Option::Some(Self::CA),
-                "CH" => std::option::Option::Some(Self::CH),
-                "CL" => std::option::Option::Some(Self::CL),
-                "CN" => std::option::Option::Some(Self::CN),
-                "CO" => std::option::Option::Some(Self::CO),
-                "CS" => std::option::Option::Some(Self::CS),
-                "CZ" => std::option::Option::Some(Self::CZ),
-                "DE" => std::option::Option::Some(Self::DE),
-                "DK" => std::option::Option::Some(Self::DK),
-                "DZ" => std::option::Option::Some(Self::DZ),
-                "EC" => std::option::Option::Some(Self::EC),
-                "EE" => std::option::Option::Some(Self::EE),
-                "EG" => std::option::Option::Some(Self::EG),
-                "ES" => std::option::Option::Some(Self::ES),
-                "FI" => std::option::Option::Some(Self::FI),
-                "FR" => std::option::Option::Some(Self::FR),
-                "GB" => std::option::Option::Some(Self::GB),
-                "GR" => std::option::Option::Some(Self::GR),
-                "HK" => std::option::Option::Some(Self::HK),
-                "HU" => std::option::Option::Some(Self::HU),
-                "ID" => std::option::Option::Some(Self::ID),
-                "IE" => std::option::Option::Some(Self::IE),
-                "IL" => std::option::Option::Some(Self::IL),
-                "IN" => std::option::Option::Some(Self::IN),
-                "IR" => std::option::Option::Some(Self::IR),
-                "IT" => std::option::Option::Some(Self::IT),
-                "JP" => std::option::Option::Some(Self::JP),
-                "KR" => std::option::Option::Some(Self::KR),
-                "LV" => std::option::Option::Some(Self::LV),
-                "MA" => std::option::Option::Some(Self::MA),
-                "MX" => std::option::Option::Some(Self::MX),
-                "MY" => std::option::Option::Some(Self::MY),
-                "NG" => std::option::Option::Some(Self::NG),
-                "NL" => std::option::Option::Some(Self::NL),
-                "NO" => std::option::Option::Some(Self::NO),
-                "NZ" => std::option::Option::Some(Self::NZ),
-                "PE" => std::option::Option::Some(Self::PE),
-                "PH" => std::option::Option::Some(Self::PH),
-                "PK" => std::option::Option::Some(Self::PK),
-                "PL" => std::option::Option::Some(Self::PL),
-                "PT" => std::option::Option::Some(Self::PT),
-                "RO" => std::option::Option::Some(Self::RO),
-                "RS" => std::option::Option::Some(Self::RS),
-                "RU" => std::option::Option::Some(Self::RU),
-                "SA" => std::option::Option::Some(Self::SA),
-                "SE" => std::option::Option::Some(Self::SE),
-                "SG" => std::option::Option::Some(Self::SG),
-                "SI" => std::option::Option::Some(Self::SI),
-                "SK" => std::option::Option::Some(Self::SK),
-                "TH" => std::option::Option::Some(Self::TH),
-                "TR" => std::option::Option::Some(Self::TR),
-                "TW" => std::option::Option::Some(Self::TW),
-                "UA" => std::option::Option::Some(Self::UA),
-                "US" => std::option::Option::Some(Self::US),
-                "VE" => std::option::Option::Some(Self::VE),
-                "VN" => std::option::Option::Some(Self::VN),
-                "ZA" => std::option::Option::Some(Self::ZA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HolidayRegion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HolidayRegion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HolidayRegion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HolidayRegion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Global,
+                2 => Self::Na,
+                3 => Self::Japac,
+                4 => Self::Emea,
+                5 => Self::Lac,
+                6 => Self::Ae,
+                7 => Self::Ar,
+                8 => Self::At,
+                9 => Self::Au,
+                10 => Self::Be,
+                11 => Self::Br,
+                12 => Self::Ca,
+                13 => Self::Ch,
+                14 => Self::Cl,
+                15 => Self::Cn,
+                16 => Self::Co,
+                17 => Self::Cs,
+                18 => Self::Cz,
+                19 => Self::De,
+                20 => Self::Dk,
+                21 => Self::Dz,
+                22 => Self::Ec,
+                23 => Self::Ee,
+                24 => Self::Eg,
+                25 => Self::Es,
+                26 => Self::Fi,
+                27 => Self::Fr,
+                28 => Self::Gb,
+                29 => Self::Gr,
+                30 => Self::Hk,
+                31 => Self::Hu,
+                32 => Self::Id,
+                33 => Self::Ie,
+                34 => Self::Il,
+                35 => Self::In,
+                36 => Self::Ir,
+                37 => Self::It,
+                38 => Self::Jp,
+                39 => Self::Kr,
+                40 => Self::Lv,
+                41 => Self::Ma,
+                42 => Self::Mx,
+                43 => Self::My,
+                44 => Self::Ng,
+                45 => Self::Nl,
+                46 => Self::No,
+                47 => Self::Nz,
+                48 => Self::Pe,
+                49 => Self::Ph,
+                50 => Self::Pk,
+                51 => Self::Pl,
+                52 => Self::Pt,
+                53 => Self::Ro,
+                54 => Self::Rs,
+                55 => Self::Ru,
+                56 => Self::Sa,
+                57 => Self::Se,
+                58 => Self::Sg,
+                59 => Self::Si,
+                60 => Self::Sk,
+                61 => Self::Th,
+                62 => Self::Tr,
+                63 => Self::Tw,
+                64 => Self::Ua,
+                65 => Self::Us,
+                66 => Self::Ve,
+                67 => Self::Vn,
+                68 => Self::Za,
+                _ => Self::UnknownValue(holiday_region::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HolidayRegion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HOLIDAY_REGION_UNSPECIFIED" => Self::Unspecified,
+                "GLOBAL" => Self::Global,
+                "NA" => Self::Na,
+                "JAPAC" => Self::Japac,
+                "EMEA" => Self::Emea,
+                "LAC" => Self::Lac,
+                "AE" => Self::Ae,
+                "AR" => Self::Ar,
+                "AT" => Self::At,
+                "AU" => Self::Au,
+                "BE" => Self::Be,
+                "BR" => Self::Br,
+                "CA" => Self::Ca,
+                "CH" => Self::Ch,
+                "CL" => Self::Cl,
+                "CN" => Self::Cn,
+                "CO" => Self::Co,
+                "CS" => Self::Cs,
+                "CZ" => Self::Cz,
+                "DE" => Self::De,
+                "DK" => Self::Dk,
+                "DZ" => Self::Dz,
+                "EC" => Self::Ec,
+                "EE" => Self::Ee,
+                "EG" => Self::Eg,
+                "ES" => Self::Es,
+                "FI" => Self::Fi,
+                "FR" => Self::Fr,
+                "GB" => Self::Gb,
+                "GR" => Self::Gr,
+                "HK" => Self::Hk,
+                "HU" => Self::Hu,
+                "ID" => Self::Id,
+                "IE" => Self::Ie,
+                "IL" => Self::Il,
+                "IN" => Self::In,
+                "IR" => Self::Ir,
+                "IT" => Self::It,
+                "JP" => Self::Jp,
+                "KR" => Self::Kr,
+                "LV" => Self::Lv,
+                "MA" => Self::Ma,
+                "MX" => Self::Mx,
+                "MY" => Self::My,
+                "NG" => Self::Ng,
+                "NL" => Self::Nl,
+                "NO" => Self::No,
+                "NZ" => Self::Nz,
+                "PE" => Self::Pe,
+                "PH" => Self::Ph,
+                "PK" => Self::Pk,
+                "PL" => Self::Pl,
+                "PT" => Self::Pt,
+                "RO" => Self::Ro,
+                "RS" => Self::Rs,
+                "RU" => Self::Ru,
+                "SA" => Self::Sa,
+                "SE" => Self::Se,
+                "SG" => Self::Sg,
+                "SI" => Self::Si,
+                "SK" => Self::Sk,
+                "TH" => Self::Th,
+                "TR" => Self::Tr,
+                "TW" => Self::Tw,
+                "UA" => Self::Ua,
+                "US" => Self::Us,
+                "VE" => Self::Ve,
+                "VN" => Self::Vn,
+                "ZA" => Self::Za,
+                _ => Self::UnknownValue(holiday_region::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HolidayRegion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Global => serializer.serialize_i32(1),
+                Self::Na => serializer.serialize_i32(2),
+                Self::Japac => serializer.serialize_i32(3),
+                Self::Emea => serializer.serialize_i32(4),
+                Self::Lac => serializer.serialize_i32(5),
+                Self::Ae => serializer.serialize_i32(6),
+                Self::Ar => serializer.serialize_i32(7),
+                Self::At => serializer.serialize_i32(8),
+                Self::Au => serializer.serialize_i32(9),
+                Self::Be => serializer.serialize_i32(10),
+                Self::Br => serializer.serialize_i32(11),
+                Self::Ca => serializer.serialize_i32(12),
+                Self::Ch => serializer.serialize_i32(13),
+                Self::Cl => serializer.serialize_i32(14),
+                Self::Cn => serializer.serialize_i32(15),
+                Self::Co => serializer.serialize_i32(16),
+                Self::Cs => serializer.serialize_i32(17),
+                Self::Cz => serializer.serialize_i32(18),
+                Self::De => serializer.serialize_i32(19),
+                Self::Dk => serializer.serialize_i32(20),
+                Self::Dz => serializer.serialize_i32(21),
+                Self::Ec => serializer.serialize_i32(22),
+                Self::Ee => serializer.serialize_i32(23),
+                Self::Eg => serializer.serialize_i32(24),
+                Self::Es => serializer.serialize_i32(25),
+                Self::Fi => serializer.serialize_i32(26),
+                Self::Fr => serializer.serialize_i32(27),
+                Self::Gb => serializer.serialize_i32(28),
+                Self::Gr => serializer.serialize_i32(29),
+                Self::Hk => serializer.serialize_i32(30),
+                Self::Hu => serializer.serialize_i32(31),
+                Self::Id => serializer.serialize_i32(32),
+                Self::Ie => serializer.serialize_i32(33),
+                Self::Il => serializer.serialize_i32(34),
+                Self::In => serializer.serialize_i32(35),
+                Self::Ir => serializer.serialize_i32(36),
+                Self::It => serializer.serialize_i32(37),
+                Self::Jp => serializer.serialize_i32(38),
+                Self::Kr => serializer.serialize_i32(39),
+                Self::Lv => serializer.serialize_i32(40),
+                Self::Ma => serializer.serialize_i32(41),
+                Self::Mx => serializer.serialize_i32(42),
+                Self::My => serializer.serialize_i32(43),
+                Self::Ng => serializer.serialize_i32(44),
+                Self::Nl => serializer.serialize_i32(45),
+                Self::No => serializer.serialize_i32(46),
+                Self::Nz => serializer.serialize_i32(47),
+                Self::Pe => serializer.serialize_i32(48),
+                Self::Ph => serializer.serialize_i32(49),
+                Self::Pk => serializer.serialize_i32(50),
+                Self::Pl => serializer.serialize_i32(51),
+                Self::Pt => serializer.serialize_i32(52),
+                Self::Ro => serializer.serialize_i32(53),
+                Self::Rs => serializer.serialize_i32(54),
+                Self::Ru => serializer.serialize_i32(55),
+                Self::Sa => serializer.serialize_i32(56),
+                Self::Se => serializer.serialize_i32(57),
+                Self::Sg => serializer.serialize_i32(58),
+                Self::Si => serializer.serialize_i32(59),
+                Self::Sk => serializer.serialize_i32(60),
+                Self::Th => serializer.serialize_i32(61),
+                Self::Tr => serializer.serialize_i32(62),
+                Self::Tw => serializer.serialize_i32(63),
+                Self::Ua => serializer.serialize_i32(64),
+                Self::Us => serializer.serialize_i32(65),
+                Self::Ve => serializer.serialize_i32(66),
+                Self::Vn => serializer.serialize_i32(67),
+                Self::Za => serializer.serialize_i32(68),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HolidayRegion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HolidayRegion>::new(
+                ".google.cloud.bigquery.v2.Model.HolidayRegion",
+            ))
         }
     }
 
     /// Enums for color space, used for processing images in Object Table.
     /// See more details at
     /// <https://www.tensorflow.org/io/tutorials/colorspace>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ColorSpace(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ColorSpace {
+        /// Unspecified color space
+        Unspecified,
+        /// RGB
+        Rgb,
+        /// HSV
+        Hsv,
+        /// YIQ
+        Yiq,
+        /// YUV
+        Yuv,
+        /// GRAYSCALE
+        Grayscale,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ColorSpace::value] or
+        /// [ColorSpace::name].
+        UnknownValue(color_space::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod color_space {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ColorSpace {
-        /// Unspecified color space
-        pub const COLOR_SPACE_UNSPECIFIED: ColorSpace = ColorSpace::new(0);
-
-        /// RGB
-        pub const RGB: ColorSpace = ColorSpace::new(1);
-
-        /// HSV
-        pub const HSV: ColorSpace = ColorSpace::new(2);
-
-        /// YIQ
-        pub const YIQ: ColorSpace = ColorSpace::new(3);
-
-        /// YUV
-        pub const YUV: ColorSpace = ColorSpace::new(4);
-
-        /// GRAYSCALE
-        pub const GRAYSCALE: ColorSpace = ColorSpace::new(5);
-
-        /// Creates a new ColorSpace instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Rgb => std::option::Option::Some(1),
+                Self::Hsv => std::option::Option::Some(2),
+                Self::Yiq => std::option::Option::Some(3),
+                Self::Yuv => std::option::Option::Some(4),
+                Self::Grayscale => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COLOR_SPACE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RGB"),
-                2 => std::borrow::Cow::Borrowed("HSV"),
-                3 => std::borrow::Cow::Borrowed("YIQ"),
-                4 => std::borrow::Cow::Borrowed("YUV"),
-                5 => std::borrow::Cow::Borrowed("GRAYSCALE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COLOR_SPACE_UNSPECIFIED"),
+                Self::Rgb => std::option::Option::Some("RGB"),
+                Self::Hsv => std::option::Option::Some("HSV"),
+                Self::Yiq => std::option::Option::Some("YIQ"),
+                Self::Yuv => std::option::Option::Some("YUV"),
+                Self::Grayscale => std::option::Option::Some("GRAYSCALE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COLOR_SPACE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COLOR_SPACE_UNSPECIFIED)
-                }
-                "RGB" => std::option::Option::Some(Self::RGB),
-                "HSV" => std::option::Option::Some(Self::HSV),
-                "YIQ" => std::option::Option::Some(Self::YIQ),
-                "YUV" => std::option::Option::Some(Self::YUV),
-                "GRAYSCALE" => std::option::Option::Some(Self::GRAYSCALE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ColorSpace {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ColorSpace {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ColorSpace {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ColorSpace {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Rgb,
+                2 => Self::Hsv,
+                3 => Self::Yiq,
+                4 => Self::Yuv,
+                5 => Self::Grayscale,
+                _ => Self::UnknownValue(color_space::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ColorSpace {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COLOR_SPACE_UNSPECIFIED" => Self::Unspecified,
+                "RGB" => Self::Rgb,
+                "HSV" => Self::Hsv,
+                "YIQ" => Self::Yiq,
+                "YUV" => Self::Yuv,
+                "GRAYSCALE" => Self::Grayscale,
+                _ => Self::UnknownValue(color_space::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ColorSpace {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Rgb => serializer.serialize_i32(1),
+                Self::Hsv => serializer.serialize_i32(2),
+                Self::Yiq => serializer.serialize_i32(3),
+                Self::Yuv => serializer.serialize_i32(4),
+                Self::Grayscale => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ColorSpace {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ColorSpace>::new(
+                ".google.cloud.bigquery.v2.Model.ColorSpace",
+            ))
         }
     }
 
     /// Indicates the learning rate optimization strategy to use.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LearnRateStrategy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LearnRateStrategy {
+        /// Default value.
+        Unspecified,
+        /// Use line search to determine learning rate.
+        LineSearch,
+        /// Use a constant learning rate.
+        Constant,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LearnRateStrategy::value] or
+        /// [LearnRateStrategy::name].
+        UnknownValue(learn_rate_strategy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod learn_rate_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LearnRateStrategy {
-        /// Default value.
-        pub const LEARN_RATE_STRATEGY_UNSPECIFIED: LearnRateStrategy = LearnRateStrategy::new(0);
-
-        /// Use line search to determine learning rate.
-        pub const LINE_SEARCH: LearnRateStrategy = LearnRateStrategy::new(1);
-
-        /// Use a constant learning rate.
-        pub const CONSTANT: LearnRateStrategy = LearnRateStrategy::new(2);
-
-        /// Creates a new LearnRateStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LineSearch => std::option::Option::Some(1),
+                Self::Constant => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LEARN_RATE_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LINE_SEARCH"),
-                2 => std::borrow::Cow::Borrowed("CONSTANT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LEARN_RATE_STRATEGY_UNSPECIFIED"),
+                Self::LineSearch => std::option::Option::Some("LINE_SEARCH"),
+                Self::Constant => std::option::Option::Some("CONSTANT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LEARN_RATE_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LEARN_RATE_STRATEGY_UNSPECIFIED)
-                }
-                "LINE_SEARCH" => std::option::Option::Some(Self::LINE_SEARCH),
-                "CONSTANT" => std::option::Option::Some(Self::CONSTANT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LearnRateStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LearnRateStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LearnRateStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LearnRateStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LineSearch,
+                2 => Self::Constant,
+                _ => Self::UnknownValue(learn_rate_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LearnRateStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LEARN_RATE_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "LINE_SEARCH" => Self::LineSearch,
+                "CONSTANT" => Self::Constant,
+                _ => Self::UnknownValue(learn_rate_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LearnRateStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LineSearch => serializer.serialize_i32(1),
+                Self::Constant => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LearnRateStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LearnRateStrategy>::new(
+                ".google.cloud.bigquery.v2.Model.LearnRateStrategy",
+            ))
         }
     }
 
     /// Indicates the optimization strategy used for training.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptimizationStrategy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OptimizationStrategy {
+        /// Default value.
+        Unspecified,
+        /// Uses an iterative batch gradient descent algorithm.
+        BatchGradientDescent,
+        /// Uses a normal equation to solve linear regression problem.
+        NormalEquation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OptimizationStrategy::value] or
+        /// [OptimizationStrategy::name].
+        UnknownValue(optimization_strategy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod optimization_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OptimizationStrategy {
-        /// Default value.
-        pub const OPTIMIZATION_STRATEGY_UNSPECIFIED: OptimizationStrategy =
-            OptimizationStrategy::new(0);
-
-        /// Uses an iterative batch gradient descent algorithm.
-        pub const BATCH_GRADIENT_DESCENT: OptimizationStrategy = OptimizationStrategy::new(1);
-
-        /// Uses a normal equation to solve linear regression problem.
-        pub const NORMAL_EQUATION: OptimizationStrategy = OptimizationStrategy::new(2);
-
-        /// Creates a new OptimizationStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BatchGradientDescent => std::option::Option::Some(1),
+                Self::NormalEquation => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPTIMIZATION_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BATCH_GRADIENT_DESCENT"),
-                2 => std::borrow::Cow::Borrowed("NORMAL_EQUATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPTIMIZATION_STRATEGY_UNSPECIFIED"),
+                Self::BatchGradientDescent => std::option::Option::Some("BATCH_GRADIENT_DESCENT"),
+                Self::NormalEquation => std::option::Option::Some("NORMAL_EQUATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPTIMIZATION_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OPTIMIZATION_STRATEGY_UNSPECIFIED)
-                }
-                "BATCH_GRADIENT_DESCENT" => std::option::Option::Some(Self::BATCH_GRADIENT_DESCENT),
-                "NORMAL_EQUATION" => std::option::Option::Some(Self::NORMAL_EQUATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OptimizationStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OptimizationStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OptimizationStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OptimizationStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BatchGradientDescent,
+                2 => Self::NormalEquation,
+                _ => Self::UnknownValue(optimization_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OptimizationStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPTIMIZATION_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "BATCH_GRADIENT_DESCENT" => Self::BatchGradientDescent,
+                "NORMAL_EQUATION" => Self::NormalEquation,
+                _ => Self::UnknownValue(optimization_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OptimizationStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BatchGradientDescent => serializer.serialize_i32(1),
+                Self::NormalEquation => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OptimizationStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OptimizationStrategy>::new(
+                ".google.cloud.bigquery.v2.Model.OptimizationStrategy",
+            ))
         }
     }
 
     /// Indicates the training algorithm to use for matrix factorization models.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FeedbackType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FeedbackType {
+        /// Default value.
+        Unspecified,
+        /// Use weighted-als for implicit feedback problems.
+        Implicit,
+        /// Use nonweighted-als for explicit feedback problems.
+        Explicit,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FeedbackType::value] or
+        /// [FeedbackType::name].
+        UnknownValue(feedback_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod feedback_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FeedbackType {
-        /// Default value.
-        pub const FEEDBACK_TYPE_UNSPECIFIED: FeedbackType = FeedbackType::new(0);
-
-        /// Use weighted-als for implicit feedback problems.
-        pub const IMPLICIT: FeedbackType = FeedbackType::new(1);
-
-        /// Use nonweighted-als for explicit feedback problems.
-        pub const EXPLICIT: FeedbackType = FeedbackType::new(2);
-
-        /// Creates a new FeedbackType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Implicit => std::option::Option::Some(1),
+                Self::Explicit => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FEEDBACK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPLICIT"),
-                2 => std::borrow::Cow::Borrowed("EXPLICIT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FEEDBACK_TYPE_UNSPECIFIED"),
+                Self::Implicit => std::option::Option::Some("IMPLICIT"),
+                Self::Explicit => std::option::Option::Some("EXPLICIT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FEEDBACK_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FEEDBACK_TYPE_UNSPECIFIED)
-                }
-                "IMPLICIT" => std::option::Option::Some(Self::IMPLICIT),
-                "EXPLICIT" => std::option::Option::Some(Self::EXPLICIT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FeedbackType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FeedbackType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FeedbackType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FeedbackType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Implicit,
+                2 => Self::Explicit,
+                _ => Self::UnknownValue(feedback_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FeedbackType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FEEDBACK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMPLICIT" => Self::Implicit,
+                "EXPLICIT" => Self::Explicit,
+                _ => Self::UnknownValue(feedback_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FeedbackType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Implicit => serializer.serialize_i32(1),
+                Self::Explicit => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FeedbackType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FeedbackType>::new(
+                ".google.cloud.bigquery.v2.Model.FeedbackType",
+            ))
         }
     }
 }
@@ -12727,72 +14792,135 @@ pub mod join_restriction_policy {
     use super::*;
 
     /// Enum for Join Restrictions policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JoinCondition(i32);
-
-    impl JoinCondition {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JoinCondition {
         /// A join is neither required nor restricted on any column. Default value.
-        pub const JOIN_CONDITION_UNSPECIFIED: JoinCondition = JoinCondition::new(0);
-
+        Unspecified,
         /// A join is required on at least one of the specified columns.
-        pub const JOIN_ANY: JoinCondition = JoinCondition::new(1);
-
+        JoinAny,
         /// A join is required on all specified columns.
-        pub const JOIN_ALL: JoinCondition = JoinCondition::new(2);
-
+        JoinAll,
         /// A join is not required, but if present it is only permitted on
         /// 'join_allowed_columns'
-        pub const JOIN_NOT_REQUIRED: JoinCondition = JoinCondition::new(3);
-
+        JoinNotRequired,
         /// Joins are blocked for all queries.
-        pub const JOIN_BLOCKED: JoinCondition = JoinCondition::new(4);
+        JoinBlocked,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JoinCondition::value] or
+        /// [JoinCondition::name].
+        UnknownValue(join_condition::UnknownValue),
+    }
 
-        /// Creates a new JoinCondition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod join_condition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl JoinCondition {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::JoinAny => std::option::Option::Some(1),
+                Self::JoinAll => std::option::Option::Some(2),
+                Self::JoinNotRequired => std::option::Option::Some(3),
+                Self::JoinBlocked => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JOIN_CONDITION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("JOIN_ANY"),
-                2 => std::borrow::Cow::Borrowed("JOIN_ALL"),
-                3 => std::borrow::Cow::Borrowed("JOIN_NOT_REQUIRED"),
-                4 => std::borrow::Cow::Borrowed("JOIN_BLOCKED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("JOIN_CONDITION_UNSPECIFIED"),
+                Self::JoinAny => std::option::Option::Some("JOIN_ANY"),
+                Self::JoinAll => std::option::Option::Some("JOIN_ALL"),
+                Self::JoinNotRequired => std::option::Option::Some("JOIN_NOT_REQUIRED"),
+                Self::JoinBlocked => std::option::Option::Some("JOIN_BLOCKED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JOIN_CONDITION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::JOIN_CONDITION_UNSPECIFIED)
-                }
-                "JOIN_ANY" => std::option::Option::Some(Self::JOIN_ANY),
-                "JOIN_ALL" => std::option::Option::Some(Self::JOIN_ALL),
-                "JOIN_NOT_REQUIRED" => std::option::Option::Some(Self::JOIN_NOT_REQUIRED),
-                "JOIN_BLOCKED" => std::option::Option::Some(Self::JOIN_BLOCKED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JoinCondition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JoinCondition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JoinCondition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JoinCondition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::JoinAny,
+                2 => Self::JoinAll,
+                3 => Self::JoinNotRequired,
+                4 => Self::JoinBlocked,
+                _ => Self::UnknownValue(join_condition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JoinCondition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JOIN_CONDITION_UNSPECIFIED" => Self::Unspecified,
+                "JOIN_ANY" => Self::JoinAny,
+                "JOIN_ALL" => Self::JoinAll,
+                "JOIN_NOT_REQUIRED" => Self::JoinNotRequired,
+                "JOIN_BLOCKED" => Self::JoinBlocked,
+                _ => Self::UnknownValue(join_condition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JoinCondition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::JoinAny => serializer.serialize_i32(1),
+                Self::JoinAll => serializer.serialize_i32(2),
+                Self::JoinNotRequired => serializer.serialize_i32(3),
+                Self::JoinBlocked => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JoinCondition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JoinCondition>::new(
+                ".google.cloud.bigquery.v2.JoinRestrictionPolicy.JoinCondition",
+            ))
         }
     }
 }
@@ -13512,58 +15640,115 @@ pub mod restriction_config {
     use super::*;
 
     /// RestrictionType specifies the type of dataset/table restriction.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestrictionType(i32);
-
-    impl RestrictionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RestrictionType {
         /// Should never be used.
-        pub const RESTRICTION_TYPE_UNSPECIFIED: RestrictionType = RestrictionType::new(0);
-
+        Unspecified,
         /// Restrict data egress. See [Data
         /// egress](https://cloud.google.com/bigquery/docs/analytics-hub-introduction#data_egress)
         /// for more details.
-        pub const RESTRICTED_DATA_EGRESS: RestrictionType = RestrictionType::new(1);
+        RestrictedDataEgress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RestrictionType::value] or
+        /// [RestrictionType::name].
+        UnknownValue(restriction_type::UnknownValue),
+    }
 
-        /// Creates a new RestrictionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod restriction_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RestrictionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RestrictedDataEgress => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESTRICTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESTRICTED_DATA_EGRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESTRICTION_TYPE_UNSPECIFIED"),
+                Self::RestrictedDataEgress => std::option::Option::Some("RESTRICTED_DATA_EGRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESTRICTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESTRICTION_TYPE_UNSPECIFIED)
-                }
-                "RESTRICTED_DATA_EGRESS" => std::option::Option::Some(Self::RESTRICTED_DATA_EGRESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RestrictionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RestrictionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RestrictionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RestrictionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RestrictedDataEgress,
+                _ => Self::UnknownValue(restriction_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RestrictionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESTRICTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "RESTRICTED_DATA_EGRESS" => Self::RestrictedDataEgress,
+                _ => Self::UnknownValue(restriction_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RestrictionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RestrictedDataEgress => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RestrictionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestrictionType>::new(
+                ".google.cloud.bigquery.v2.RestrictionConfig.RestrictionType",
+            ))
         }
     }
 }
@@ -13995,124 +16180,252 @@ pub mod routine {
         use super::*;
 
         /// Represents the kind of a given argument.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ArgumentKind(i32);
-
-        impl ArgumentKind {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ArgumentKind {
             /// Default value.
-            pub const ARGUMENT_KIND_UNSPECIFIED: ArgumentKind = ArgumentKind::new(0);
-
+            Unspecified,
             /// The argument is a variable with fully specified type, which can be a
             /// struct or an array, but not a table.
-            pub const FIXED_TYPE: ArgumentKind = ArgumentKind::new(1);
-
+            FixedType,
             /// The argument is any type, including struct or array, but not a table.
-            pub const ANY_TYPE: ArgumentKind = ArgumentKind::new(2);
+            AnyType,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ArgumentKind::value] or
+            /// [ArgumentKind::name].
+            UnknownValue(argument_kind::UnknownValue),
+        }
 
-            /// Creates a new ArgumentKind instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod argument_kind {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ArgumentKind {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::FixedType => std::option::Option::Some(1),
+                    Self::AnyType => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ARGUMENT_KIND_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("FIXED_TYPE"),
-                    2 => std::borrow::Cow::Borrowed("ANY_TYPE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ARGUMENT_KIND_UNSPECIFIED"),
+                    Self::FixedType => std::option::Option::Some("FIXED_TYPE"),
+                    Self::AnyType => std::option::Option::Some("ANY_TYPE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ARGUMENT_KIND_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ARGUMENT_KIND_UNSPECIFIED)
-                    }
-                    "FIXED_TYPE" => std::option::Option::Some(Self::FIXED_TYPE),
-                    "ANY_TYPE" => std::option::Option::Some(Self::ANY_TYPE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ArgumentKind {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ArgumentKind {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ArgumentKind {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ArgumentKind {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::FixedType,
+                    2 => Self::AnyType,
+                    _ => Self::UnknownValue(argument_kind::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ArgumentKind {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ARGUMENT_KIND_UNSPECIFIED" => Self::Unspecified,
+                    "FIXED_TYPE" => Self::FixedType,
+                    "ANY_TYPE" => Self::AnyType,
+                    _ => Self::UnknownValue(argument_kind::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ArgumentKind {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::FixedType => serializer.serialize_i32(1),
+                    Self::AnyType => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ArgumentKind {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ArgumentKind>::new(
+                    ".google.cloud.bigquery.v2.Routine.Argument.ArgumentKind",
+                ))
             }
         }
 
         /// The input/output mode of the argument.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Mode {
+            /// Default value.
+            Unspecified,
+            /// The argument is input-only.
+            In,
+            /// The argument is output-only.
+            Out,
+            /// The argument is both an input and an output.
+            Inout,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Mode::value] or
+            /// [Mode::name].
+            UnknownValue(mode::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Mode {
-            /// Default value.
-            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-            /// The argument is input-only.
-            pub const IN: Mode = Mode::new(1);
-
-            /// The argument is output-only.
-            pub const OUT: Mode = Mode::new(2);
-
-            /// The argument is both an input and an output.
-            pub const INOUT: Mode = Mode::new(3);
-
-            /// Creates a new Mode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::In => std::option::Option::Some(1),
+                    Self::Out => std::option::Option::Some(2),
+                    Self::Inout => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IN"),
-                    2 => std::borrow::Cow::Borrowed("OUT"),
-                    3 => std::borrow::Cow::Borrowed("INOUT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                    Self::In => std::option::Option::Some("IN"),
+                    Self::Out => std::option::Option::Some("OUT"),
+                    Self::Inout => std::option::Option::Some("INOUT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                    "IN" => std::option::Option::Some(Self::IN),
-                    "OUT" => std::option::Option::Some(Self::OUT),
-                    "INOUT" => std::option::Option::Some(Self::INOUT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Mode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Mode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::In,
+                    2 => Self::Out,
+                    3 => Self::Inout,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Mode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODE_UNSPECIFIED" => Self::Unspecified,
+                    "IN" => Self::In,
+                    "OUT" => Self::Out,
+                    "INOUT" => Self::Inout,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Mode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::In => serializer.serialize_i32(1),
+                    Self::Out => serializer.serialize_i32(2),
+                    Self::Inout => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Mode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                    ".google.cloud.bigquery.v2.Routine.Argument.Mode",
+                ))
             }
         }
     }
@@ -14197,143 +16510,273 @@ pub mod routine {
     }
 
     /// The fine-grained type of the routine.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutineType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoutineType {
+        /// Default value.
+        Unspecified,
+        /// Non-built-in persistent scalar function.
+        ScalarFunction,
+        /// Stored procedure.
+        Procedure,
+        /// Non-built-in persistent TVF.
+        TableValuedFunction,
+        /// Non-built-in persistent aggregate function.
+        AggregateFunction,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoutineType::value] or
+        /// [RoutineType::name].
+        UnknownValue(routine_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod routine_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RoutineType {
-        /// Default value.
-        pub const ROUTINE_TYPE_UNSPECIFIED: RoutineType = RoutineType::new(0);
-
-        /// Non-built-in persistent scalar function.
-        pub const SCALAR_FUNCTION: RoutineType = RoutineType::new(1);
-
-        /// Stored procedure.
-        pub const PROCEDURE: RoutineType = RoutineType::new(2);
-
-        /// Non-built-in persistent TVF.
-        pub const TABLE_VALUED_FUNCTION: RoutineType = RoutineType::new(3);
-
-        /// Non-built-in persistent aggregate function.
-        pub const AGGREGATE_FUNCTION: RoutineType = RoutineType::new(4);
-
-        /// Creates a new RoutineType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ScalarFunction => std::option::Option::Some(1),
+                Self::Procedure => std::option::Option::Some(2),
+                Self::TableValuedFunction => std::option::Option::Some(3),
+                Self::AggregateFunction => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUTINE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCALAR_FUNCTION"),
-                2 => std::borrow::Cow::Borrowed("PROCEDURE"),
-                3 => std::borrow::Cow::Borrowed("TABLE_VALUED_FUNCTION"),
-                4 => std::borrow::Cow::Borrowed("AGGREGATE_FUNCTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUTINE_TYPE_UNSPECIFIED"),
+                Self::ScalarFunction => std::option::Option::Some("SCALAR_FUNCTION"),
+                Self::Procedure => std::option::Option::Some("PROCEDURE"),
+                Self::TableValuedFunction => std::option::Option::Some("TABLE_VALUED_FUNCTION"),
+                Self::AggregateFunction => std::option::Option::Some("AGGREGATE_FUNCTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUTINE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROUTINE_TYPE_UNSPECIFIED)
-                }
-                "SCALAR_FUNCTION" => std::option::Option::Some(Self::SCALAR_FUNCTION),
-                "PROCEDURE" => std::option::Option::Some(Self::PROCEDURE),
-                "TABLE_VALUED_FUNCTION" => std::option::Option::Some(Self::TABLE_VALUED_FUNCTION),
-                "AGGREGATE_FUNCTION" => std::option::Option::Some(Self::AGGREGATE_FUNCTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RoutineType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutineType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoutineType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoutineType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ScalarFunction,
+                2 => Self::Procedure,
+                3 => Self::TableValuedFunction,
+                4 => Self::AggregateFunction,
+                _ => Self::UnknownValue(routine_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoutineType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUTINE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCALAR_FUNCTION" => Self::ScalarFunction,
+                "PROCEDURE" => Self::Procedure,
+                "TABLE_VALUED_FUNCTION" => Self::TableValuedFunction,
+                "AGGREGATE_FUNCTION" => Self::AggregateFunction,
+                _ => Self::UnknownValue(routine_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoutineType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ScalarFunction => serializer.serialize_i32(1),
+                Self::Procedure => serializer.serialize_i32(2),
+                Self::TableValuedFunction => serializer.serialize_i32(3),
+                Self::AggregateFunction => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoutineType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoutineType>::new(
+                ".google.cloud.bigquery.v2.Routine.RoutineType",
+            ))
         }
     }
 
     /// The language of the routine.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Language(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Language {
+        /// Default value.
+        Unspecified,
+        /// SQL language.
+        Sql,
+        /// JavaScript language.
+        Javascript,
+        /// Python language.
+        Python,
+        /// Java language.
+        Java,
+        /// Scala language.
+        Scala,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Language::value] or
+        /// [Language::name].
+        UnknownValue(language::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod language {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Language {
-        /// Default value.
-        pub const LANGUAGE_UNSPECIFIED: Language = Language::new(0);
-
-        /// SQL language.
-        pub const SQL: Language = Language::new(1);
-
-        /// JavaScript language.
-        pub const JAVASCRIPT: Language = Language::new(2);
-
-        /// Python language.
-        pub const PYTHON: Language = Language::new(3);
-
-        /// Java language.
-        pub const JAVA: Language = Language::new(4);
-
-        /// Scala language.
-        pub const SCALA: Language = Language::new(5);
-
-        /// Creates a new Language instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Sql => std::option::Option::Some(1),
+                Self::Javascript => std::option::Option::Some(2),
+                Self::Python => std::option::Option::Some(3),
+                Self::Java => std::option::Option::Some(4),
+                Self::Scala => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LANGUAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SQL"),
-                2 => std::borrow::Cow::Borrowed("JAVASCRIPT"),
-                3 => std::borrow::Cow::Borrowed("PYTHON"),
-                4 => std::borrow::Cow::Borrowed("JAVA"),
-                5 => std::borrow::Cow::Borrowed("SCALA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LANGUAGE_UNSPECIFIED"),
+                Self::Sql => std::option::Option::Some("SQL"),
+                Self::Javascript => std::option::Option::Some("JAVASCRIPT"),
+                Self::Python => std::option::Option::Some("PYTHON"),
+                Self::Java => std::option::Option::Some("JAVA"),
+                Self::Scala => std::option::Option::Some("SCALA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LANGUAGE_UNSPECIFIED" => std::option::Option::Some(Self::LANGUAGE_UNSPECIFIED),
-                "SQL" => std::option::Option::Some(Self::SQL),
-                "JAVASCRIPT" => std::option::Option::Some(Self::JAVASCRIPT),
-                "PYTHON" => std::option::Option::Some(Self::PYTHON),
-                "JAVA" => std::option::Option::Some(Self::JAVA),
-                "SCALA" => std::option::Option::Some(Self::SCALA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Language {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Language {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Language {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Language {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Sql,
+                2 => Self::Javascript,
+                3 => Self::Python,
+                4 => Self::Java,
+                5 => Self::Scala,
+                _ => Self::UnknownValue(language::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Language {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LANGUAGE_UNSPECIFIED" => Self::Unspecified,
+                "SQL" => Self::Sql,
+                "JAVASCRIPT" => Self::Javascript,
+                "PYTHON" => Self::Python,
+                "JAVA" => Self::Java,
+                "SCALA" => Self::Scala,
+                _ => Self::UnknownValue(language::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Language {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Sql => serializer.serialize_i32(1),
+                Self::Javascript => serializer.serialize_i32(2),
+                Self::Python => serializer.serialize_i32(3),
+                Self::Java => serializer.serialize_i32(4),
+                Self::Scala => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Language {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Language>::new(
+                ".google.cloud.bigquery.v2.Routine.Language",
+            ))
         }
     }
 
@@ -14350,177 +16793,352 @@ pub mod routine {
     ///
     /// SQL UDFs cannot have determinism specified. Their determinism is
     /// automatically determined.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeterminismLevel(i32);
-
-    impl DeterminismLevel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DeterminismLevel {
         /// The determinism of the UDF is unspecified.
-        pub const DETERMINISM_LEVEL_UNSPECIFIED: DeterminismLevel = DeterminismLevel::new(0);
-
+        Unspecified,
         /// The UDF is deterministic, meaning that 2 function calls with the same
         /// inputs always produce the same result, even across 2 query runs.
-        pub const DETERMINISTIC: DeterminismLevel = DeterminismLevel::new(1);
-
+        Deterministic,
         /// The UDF is not deterministic.
-        pub const NOT_DETERMINISTIC: DeterminismLevel = DeterminismLevel::new(2);
+        NotDeterministic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DeterminismLevel::value] or
+        /// [DeterminismLevel::name].
+        UnknownValue(determinism_level::UnknownValue),
+    }
 
-        /// Creates a new DeterminismLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod determinism_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DeterminismLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Deterministic => std::option::Option::Some(1),
+                Self::NotDeterministic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DETERMINISM_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DETERMINISTIC"),
-                2 => std::borrow::Cow::Borrowed("NOT_DETERMINISTIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DETERMINISM_LEVEL_UNSPECIFIED"),
+                Self::Deterministic => std::option::Option::Some("DETERMINISTIC"),
+                Self::NotDeterministic => std::option::Option::Some("NOT_DETERMINISTIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DETERMINISM_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DETERMINISM_LEVEL_UNSPECIFIED)
-                }
-                "DETERMINISTIC" => std::option::Option::Some(Self::DETERMINISTIC),
-                "NOT_DETERMINISTIC" => std::option::Option::Some(Self::NOT_DETERMINISTIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DeterminismLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DeterminismLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DeterminismLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DeterminismLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Deterministic,
+                2 => Self::NotDeterministic,
+                _ => Self::UnknownValue(determinism_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DeterminismLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DETERMINISM_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "DETERMINISTIC" => Self::Deterministic,
+                "NOT_DETERMINISTIC" => Self::NotDeterministic,
+                _ => Self::UnknownValue(determinism_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DeterminismLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Deterministic => serializer.serialize_i32(1),
+                Self::NotDeterministic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DeterminismLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeterminismLevel>::new(
+                ".google.cloud.bigquery.v2.Routine.DeterminismLevel",
+            ))
         }
     }
 
     /// Security mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SecurityMode(i32);
-
-    impl SecurityMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SecurityMode {
         /// The security mode of the routine is unspecified.
-        pub const SECURITY_MODE_UNSPECIFIED: SecurityMode = SecurityMode::new(0);
-
+        Unspecified,
         /// The routine is to be executed with the privileges of the user who
         /// defines it.
-        pub const DEFINER: SecurityMode = SecurityMode::new(1);
-
+        Definer,
         /// The routine is to be executed with the privileges of the user who
         /// invokes it.
-        pub const INVOKER: SecurityMode = SecurityMode::new(2);
+        Invoker,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SecurityMode::value] or
+        /// [SecurityMode::name].
+        UnknownValue(security_mode::UnknownValue),
+    }
 
-        /// Creates a new SecurityMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod security_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SecurityMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Definer => std::option::Option::Some(1),
+                Self::Invoker => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SECURITY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFINER"),
-                2 => std::borrow::Cow::Borrowed("INVOKER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SECURITY_MODE_UNSPECIFIED"),
+                Self::Definer => std::option::Option::Some("DEFINER"),
+                Self::Invoker => std::option::Option::Some("INVOKER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SECURITY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SECURITY_MODE_UNSPECIFIED)
-                }
-                "DEFINER" => std::option::Option::Some(Self::DEFINER),
-                "INVOKER" => std::option::Option::Some(Self::INVOKER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SecurityMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SecurityMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SecurityMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SecurityMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Definer,
+                2 => Self::Invoker,
+                _ => Self::UnknownValue(security_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SecurityMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SECURITY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DEFINER" => Self::Definer,
+                "INVOKER" => Self::Invoker,
+                _ => Self::UnknownValue(security_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SecurityMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Definer => serializer.serialize_i32(1),
+                Self::Invoker => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SecurityMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SecurityMode>::new(
+                ".google.cloud.bigquery.v2.Routine.SecurityMode",
+            ))
         }
     }
 
     /// Data governance type values. Only supports `DATA_MASKING`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataGovernanceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataGovernanceType {
+        /// The data governance type is unspecified.
+        Unspecified,
+        /// The data governance type is data masking.
+        DataMasking,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataGovernanceType::value] or
+        /// [DataGovernanceType::name].
+        UnknownValue(data_governance_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_governance_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataGovernanceType {
-        /// The data governance type is unspecified.
-        pub const DATA_GOVERNANCE_TYPE_UNSPECIFIED: DataGovernanceType = DataGovernanceType::new(0);
-
-        /// The data governance type is data masking.
-        pub const DATA_MASKING: DataGovernanceType = DataGovernanceType::new(1);
-
-        /// Creates a new DataGovernanceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DataMasking => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_GOVERNANCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATA_MASKING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_GOVERNANCE_TYPE_UNSPECIFIED"),
+                Self::DataMasking => std::option::Option::Some("DATA_MASKING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_GOVERNANCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_GOVERNANCE_TYPE_UNSPECIFIED)
-                }
-                "DATA_MASKING" => std::option::Option::Some(Self::DATA_MASKING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataGovernanceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataGovernanceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataGovernanceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataGovernanceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DataMasking,
+                _ => Self::UnknownValue(data_governance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataGovernanceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_GOVERNANCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DATA_MASKING" => Self::DataMasking,
+                _ => Self::UnknownValue(data_governance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataGovernanceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DataMasking => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataGovernanceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataGovernanceType>::new(
+                ".google.cloud.bigquery.v2.Routine.DataGovernanceType",
+            ))
         }
     }
 }
@@ -16072,137 +18690,228 @@ pub mod standard_sql_data_type {
     use super::*;
 
     /// The kind of the datatype.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TypeKind(i32);
-
-    impl TypeKind {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TypeKind {
         /// Invalid type.
-        pub const TYPE_KIND_UNSPECIFIED: TypeKind = TypeKind::new(0);
-
+        Unspecified,
         /// Encoded as a string in decimal format.
-        pub const INT64: TypeKind = TypeKind::new(2);
-
+        Int64,
         /// Encoded as a boolean "false" or "true".
-        pub const BOOL: TypeKind = TypeKind::new(5);
-
+        Bool,
         /// Encoded as a number, or string "NaN", "Infinity" or "-Infinity".
-        pub const FLOAT64: TypeKind = TypeKind::new(7);
-
+        Float64,
         /// Encoded as a string value.
-        pub const STRING: TypeKind = TypeKind::new(8);
-
+        String,
         /// Encoded as a base64 string per RFC 4648, section 4.
-        pub const BYTES: TypeKind = TypeKind::new(9);
-
+        Bytes,
         /// Encoded as an RFC 3339 timestamp with mandatory "Z" time zone string:
         /// 1985-04-12T23:20:50.52Z
-        pub const TIMESTAMP: TypeKind = TypeKind::new(19);
-
+        Timestamp,
         /// Encoded as RFC 3339 full-date format string: 1985-04-12
-        pub const DATE: TypeKind = TypeKind::new(10);
-
+        Date,
         /// Encoded as RFC 3339 partial-time format string: 23:20:50.52
-        pub const TIME: TypeKind = TypeKind::new(20);
-
+        Time,
         /// Encoded as RFC 3339 full-date "T" partial-time: 1985-04-12T23:20:50.52
-        pub const DATETIME: TypeKind = TypeKind::new(21);
-
+        Datetime,
         /// Encoded as fully qualified 3 part: 0-5 15 2:30:45.6
-        pub const INTERVAL: TypeKind = TypeKind::new(26);
-
+        Interval,
         /// Encoded as WKT
-        pub const GEOGRAPHY: TypeKind = TypeKind::new(22);
-
+        Geography,
         /// Encoded as a decimal string.
-        pub const NUMERIC: TypeKind = TypeKind::new(23);
-
+        Numeric,
         /// Encoded as a decimal string.
-        pub const BIGNUMERIC: TypeKind = TypeKind::new(24);
-
+        Bignumeric,
         /// Encoded as a string.
-        pub const JSON: TypeKind = TypeKind::new(25);
-
+        Json,
         /// Encoded as a list with types matching Type.array_type.
-        pub const ARRAY: TypeKind = TypeKind::new(16);
-
+        Array,
         /// Encoded as a list with fields of type Type.struct_type[i]. List is used
         /// because a JSON object cannot have duplicate field names.
-        pub const STRUCT: TypeKind = TypeKind::new(17);
-
+        Struct,
         /// Encoded as a pair with types matching range_element_type. Pairs must
         /// begin with "[", end with ")", and be separated by ", ".
-        pub const RANGE: TypeKind = TypeKind::new(29);
+        Range,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TypeKind::value] or
+        /// [TypeKind::name].
+        UnknownValue(type_kind::UnknownValue),
+    }
 
-        /// Creates a new TypeKind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod type_kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TypeKind {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Int64 => std::option::Option::Some(2),
+                Self::Bool => std::option::Option::Some(5),
+                Self::Float64 => std::option::Option::Some(7),
+                Self::String => std::option::Option::Some(8),
+                Self::Bytes => std::option::Option::Some(9),
+                Self::Timestamp => std::option::Option::Some(19),
+                Self::Date => std::option::Option::Some(10),
+                Self::Time => std::option::Option::Some(20),
+                Self::Datetime => std::option::Option::Some(21),
+                Self::Interval => std::option::Option::Some(26),
+                Self::Geography => std::option::Option::Some(22),
+                Self::Numeric => std::option::Option::Some(23),
+                Self::Bignumeric => std::option::Option::Some(24),
+                Self::Json => std::option::Option::Some(25),
+                Self::Array => std::option::Option::Some(16),
+                Self::Struct => std::option::Option::Some(17),
+                Self::Range => std::option::Option::Some(29),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_KIND_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("INT64"),
-                5 => std::borrow::Cow::Borrowed("BOOL"),
-                7 => std::borrow::Cow::Borrowed("FLOAT64"),
-                8 => std::borrow::Cow::Borrowed("STRING"),
-                9 => std::borrow::Cow::Borrowed("BYTES"),
-                10 => std::borrow::Cow::Borrowed("DATE"),
-                16 => std::borrow::Cow::Borrowed("ARRAY"),
-                17 => std::borrow::Cow::Borrowed("STRUCT"),
-                19 => std::borrow::Cow::Borrowed("TIMESTAMP"),
-                20 => std::borrow::Cow::Borrowed("TIME"),
-                21 => std::borrow::Cow::Borrowed("DATETIME"),
-                22 => std::borrow::Cow::Borrowed("GEOGRAPHY"),
-                23 => std::borrow::Cow::Borrowed("NUMERIC"),
-                24 => std::borrow::Cow::Borrowed("BIGNUMERIC"),
-                25 => std::borrow::Cow::Borrowed("JSON"),
-                26 => std::borrow::Cow::Borrowed("INTERVAL"),
-                29 => std::borrow::Cow::Borrowed("RANGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_KIND_UNSPECIFIED"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::Float64 => std::option::Option::Some("FLOAT64"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Bytes => std::option::Option::Some("BYTES"),
+                Self::Timestamp => std::option::Option::Some("TIMESTAMP"),
+                Self::Date => std::option::Option::Some("DATE"),
+                Self::Time => std::option::Option::Some("TIME"),
+                Self::Datetime => std::option::Option::Some("DATETIME"),
+                Self::Interval => std::option::Option::Some("INTERVAL"),
+                Self::Geography => std::option::Option::Some("GEOGRAPHY"),
+                Self::Numeric => std::option::Option::Some("NUMERIC"),
+                Self::Bignumeric => std::option::Option::Some("BIGNUMERIC"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::Array => std::option::Option::Some("ARRAY"),
+                Self::Struct => std::option::Option::Some("STRUCT"),
+                Self::Range => std::option::Option::Some("RANGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_KIND_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_KIND_UNSPECIFIED),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "FLOAT64" => std::option::Option::Some(Self::FLOAT64),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "BYTES" => std::option::Option::Some(Self::BYTES),
-                "TIMESTAMP" => std::option::Option::Some(Self::TIMESTAMP),
-                "DATE" => std::option::Option::Some(Self::DATE),
-                "TIME" => std::option::Option::Some(Self::TIME),
-                "DATETIME" => std::option::Option::Some(Self::DATETIME),
-                "INTERVAL" => std::option::Option::Some(Self::INTERVAL),
-                "GEOGRAPHY" => std::option::Option::Some(Self::GEOGRAPHY),
-                "NUMERIC" => std::option::Option::Some(Self::NUMERIC),
-                "BIGNUMERIC" => std::option::Option::Some(Self::BIGNUMERIC),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                "ARRAY" => std::option::Option::Some(Self::ARRAY),
-                "STRUCT" => std::option::Option::Some(Self::STRUCT),
-                "RANGE" => std::option::Option::Some(Self::RANGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TypeKind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TypeKind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TypeKind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TypeKind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Int64,
+                5 => Self::Bool,
+                7 => Self::Float64,
+                8 => Self::String,
+                9 => Self::Bytes,
+                10 => Self::Date,
+                16 => Self::Array,
+                17 => Self::Struct,
+                19 => Self::Timestamp,
+                20 => Self::Time,
+                21 => Self::Datetime,
+                22 => Self::Geography,
+                23 => Self::Numeric,
+                24 => Self::Bignumeric,
+                25 => Self::Json,
+                26 => Self::Interval,
+                29 => Self::Range,
+                _ => Self::UnknownValue(type_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TypeKind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_KIND_UNSPECIFIED" => Self::Unspecified,
+                "INT64" => Self::Int64,
+                "BOOL" => Self::Bool,
+                "FLOAT64" => Self::Float64,
+                "STRING" => Self::String,
+                "BYTES" => Self::Bytes,
+                "TIMESTAMP" => Self::Timestamp,
+                "DATE" => Self::Date,
+                "TIME" => Self::Time,
+                "DATETIME" => Self::Datetime,
+                "INTERVAL" => Self::Interval,
+                "GEOGRAPHY" => Self::Geography,
+                "NUMERIC" => Self::Numeric,
+                "BIGNUMERIC" => Self::Bignumeric,
+                "JSON" => Self::Json,
+                "ARRAY" => Self::Array,
+                "STRUCT" => Self::Struct,
+                "RANGE" => Self::Range,
+                _ => Self::UnknownValue(type_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TypeKind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Int64 => serializer.serialize_i32(2),
+                Self::Bool => serializer.serialize_i32(5),
+                Self::Float64 => serializer.serialize_i32(7),
+                Self::String => serializer.serialize_i32(8),
+                Self::Bytes => serializer.serialize_i32(9),
+                Self::Timestamp => serializer.serialize_i32(19),
+                Self::Date => serializer.serialize_i32(10),
+                Self::Time => serializer.serialize_i32(20),
+                Self::Datetime => serializer.serialize_i32(21),
+                Self::Interval => serializer.serialize_i32(26),
+                Self::Geography => serializer.serialize_i32(22),
+                Self::Numeric => serializer.serialize_i32(23),
+                Self::Bignumeric => serializer.serialize_i32(24),
+                Self::Json => serializer.serialize_i32(25),
+                Self::Array => serializer.serialize_i32(16),
+                Self::Struct => serializer.serialize_i32(17),
+                Self::Range => serializer.serialize_i32(29),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TypeKind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TypeKind>::new(
+                ".google.cloud.bigquery.v2.StandardSqlDataType.TypeKind",
+            ))
         }
     }
 
@@ -16499,73 +19208,136 @@ pub mod table_replication_info {
 
     /// Replication status of the table created using `AS REPLICA` like:
     /// `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicationStatus(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReplicationStatus {
+        /// Default value.
+        Unspecified,
+        /// Replication is Active with no errors.
+        Active,
+        /// Source object is deleted.
+        SourceDeleted,
+        /// Source revoked replication permissions.
+        PermissionDenied,
+        /// Source configuration doesn’t allow replication.
+        UnsupportedConfiguration,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReplicationStatus::value] or
+        /// [ReplicationStatus::name].
+        UnknownValue(replication_status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod replication_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ReplicationStatus {
-        /// Default value.
-        pub const REPLICATION_STATUS_UNSPECIFIED: ReplicationStatus = ReplicationStatus::new(0);
-
-        /// Replication is Active with no errors.
-        pub const ACTIVE: ReplicationStatus = ReplicationStatus::new(1);
-
-        /// Source object is deleted.
-        pub const SOURCE_DELETED: ReplicationStatus = ReplicationStatus::new(2);
-
-        /// Source revoked replication permissions.
-        pub const PERMISSION_DENIED: ReplicationStatus = ReplicationStatus::new(3);
-
-        /// Source configuration doesn’t allow replication.
-        pub const UNSUPPORTED_CONFIGURATION: ReplicationStatus = ReplicationStatus::new(4);
-
-        /// Creates a new ReplicationStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::SourceDeleted => std::option::Option::Some(2),
+                Self::PermissionDenied => std::option::Option::Some(3),
+                Self::UnsupportedConfiguration => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REPLICATION_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("SOURCE_DELETED"),
-                3 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                4 => std::borrow::Cow::Borrowed("UNSUPPORTED_CONFIGURATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REPLICATION_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REPLICATION_STATUS_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REPLICATION_STATUS_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::SourceDeleted => std::option::Option::Some("SOURCE_DELETED"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::UnsupportedConfiguration => {
+                    std::option::Option::Some("UNSUPPORTED_CONFIGURATION")
                 }
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SOURCE_DELETED" => std::option::Option::Some(Self::SOURCE_DELETED),
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                "UNSUPPORTED_CONFIGURATION" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_CONFIGURATION)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ReplicationStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicationStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReplicationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReplicationStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::SourceDeleted,
+                3 => Self::PermissionDenied,
+                4 => Self::UnsupportedConfiguration,
+                _ => Self::UnknownValue(replication_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReplicationStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REPLICATION_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "SOURCE_DELETED" => Self::SourceDeleted,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                "UNSUPPORTED_CONFIGURATION" => Self::UnsupportedConfiguration,
+                _ => Self::UnknownValue(replication_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReplicationStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::SourceDeleted => serializer.serialize_i32(2),
+                Self::PermissionDenied => serializer.serialize_i32(3),
+                Self::UnsupportedConfiguration => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReplicationStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReplicationStatus>::new(
+                ".google.cloud.bigquery.v2.TableReplicationInfo.ReplicationStatus",
+            ))
         }
     }
 }
@@ -17930,73 +20702,134 @@ pub mod get_table_request {
     use super::*;
 
     /// TableMetadataView specifies which table information is returned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TableMetadataView(i32);
-
-    impl TableMetadataView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TableMetadataView {
         /// The default value.
         /// Default to the STORAGE_STATS view.
-        pub const TABLE_METADATA_VIEW_UNSPECIFIED: TableMetadataView = TableMetadataView::new(0);
-
+        Unspecified,
         /// Includes basic table information including schema and
         /// partitioning specification. This view does not include storage statistics
         /// such as numRows or numBytes. This view is significantly more efficient
         /// and should be used to support high query rates.
-        pub const BASIC: TableMetadataView = TableMetadataView::new(1);
-
+        Basic,
         /// Includes all information in the BASIC view as well as storage statistics
         /// (numBytes, numLongTermBytes, numRows and lastModifiedTime).
-        pub const STORAGE_STATS: TableMetadataView = TableMetadataView::new(2);
-
+        StorageStats,
         /// Includes all table information, including storage statistics.
         /// It returns same information as STORAGE_STATS view, but may contain
         /// additional information in the future.
-        pub const FULL: TableMetadataView = TableMetadataView::new(3);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TableMetadataView::value] or
+        /// [TableMetadataView::name].
+        UnknownValue(table_metadata_view::UnknownValue),
+    }
 
-        /// Creates a new TableMetadataView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod table_metadata_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TableMetadataView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::StorageStats => std::option::Option::Some(2),
+                Self::Full => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TABLE_METADATA_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("STORAGE_STATS"),
-                3 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TABLE_METADATA_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::StorageStats => std::option::Option::Some("STORAGE_STATS"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TABLE_METADATA_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TABLE_METADATA_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "STORAGE_STATS" => std::option::Option::Some(Self::STORAGE_STATS),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TableMetadataView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TableMetadataView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TableMetadataView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TableMetadataView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::StorageStats,
+                3 => Self::Full,
+                _ => Self::UnknownValue(table_metadata_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TableMetadataView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TABLE_METADATA_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "STORAGE_STATS" => Self::StorageStats,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(table_metadata_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TableMetadataView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::StorageStats => serializer.serialize_i32(2),
+                Self::Full => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TableMetadataView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableMetadataView>::new(
+                ".google.cloud.bigquery.v2.GetTableRequest.TableMetadataView",
+            ))
         }
     }
 }
@@ -18931,56 +21764,113 @@ pub mod foreign_type_info {
 
     /// External systems, such as query engines or table formats, that have their
     /// own data types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TypeSystem(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TypeSystem {
+        /// TypeSystem not specified.
+        Unspecified,
+        /// Represents Hive data types.
+        Hive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TypeSystem::value] or
+        /// [TypeSystem::name].
+        UnknownValue(type_system::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod type_system {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TypeSystem {
-        /// TypeSystem not specified.
-        pub const TYPE_SYSTEM_UNSPECIFIED: TypeSystem = TypeSystem::new(0);
-
-        /// Represents Hive data types.
-        pub const HIVE: TypeSystem = TypeSystem::new(1);
-
-        /// Creates a new TypeSystem instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hive => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_SYSTEM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_SYSTEM_UNSPECIFIED"),
+                Self::Hive => std::option::Option::Some("HIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_SYSTEM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TYPE_SYSTEM_UNSPECIFIED)
-                }
-                "HIVE" => std::option::Option::Some(Self::HIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TypeSystem {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TypeSystem {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TypeSystem {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TypeSystem {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hive,
+                _ => Self::UnknownValue(type_system::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TypeSystem {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_SYSTEM_UNSPECIFIED" => Self::Unspecified,
+                "HIVE" => Self::Hive,
+                _ => Self::UnknownValue(type_system::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TypeSystem {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hive => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TypeSystem {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TypeSystem>::new(
+                ".google.cloud.bigquery.v2.ForeignTypeInfo.TypeSystem",
+            ))
         }
     }
 }
@@ -19397,21 +22287,18 @@ pub mod table_field_schema {
 
     /// Rounding mode options that can be used when storing NUMERIC
     /// or BIGNUMERIC values.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoundingMode(i32);
-
-    impl RoundingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoundingMode {
         /// Unspecified will default to using ROUND_HALF_AWAY_FROM_ZERO.
-        pub const ROUNDING_MODE_UNSPECIFIED: RoundingMode = RoundingMode::new(0);
-
+        Unspecified,
         /// ROUND_HALF_AWAY_FROM_ZERO rounds half values away from zero
         /// when applying precision and scale upon writing of NUMERIC and BIGNUMERIC
         /// values.
         /// For Scale: 0
         /// 1.1, 1.2, 1.3, 1.4 => 1
         /// 1.5, 1.6, 1.7, 1.8, 1.9 => 2
-        pub const ROUND_HALF_AWAY_FROM_ZERO: RoundingMode = RoundingMode::new(1);
-
+        RoundHalfAwayFromZero,
         /// ROUND_HALF_EVEN rounds half values to the nearest even value
         /// when applying precision and scale upon writing of NUMERIC and BIGNUMERIC
         /// values.
@@ -19420,52 +22307,114 @@ pub mod table_field_schema {
         /// 1.5 => 2
         /// 1.6, 1.7, 1.8, 1.9 => 2
         /// 2.5 => 2
-        pub const ROUND_HALF_EVEN: RoundingMode = RoundingMode::new(2);
+        RoundHalfEven,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoundingMode::value] or
+        /// [RoundingMode::name].
+        UnknownValue(rounding_mode::UnknownValue),
+    }
 
-        /// Creates a new RoundingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod rounding_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RoundingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RoundHalfAwayFromZero => std::option::Option::Some(1),
+                Self::RoundHalfEven => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUNDING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ROUND_HALF_AWAY_FROM_ZERO"),
-                2 => std::borrow::Cow::Borrowed("ROUND_HALF_EVEN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUNDING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROUNDING_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUNDING_MODE_UNSPECIFIED"),
+                Self::RoundHalfAwayFromZero => {
+                    std::option::Option::Some("ROUND_HALF_AWAY_FROM_ZERO")
                 }
-                "ROUND_HALF_AWAY_FROM_ZERO" => {
-                    std::option::Option::Some(Self::ROUND_HALF_AWAY_FROM_ZERO)
-                }
-                "ROUND_HALF_EVEN" => std::option::Option::Some(Self::ROUND_HALF_EVEN),
-                _ => std::option::Option::None,
+                Self::RoundHalfEven => std::option::Option::Some("ROUND_HALF_EVEN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for RoundingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoundingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoundingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoundingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RoundHalfAwayFromZero,
+                2 => Self::RoundHalfEven,
+                _ => Self::UnknownValue(rounding_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoundingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUNDING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ROUND_HALF_AWAY_FROM_ZERO" => Self::RoundHalfAwayFromZero,
+                "ROUND_HALF_EVEN" => Self::RoundHalfEven,
+                _ => Self::UnknownValue(rounding_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoundingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RoundHalfAwayFromZero => serializer.serialize_i32(1),
+                Self::RoundHalfEven => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoundingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoundingMode>::new(
+                ".google.cloud.bigquery.v2.TableFieldSchema.RoundingMode",
+            ))
         }
     }
 }
@@ -19595,299 +22544,591 @@ impl wkt::message::Message for UserDefinedFunctionResource {
 
 /// The data types that could be used as a target type when converting decimal
 /// values.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DecimalTargetType(i32);
-
-impl DecimalTargetType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DecimalTargetType {
     /// Invalid type.
-    pub const DECIMAL_TARGET_TYPE_UNSPECIFIED: DecimalTargetType = DecimalTargetType::new(0);
-
+    Unspecified,
     /// Decimal values could be converted to NUMERIC
     /// type.
-    pub const NUMERIC: DecimalTargetType = DecimalTargetType::new(1);
-
+    Numeric,
     /// Decimal values could be converted to BIGNUMERIC
     /// type.
-    pub const BIGNUMERIC: DecimalTargetType = DecimalTargetType::new(2);
-
+    Bignumeric,
     /// Decimal values could be converted to STRING type.
-    pub const STRING: DecimalTargetType = DecimalTargetType::new(3);
+    String,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DecimalTargetType::value] or
+    /// [DecimalTargetType::name].
+    UnknownValue(decimal_target_type::UnknownValue),
+}
 
-    /// Creates a new DecimalTargetType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod decimal_target_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DecimalTargetType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Numeric => std::option::Option::Some(1),
+            Self::Bignumeric => std::option::Option::Some(2),
+            Self::String => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DECIMAL_TARGET_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NUMERIC"),
-            2 => std::borrow::Cow::Borrowed("BIGNUMERIC"),
-            3 => std::borrow::Cow::Borrowed("STRING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DECIMAL_TARGET_TYPE_UNSPECIFIED"),
+            Self::Numeric => std::option::Option::Some("NUMERIC"),
+            Self::Bignumeric => std::option::Option::Some("BIGNUMERIC"),
+            Self::String => std::option::Option::Some("STRING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DECIMAL_TARGET_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DECIMAL_TARGET_TYPE_UNSPECIFIED)
-            }
-            "NUMERIC" => std::option::Option::Some(Self::NUMERIC),
-            "BIGNUMERIC" => std::option::Option::Some(Self::BIGNUMERIC),
-            "STRING" => std::option::Option::Some(Self::STRING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DecimalTargetType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DecimalTargetType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DecimalTargetType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DecimalTargetType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Numeric,
+            2 => Self::Bignumeric,
+            3 => Self::String,
+            _ => Self::UnknownValue(decimal_target_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DecimalTargetType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DECIMAL_TARGET_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "NUMERIC" => Self::Numeric,
+            "BIGNUMERIC" => Self::Bignumeric,
+            "STRING" => Self::String,
+            _ => Self::UnknownValue(decimal_target_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DecimalTargetType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Numeric => serializer.serialize_i32(1),
+            Self::Bignumeric => serializer.serialize_i32(2),
+            Self::String => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DecimalTargetType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DecimalTargetType>::new(
+            ".google.cloud.bigquery.v2.DecimalTargetType",
+        ))
     }
 }
 
 /// This enum defines how to interpret source URIs for load jobs and external
 /// tables.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FileSetSpecType(i32);
-
-impl FileSetSpecType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FileSetSpecType {
     /// This option expands source URIs by listing files from the object store. It
     /// is the default behavior if FileSetSpecType is not set.
-    pub const FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH: FileSetSpecType = FileSetSpecType::new(0);
-
+    FileSystemMatch,
     /// This option indicates that the provided URIs are newline-delimited manifest
     /// files, with one URI per line. Wildcard URIs are not supported.
-    pub const FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST: FileSetSpecType =
-        FileSetSpecType::new(1);
+    NewLineDelimitedManifest,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FileSetSpecType::value] or
+    /// [FileSetSpecType::name].
+    UnknownValue(file_set_spec_type::UnknownValue),
+}
 
-    /// Creates a new FileSetSpecType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod file_set_spec_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl FileSetSpecType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::FileSystemMatch => std::option::Option::Some(0),
+            Self::NewLineDelimitedManifest => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH"),
-            1 => std::borrow::Cow::Borrowed("FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH" => {
-                std::option::Option::Some(Self::FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::FileSystemMatch => {
+                std::option::Option::Some("FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH")
             }
-            "FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST" => {
-                std::option::Option::Some(Self::FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST)
+            Self::NewLineDelimitedManifest => {
+                std::option::Option::Some("FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST")
             }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for FileSetSpecType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FileSetSpecType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FileSetSpecType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FileSetSpecType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::FileSystemMatch,
+            1 => Self::NewLineDelimitedManifest,
+            _ => Self::UnknownValue(file_set_spec_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FileSetSpecType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FILE_SET_SPEC_TYPE_FILE_SYSTEM_MATCH" => Self::FileSystemMatch,
+            "FILE_SET_SPEC_TYPE_NEW_LINE_DELIMITED_MANIFEST" => Self::NewLineDelimitedManifest,
+            _ => Self::UnknownValue(file_set_spec_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FileSetSpecType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::FileSystemMatch => serializer.serialize_i32(0),
+            Self::NewLineDelimitedManifest => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FileSetSpecType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileSetSpecType>::new(
+            ".google.cloud.bigquery.v2.FileSetSpecType",
+        ))
     }
 }
 
 /// Used to indicate that a JSON variant, rather than normal JSON, is being used
 /// as the source_format. This should only be used in combination with the
 /// JSON source format.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JsonExtension(i32);
-
-impl JsonExtension {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum JsonExtension {
     /// The default if provided value is not one included in the enum, or the value
     /// is not specified. The source format is parsed without any modification.
-    pub const JSON_EXTENSION_UNSPECIFIED: JsonExtension = JsonExtension::new(0);
-
+    Unspecified,
     /// Use GeoJSON variant of JSON. See <https://tools.ietf.org/html/rfc7946>.
-    pub const GEOJSON: JsonExtension = JsonExtension::new(1);
+    Geojson,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [JsonExtension::value] or
+    /// [JsonExtension::name].
+    UnknownValue(json_extension::UnknownValue),
+}
 
-    /// Creates a new JsonExtension instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod json_extension {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl JsonExtension {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Geojson => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("JSON_EXTENSION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GEOJSON"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("JSON_EXTENSION_UNSPECIFIED"),
+            Self::Geojson => std::option::Option::Some("GEOJSON"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "JSON_EXTENSION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::JSON_EXTENSION_UNSPECIFIED)
-            }
-            "GEOJSON" => std::option::Option::Some(Self::GEOJSON),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for JsonExtension {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for JsonExtension {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for JsonExtension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for JsonExtension {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Geojson,
+            _ => Self::UnknownValue(json_extension::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for JsonExtension {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "JSON_EXTENSION_UNSPECIFIED" => Self::Unspecified,
+            "GEOJSON" => Self::Geojson,
+            _ => Self::UnknownValue(json_extension::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for JsonExtension {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Geojson => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for JsonExtension {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<JsonExtension>::new(
+            ".google.cloud.bigquery.v2.JsonExtension",
+        ))
     }
 }
 
 /// The classification of managed table types that can be created.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ManagedTableType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ManagedTableType {
+    /// No managed table type specified.
+    Unspecified,
+    /// The managed table is a native BigQuery table.
+    Native,
+    /// The managed table is a BigQuery table for Apache Iceberg.
+    Iceberg,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ManagedTableType::value] or
+    /// [ManagedTableType::name].
+    UnknownValue(managed_table_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod managed_table_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ManagedTableType {
-    /// No managed table type specified.
-    pub const MANAGED_TABLE_TYPE_UNSPECIFIED: ManagedTableType = ManagedTableType::new(0);
-
-    /// The managed table is a native BigQuery table.
-    pub const NATIVE: ManagedTableType = ManagedTableType::new(1);
-
-    /// The managed table is a BigQuery table for Apache Iceberg.
-    pub const ICEBERG: ManagedTableType = ManagedTableType::new(2);
-
-    /// Creates a new ManagedTableType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Native => std::option::Option::Some(1),
+            Self::Iceberg => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MANAGED_TABLE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NATIVE"),
-            2 => std::borrow::Cow::Borrowed("ICEBERG"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MANAGED_TABLE_TYPE_UNSPECIFIED"),
+            Self::Native => std::option::Option::Some("NATIVE"),
+            Self::Iceberg => std::option::Option::Some("ICEBERG"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MANAGED_TABLE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MANAGED_TABLE_TYPE_UNSPECIFIED)
-            }
-            "NATIVE" => std::option::Option::Some(Self::NATIVE),
-            "ICEBERG" => std::option::Option::Some(Self::ICEBERG),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ManagedTableType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ManagedTableType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ManagedTableType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ManagedTableType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Native,
+            2 => Self::Iceberg,
+            _ => Self::UnknownValue(managed_table_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ManagedTableType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MANAGED_TABLE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "NATIVE" => Self::Native,
+            "ICEBERG" => Self::Iceberg,
+            _ => Self::UnknownValue(managed_table_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ManagedTableType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Native => serializer.serialize_i32(1),
+            Self::Iceberg => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ManagedTableType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ManagedTableType>::new(
+            ".google.cloud.bigquery.v2.ManagedTableType",
+        ))
     }
 }
 
 /// Indicates the map target type. Only applies to parquet maps.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MapTargetType(i32);
-
-impl MapTargetType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MapTargetType {
     /// In this mode, the map will have the following schema:
     /// struct map_field_name {  repeated struct key_value {  key  value  } }.
-    pub const MAP_TARGET_TYPE_UNSPECIFIED: MapTargetType = MapTargetType::new(0);
-
+    Unspecified,
     /// In this mode, the map will have the following schema:
     /// repeated struct map_field_name {  key  value }.
-    pub const ARRAY_OF_STRUCT: MapTargetType = MapTargetType::new(1);
+    ArrayOfStruct,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MapTargetType::value] or
+    /// [MapTargetType::name].
+    UnknownValue(map_target_type::UnknownValue),
+}
 
-    /// Creates a new MapTargetType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod map_target_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl MapTargetType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ArrayOfStruct => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MAP_TARGET_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ARRAY_OF_STRUCT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MAP_TARGET_TYPE_UNSPECIFIED"),
+            Self::ArrayOfStruct => std::option::Option::Some("ARRAY_OF_STRUCT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MAP_TARGET_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MAP_TARGET_TYPE_UNSPECIFIED)
-            }
-            "ARRAY_OF_STRUCT" => std::option::Option::Some(Self::ARRAY_OF_STRUCT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MapTargetType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MapTargetType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MapTargetType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MapTargetType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ArrayOfStruct,
+            _ => Self::UnknownValue(map_target_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MapTargetType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MAP_TARGET_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ARRAY_OF_STRUCT" => Self::ArrayOfStruct,
+            _ => Self::UnknownValue(map_target_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MapTargetType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ArrayOfStruct => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MapTargetType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MapTargetType>::new(
+            ".google.cloud.bigquery.v2.MapTargetType",
+        ))
     }
 }

--- a/src/generated/cloud/bigquery/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/v2/src/transport.rs
@@ -60,7 +60,7 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("datasetView", &req.dataset_view.value())]);
+        let builder = builder.query(&[("datasetView", &req.dataset_view)]);
         let builder = builder.query(&[("accessPolicyVersion", &req.access_policy_version)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
@@ -110,7 +110,7 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("updateMode", &req.update_mode.value())]);
+        let builder = builder.query(&[("updateMode", &req.update_mode)]);
         let builder = builder.query(&[("accessPolicyVersion", &req.access_policy_version)]);
         self.inner
             .execute(builder, Some(req.dataset), options)
@@ -137,7 +137,7 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("updateMode", &req.update_mode.value())]);
+        let builder = builder.query(&[("updateMode", &req.update_mode)]);
         let builder = builder.query(&[("accessPolicyVersion", &req.access_policy_version)]);
         self.inner
             .execute(builder, Some(req.dataset), options)
@@ -807,7 +807,7 @@ impl super::stub::TableService for TableService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("selectedFields", &req.selected_fields)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -1376,117 +1376,234 @@ pub mod aggregation_info {
     /// The level at which usage is aggregated to compute cost.
     /// Example: "ACCOUNT" aggregation level indicates that usage for tiered
     /// pricing is aggregated across all projects in a single account.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AggregationLevel {
+        Unspecified,
+        Account,
+        Project,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AggregationLevel::value] or
+        /// [AggregationLevel::name].
+        UnknownValue(aggregation_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod aggregation_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AggregationLevel {
-        pub const AGGREGATION_LEVEL_UNSPECIFIED: AggregationLevel = AggregationLevel::new(0);
-
-        pub const ACCOUNT: AggregationLevel = AggregationLevel::new(1);
-
-        pub const PROJECT: AggregationLevel = AggregationLevel::new(2);
-
-        /// Creates a new AggregationLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Account => std::option::Option::Some(1),
+                Self::Project => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AGGREGATION_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACCOUNT"),
-                2 => std::borrow::Cow::Borrowed("PROJECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AGGREGATION_LEVEL_UNSPECIFIED"),
+                Self::Account => std::option::Option::Some("ACCOUNT"),
+                Self::Project => std::option::Option::Some("PROJECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AGGREGATION_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AGGREGATION_LEVEL_UNSPECIFIED)
-                }
-                "ACCOUNT" => std::option::Option::Some(Self::ACCOUNT),
-                "PROJECT" => std::option::Option::Some(Self::PROJECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AggregationLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AggregationLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AggregationLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Account,
+                2 => Self::Project,
+                _ => Self::UnknownValue(aggregation_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AggregationLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AGGREGATION_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "ACCOUNT" => Self::Account,
+                "PROJECT" => Self::Project,
+                _ => Self::UnknownValue(aggregation_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AggregationLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Account => serializer.serialize_i32(1),
+                Self::Project => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AggregationLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AggregationLevel>::new(
+                ".google.cloud.billing.v1.AggregationInfo.AggregationLevel",
+            ))
         }
     }
 
     /// The interval at which usage is aggregated to compute cost.
     /// Example: "MONTHLY" aggregation interval indicates that usage for tiered
     /// pricing is aggregated every month.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationInterval(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AggregationInterval {
+        Unspecified,
+        Daily,
+        Monthly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AggregationInterval::value] or
+        /// [AggregationInterval::name].
+        UnknownValue(aggregation_interval::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod aggregation_interval {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AggregationInterval {
-        pub const AGGREGATION_INTERVAL_UNSPECIFIED: AggregationInterval =
-            AggregationInterval::new(0);
-
-        pub const DAILY: AggregationInterval = AggregationInterval::new(1);
-
-        pub const MONTHLY: AggregationInterval = AggregationInterval::new(2);
-
-        /// Creates a new AggregationInterval instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Daily => std::option::Option::Some(1),
+                Self::Monthly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AGGREGATION_INTERVAL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DAILY"),
-                2 => std::borrow::Cow::Borrowed("MONTHLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AGGREGATION_INTERVAL_UNSPECIFIED"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AGGREGATION_INTERVAL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AGGREGATION_INTERVAL_UNSPECIFIED)
-                }
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AggregationInterval {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationInterval {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AggregationInterval {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AggregationInterval {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Daily,
+                2 => Self::Monthly,
+                _ => Self::UnknownValue(aggregation_interval::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AggregationInterval {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AGGREGATION_INTERVAL_UNSPECIFIED" => Self::Unspecified,
+                "DAILY" => Self::Daily,
+                "MONTHLY" => Self::Monthly,
+                _ => Self::UnknownValue(aggregation_interval::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AggregationInterval {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Daily => serializer.serialize_i32(1),
+                Self::Monthly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AggregationInterval {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AggregationInterval>::new(
+                ".google.cloud.billing.v1.AggregationInfo.AggregationInterval",
+            ))
         }
     }
 }
@@ -1548,66 +1665,129 @@ pub mod geo_taxonomy {
     use super::*;
 
     /// The type of Geo Taxonomy: GLOBAL, REGIONAL, or MULTI_REGIONAL.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// The type is not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The sku is global in nature, e.g. a license sku. Global skus are
         /// available in all regions, and so have an empty region list.
-        pub const GLOBAL: Type = Type::new(1);
-
+        Global,
         /// The sku is available in a specific region, e.g. "us-west2".
-        pub const REGIONAL: Type = Type::new(2);
-
+        Regional,
         /// The sku is associated with multiple regions, e.g. "us-west2" and
         /// "us-east1".
-        pub const MULTI_REGIONAL: Type = Type::new(3);
+        MultiRegional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Global => std::option::Option::Some(1),
+                Self::Regional => std::option::Option::Some(2),
+                Self::MultiRegional => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GLOBAL"),
-                2 => std::borrow::Cow::Borrowed("REGIONAL"),
-                3 => std::borrow::Cow::Borrowed("MULTI_REGIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Global => std::option::Option::Some("GLOBAL"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::MultiRegional => std::option::Option::Some("MULTI_REGIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                "MULTI_REGIONAL" => std::option::Option::Some(Self::MULTI_REGIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Global,
+                2 => Self::Regional,
+                3 => Self::MultiRegional,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GLOBAL" => Self::Global,
+                "REGIONAL" => Self::Regional,
+                "MULTI_REGIONAL" => Self::MultiRegional,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Global => serializer.serialize_i32(1),
+                Self::Regional => serializer.serialize_i32(2),
+                Self::MultiRegional => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.billing.v1.GeoTaxonomy.Type",
+            ))
         }
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -227,62 +227,124 @@ pub mod policy {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GlobalPolicyEvaluationMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum GlobalPolicyEvaluationMode {
+        /// Not specified: DISABLE is assumed.
+        Unspecified,
+        /// Enables system policy evaluation.
+        Enable,
+        /// Disables system policy evaluation.
+        Disable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [GlobalPolicyEvaluationMode::value] or
+        /// [GlobalPolicyEvaluationMode::name].
+        UnknownValue(global_policy_evaluation_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod global_policy_evaluation_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl GlobalPolicyEvaluationMode {
-        /// Not specified: DISABLE is assumed.
-        pub const GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED: GlobalPolicyEvaluationMode =
-            GlobalPolicyEvaluationMode::new(0);
-
-        /// Enables system policy evaluation.
-        pub const ENABLE: GlobalPolicyEvaluationMode = GlobalPolicyEvaluationMode::new(1);
-
-        /// Disables system policy evaluation.
-        pub const DISABLE: GlobalPolicyEvaluationMode = GlobalPolicyEvaluationMode::new(2);
-
-        /// Creates a new GlobalPolicyEvaluationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enable => std::option::Option::Some(1),
+                Self::Disable => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLE"),
-                2 => std::borrow::Cow::Borrowed("DISABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED")
                 }
-                "ENABLE" => std::option::Option::Some(Self::ENABLE),
-                "DISABLE" => std::option::Option::Some(Self::DISABLE),
-                _ => std::option::Option::None,
+                Self::Enable => std::option::Option::Some("ENABLE"),
+                Self::Disable => std::option::Option::Some("DISABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for GlobalPolicyEvaluationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for GlobalPolicyEvaluationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for GlobalPolicyEvaluationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for GlobalPolicyEvaluationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enable,
+                2 => Self::Disable,
+                _ => Self::UnknownValue(global_policy_evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for GlobalPolicyEvaluationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLE" => Self::Enable,
+                "DISABLE" => Self::Disable,
+                _ => Self::UnknownValue(global_policy_evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for GlobalPolicyEvaluationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enable => serializer.serialize_i32(1),
+                Self::Disable => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for GlobalPolicyEvaluationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<GlobalPolicyEvaluationMode>::new(
+                    ".google.cloud.binaryauthorization.v1.Policy.GlobalPolicyEvaluationMode",
+                ),
+            )
         }
     }
 }
@@ -413,131 +475,251 @@ pub mod admission_rule {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationMode(i32);
-
-    impl EvaluationMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EvaluationMode {
         /// Do not use.
-        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode = EvaluationMode::new(0);
-
+        Unspecified,
         /// This rule allows all all pod creations.
-        pub const ALWAYS_ALLOW: EvaluationMode = EvaluationMode::new(1);
-
+        AlwaysAllow,
         /// This rule allows a pod creation if all the attestors listed in
         /// 'require_attestations_by' have valid attestations for all of the
         /// images in the pod spec.
-        pub const REQUIRE_ATTESTATION: EvaluationMode = EvaluationMode::new(2);
-
+        RequireAttestation,
         /// This rule denies all pod creations.
-        pub const ALWAYS_DENY: EvaluationMode = EvaluationMode::new(3);
+        AlwaysDeny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EvaluationMode::value] or
+        /// [EvaluationMode::name].
+        UnknownValue(evaluation_mode::UnknownValue),
+    }
 
-        /// Creates a new EvaluationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod evaluation_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EvaluationMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AlwaysAllow => std::option::Option::Some(1),
+                Self::RequireAttestation => std::option::Option::Some(2),
+                Self::AlwaysDeny => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVALUATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALWAYS_ALLOW"),
-                2 => std::borrow::Cow::Borrowed("REQUIRE_ATTESTATION"),
-                3 => std::borrow::Cow::Borrowed("ALWAYS_DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVALUATION_MODE_UNSPECIFIED"),
+                Self::AlwaysAllow => std::option::Option::Some("ALWAYS_ALLOW"),
+                Self::RequireAttestation => std::option::Option::Some("REQUIRE_ATTESTATION"),
+                Self::AlwaysDeny => std::option::Option::Some("ALWAYS_DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVALUATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVALUATION_MODE_UNSPECIFIED)
-                }
-                "ALWAYS_ALLOW" => std::option::Option::Some(Self::ALWAYS_ALLOW),
-                "REQUIRE_ATTESTATION" => std::option::Option::Some(Self::REQUIRE_ATTESTATION),
-                "ALWAYS_DENY" => std::option::Option::Some(Self::ALWAYS_DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EvaluationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EvaluationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EvaluationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AlwaysAllow,
+                2 => Self::RequireAttestation,
+                3 => Self::AlwaysDeny,
+                _ => Self::UnknownValue(evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EvaluationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVALUATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ALWAYS_ALLOW" => Self::AlwaysAllow,
+                "REQUIRE_ATTESTATION" => Self::RequireAttestation,
+                "ALWAYS_DENY" => Self::AlwaysDeny,
+                _ => Self::UnknownValue(evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EvaluationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AlwaysAllow => serializer.serialize_i32(1),
+                Self::RequireAttestation => serializer.serialize_i32(2),
+                Self::AlwaysDeny => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EvaluationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EvaluationMode>::new(
+                ".google.cloud.binaryauthorization.v1.AdmissionRule.EvaluationMode",
+            ))
         }
     }
 
     /// Defines the possible actions when a pod creation is denied by an admission
     /// rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EnforcementMode(i32);
-
-    impl EnforcementMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EnforcementMode {
         /// Do not use.
-        pub const ENFORCEMENT_MODE_UNSPECIFIED: EnforcementMode = EnforcementMode::new(0);
-
+        Unspecified,
         /// Enforce the admission rule by blocking the pod creation.
-        pub const ENFORCED_BLOCK_AND_AUDIT_LOG: EnforcementMode = EnforcementMode::new(1);
-
+        EnforcedBlockAndAuditLog,
         /// Dryrun mode: Audit logging only.  This will allow the pod creation as if
         /// the admission request had specified break-glass.
-        pub const DRYRUN_AUDIT_LOG_ONLY: EnforcementMode = EnforcementMode::new(2);
+        DryrunAuditLogOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EnforcementMode::value] or
+        /// [EnforcementMode::name].
+        UnknownValue(enforcement_mode::UnknownValue),
+    }
 
-        /// Creates a new EnforcementMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod enforcement_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EnforcementMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::EnforcedBlockAndAuditLog => std::option::Option::Some(1),
+                Self::DryrunAuditLogOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENFORCEMENT_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENFORCED_BLOCK_AND_AUDIT_LOG"),
-                2 => std::borrow::Cow::Borrowed("DRYRUN_AUDIT_LOG_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENFORCEMENT_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENFORCEMENT_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENFORCEMENT_MODE_UNSPECIFIED"),
+                Self::EnforcedBlockAndAuditLog => {
+                    std::option::Option::Some("ENFORCED_BLOCK_AND_AUDIT_LOG")
                 }
-                "ENFORCED_BLOCK_AND_AUDIT_LOG" => {
-                    std::option::Option::Some(Self::ENFORCED_BLOCK_AND_AUDIT_LOG)
-                }
-                "DRYRUN_AUDIT_LOG_ONLY" => std::option::Option::Some(Self::DRYRUN_AUDIT_LOG_ONLY),
-                _ => std::option::Option::None,
+                Self::DryrunAuditLogOnly => std::option::Option::Some("DRYRUN_AUDIT_LOG_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for EnforcementMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EnforcementMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EnforcementMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EnforcementMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::EnforcedBlockAndAuditLog,
+                2 => Self::DryrunAuditLogOnly,
+                _ => Self::UnknownValue(enforcement_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EnforcementMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENFORCEMENT_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ENFORCED_BLOCK_AND_AUDIT_LOG" => Self::EnforcedBlockAndAuditLog,
+                "DRYRUN_AUDIT_LOG_ONLY" => Self::DryrunAuditLogOnly,
+                _ => Self::UnknownValue(enforcement_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EnforcementMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::EnforcedBlockAndAuditLog => serializer.serialize_i32(1),
+                Self::DryrunAuditLogOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EnforcementMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnforcementMode>::new(
+                ".google.cloud.binaryauthorization.v1.AdmissionRule.EnforcementMode",
+            ))
         }
     }
 }
@@ -817,126 +999,209 @@ pub mod pkix_public_key {
     /// PemKeyType, which is in turn based on KMS's supported signing algorithms.
     /// See <https://cloud.google.com/kms/docs/algorithms>. In the future, BinAuthz
     /// might support additional public key types independently of Tink and/or KMS.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SignatureAlgorithm(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SignatureAlgorithm {
+        /// Not specified.
+        Unspecified,
+        /// RSASSA-PSS 2048 bit key with a SHA256 digest.
+        RsaPss2048Sha256,
+        /// RSASSA-PSS 3072 bit key with a SHA256 digest.
+        RsaPss3072Sha256,
+        /// RSASSA-PSS 4096 bit key with a SHA256 digest.
+        RsaPss4096Sha256,
+        /// RSASSA-PSS 4096 bit key with a SHA512 digest.
+        RsaPss4096Sha512,
+        /// RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
+        RsaSignPkcs12048Sha256,
+        /// RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
+        RsaSignPkcs13072Sha256,
+        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
+        RsaSignPkcs14096Sha256,
+        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
+        RsaSignPkcs14096Sha512,
+        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
+        EcdsaP256Sha256,
+        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
+        EcSignP256Sha256,
+        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
+        EcdsaP384Sha384,
+        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
+        EcSignP384Sha384,
+        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
+        EcdsaP521Sha512,
+        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
+        EcSignP521Sha512,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SignatureAlgorithm::value] or
+        /// [SignatureAlgorithm::name].
+        UnknownValue(signature_algorithm::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod signature_algorithm {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SignatureAlgorithm {
-        /// Not specified.
-        pub const SIGNATURE_ALGORITHM_UNSPECIFIED: SignatureAlgorithm = SignatureAlgorithm::new(0);
-
-        /// RSASSA-PSS 2048 bit key with a SHA256 digest.
-        pub const RSA_PSS_2048_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(1);
-
-        /// RSASSA-PSS 3072 bit key with a SHA256 digest.
-        pub const RSA_PSS_3072_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(2);
-
-        /// RSASSA-PSS 4096 bit key with a SHA256 digest.
-        pub const RSA_PSS_4096_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(3);
-
-        /// RSASSA-PSS 4096 bit key with a SHA512 digest.
-        pub const RSA_PSS_4096_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(4);
-
-        /// RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_2048_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(5);
-
-        /// RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_3072_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(6);
-
-        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_4096_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(7);
-
-        /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
-        pub const RSA_SIGN_PKCS1_4096_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(8);
-
-        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
-        pub const ECDSA_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(9);
-
-        /// ECDSA on the NIST P-256 curve with a SHA256 digest.
-        pub const EC_SIGN_P256_SHA256: SignatureAlgorithm = SignatureAlgorithm::new(9);
-
-        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
-        pub const ECDSA_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm::new(10);
-
-        /// ECDSA on the NIST P-384 curve with a SHA384 digest.
-        pub const EC_SIGN_P384_SHA384: SignatureAlgorithm = SignatureAlgorithm::new(10);
-
-        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
-        pub const ECDSA_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(11);
-
-        /// ECDSA on the NIST P-521 curve with a SHA512 digest.
-        pub const EC_SIGN_P521_SHA512: SignatureAlgorithm = SignatureAlgorithm::new(11);
-
-        /// Creates a new SignatureAlgorithm instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RsaPss2048Sha256 => std::option::Option::Some(1),
+                Self::RsaPss3072Sha256 => std::option::Option::Some(2),
+                Self::RsaPss4096Sha256 => std::option::Option::Some(3),
+                Self::RsaPss4096Sha512 => std::option::Option::Some(4),
+                Self::RsaSignPkcs12048Sha256 => std::option::Option::Some(5),
+                Self::RsaSignPkcs13072Sha256 => std::option::Option::Some(6),
+                Self::RsaSignPkcs14096Sha256 => std::option::Option::Some(7),
+                Self::RsaSignPkcs14096Sha512 => std::option::Option::Some(8),
+                Self::EcdsaP256Sha256 => std::option::Option::Some(9),
+                Self::EcSignP256Sha256 => std::option::Option::Some(9),
+                Self::EcdsaP384Sha384 => std::option::Option::Some(10),
+                Self::EcSignP384Sha384 => std::option::Option::Some(10),
+                Self::EcdsaP521Sha512 => std::option::Option::Some(11),
+                Self::EcSignP521Sha512 => std::option::Option::Some(11),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SIGNATURE_ALGORITHM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RSA_PSS_2048_SHA256"),
-                2 => std::borrow::Cow::Borrowed("RSA_PSS_3072_SHA256"),
-                3 => std::borrow::Cow::Borrowed("RSA_PSS_4096_SHA256"),
-                4 => std::borrow::Cow::Borrowed("RSA_PSS_4096_SHA512"),
-                5 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_2048_SHA256"),
-                6 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_3072_SHA256"),
-                7 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA256"),
-                8 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA512"),
-                9 => std::borrow::Cow::Borrowed("ECDSA_P256_SHA256"),
-                10 => std::borrow::Cow::Borrowed("ECDSA_P384_SHA384"),
-                11 => std::borrow::Cow::Borrowed("ECDSA_P521_SHA512"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SIGNATURE_ALGORITHM_UNSPECIFIED"),
+                Self::RsaPss2048Sha256 => std::option::Option::Some("RSA_PSS_2048_SHA256"),
+                Self::RsaPss3072Sha256 => std::option::Option::Some("RSA_PSS_3072_SHA256"),
+                Self::RsaPss4096Sha256 => std::option::Option::Some("RSA_PSS_4096_SHA256"),
+                Self::RsaPss4096Sha512 => std::option::Option::Some("RSA_PSS_4096_SHA512"),
+                Self::RsaSignPkcs12048Sha256 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_2048_SHA256")
+                }
+                Self::RsaSignPkcs13072Sha256 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_3072_SHA256")
+                }
+                Self::RsaSignPkcs14096Sha256 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_4096_SHA256")
+                }
+                Self::RsaSignPkcs14096Sha512 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_4096_SHA512")
+                }
+                Self::EcdsaP256Sha256 => std::option::Option::Some("ECDSA_P256_SHA256"),
+                Self::EcSignP256Sha256 => std::option::Option::Some("EC_SIGN_P256_SHA256"),
+                Self::EcdsaP384Sha384 => std::option::Option::Some("ECDSA_P384_SHA384"),
+                Self::EcSignP384Sha384 => std::option::Option::Some("EC_SIGN_P384_SHA384"),
+                Self::EcdsaP521Sha512 => std::option::Option::Some("ECDSA_P521_SHA512"),
+                Self::EcSignP521Sha512 => std::option::Option::Some("EC_SIGN_P521_SHA512"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SIGNATURE_ALGORITHM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SIGNATURE_ALGORITHM_UNSPECIFIED)
-                }
-                "RSA_PSS_2048_SHA256" => std::option::Option::Some(Self::RSA_PSS_2048_SHA256),
-                "RSA_PSS_3072_SHA256" => std::option::Option::Some(Self::RSA_PSS_3072_SHA256),
-                "RSA_PSS_4096_SHA256" => std::option::Option::Some(Self::RSA_PSS_4096_SHA256),
-                "RSA_PSS_4096_SHA512" => std::option::Option::Some(Self::RSA_PSS_4096_SHA512),
-                "RSA_SIGN_PKCS1_2048_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_2048_SHA256)
-                }
-                "RSA_SIGN_PKCS1_3072_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_3072_SHA256)
-                }
-                "RSA_SIGN_PKCS1_4096_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA256)
-                }
-                "RSA_SIGN_PKCS1_4096_SHA512" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA512)
-                }
-                "ECDSA_P256_SHA256" => std::option::Option::Some(Self::ECDSA_P256_SHA256),
-                "EC_SIGN_P256_SHA256" => std::option::Option::Some(Self::EC_SIGN_P256_SHA256),
-                "ECDSA_P384_SHA384" => std::option::Option::Some(Self::ECDSA_P384_SHA384),
-                "EC_SIGN_P384_SHA384" => std::option::Option::Some(Self::EC_SIGN_P384_SHA384),
-                "ECDSA_P521_SHA512" => std::option::Option::Some(Self::ECDSA_P521_SHA512),
-                "EC_SIGN_P521_SHA512" => std::option::Option::Some(Self::EC_SIGN_P521_SHA512),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SignatureAlgorithm {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SignatureAlgorithm {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SignatureAlgorithm {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SignatureAlgorithm {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RsaPss2048Sha256,
+                2 => Self::RsaPss3072Sha256,
+                3 => Self::RsaPss4096Sha256,
+                4 => Self::RsaPss4096Sha512,
+                5 => Self::RsaSignPkcs12048Sha256,
+                6 => Self::RsaSignPkcs13072Sha256,
+                7 => Self::RsaSignPkcs14096Sha256,
+                8 => Self::RsaSignPkcs14096Sha512,
+                9 => Self::EcdsaP256Sha256,
+                10 => Self::EcdsaP384Sha384,
+                11 => Self::EcdsaP521Sha512,
+                _ => Self::UnknownValue(signature_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SignatureAlgorithm {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SIGNATURE_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                "RSA_PSS_2048_SHA256" => Self::RsaPss2048Sha256,
+                "RSA_PSS_3072_SHA256" => Self::RsaPss3072Sha256,
+                "RSA_PSS_4096_SHA256" => Self::RsaPss4096Sha256,
+                "RSA_PSS_4096_SHA512" => Self::RsaPss4096Sha512,
+                "RSA_SIGN_PKCS1_2048_SHA256" => Self::RsaSignPkcs12048Sha256,
+                "RSA_SIGN_PKCS1_3072_SHA256" => Self::RsaSignPkcs13072Sha256,
+                "RSA_SIGN_PKCS1_4096_SHA256" => Self::RsaSignPkcs14096Sha256,
+                "RSA_SIGN_PKCS1_4096_SHA512" => Self::RsaSignPkcs14096Sha512,
+                "ECDSA_P256_SHA256" => Self::EcdsaP256Sha256,
+                "EC_SIGN_P256_SHA256" => Self::EcSignP256Sha256,
+                "ECDSA_P384_SHA384" => Self::EcdsaP384Sha384,
+                "EC_SIGN_P384_SHA384" => Self::EcSignP384Sha384,
+                "ECDSA_P521_SHA512" => Self::EcdsaP521Sha512,
+                "EC_SIGN_P521_SHA512" => Self::EcSignP521Sha512,
+                _ => Self::UnknownValue(signature_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SignatureAlgorithm {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RsaPss2048Sha256 => serializer.serialize_i32(1),
+                Self::RsaPss3072Sha256 => serializer.serialize_i32(2),
+                Self::RsaPss4096Sha256 => serializer.serialize_i32(3),
+                Self::RsaPss4096Sha512 => serializer.serialize_i32(4),
+                Self::RsaSignPkcs12048Sha256 => serializer.serialize_i32(5),
+                Self::RsaSignPkcs13072Sha256 => serializer.serialize_i32(6),
+                Self::RsaSignPkcs14096Sha256 => serializer.serialize_i32(7),
+                Self::RsaSignPkcs14096Sha512 => serializer.serialize_i32(8),
+                Self::EcdsaP256Sha256 => serializer.serialize_i32(9),
+                Self::EcSignP256Sha256 => serializer.serialize_i32(9),
+                Self::EcdsaP384Sha384 => serializer.serialize_i32(10),
+                Self::EcSignP384Sha384 => serializer.serialize_i32(10),
+                Self::EcdsaP521Sha512 => serializer.serialize_i32(11),
+                Self::EcSignP521Sha512 => serializer.serialize_i32(11),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SignatureAlgorithm {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SignatureAlgorithm>::new(
+                ".google.cloud.binaryauthorization.v1.PkixPublicKey.SignatureAlgorithm",
+            ))
         }
     }
 }
@@ -1645,61 +1910,122 @@ pub mod validate_attestation_occurrence_response {
     use super::*;
 
     /// The enum returned in the "result" field.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Result {
+        /// Unspecified.
+        Unspecified,
+        /// The Attestation was able to verified by the Attestor.
+        Verified,
+        /// The Attestation was not able to verified by the Attestor.
+        AttestationNotVerifiable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Result::value] or
+        /// [Result::name].
+        UnknownValue(result::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Result {
-        /// Unspecified.
-        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
-
-        /// The Attestation was able to verified by the Attestor.
-        pub const VERIFIED: Result = Result::new(1);
-
-        /// The Attestation was not able to verified by the Attestor.
-        pub const ATTESTATION_NOT_VERIFIABLE: Result = Result::new(2);
-
-        /// Creates a new Result instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Verified => std::option::Option::Some(1),
+                Self::AttestationNotVerifiable => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VERIFIED"),
-                2 => std::borrow::Cow::Borrowed("ATTESTATION_NOT_VERIFIABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
-                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
-                "ATTESTATION_NOT_VERIFIABLE" => {
-                    std::option::Option::Some(Self::ATTESTATION_NOT_VERIFIABLE)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESULT_UNSPECIFIED"),
+                Self::Verified => std::option::Option::Some("VERIFIED"),
+                Self::AttestationNotVerifiable => {
+                    std::option::Option::Some("ATTESTATION_NOT_VERIFIABLE")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Result {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Verified,
+                2 => Self::AttestationNotVerifiable,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Result {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESULT_UNSPECIFIED" => Self::Unspecified,
+                "VERIFIED" => Self::Verified,
+                "ATTESTATION_NOT_VERIFIABLE" => Self::AttestationNotVerifiable,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Result {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Verified => serializer.serialize_i32(1),
+                Self::AttestationNotVerifiable => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Result {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Result>::new(
+                ".google.cloud.binaryauthorization.v1.ValidateAttestationOccurrenceResponse.Result",
+            ))
         }
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -579,61 +579,120 @@ pub mod certificate_issuance_config {
     }
 
     /// The type of keypair to generate.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyAlgorithm(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KeyAlgorithm {
+        /// Unspecified key algorithm.
+        Unspecified,
+        /// Specifies RSA with a 2048-bit modulus.
+        Rsa2048,
+        /// Specifies ECDSA with curve P256.
+        EcdsaP256,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KeyAlgorithm::value] or
+        /// [KeyAlgorithm::name].
+        UnknownValue(key_algorithm::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod key_algorithm {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl KeyAlgorithm {
-        /// Unspecified key algorithm.
-        pub const KEY_ALGORITHM_UNSPECIFIED: KeyAlgorithm = KeyAlgorithm::new(0);
-
-        /// Specifies RSA with a 2048-bit modulus.
-        pub const RSA_2048: KeyAlgorithm = KeyAlgorithm::new(1);
-
-        /// Specifies ECDSA with curve P256.
-        pub const ECDSA_P256: KeyAlgorithm = KeyAlgorithm::new(4);
-
-        /// Creates a new KeyAlgorithm instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Rsa2048 => std::option::Option::Some(1),
+                Self::EcdsaP256 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KEY_ALGORITHM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RSA_2048"),
-                4 => std::borrow::Cow::Borrowed("ECDSA_P256"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KEY_ALGORITHM_UNSPECIFIED"),
+                Self::Rsa2048 => std::option::Option::Some("RSA_2048"),
+                Self::EcdsaP256 => std::option::Option::Some("ECDSA_P256"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KEY_ALGORITHM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KEY_ALGORITHM_UNSPECIFIED)
-                }
-                "RSA_2048" => std::option::Option::Some(Self::RSA_2048),
-                "ECDSA_P256" => std::option::Option::Some(Self::ECDSA_P256),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for KeyAlgorithm {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyAlgorithm {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KeyAlgorithm {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KeyAlgorithm {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Rsa2048,
+                4 => Self::EcdsaP256,
+                _ => Self::UnknownValue(key_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KeyAlgorithm {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KEY_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                "RSA_2048" => Self::Rsa2048,
+                "ECDSA_P256" => Self::EcdsaP256,
+                _ => Self::UnknownValue(key_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KeyAlgorithm {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Rsa2048 => serializer.serialize_i32(1),
+                Self::EcdsaP256 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KeyAlgorithm {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KeyAlgorithm>::new(
+                ".google.cloud.certificatemanager.v1.CertificateIssuanceConfig.KeyAlgorithm",
+            ))
         }
     }
 }
@@ -2540,65 +2599,128 @@ pub mod certificate {
             use super::*;
 
             /// Reason for provisioning failures.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Reason(i32);
-
-            impl Reason {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Reason {
                 /// Reason is unspecified.
-                pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
-
+                Unspecified,
                 /// Certificate provisioning failed due to an issue with one or more of
                 /// the domains on the certificate.
                 /// For details of which domains failed, consult the
                 /// `authorization_attempt_info` field.
-                pub const AUTHORIZATION_ISSUE: Reason = Reason::new(1);
-
+                AuthorizationIssue,
                 /// Exceeded Certificate Authority quotas or internal rate limits of the
                 /// system. Provisioning may take longer to complete.
-                pub const RATE_LIMITED: Reason = Reason::new(2);
+                RateLimited,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Reason::value] or
+                /// [Reason::name].
+                UnknownValue(reason::UnknownValue),
+            }
 
-                /// Creates a new Reason instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod reason {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl Reason {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::AuthorizationIssue => std::option::Option::Some(1),
+                        Self::RateLimited => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("AUTHORIZATION_ISSUE"),
-                        2 => std::borrow::Cow::Borrowed("RATE_LIMITED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
-                        "AUTHORIZATION_ISSUE" => {
-                            std::option::Option::Some(Self::AUTHORIZATION_ISSUE)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("REASON_UNSPECIFIED"),
+                        Self::AuthorizationIssue => {
+                            std::option::Option::Some("AUTHORIZATION_ISSUE")
                         }
-                        "RATE_LIMITED" => std::option::Option::Some(Self::RATE_LIMITED),
-                        _ => std::option::Option::None,
+                        Self::RateLimited => std::option::Option::Some("RATE_LIMITED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for Reason {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Reason {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Reason {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Reason {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::AuthorizationIssue,
+                        2 => Self::RateLimited,
+                        _ => Self::UnknownValue(reason::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Reason {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "REASON_UNSPECIFIED" => Self::Unspecified,
+                        "AUTHORIZATION_ISSUE" => Self::AuthorizationIssue,
+                        "RATE_LIMITED" => Self::RateLimited,
+                        _ => Self::UnknownValue(reason::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Reason {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::AuthorizationIssue => serializer.serialize_i32(1),
+                        Self::RateLimited => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Reason {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Reason>::new(
+                        ".google.cloud.certificatemanager.v1.Certificate.ManagedCertificate.ProvisioningIssue.Reason"))
                 }
             }
         }
@@ -2674,265 +2796,522 @@ pub mod certificate {
             use super::*;
 
             /// State of the domain for managed certificate issuance.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct State(i32);
-
-            impl State {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum State {
                 /// State is unspecified.
-                pub const STATE_UNSPECIFIED: State = State::new(0);
-
+                Unspecified,
                 /// Certificate provisioning for this domain is under way. Google Cloud
                 /// will attempt to authorize the domain.
-                pub const AUTHORIZING: State = State::new(1);
-
+                Authorizing,
                 /// A managed certificate can be provisioned, no issues for this domain.
-                pub const AUTHORIZED: State = State::new(6);
-
+                Authorized,
                 /// Attempt to authorize the domain failed. This prevents the Managed
                 /// Certificate from being issued.
                 /// See `failure_reason` and `details` fields for more information.
-                pub const FAILED: State = State::new(7);
+                Failed,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [State::value] or
+                /// [State::name].
+                UnknownValue(state::UnknownValue),
+            }
 
-                /// Creates a new State instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl State {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Authorizing => std::option::Option::Some(1),
+                        Self::Authorized => std::option::Option::Some(6),
+                        Self::Failed => std::option::Option::Some(7),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("AUTHORIZING"),
-                        6 => std::borrow::Cow::Borrowed("AUTHORIZED"),
-                        7 => std::borrow::Cow::Borrowed("FAILED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                        Self::Authorizing => std::option::Option::Some("AUTHORIZING"),
+                        Self::Authorized => std::option::Option::Some("AUTHORIZED"),
+                        Self::Failed => std::option::Option::Some("FAILED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                        "AUTHORIZING" => std::option::Option::Some(Self::AUTHORIZING),
-                        "AUTHORIZED" => std::option::Option::Some(Self::AUTHORIZED),
-                        "FAILED" => std::option::Option::Some(Self::FAILED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for State {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for State {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for State {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for State {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Authorizing,
+                        6 => Self::Authorized,
+                        7 => Self::Failed,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for State {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "STATE_UNSPECIFIED" => Self::Unspecified,
+                        "AUTHORIZING" => Self::Authorizing,
+                        "AUTHORIZED" => Self::Authorized,
+                        "FAILED" => Self::Failed,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for State {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Authorizing => serializer.serialize_i32(1),
+                        Self::Authorized => serializer.serialize_i32(6),
+                        Self::Failed => serializer.serialize_i32(7),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for State {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                        ".google.cloud.certificatemanager.v1.Certificate.ManagedCertificate.AuthorizationAttemptInfo.State"))
                 }
             }
 
             /// Reason for failure of the authorization attempt for the domain.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct FailureReason(i32);
-
-            impl FailureReason {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum FailureReason {
                 /// FailureReason is unspecified.
-                pub const FAILURE_REASON_UNSPECIFIED: FailureReason = FailureReason::new(0);
-
+                Unspecified,
                 /// There was a problem with the user's DNS or load balancer
                 /// configuration for this domain.
-                pub const CONFIG: FailureReason = FailureReason::new(1);
-
+                Config,
                 /// Certificate issuance forbidden by an explicit CAA record for the
                 /// domain or a failure to check CAA records for the domain.
-                pub const CAA: FailureReason = FailureReason::new(2);
-
+                Caa,
                 /// Reached a CA or internal rate-limit for the domain,
                 /// e.g. for certificates per top-level private domain.
-                pub const RATE_LIMITED: FailureReason = FailureReason::new(3);
+                RateLimited,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [FailureReason::value] or
+                /// [FailureReason::name].
+                UnknownValue(failure_reason::UnknownValue),
+            }
 
-                /// Creates a new FailureReason instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod failure_reason {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl FailureReason {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Config => std::option::Option::Some(1),
+                        Self::Caa => std::option::Option::Some(2),
+                        Self::RateLimited => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("FAILURE_REASON_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("CONFIG"),
-                        2 => std::borrow::Cow::Borrowed("CAA"),
-                        3 => std::borrow::Cow::Borrowed("RATE_LIMITED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "FAILURE_REASON_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::FAILURE_REASON_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("FAILURE_REASON_UNSPECIFIED")
                         }
-                        "CONFIG" => std::option::Option::Some(Self::CONFIG),
-                        "CAA" => std::option::Option::Some(Self::CAA),
-                        "RATE_LIMITED" => std::option::Option::Some(Self::RATE_LIMITED),
-                        _ => std::option::Option::None,
+                        Self::Config => std::option::Option::Some("CONFIG"),
+                        Self::Caa => std::option::Option::Some("CAA"),
+                        Self::RateLimited => std::option::Option::Some("RATE_LIMITED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for FailureReason {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for FailureReason {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for FailureReason {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for FailureReason {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Config,
+                        2 => Self::Caa,
+                        3 => Self::RateLimited,
+                        _ => Self::UnknownValue(failure_reason::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for FailureReason {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "FAILURE_REASON_UNSPECIFIED" => Self::Unspecified,
+                        "CONFIG" => Self::Config,
+                        "CAA" => Self::Caa,
+                        "RATE_LIMITED" => Self::RateLimited,
+                        _ => Self::UnknownValue(failure_reason::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for FailureReason {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Config => serializer.serialize_i32(1),
+                        Self::Caa => serializer.serialize_i32(2),
+                        Self::RateLimited => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for FailureReason {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureReason>::new(
+                        ".google.cloud.certificatemanager.v1.Certificate.ManagedCertificate.AuthorizationAttemptInfo.FailureReason"))
                 }
             }
         }
 
         /// State of the managed certificate resource.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// State is unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// Certificate Manager attempts to provision or renew the certificate.
             /// If the process takes longer than expected, consult the
             /// `provisioning_issue` field.
-            pub const PROVISIONING: State = State::new(1);
-
+            Provisioning,
             /// Multiple certificate provisioning attempts failed and Certificate
             /// Manager gave up. To try again, delete and create a new managed
             /// Certificate resource.
             /// For details see the `provisioning_issue` field.
-            pub const FAILED: State = State::new(2);
-
+            Failed,
             /// The certificate management is working, and a certificate has been
             /// provisioned.
-            pub const ACTIVE: State = State::new(3);
+            Active,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Provisioning => std::option::Option::Some(1),
+                    Self::Failed => std::option::Option::Some(2),
+                    Self::Active => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                    2 => std::borrow::Cow::Borrowed("FAILED"),
-                    3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::Active => std::option::Option::Some("ACTIVE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Provisioning,
+                    2 => Self::Failed,
+                    3 => Self::Active,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "PROVISIONING" => Self::Provisioning,
+                    "FAILED" => Self::Failed,
+                    "ACTIVE" => Self::Active,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Provisioning => serializer.serialize_i32(1),
+                    Self::Failed => serializer.serialize_i32(2),
+                    Self::Active => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.certificatemanager.v1.Certificate.ManagedCertificate.State",
+                ))
             }
         }
     }
 
     /// Certificate scope.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
-
-    impl Scope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
         /// Certificates with default scope are served from core Google data centers.
         /// If unsure, choose this option.
-        pub const DEFAULT: Scope = Scope::new(0);
-
+        Default,
         /// Certificates with scope EDGE_CACHE are special-purposed certificates,
         /// served from Edge Points of Presence.
         /// See <https://cloud.google.com/vpc/docs/edge-locations>.
-        pub const EDGE_CACHE: Scope = Scope::new(1);
-
+        EdgeCache,
         /// Certificates with ALL_REGIONS scope are served from all Google Cloud
         /// regions. See <https://cloud.google.com/compute/docs/regions-zones>.
-        pub const ALL_REGIONS: Scope = Scope::new(2);
+        AllRegions,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
 
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Scope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Default => std::option::Option::Some(0),
+                Self::EdgeCache => std::option::Option::Some(1),
+                Self::AllRegions => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEFAULT"),
-                1 => std::borrow::Cow::Borrowed("EDGE_CACHE"),
-                2 => std::borrow::Cow::Borrowed("ALL_REGIONS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::EdgeCache => std::option::Option::Some("EDGE_CACHE"),
+                Self::AllRegions => std::option::Option::Some("ALL_REGIONS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "EDGE_CACHE" => std::option::Option::Some(Self::EDGE_CACHE),
-                "ALL_REGIONS" => std::option::Option::Some(Self::ALL_REGIONS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Default,
+                1 => Self::EdgeCache,
+                2 => Self::AllRegions,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEFAULT" => Self::Default,
+                "EDGE_CACHE" => Self::EdgeCache,
+                "ALL_REGIONS" => Self::AllRegions,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Default => serializer.serialize_i32(0),
+                Self::EdgeCache => serializer.serialize_i32(1),
+                Self::AllRegions => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".google.cloud.certificatemanager.v1.Certificate.Scope",
+            ))
         }
     }
 
@@ -3427,55 +3806,114 @@ pub mod certificate_map_entry {
 
     /// Defines predefined cases other than SNI-hostname match when this
     /// configuration should be applied.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Matcher(i32);
-
-    impl Matcher {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Matcher {
         /// A matcher has't been recognized.
-        pub const MATCHER_UNSPECIFIED: Matcher = Matcher::new(0);
-
+        Unspecified,
         /// A primary certificate that is served when SNI wasn't specified in the
         /// request or SNI couldn't be found in the map.
-        pub const PRIMARY: Matcher = Matcher::new(1);
+        Primary,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Matcher::value] or
+        /// [Matcher::name].
+        UnknownValue(matcher::UnknownValue),
+    }
 
-        /// Creates a new Matcher instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod matcher {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Matcher {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Primary => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MATCHER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIMARY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MATCHER_UNSPECIFIED"),
+                Self::Primary => std::option::Option::Some("PRIMARY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MATCHER_UNSPECIFIED" => std::option::Option::Some(Self::MATCHER_UNSPECIFIED),
-                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Matcher {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Matcher {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Matcher {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Matcher {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Primary,
+                _ => Self::UnknownValue(matcher::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Matcher {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MATCHER_UNSPECIFIED" => Self::Unspecified,
+                "PRIMARY" => Self::Primary,
+                _ => Self::UnknownValue(matcher::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Matcher {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Primary => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Matcher {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Matcher>::new(
+                ".google.cloud.certificatemanager.v1.CertificateMapEntry.Matcher",
+            ))
         }
     }
 
@@ -3688,61 +4126,122 @@ pub mod dns_authorization {
     }
 
     /// DnsAuthorization type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Type is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// FIXED_RECORD DNS authorization uses DNS-01 validation method.
-        pub const FIXED_RECORD: Type = Type::new(1);
-
+        FixedRecord,
         /// PER_PROJECT_RECORD DNS authorization allows for independent management
         /// of Google-managed certificates with DNS authorization across multiple
         /// projects.
-        pub const PER_PROJECT_RECORD: Type = Type::new(2);
+        PerProjectRecord,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FixedRecord => std::option::Option::Some(1),
+                Self::PerProjectRecord => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIXED_RECORD"),
-                2 => std::borrow::Cow::Borrowed("PER_PROJECT_RECORD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::FixedRecord => std::option::Option::Some("FIXED_RECORD"),
+                Self::PerProjectRecord => std::option::Option::Some("PER_PROJECT_RECORD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "FIXED_RECORD" => std::option::Option::Some(Self::FIXED_RECORD),
-                "PER_PROJECT_RECORD" => std::option::Option::Some(Self::PER_PROJECT_RECORD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FixedRecord,
+                2 => Self::PerProjectRecord,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FIXED_RECORD" => Self::FixedRecord,
+                "PER_PROJECT_RECORD" => Self::PerProjectRecord,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FixedRecord => serializer.serialize_i32(1),
+                Self::PerProjectRecord => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.certificatemanager.v1.DnsAuthorization.Type",
+            ))
         }
     }
 }
@@ -4442,60 +4941,119 @@ pub mod trust_config {
 }
 
 /// Defines set of serving states associated with a resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServingState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServingState {
+    /// The status is undefined.
+    Unspecified,
+    /// The configuration is serving.
+    Active,
+    /// Update is in progress. Some frontends may serve this configuration.
+    Pending,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServingState::value] or
+    /// [ServingState::name].
+    UnknownValue(serving_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod serving_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ServingState {
-    /// The status is undefined.
-    pub const SERVING_STATE_UNSPECIFIED: ServingState = ServingState::new(0);
-
-    /// The configuration is serving.
-    pub const ACTIVE: ServingState = ServingState::new(1);
-
-    /// Update is in progress. Some frontends may serve this configuration.
-    pub const PENDING: ServingState = ServingState::new(2);
-
-    /// Creates a new ServingState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Active => std::option::Option::Some(1),
+            Self::Pending => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SERVING_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVE"),
-            2 => std::borrow::Cow::Borrowed("PENDING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SERVING_STATE_UNSPECIFIED"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::Pending => std::option::Option::Some("PENDING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SERVING_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SERVING_STATE_UNSPECIFIED)
-            }
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "PENDING" => std::option::Option::Some(Self::PENDING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServingState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServingState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServingState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServingState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Active,
+            2 => Self::Pending,
+            _ => Self::UnknownValue(serving_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServingState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SERVING_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVE" => Self::Active,
+            "PENDING" => Self::Pending,
+            _ => Self::UnknownValue(serving_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServingState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Active => serializer.serialize_i32(1),
+            Self::Pending => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServingState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServingState>::new(
+            ".google.cloud.certificatemanager.v1.ServingState",
+        ))
     }
 }

--- a/src/generated/cloud/chronicle/v1/src/model.rs
+++ b/src/generated/cloud/chronicle/v1/src/model.rs
@@ -2824,63 +2824,122 @@ pub mod rule {
     use super::*;
 
     /// The current compilation state of the rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompilationState(i32);
-
-    impl CompilationState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompilationState {
         /// The compilation state is unspecified/unknown.
-        pub const COMPILATION_STATE_UNSPECIFIED: CompilationState = CompilationState::new(0);
-
+        Unspecified,
         /// The Rule can successfully compile.
-        pub const SUCCEEDED: CompilationState = CompilationState::new(1);
-
+        Succeeded,
         /// The Rule cannot successfully compile.
         /// This is possible if a backwards-incompatible change was made to the
         /// compiler.
-        pub const FAILED: CompilationState = CompilationState::new(2);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompilationState::value] or
+        /// [CompilationState::name].
+        UnknownValue(compilation_state::UnknownValue),
+    }
 
-        /// Creates a new CompilationState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod compilation_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CompilationState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPILATION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPILATION_STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPILATION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPILATION_STATE_UNSPECIFIED)
-                }
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompilationState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompilationState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompilationState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompilationState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                _ => Self::UnknownValue(compilation_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompilationState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPILATION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(compilation_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompilationState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompilationState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompilationState>::new(
+                ".google.cloud.chronicle.v1.Rule.CompilationState",
+            ))
         }
     }
 }
@@ -3058,66 +3117,127 @@ pub mod rule_deployment {
     use super::*;
 
     /// The possible execution states the rule deployment can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExecutionState {
+        /// Unspecified or unknown execution state.
+        Unspecified,
+        /// Default execution state.
+        Default,
+        /// Rules in limited state may not have their executions guaranteed.
+        Limited,
+        /// Paused rules are not executed at all.
+        Paused,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExecutionState::value] or
+        /// [ExecutionState::name].
+        UnknownValue(execution_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod execution_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ExecutionState {
-        /// Unspecified or unknown execution state.
-        pub const EXECUTION_STATE_UNSPECIFIED: ExecutionState = ExecutionState::new(0);
-
-        /// Default execution state.
-        pub const DEFAULT: ExecutionState = ExecutionState::new(1);
-
-        /// Rules in limited state may not have their executions guaranteed.
-        pub const LIMITED: ExecutionState = ExecutionState::new(2);
-
-        /// Paused rules are not executed at all.
-        pub const PAUSED: ExecutionState = ExecutionState::new(3);
-
-        /// Creates a new ExecutionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::Limited => std::option::Option::Some(2),
+                Self::Paused => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXECUTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("LIMITED"),
-                3 => std::borrow::Cow::Borrowed("PAUSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXECUTION_STATE_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Limited => std::option::Option::Some("LIMITED"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXECUTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXECUTION_STATE_UNSPECIFIED)
-                }
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "LIMITED" => std::option::Option::Some(Self::LIMITED),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExecutionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExecutionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExecutionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::Limited,
+                3 => Self::Paused,
+                _ => Self::UnknownValue(execution_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExecutionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXECUTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "LIMITED" => Self::Limited,
+                "PAUSED" => Self::Paused,
+                _ => Self::UnknownValue(execution_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExecutionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::Limited => serializer.serialize_i32(2),
+                Self::Paused => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExecutionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionState>::new(
+                ".google.cloud.chronicle.v1.RuleDeployment.ExecutionState",
+            ))
         }
     }
 }
@@ -3220,69 +3340,134 @@ pub mod retrohunt {
     use super::*;
 
     /// The possible states a retrohunt can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified or unknown retrohunt state.
+        Unspecified,
+        /// Running state.
+        Running,
+        /// Done state.
+        Done,
+        /// Cancelled state.
+        Cancelled,
+        /// Failed state.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified or unknown retrohunt state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Running state.
-        pub const RUNNING: State = State::new(1);
-
-        /// Done state.
-        pub const DONE: State = State::new(2);
-
-        /// Cancelled state.
-        pub const CANCELLED: State = State::new(3);
-
-        /// Failed state.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Done => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("DONE"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Done,
+                3 => Self::Cancelled,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Done => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.chronicle.v1.Retrohunt.State",
+            ))
         }
     }
 }
@@ -4341,59 +4526,120 @@ pub mod compilation_diagnostic {
     use super::*;
 
     /// The severity level of the compilation diagnostic.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// An unspecified severity level.
+        Unspecified,
+        /// A compilation warning.
+        Warning,
+        /// A compilation error.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// An unspecified severity level.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// A compilation warning.
-        pub const WARNING: Severity = Severity::new(1);
-
-        /// A compilation error.
-        pub const ERROR: Severity = Severity::new(2);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Warning => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WARNING"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Warning,
+                2 => Self::Error,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Warning => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.chronicle.v1.CompilationDiagnostic.Severity",
+            ))
         }
     }
 }
@@ -4546,336 +4792,633 @@ impl wkt::message::Message for InputsUsed {
 }
 
 /// The syntax type indicating how list entries should be validated.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ReferenceListSyntaxType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ReferenceListSyntaxType {
+    /// Defaults to REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING.
+    Unspecified,
+    /// List contains plain text patterns.
+    PlainTextString,
+    /// List contains only Regular Expression patterns.
+    Regex,
+    /// List contains only CIDR patterns.
+    Cidr,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ReferenceListSyntaxType::value] or
+    /// [ReferenceListSyntaxType::name].
+    UnknownValue(reference_list_syntax_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod reference_list_syntax_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ReferenceListSyntaxType {
-    /// Defaults to REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING.
-    pub const REFERENCE_LIST_SYNTAX_TYPE_UNSPECIFIED: ReferenceListSyntaxType =
-        ReferenceListSyntaxType::new(0);
-
-    /// List contains plain text patterns.
-    pub const REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING: ReferenceListSyntaxType =
-        ReferenceListSyntaxType::new(1);
-
-    /// List contains only Regular Expression patterns.
-    pub const REFERENCE_LIST_SYNTAX_TYPE_REGEX: ReferenceListSyntaxType =
-        ReferenceListSyntaxType::new(2);
-
-    /// List contains only CIDR patterns.
-    pub const REFERENCE_LIST_SYNTAX_TYPE_CIDR: ReferenceListSyntaxType =
-        ReferenceListSyntaxType::new(3);
-
-    /// Creates a new ReferenceListSyntaxType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PlainTextString => std::option::Option::Some(1),
+            Self::Regex => std::option::Option::Some(2),
+            Self::Cidr => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REFERENCE_LIST_SYNTAX_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING"),
-            2 => std::borrow::Cow::Borrowed("REFERENCE_LIST_SYNTAX_TYPE_REGEX"),
-            3 => std::borrow::Cow::Borrowed("REFERENCE_LIST_SYNTAX_TYPE_CIDR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("REFERENCE_LIST_SYNTAX_TYPE_UNSPECIFIED")
+            }
+            Self::PlainTextString => {
+                std::option::Option::Some("REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING")
+            }
+            Self::Regex => std::option::Option::Some("REFERENCE_LIST_SYNTAX_TYPE_REGEX"),
+            Self::Cidr => std::option::Option::Some("REFERENCE_LIST_SYNTAX_TYPE_CIDR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REFERENCE_LIST_SYNTAX_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::REFERENCE_LIST_SYNTAX_TYPE_UNSPECIFIED)
-            }
-            "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING" => {
-                std::option::Option::Some(Self::REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING)
-            }
-            "REFERENCE_LIST_SYNTAX_TYPE_REGEX" => {
-                std::option::Option::Some(Self::REFERENCE_LIST_SYNTAX_TYPE_REGEX)
-            }
-            "REFERENCE_LIST_SYNTAX_TYPE_CIDR" => {
-                std::option::Option::Some(Self::REFERENCE_LIST_SYNTAX_TYPE_CIDR)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ReferenceListSyntaxType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ReferenceListSyntaxType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ReferenceListSyntaxType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ReferenceListSyntaxType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PlainTextString,
+            2 => Self::Regex,
+            3 => Self::Cidr,
+            _ => Self::UnknownValue(reference_list_syntax_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ReferenceListSyntaxType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REFERENCE_LIST_SYNTAX_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING" => Self::PlainTextString,
+            "REFERENCE_LIST_SYNTAX_TYPE_REGEX" => Self::Regex,
+            "REFERENCE_LIST_SYNTAX_TYPE_CIDR" => Self::Cidr,
+            _ => Self::UnknownValue(reference_list_syntax_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ReferenceListSyntaxType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PlainTextString => serializer.serialize_i32(1),
+            Self::Regex => serializer.serialize_i32(2),
+            Self::Cidr => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ReferenceListSyntaxType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReferenceListSyntaxType>::new(
+            ".google.cloud.chronicle.v1.ReferenceListSyntaxType",
+        ))
     }
 }
 
 /// ReferenceListView is a mechanism for viewing partial responses of the
 /// ReferenceList resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ReferenceListView(i32);
-
-impl ReferenceListView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ReferenceListView {
     /// The default / unset value.
     /// The API will default to the BASIC view for ListReferenceLists.
     /// The API will default to the FULL view for methods that return a single
     /// ReferenceList resource.
-    pub const REFERENCE_LIST_VIEW_UNSPECIFIED: ReferenceListView = ReferenceListView::new(0);
-
+    Unspecified,
     /// Include metadata about the ReferenceList.
     /// This is the default view for ListReferenceLists.
-    pub const REFERENCE_LIST_VIEW_BASIC: ReferenceListView = ReferenceListView::new(1);
-
+    Basic,
     /// Include all details about the ReferenceList: metadata, content lines,
     /// associated rule counts. This is the default view for GetReferenceList.
-    pub const REFERENCE_LIST_VIEW_FULL: ReferenceListView = ReferenceListView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ReferenceListView::value] or
+    /// [ReferenceListView::name].
+    UnknownValue(reference_list_view::UnknownValue),
+}
 
-    /// Creates a new ReferenceListView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod reference_list_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ReferenceListView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REFERENCE_LIST_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("REFERENCE_LIST_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("REFERENCE_LIST_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("REFERENCE_LIST_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("REFERENCE_LIST_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("REFERENCE_LIST_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REFERENCE_LIST_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::REFERENCE_LIST_VIEW_UNSPECIFIED)
-            }
-            "REFERENCE_LIST_VIEW_BASIC" => {
-                std::option::Option::Some(Self::REFERENCE_LIST_VIEW_BASIC)
-            }
-            "REFERENCE_LIST_VIEW_FULL" => std::option::Option::Some(Self::REFERENCE_LIST_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ReferenceListView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ReferenceListView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ReferenceListView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ReferenceListView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(reference_list_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ReferenceListView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REFERENCE_LIST_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "REFERENCE_LIST_VIEW_BASIC" => Self::Basic,
+            "REFERENCE_LIST_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(reference_list_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ReferenceListView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ReferenceListView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReferenceListView>::new(
+            ".google.cloud.chronicle.v1.ReferenceListView",
+        ))
     }
 }
 
 /// RunFrequency indicates the run frequency at which a YARA-L 2 rule will run if
 /// enabled.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RunFrequency(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RunFrequency {
+    /// The run frequency is unspecified/unknown.
+    Unspecified,
+    /// Executes in real time.
+    Live,
+    /// Executes once per hour.
+    Hourly,
+    /// Executes once per day.
+    Daily,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RunFrequency::value] or
+    /// [RunFrequency::name].
+    UnknownValue(run_frequency::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod run_frequency {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RunFrequency {
-    /// The run frequency is unspecified/unknown.
-    pub const RUN_FREQUENCY_UNSPECIFIED: RunFrequency = RunFrequency::new(0);
-
-    /// Executes in real time.
-    pub const LIVE: RunFrequency = RunFrequency::new(1);
-
-    /// Executes once per hour.
-    pub const HOURLY: RunFrequency = RunFrequency::new(2);
-
-    /// Executes once per day.
-    pub const DAILY: RunFrequency = RunFrequency::new(3);
-
-    /// Creates a new RunFrequency instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Live => std::option::Option::Some(1),
+            Self::Hourly => std::option::Option::Some(2),
+            Self::Daily => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RUN_FREQUENCY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LIVE"),
-            2 => std::borrow::Cow::Borrowed("HOURLY"),
-            3 => std::borrow::Cow::Borrowed("DAILY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RUN_FREQUENCY_UNSPECIFIED"),
+            Self::Live => std::option::Option::Some("LIVE"),
+            Self::Hourly => std::option::Option::Some("HOURLY"),
+            Self::Daily => std::option::Option::Some("DAILY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RUN_FREQUENCY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RUN_FREQUENCY_UNSPECIFIED)
-            }
-            "LIVE" => std::option::Option::Some(Self::LIVE),
-            "HOURLY" => std::option::Option::Some(Self::HOURLY),
-            "DAILY" => std::option::Option::Some(Self::DAILY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RunFrequency {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RunFrequency {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RunFrequency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RunFrequency {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Live,
+            2 => Self::Hourly,
+            3 => Self::Daily,
+            _ => Self::UnknownValue(run_frequency::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RunFrequency {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RUN_FREQUENCY_UNSPECIFIED" => Self::Unspecified,
+            "LIVE" => Self::Live,
+            "HOURLY" => Self::Hourly,
+            "DAILY" => Self::Daily,
+            _ => Self::UnknownValue(run_frequency::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RunFrequency {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Live => serializer.serialize_i32(1),
+            Self::Hourly => serializer.serialize_i32(2),
+            Self::Daily => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RunFrequency {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RunFrequency>::new(
+            ".google.cloud.chronicle.v1.RunFrequency",
+        ))
     }
 }
 
 /// RuleType indicates the YARA-L rule type of user-created and Google Cloud
 /// Threat Intelligence (GCTI) authored rules.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RuleType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RuleType {
+    /// The rule type is unspecified/unknown.
+    Unspecified,
+    /// Rule checks for the existence of a single event.
+    SingleEvent,
+    /// Rule checks for correlation between multiple events
+    MultiEvent,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RuleType::value] or
+    /// [RuleType::name].
+    UnknownValue(rule_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod rule_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RuleType {
-    /// The rule type is unspecified/unknown.
-    pub const RULE_TYPE_UNSPECIFIED: RuleType = RuleType::new(0);
-
-    /// Rule checks for the existence of a single event.
-    pub const SINGLE_EVENT: RuleType = RuleType::new(1);
-
-    /// Rule checks for correlation between multiple events
-    pub const MULTI_EVENT: RuleType = RuleType::new(2);
-
-    /// Creates a new RuleType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SingleEvent => std::option::Option::Some(1),
+            Self::MultiEvent => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RULE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SINGLE_EVENT"),
-            2 => std::borrow::Cow::Borrowed("MULTI_EVENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RULE_TYPE_UNSPECIFIED"),
+            Self::SingleEvent => std::option::Option::Some("SINGLE_EVENT"),
+            Self::MultiEvent => std::option::Option::Some("MULTI_EVENT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RULE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RULE_TYPE_UNSPECIFIED),
-            "SINGLE_EVENT" => std::option::Option::Some(Self::SINGLE_EVENT),
-            "MULTI_EVENT" => std::option::Option::Some(Self::MULTI_EVENT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RuleType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RuleType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RuleType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RuleType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::SingleEvent,
+            2 => Self::MultiEvent,
+            _ => Self::UnknownValue(rule_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RuleType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SINGLE_EVENT" => Self::SingleEvent,
+            "MULTI_EVENT" => Self::MultiEvent,
+            _ => Self::UnknownValue(rule_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RuleType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SingleEvent => serializer.serialize_i32(1),
+            Self::MultiEvent => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RuleType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RuleType>::new(
+            ".google.cloud.chronicle.v1.RuleType",
+        ))
     }
 }
 
 /// RuleView indicates the scope of fields to populate when returning the Rule
 /// resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RuleView(i32);
-
-impl RuleView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RuleView {
     /// The default/unset value.
     /// The API will default to the BASIC view for ListRules/ListRuleRevisions.
     /// The API will default to the FULL view for GetRule.
-    pub const RULE_VIEW_UNSPECIFIED: RuleView = RuleView::new(0);
-
+    Unspecified,
     /// Include basic metadata about the rule, but not the full contents.
     /// Returned fields include: revision_id, revision_create_time, display_name,
     /// author, severity, type, allowed_run_frequency,
     /// near_real_time_live_rule_eligible, etag, and scope.
     /// This is the default value for ListRules and ListRuleRevisions.
-    pub const BASIC: RuleView = RuleView::new(1);
-
+    Basic,
     /// Include all fields.
     /// This is the default value for GetRule.
-    pub const FULL: RuleView = RuleView::new(2);
-
+    Full,
     /// Include basic metadata about the rule's revision only.
     /// Returned fields include: revision_id and revision_create_time.
-    pub const REVISION_METADATA_ONLY: RuleView = RuleView::new(3);
+    RevisionMetadataOnly,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RuleView::value] or
+    /// [RuleView::name].
+    UnknownValue(rule_view::UnknownValue),
+}
 
-    /// Creates a new RuleView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod rule_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl RuleView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::RevisionMetadataOnly => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RULE_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            3 => std::borrow::Cow::Borrowed("REVISION_METADATA_ONLY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RULE_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::RevisionMetadataOnly => std::option::Option::Some("REVISION_METADATA_ONLY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RULE_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::RULE_VIEW_UNSPECIFIED),
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            "REVISION_METADATA_ONLY" => std::option::Option::Some(Self::REVISION_METADATA_ONLY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RuleView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RuleView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RuleView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RuleView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            3 => Self::RevisionMetadataOnly,
+            _ => Self::UnknownValue(rule_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RuleView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RULE_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            "REVISION_METADATA_ONLY" => Self::RevisionMetadataOnly,
+            _ => Self::UnknownValue(rule_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RuleView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::RevisionMetadataOnly => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RuleView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RuleView>::new(
+            ".google.cloud.chronicle.v1.RuleView",
+        ))
     }
 }

--- a/src/generated/cloud/chronicle/v1/src/transport.rs
+++ b/src/generated/cloud/chronicle/v1/src/transport.rs
@@ -773,7 +773,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -798,7 +798,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1001,7 +1001,7 @@ impl super::stub::RuleService for RuleService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1023,7 +1023,7 @@ impl super::stub::RuleService for RuleService {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
@@ -1105,7 +1105,7 @@ impl super::stub::RuleService for RuleService {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -314,13 +314,11 @@ pub mod access_reason {
     use super::*;
 
     /// Type of access justification.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Default value for proto, shouldn't be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Customer made a request or raised an issue that required the principal to
         /// access customer data. `detail` is of the form ("#####" is the issue ID):
         ///
@@ -330,91 +328,160 @@ pub mod access_reason {
         /// - "E-PIN Reference: #####"
         /// - "Google-#####"
         /// - "T-#####"
-        pub const CUSTOMER_INITIATED_SUPPORT: Type = Type::new(1);
-
+        CustomerInitiatedSupport,
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services. Often this access is used to confirm that
         /// customers are not affected by a suspected service issue or to remediate a
         /// reversible system issue.
-        pub const GOOGLE_INITIATED_SERVICE: Type = Type::new(2);
-
+        GoogleInitiatedService,
         /// Google initiated service for security, fraud, abuse, or compliance
         /// purposes.
-        pub const GOOGLE_INITIATED_REVIEW: Type = Type::new(3);
-
+        GoogleInitiatedReview,
         /// The principal was compelled to access customer data in order to respond
         /// to a legal third party data request or process, including legal processes
         /// from customers themselves.
-        pub const THIRD_PARTY_DATA_REQUEST: Type = Type::new(4);
-
+        ThirdPartyDataRequest,
         /// The principal accessed customer data in order to diagnose or resolve a
         /// suspected issue in services or a known outage.
-        pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: Type = Type::new(5);
-
+        GoogleResponseToProductionAlert,
         /// Similar to 'GOOGLE_INITIATED_SERVICE' or 'GOOGLE_INITIATED_REVIEW', but
         /// with universe agnostic naming. The principal accessed customer data in
         /// order to diagnose or resolve a suspected issue in services or a known
         /// outage, or for security, fraud, abuse, or compliance review purposes.
-        pub const CLOUD_INITIATED_ACCESS: Type = Type::new(6);
+        CloudInitiatedAccess,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CustomerInitiatedSupport => std::option::Option::Some(1),
+                Self::GoogleInitiatedService => std::option::Option::Some(2),
+                Self::GoogleInitiatedReview => std::option::Option::Some(3),
+                Self::ThirdPartyDataRequest => std::option::Option::Some(4),
+                Self::GoogleResponseToProductionAlert => std::option::Option::Some(5),
+                Self::CloudInitiatedAccess => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_SUPPORT"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SERVICE"),
-                3 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_REVIEW"),
-                4 => std::borrow::Cow::Borrowed("THIRD_PARTY_DATA_REQUEST"),
-                5 => std::borrow::Cow::Borrowed("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT"),
-                6 => std::borrow::Cow::Borrowed("CLOUD_INITIATED_ACCESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::CustomerInitiatedSupport => {
+                    std::option::Option::Some("CUSTOMER_INITIATED_SUPPORT")
+                }
+                Self::GoogleInitiatedService => {
+                    std::option::Option::Some("GOOGLE_INITIATED_SERVICE")
+                }
+                Self::GoogleInitiatedReview => std::option::Option::Some("GOOGLE_INITIATED_REVIEW"),
+                Self::ThirdPartyDataRequest => {
+                    std::option::Option::Some("THIRD_PARTY_DATA_REQUEST")
+                }
+                Self::GoogleResponseToProductionAlert => {
+                    std::option::Option::Some("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT")
+                }
+                Self::CloudInitiatedAccess => std::option::Option::Some("CLOUD_INITIATED_ACCESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CUSTOMER_INITIATED_SUPPORT" => {
-                    std::option::Option::Some(Self::CUSTOMER_INITIATED_SUPPORT)
-                }
-                "GOOGLE_INITIATED_SERVICE" => {
-                    std::option::Option::Some(Self::GOOGLE_INITIATED_SERVICE)
-                }
-                "GOOGLE_INITIATED_REVIEW" => {
-                    std::option::Option::Some(Self::GOOGLE_INITIATED_REVIEW)
-                }
-                "THIRD_PARTY_DATA_REQUEST" => {
-                    std::option::Option::Some(Self::THIRD_PARTY_DATA_REQUEST)
-                }
-                "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => {
-                    std::option::Option::Some(Self::GOOGLE_RESPONSE_TO_PRODUCTION_ALERT)
-                }
-                "CLOUD_INITIATED_ACCESS" => std::option::Option::Some(Self::CLOUD_INITIATED_ACCESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CustomerInitiatedSupport,
+                2 => Self::GoogleInitiatedService,
+                3 => Self::GoogleInitiatedReview,
+                4 => Self::ThirdPartyDataRequest,
+                5 => Self::GoogleResponseToProductionAlert,
+                6 => Self::CloudInitiatedAccess,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CUSTOMER_INITIATED_SUPPORT" => Self::CustomerInitiatedSupport,
+                "GOOGLE_INITIATED_SERVICE" => Self::GoogleInitiatedService,
+                "GOOGLE_INITIATED_REVIEW" => Self::GoogleInitiatedReview,
+                "THIRD_PARTY_DATA_REQUEST" => Self::ThirdPartyDataRequest,
+                "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => Self::GoogleResponseToProductionAlert,
+                "CLOUD_INITIATED_ACCESS" => Self::CloudInitiatedAccess,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CustomerInitiatedSupport => serializer.serialize_i32(1),
+                Self::GoogleInitiatedService => serializer.serialize_i32(2),
+                Self::GoogleInitiatedReview => serializer.serialize_i32(3),
+                Self::ThirdPartyDataRequest => serializer.serialize_i32(4),
+                Self::GoogleResponseToProductionAlert => serializer.serialize_i32(5),
+                Self::CloudInitiatedAccess => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.cloudcontrolspartner.v1.AccessReason.Type",
+            ))
         }
     }
 }
@@ -656,92 +723,161 @@ pub mod workload {
     use super::*;
 
     /// Supported Assured Workloads Partners.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Partner(i32);
-
-    impl Partner {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Partner {
         /// Unknown Partner.
-        pub const PARTNER_UNSPECIFIED: Partner = Partner::new(0);
-
+        Unspecified,
         /// Enum representing S3NS (Thales) partner.
-        pub const PARTNER_LOCAL_CONTROLS_BY_S3NS: Partner = Partner::new(1);
-
+        LocalControlsByS3Ns,
         /// Enum representing T_SYSTEM (TSI) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS: Partner = Partner::new(2);
-
+        SovereignControlsByTSystems,
         /// Enum representing SIA_MINSAIT (Indra) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT: Partner = Partner::new(3);
-
+        SovereignControlsBySiaMinsait,
         /// Enum representing PSN (TIM) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_PSN: Partner = Partner::new(4);
-
+        SovereignControlsByPsn,
         /// Enum representing CNTXT (Kingdom of Saudi Arabia) partner.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT: Partner = Partner::new(6);
-
+        SovereignControlsByCntxt,
         /// Enum representing CNXT (Kingdom of Saudi Arabia) partner offering without
         /// EKM provisioning.
-        pub const PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM: Partner = Partner::new(7);
+        SovereignControlsByCntxtNoEkm,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Partner::value] or
+        /// [Partner::name].
+        UnknownValue(partner::UnknownValue),
+    }
 
-        /// Creates a new Partner instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod partner {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Partner {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LocalControlsByS3Ns => std::option::Option::Some(1),
+                Self::SovereignControlsByTSystems => std::option::Option::Some(2),
+                Self::SovereignControlsBySiaMinsait => std::option::Option::Some(3),
+                Self::SovereignControlsByPsn => std::option::Option::Some(4),
+                Self::SovereignControlsByCntxt => std::option::Option::Some(6),
+                Self::SovereignControlsByCntxtNoEkm => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PARTNER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PARTNER_LOCAL_CONTROLS_BY_S3NS"),
-                2 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS"),
-                3 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT"),
-                4 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_PSN"),
-                6 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT"),
-                7 => std::borrow::Cow::Borrowed("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PARTNER_UNSPECIFIED"),
+                Self::LocalControlsByS3Ns => {
+                    std::option::Option::Some("PARTNER_LOCAL_CONTROLS_BY_S3NS")
+                }
+                Self::SovereignControlsByTSystems => {
+                    std::option::Option::Some("PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS")
+                }
+                Self::SovereignControlsBySiaMinsait => {
+                    std::option::Option::Some("PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT")
+                }
+                Self::SovereignControlsByPsn => {
+                    std::option::Option::Some("PARTNER_SOVEREIGN_CONTROLS_BY_PSN")
+                }
+                Self::SovereignControlsByCntxt => {
+                    std::option::Option::Some("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT")
+                }
+                Self::SovereignControlsByCntxtNoEkm => {
+                    std::option::Option::Some("PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PARTNER_UNSPECIFIED" => std::option::Option::Some(Self::PARTNER_UNSPECIFIED),
-                "PARTNER_LOCAL_CONTROLS_BY_S3NS" => {
-                    std::option::Option::Some(Self::PARTNER_LOCAL_CONTROLS_BY_S3NS)
-                }
-                "PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS" => {
-                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS)
-                }
-                "PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT" => {
-                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT)
-                }
-                "PARTNER_SOVEREIGN_CONTROLS_BY_PSN" => {
-                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_PSN)
-                }
-                "PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT" => {
-                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT)
-                }
-                "PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM" => {
-                    std::option::Option::Some(Self::PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Partner {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Partner {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Partner {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Partner {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LocalControlsByS3Ns,
+                2 => Self::SovereignControlsByTSystems,
+                3 => Self::SovereignControlsBySiaMinsait,
+                4 => Self::SovereignControlsByPsn,
+                6 => Self::SovereignControlsByCntxt,
+                7 => Self::SovereignControlsByCntxtNoEkm,
+                _ => Self::UnknownValue(partner::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Partner {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PARTNER_UNSPECIFIED" => Self::Unspecified,
+                "PARTNER_LOCAL_CONTROLS_BY_S3NS" => Self::LocalControlsByS3Ns,
+                "PARTNER_SOVEREIGN_CONTROLS_BY_T_SYSTEMS" => Self::SovereignControlsByTSystems,
+                "PARTNER_SOVEREIGN_CONTROLS_BY_SIA_MINSAIT" => Self::SovereignControlsBySiaMinsait,
+                "PARTNER_SOVEREIGN_CONTROLS_BY_PSN" => Self::SovereignControlsByPsn,
+                "PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT" => Self::SovereignControlsByCntxt,
+                "PARTNER_SOVEREIGN_CONTROLS_BY_CNTXT_NO_EKM" => Self::SovereignControlsByCntxtNoEkm,
+                _ => Self::UnknownValue(partner::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Partner {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LocalControlsByS3Ns => serializer.serialize_i32(1),
+                Self::SovereignControlsByTSystems => serializer.serialize_i32(2),
+                Self::SovereignControlsBySiaMinsait => serializer.serialize_i32(3),
+                Self::SovereignControlsByPsn => serializer.serialize_i32(4),
+                Self::SovereignControlsByCntxt => serializer.serialize_i32(6),
+                Self::SovereignControlsByCntxtNoEkm => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Partner {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Partner>::new(
+                ".google.cloud.cloudcontrolspartner.v1.Workload.Partner",
+            ))
         }
     }
 }
@@ -1047,61 +1183,122 @@ pub mod workload_onboarding_step {
     use super::*;
 
     /// Enum for possible onboarding steps.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Step(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Step {
+        /// Unspecified step.
+        Unspecified,
+        /// EKM Provisioned step.
+        EkmProvisioned,
+        /// Signed Access Approval step.
+        SignedAccessApprovalConfigured,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Step::value] or
+        /// [Step::name].
+        UnknownValue(step::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod step {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Step {
-        /// Unspecified step.
-        pub const STEP_UNSPECIFIED: Step = Step::new(0);
-
-        /// EKM Provisioned step.
-        pub const EKM_PROVISIONED: Step = Step::new(1);
-
-        /// Signed Access Approval step.
-        pub const SIGNED_ACCESS_APPROVAL_CONFIGURED: Step = Step::new(2);
-
-        /// Creates a new Step instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::EkmProvisioned => std::option::Option::Some(1),
+                Self::SignedAccessApprovalConfigured => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STEP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EKM_PROVISIONED"),
-                2 => std::borrow::Cow::Borrowed("SIGNED_ACCESS_APPROVAL_CONFIGURED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STEP_UNSPECIFIED" => std::option::Option::Some(Self::STEP_UNSPECIFIED),
-                "EKM_PROVISIONED" => std::option::Option::Some(Self::EKM_PROVISIONED),
-                "SIGNED_ACCESS_APPROVAL_CONFIGURED" => {
-                    std::option::Option::Some(Self::SIGNED_ACCESS_APPROVAL_CONFIGURED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STEP_UNSPECIFIED"),
+                Self::EkmProvisioned => std::option::Option::Some("EKM_PROVISIONED"),
+                Self::SignedAccessApprovalConfigured => {
+                    std::option::Option::Some("SIGNED_ACCESS_APPROVAL_CONFIGURED")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Step {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Step {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Step {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Step {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::EkmProvisioned,
+                2 => Self::SignedAccessApprovalConfigured,
+                _ => Self::UnknownValue(step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Step {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STEP_UNSPECIFIED" => Self::Unspecified,
+                "EKM_PROVISIONED" => Self::EkmProvisioned,
+                "SIGNED_ACCESS_APPROVAL_CONFIGURED" => Self::SignedAccessApprovalConfigured,
+                _ => Self::UnknownValue(step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Step {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::EkmProvisioned => serializer.serialize_i32(1),
+                Self::SignedAccessApprovalConfigured => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Step {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Step>::new(
+                ".google.cloud.cloudcontrolspartner.v1.WorkloadOnboardingStep.Step",
+            ))
         }
     }
 }
@@ -1474,59 +1671,120 @@ pub mod customer_onboarding_step {
     use super::*;
 
     /// Enum for possible onboarding steps
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Step(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Step {
+        /// Unspecified step
+        Unspecified,
+        /// KAJ Enrollment
+        KajEnrollment,
+        /// Customer Environment
+        CustomerEnvironment,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Step::value] or
+        /// [Step::name].
+        UnknownValue(step::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod step {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Step {
-        /// Unspecified step
-        pub const STEP_UNSPECIFIED: Step = Step::new(0);
-
-        /// KAJ Enrollment
-        pub const KAJ_ENROLLMENT: Step = Step::new(1);
-
-        /// Customer Environment
-        pub const CUSTOMER_ENVIRONMENT: Step = Step::new(2);
-
-        /// Creates a new Step instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::KajEnrollment => std::option::Option::Some(1),
+                Self::CustomerEnvironment => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STEP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KAJ_ENROLLMENT"),
-                2 => std::borrow::Cow::Borrowed("CUSTOMER_ENVIRONMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STEP_UNSPECIFIED"),
+                Self::KajEnrollment => std::option::Option::Some("KAJ_ENROLLMENT"),
+                Self::CustomerEnvironment => std::option::Option::Some("CUSTOMER_ENVIRONMENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STEP_UNSPECIFIED" => std::option::Option::Some(Self::STEP_UNSPECIFIED),
-                "KAJ_ENROLLMENT" => std::option::Option::Some(Self::KAJ_ENROLLMENT),
-                "CUSTOMER_ENVIRONMENT" => std::option::Option::Some(Self::CUSTOMER_ENVIRONMENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Step {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Step {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Step {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Step {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::KajEnrollment,
+                2 => Self::CustomerEnvironment,
+                _ => Self::UnknownValue(step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Step {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STEP_UNSPECIFIED" => Self::Unspecified,
+                "KAJ_ENROLLMENT" => Self::KajEnrollment,
+                "CUSTOMER_ENVIRONMENT" => Self::CustomerEnvironment,
+                _ => Self::UnknownValue(step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Step {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::KajEnrollment => serializer.serialize_i32(1),
+                Self::CustomerEnvironment => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Step {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Step>::new(
+                ".google.cloud.cloudcontrolspartner.v1.CustomerOnboardingStep.Step",
+            ))
         }
     }
 }
@@ -1729,71 +1987,134 @@ pub mod ekm_connection {
     }
 
     /// The EKM connection state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectionState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConnectionState {
+        /// Unspecified EKM connection state
+        Unspecified,
+        /// Available EKM connection state
+        Available,
+        /// Not available EKM connection state
+        NotAvailable,
+        /// Error EKM connection state
+        Error,
+        /// Permission denied EKM connection state
+        PermissionDenied,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConnectionState::value] or
+        /// [ConnectionState::name].
+        UnknownValue(connection_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod connection_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConnectionState {
-        /// Unspecified EKM connection state
-        pub const CONNECTION_STATE_UNSPECIFIED: ConnectionState = ConnectionState::new(0);
-
-        /// Available EKM connection state
-        pub const AVAILABLE: ConnectionState = ConnectionState::new(1);
-
-        /// Not available EKM connection state
-        pub const NOT_AVAILABLE: ConnectionState = ConnectionState::new(2);
-
-        /// Error EKM connection state
-        pub const ERROR: ConnectionState = ConnectionState::new(3);
-
-        /// Permission denied EKM connection state
-        pub const PERMISSION_DENIED: ConnectionState = ConnectionState::new(4);
-
-        /// Creates a new ConnectionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Available => std::option::Option::Some(1),
+                Self::NotAvailable => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::PermissionDenied => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONNECTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("NOT_AVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                4 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONNECTION_STATE_UNSPECIFIED"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::NotAvailable => std::option::Option::Some("NOT_AVAILABLE"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONNECTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONNECTION_STATE_UNSPECIFIED)
-                }
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "NOT_AVAILABLE" => std::option::Option::Some(Self::NOT_AVAILABLE),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConnectionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConnectionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConnectionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Available,
+                2 => Self::NotAvailable,
+                3 => Self::Error,
+                4 => Self::PermissionDenied,
+                _ => Self::UnknownValue(connection_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConnectionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONNECTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "AVAILABLE" => Self::Available,
+                "NOT_AVAILABLE" => Self::NotAvailable,
+                "ERROR" => Self::Error,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                _ => Self::UnknownValue(connection_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConnectionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Available => serializer.serialize_i32(1),
+                Self::NotAvailable => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::PermissionDenied => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConnectionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionState>::new(
+                ".google.cloud.cloudcontrolspartner.v1.EkmConnection.ConnectionState",
+            ))
         }
     }
 }
@@ -1851,84 +2172,157 @@ pub mod partner_permissions {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Permission(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Permission {
+        /// Unspecified partner permission
+        Unspecified,
+        /// Permission for Access Transparency and emergency logs
+        AccessTransparencyAndEmergencyAccessLogs,
+        /// Permission for Assured Workloads monitoring violations
+        AssuredWorkloadsMonitoring,
+        /// Permission for Access Approval requests
+        AccessApprovalRequests,
+        /// Permission for External Key Manager connection status
+        AssuredWorkloadsEkmConnectionStatus,
+        /// Permission for support case details for Access Transparency log entries
+        AccessTransparencyLogsSupportCaseViewer,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Permission::value] or
+        /// [Permission::name].
+        UnknownValue(permission::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod permission {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Permission {
-        /// Unspecified partner permission
-        pub const PERMISSION_UNSPECIFIED: Permission = Permission::new(0);
-
-        /// Permission for Access Transparency and emergency logs
-        pub const ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS: Permission = Permission::new(1);
-
-        /// Permission for Assured Workloads monitoring violations
-        pub const ASSURED_WORKLOADS_MONITORING: Permission = Permission::new(2);
-
-        /// Permission for Access Approval requests
-        pub const ACCESS_APPROVAL_REQUESTS: Permission = Permission::new(3);
-
-        /// Permission for External Key Manager connection status
-        pub const ASSURED_WORKLOADS_EKM_CONNECTION_STATUS: Permission = Permission::new(4);
-
-        /// Permission for support case details for Access Transparency log entries
-        pub const ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER: Permission = Permission::new(5);
-
-        /// Creates a new Permission instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AccessTransparencyAndEmergencyAccessLogs => std::option::Option::Some(1),
+                Self::AssuredWorkloadsMonitoring => std::option::Option::Some(2),
+                Self::AccessApprovalRequests => std::option::Option::Some(3),
+                Self::AssuredWorkloadsEkmConnectionStatus => std::option::Option::Some(4),
+                Self::AccessTransparencyLogsSupportCaseViewer => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERMISSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS"),
-                2 => std::borrow::Cow::Borrowed("ASSURED_WORKLOADS_MONITORING"),
-                3 => std::borrow::Cow::Borrowed("ACCESS_APPROVAL_REQUESTS"),
-                4 => std::borrow::Cow::Borrowed("ASSURED_WORKLOADS_EKM_CONNECTION_STATUS"),
-                5 => std::borrow::Cow::Borrowed("ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERMISSION_UNSPECIFIED"),
+                Self::AccessTransparencyAndEmergencyAccessLogs => {
+                    std::option::Option::Some("ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS")
+                }
+                Self::AssuredWorkloadsMonitoring => {
+                    std::option::Option::Some("ASSURED_WORKLOADS_MONITORING")
+                }
+                Self::AccessApprovalRequests => {
+                    std::option::Option::Some("ACCESS_APPROVAL_REQUESTS")
+                }
+                Self::AssuredWorkloadsEkmConnectionStatus => {
+                    std::option::Option::Some("ASSURED_WORKLOADS_EKM_CONNECTION_STATUS")
+                }
+                Self::AccessTransparencyLogsSupportCaseViewer => {
+                    std::option::Option::Some("ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERMISSION_UNSPECIFIED" => std::option::Option::Some(Self::PERMISSION_UNSPECIFIED),
-                "ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS" => {
-                    std::option::Option::Some(Self::ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS)
-                }
-                "ASSURED_WORKLOADS_MONITORING" => {
-                    std::option::Option::Some(Self::ASSURED_WORKLOADS_MONITORING)
-                }
-                "ACCESS_APPROVAL_REQUESTS" => {
-                    std::option::Option::Some(Self::ACCESS_APPROVAL_REQUESTS)
-                }
-                "ASSURED_WORKLOADS_EKM_CONNECTION_STATUS" => {
-                    std::option::Option::Some(Self::ASSURED_WORKLOADS_EKM_CONNECTION_STATUS)
-                }
-                "ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER" => {
-                    std::option::Option::Some(Self::ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Permission {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Permission {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Permission {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Permission {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AccessTransparencyAndEmergencyAccessLogs,
+                2 => Self::AssuredWorkloadsMonitoring,
+                3 => Self::AccessApprovalRequests,
+                4 => Self::AssuredWorkloadsEkmConnectionStatus,
+                5 => Self::AccessTransparencyLogsSupportCaseViewer,
+                _ => Self::UnknownValue(permission::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Permission {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERMISSION_UNSPECIFIED" => Self::Unspecified,
+                "ACCESS_TRANSPARENCY_AND_EMERGENCY_ACCESS_LOGS" => {
+                    Self::AccessTransparencyAndEmergencyAccessLogs
+                }
+                "ASSURED_WORKLOADS_MONITORING" => Self::AssuredWorkloadsMonitoring,
+                "ACCESS_APPROVAL_REQUESTS" => Self::AccessApprovalRequests,
+                "ASSURED_WORKLOADS_EKM_CONNECTION_STATUS" => {
+                    Self::AssuredWorkloadsEkmConnectionStatus
+                }
+                "ACCESS_TRANSPARENCY_LOGS_SUPPORT_CASE_VIEWER" => {
+                    Self::AccessTransparencyLogsSupportCaseViewer
+                }
+                _ => Self::UnknownValue(permission::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Permission {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AccessTransparencyAndEmergencyAccessLogs => serializer.serialize_i32(1),
+                Self::AssuredWorkloadsMonitoring => serializer.serialize_i32(2),
+                Self::AccessApprovalRequests => serializer.serialize_i32(3),
+                Self::AssuredWorkloadsEkmConnectionStatus => serializer.serialize_i32(4),
+                Self::AccessTransparencyLogsSupportCaseViewer => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Permission {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Permission>::new(
+                ".google.cloud.cloudcontrolspartner.v1.PartnerPermissions.Permission",
+            ))
         }
     }
 }
@@ -2222,71 +2616,134 @@ pub mod ekm_metadata {
     /// Represents Google Cloud supported external key management partners
     /// [Google Cloud EKM partners
     /// docs](https://cloud.google.com/kms/docs/ekm#supported_partners).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EkmSolution(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EkmSolution {
+        /// Unspecified EKM solution
+        Unspecified,
+        /// EKM Partner Fortanix
+        Fortanix,
+        /// EKM Partner FutureX
+        Futurex,
+        /// EKM Partner Thales
+        Thales,
+        /// EKM Partner Virtu
+        Virtru,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EkmSolution::value] or
+        /// [EkmSolution::name].
+        UnknownValue(ekm_solution::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ekm_solution {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EkmSolution {
-        /// Unspecified EKM solution
-        pub const EKM_SOLUTION_UNSPECIFIED: EkmSolution = EkmSolution::new(0);
-
-        /// EKM Partner Fortanix
-        pub const FORTANIX: EkmSolution = EkmSolution::new(1);
-
-        /// EKM Partner FutureX
-        pub const FUTUREX: EkmSolution = EkmSolution::new(2);
-
-        /// EKM Partner Thales
-        pub const THALES: EkmSolution = EkmSolution::new(3);
-
-        /// EKM Partner Virtu
-        pub const VIRTRU: EkmSolution = EkmSolution::new(4);
-
-        /// Creates a new EkmSolution instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Fortanix => std::option::Option::Some(1),
+                Self::Futurex => std::option::Option::Some(2),
+                Self::Thales => std::option::Option::Some(3),
+                Self::Virtru => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EKM_SOLUTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FORTANIX"),
-                2 => std::borrow::Cow::Borrowed("FUTUREX"),
-                3 => std::borrow::Cow::Borrowed("THALES"),
-                4 => std::borrow::Cow::Borrowed("VIRTRU"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EKM_SOLUTION_UNSPECIFIED"),
+                Self::Fortanix => std::option::Option::Some("FORTANIX"),
+                Self::Futurex => std::option::Option::Some("FUTUREX"),
+                Self::Thales => std::option::Option::Some("THALES"),
+                Self::Virtru => std::option::Option::Some("VIRTRU"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EKM_SOLUTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EKM_SOLUTION_UNSPECIFIED)
-                }
-                "FORTANIX" => std::option::Option::Some(Self::FORTANIX),
-                "FUTUREX" => std::option::Option::Some(Self::FUTUREX),
-                "THALES" => std::option::Option::Some(Self::THALES),
-                "VIRTRU" => std::option::Option::Some(Self::VIRTRU),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EkmSolution {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EkmSolution {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EkmSolution {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EkmSolution {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Fortanix,
+                2 => Self::Futurex,
+                3 => Self::Thales,
+                4 => Self::Virtru,
+                _ => Self::UnknownValue(ekm_solution::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EkmSolution {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EKM_SOLUTION_UNSPECIFIED" => Self::Unspecified,
+                "FORTANIX" => Self::Fortanix,
+                "FUTUREX" => Self::Futurex,
+                "THALES" => Self::Thales,
+                "VIRTRU" => Self::Virtru,
+                _ => Self::UnknownValue(ekm_solution::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EkmSolution {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Fortanix => serializer.serialize_i32(1),
+                Self::Futurex => serializer.serialize_i32(2),
+                Self::Thales => serializer.serialize_i32(3),
+                Self::Virtru => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EkmSolution {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EkmSolution>::new(
+                ".google.cloud.cloudcontrolspartner.v1.EkmMetadata.EkmSolution",
+            ))
         }
     }
 }
@@ -2729,149 +3186,308 @@ pub mod violation {
         /// violation. For example, violations caused due to changes in boolean org
         /// policy requires different remediation instructions compared to violation
         /// caused due to changes in allowed values of list org policy.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RemediationType(i32);
-
-        impl RemediationType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum RemediationType {
             /// Unspecified remediation type
-            pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType = RemediationType::new(0);
-
+            Unspecified,
             /// Remediation type for boolean org policy
-            pub const REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new(1);
-
+            RemediationBooleanOrgPolicyViolation,
             /// Remediation type for list org policy which have allowed values in the
             /// monitoring rule
-            pub const REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new(2);
-
+            RemediationListAllowedValuesOrgPolicyViolation,
             /// Remediation type for list org policy which have denied values in the
             /// monitoring rule
-            pub const REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION: RemediationType =
-                RemediationType::new(3);
-
+            RemediationListDeniedValuesOrgPolicyViolation,
             /// Remediation type for gcp.restrictCmekCryptoKeyProjects
-            pub const REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION:
-                RemediationType = RemediationType::new(4);
-
+            RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation,
             /// Remediation type for resource violation.
-            pub const REMEDIATION_RESOURCE_VIOLATION: RemediationType = RemediationType::new(5);
+            RemediationResourceViolation,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [RemediationType::value] or
+            /// [RemediationType::name].
+            UnknownValue(remediation_type::UnknownValue),
+        }
 
-            /// Creates a new RemediationType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod remediation_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl RemediationType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::RemediationBooleanOrgPolicyViolation => std::option::Option::Some(1),
+                    Self::RemediationListAllowedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(2)
+                    }
+                    Self::RemediationListDeniedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(3)
+                    }
+                    Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation => {
+                        std::option::Option::Some(4)
+                    }
+                    Self::RemediationResourceViolation => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("REMEDIATION_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION"),
-                    2 => std::borrow::Cow::Borrowed(
-                        "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION",
-                    ),
-                    3 => std::borrow::Cow::Borrowed(
-                        "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION",
-                    ),
-                    4 => std::borrow::Cow::Borrowed(
-                        "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
-                    ),
-                    5 => std::borrow::Cow::Borrowed("REMEDIATION_RESOURCE_VIOLATION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("REMEDIATION_TYPE_UNSPECIFIED"),
+                    Self::RemediationBooleanOrgPolicyViolation => {
+                        std::option::Option::Some("REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION")
+                    }
+                    Self::RemediationListAllowedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(
+                            "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION",
+                        )
+                    }
+                    Self::RemediationListDeniedValuesOrgPolicyViolation => {
+                        std::option::Option::Some(
+                            "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION",
+                        )
+                    }
+                    Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation => {
+                        std::option::Option::Some(
+                            "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION",
+                        )
+                    }
+                    Self::RemediationResourceViolation => {
+                        std::option::Option::Some("REMEDIATION_RESOURCE_VIOLATION")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "REMEDIATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REMEDIATION_TYPE_UNSPECIFIED),
-                    "REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION),
-                    "REMEDIATION_RESOURCE_VIOLATION" => std::option::Option::Some(Self::REMEDIATION_RESOURCE_VIOLATION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for RemediationType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for RemediationType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for RemediationType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for RemediationType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::RemediationBooleanOrgPolicyViolation,
+                    2 => Self::RemediationListAllowedValuesOrgPolicyViolation,
+                    3 => Self::RemediationListDeniedValuesOrgPolicyViolation,
+                    4 => Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation,
+                    5 => Self::RemediationResourceViolation,
+                    _ => Self::UnknownValue(remediation_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for RemediationType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "REMEDIATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "REMEDIATION_BOOLEAN_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationBooleanOrgPolicyViolation
+                    }
+                    "REMEDIATION_LIST_ALLOWED_VALUES_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationListAllowedValuesOrgPolicyViolation
+                    }
+                    "REMEDIATION_LIST_DENIED_VALUES_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationListDeniedValuesOrgPolicyViolation
+                    }
+                    "REMEDIATION_RESTRICT_CMEK_CRYPTO_KEY_PROJECTS_ORG_POLICY_VIOLATION" => {
+                        Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation
+                    }
+                    "REMEDIATION_RESOURCE_VIOLATION" => Self::RemediationResourceViolation,
+                    _ => Self::UnknownValue(remediation_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for RemediationType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::RemediationBooleanOrgPolicyViolation => serializer.serialize_i32(1),
+                    Self::RemediationListAllowedValuesOrgPolicyViolation => {
+                        serializer.serialize_i32(2)
+                    }
+                    Self::RemediationListDeniedValuesOrgPolicyViolation => {
+                        serializer.serialize_i32(3)
+                    }
+                    Self::RemediationRestrictCmekCryptoKeyProjectsOrgPolicyViolation => {
+                        serializer.serialize_i32(4)
+                    }
+                    Self::RemediationResourceViolation => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for RemediationType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<RemediationType>::new(
+                    ".google.cloud.cloudcontrolspartner.v1.Violation.Remediation.RemediationType",
+                ))
             }
         }
     }
 
     /// Violation State Values
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// Violation is resolved.
+        Resolved,
+        /// Violation is Unresolved
+        Unresolved,
+        /// Violation is Exception
+        Exception,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Violation is resolved.
-        pub const RESOLVED: State = State::new(1);
-
-        /// Violation is Unresolved
-        pub const UNRESOLVED: State = State::new(2);
-
-        /// Violation is Exception
-        pub const EXCEPTION: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Resolved => std::option::Option::Some(1),
+                Self::Unresolved => std::option::Option::Some(2),
+                Self::Exception => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESOLVED"),
-                2 => std::borrow::Cow::Borrowed("UNRESOLVED"),
-                3 => std::borrow::Cow::Borrowed("EXCEPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Resolved => std::option::Option::Some("RESOLVED"),
+                Self::Unresolved => std::option::Option::Some("UNRESOLVED"),
+                Self::Exception => std::option::Option::Some("EXCEPTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
-                "UNRESOLVED" => std::option::Option::Some(Self::UNRESOLVED),
-                "EXCEPTION" => std::option::Option::Some(Self::EXCEPTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Resolved,
+                2 => Self::Unresolved,
+                3 => Self::Exception,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RESOLVED" => Self::Resolved,
+                "UNRESOLVED" => Self::Unresolved,
+                "EXCEPTION" => Self::Exception,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Resolved => serializer.serialize_i32(1),
+                Self::Unresolved => serializer.serialize_i32(2),
+                Self::Exception => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.cloudcontrolspartner.v1.Violation.State",
+            ))
         }
     }
 }
@@ -3079,70 +3695,133 @@ impl wkt::message::Message for GetViolationRequest {
 }
 
 /// Enum for possible completion states.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CompletionState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CompletionState {
+    /// Unspecified completion state.
+    Unspecified,
+    /// Task started (has start date) but not yet completed.
+    Pending,
+    /// Succeeded state.
+    Succeeded,
+    /// Failed state.
+    Failed,
+    /// Not applicable state.
+    NotApplicable,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CompletionState::value] or
+    /// [CompletionState::name].
+    UnknownValue(completion_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod completion_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CompletionState {
-    /// Unspecified completion state.
-    pub const COMPLETION_STATE_UNSPECIFIED: CompletionState = CompletionState::new(0);
-
-    /// Task started (has start date) but not yet completed.
-    pub const PENDING: CompletionState = CompletionState::new(1);
-
-    /// Succeeded state.
-    pub const SUCCEEDED: CompletionState = CompletionState::new(2);
-
-    /// Failed state.
-    pub const FAILED: CompletionState = CompletionState::new(3);
-
-    /// Not applicable state.
-    pub const NOT_APPLICABLE: CompletionState = CompletionState::new(4);
-
-    /// Creates a new CompletionState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Pending => std::option::Option::Some(1),
+            Self::Succeeded => std::option::Option::Some(2),
+            Self::Failed => std::option::Option::Some(3),
+            Self::NotApplicable => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPLETION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PENDING"),
-            2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-            3 => std::borrow::Cow::Borrowed("FAILED"),
-            4 => std::borrow::Cow::Borrowed("NOT_APPLICABLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMPLETION_STATE_UNSPECIFIED"),
+            Self::Pending => std::option::Option::Some("PENDING"),
+            Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::NotApplicable => std::option::Option::Some("NOT_APPLICABLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPLETION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMPLETION_STATE_UNSPECIFIED)
-            }
-            "PENDING" => std::option::Option::Some(Self::PENDING),
-            "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            "NOT_APPLICABLE" => std::option::Option::Some(Self::NOT_APPLICABLE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CompletionState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CompletionState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CompletionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CompletionState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Pending,
+            2 => Self::Succeeded,
+            3 => Self::Failed,
+            4 => Self::NotApplicable,
+            _ => Self::UnknownValue(completion_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CompletionState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPLETION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "PENDING" => Self::Pending,
+            "SUCCEEDED" => Self::Succeeded,
+            "FAILED" => Self::Failed,
+            "NOT_APPLICABLE" => Self::NotApplicable,
+            _ => Self::UnknownValue(completion_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CompletionState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Pending => serializer.serialize_i32(1),
+            Self::Succeeded => serializer.serialize_i32(2),
+            Self::Failed => serializer.serialize_i32(3),
+            Self::NotApplicable => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CompletionState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompletionState>::new(
+            ".google.cloud.cloudcontrolspartner.v1.CompletionState",
+        ))
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -3165,66 +3165,127 @@ pub mod describe_database_entities_request {
     use super::*;
 
     /// The type of a tree to return
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DBTreeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DBTreeType {
+        /// Unspecified tree type.
+        Unspecified,
+        /// The source database tree.
+        SourceTree,
+        /// The draft database tree.
+        DraftTree,
+        /// The destination database tree.
+        DestinationTree,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DBTreeType::value] or
+        /// [DBTreeType::name].
+        UnknownValue(db_tree_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod db_tree_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DBTreeType {
-        /// Unspecified tree type.
-        pub const DB_TREE_TYPE_UNSPECIFIED: DBTreeType = DBTreeType::new(0);
-
-        /// The source database tree.
-        pub const SOURCE_TREE: DBTreeType = DBTreeType::new(1);
-
-        /// The draft database tree.
-        pub const DRAFT_TREE: DBTreeType = DBTreeType::new(2);
-
-        /// The destination database tree.
-        pub const DESTINATION_TREE: DBTreeType = DBTreeType::new(3);
-
-        /// Creates a new DBTreeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SourceTree => std::option::Option::Some(1),
+                Self::DraftTree => std::option::Option::Some(2),
+                Self::DestinationTree => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DB_TREE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SOURCE_TREE"),
-                2 => std::borrow::Cow::Borrowed("DRAFT_TREE"),
-                3 => std::borrow::Cow::Borrowed("DESTINATION_TREE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DB_TREE_TYPE_UNSPECIFIED"),
+                Self::SourceTree => std::option::Option::Some("SOURCE_TREE"),
+                Self::DraftTree => std::option::Option::Some("DRAFT_TREE"),
+                Self::DestinationTree => std::option::Option::Some("DESTINATION_TREE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DB_TREE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DB_TREE_TYPE_UNSPECIFIED)
-                }
-                "SOURCE_TREE" => std::option::Option::Some(Self::SOURCE_TREE),
-                "DRAFT_TREE" => std::option::Option::Some(Self::DRAFT_TREE),
-                "DESTINATION_TREE" => std::option::Option::Some(Self::DESTINATION_TREE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DBTreeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DBTreeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DBTreeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DBTreeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SourceTree,
+                2 => Self::DraftTree,
+                3 => Self::DestinationTree,
+                _ => Self::UnknownValue(db_tree_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DBTreeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DB_TREE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SOURCE_TREE" => Self::SourceTree,
+                "DRAFT_TREE" => Self::DraftTree,
+                "DESTINATION_TREE" => Self::DestinationTree,
+                _ => Self::UnknownValue(db_tree_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DBTreeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SourceTree => serializer.serialize_i32(1),
+                Self::DraftTree => serializer.serialize_i32(2),
+                Self::DestinationTree => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DBTreeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DBTreeType>::new(
+                ".google.cloud.clouddms.v1.DescribeDatabaseEntitiesRequest.DBTreeType",
+            ))
         }
     }
 }
@@ -3794,60 +3855,121 @@ pub mod ssl_config {
     use super::*;
 
     /// Specifies The kind of ssl configuration used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslType(i32);
-
-    impl SslType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SslType {
         /// Unspecified.
-        pub const SSL_TYPE_UNSPECIFIED: SslType = SslType::new(0);
-
+        Unspecified,
         /// Only 'ca_certificate' specified.
-        pub const SERVER_ONLY: SslType = SslType::new(1);
-
+        ServerOnly,
         /// Both server ('ca_certificate'), and client ('client_key',
         /// 'client_certificate') specified.
-        pub const SERVER_CLIENT: SslType = SslType::new(2);
+        ServerClient,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SslType::value] or
+        /// [SslType::name].
+        UnknownValue(ssl_type::UnknownValue),
+    }
 
-        /// Creates a new SslType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod ssl_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SslType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ServerOnly => std::option::Option::Some(1),
+                Self::ServerClient => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SSL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVER_ONLY"),
-                2 => std::borrow::Cow::Borrowed("SERVER_CLIENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SSL_TYPE_UNSPECIFIED"),
+                Self::ServerOnly => std::option::Option::Some("SERVER_ONLY"),
+                Self::ServerClient => std::option::Option::Some("SERVER_CLIENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SSL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_TYPE_UNSPECIFIED),
-                "SERVER_ONLY" => std::option::Option::Some(Self::SERVER_ONLY),
-                "SERVER_CLIENT" => std::option::Option::Some(Self::SERVER_CLIENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SslType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SslType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SslType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SslType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ServerOnly,
+                2 => Self::ServerClient,
+                _ => Self::UnknownValue(ssl_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SslType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SSL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SERVER_ONLY" => Self::ServerOnly,
+                "SERVER_CLIENT" => Self::ServerClient,
+                _ => Self::UnknownValue(ssl_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SslType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ServerOnly => serializer.serialize_i32(1),
+                Self::ServerClient => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SslType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SslType>::new(
+                ".google.cloud.clouddms.v1.SslConfig.SslType",
+            ))
         }
     }
 }
@@ -5076,338 +5198,649 @@ pub mod cloud_sql_settings {
     use super::*;
 
     /// Specifies when the instance should be activated.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlActivationPolicy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlActivationPolicy {
+        /// unspecified policy.
+        Unspecified,
+        /// The instance is always up and running.
+        Always,
+        /// The instance should never spin up.
+        Never,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlActivationPolicy::value] or
+        /// [SqlActivationPolicy::name].
+        UnknownValue(sql_activation_policy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sql_activation_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SqlActivationPolicy {
-        /// unspecified policy.
-        pub const SQL_ACTIVATION_POLICY_UNSPECIFIED: SqlActivationPolicy =
-            SqlActivationPolicy::new(0);
-
-        /// The instance is always up and running.
-        pub const ALWAYS: SqlActivationPolicy = SqlActivationPolicy::new(1);
-
-        /// The instance should never spin up.
-        pub const NEVER: SqlActivationPolicy = SqlActivationPolicy::new(2);
-
-        /// Creates a new SqlActivationPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Always => std::option::Option::Some(1),
+                Self::Never => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_ACTIVATION_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALWAYS"),
-                2 => std::borrow::Cow::Borrowed("NEVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_ACTIVATION_POLICY_UNSPECIFIED"),
+                Self::Always => std::option::Option::Some("ALWAYS"),
+                Self::Never => std::option::Option::Some("NEVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_ACTIVATION_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SQL_ACTIVATION_POLICY_UNSPECIFIED)
-                }
-                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
-                "NEVER" => std::option::Option::Some(Self::NEVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SqlActivationPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlActivationPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlActivationPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlActivationPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Always,
+                2 => Self::Never,
+                _ => Self::UnknownValue(sql_activation_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlActivationPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_ACTIVATION_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "ALWAYS" => Self::Always,
+                "NEVER" => Self::Never,
+                _ => Self::UnknownValue(sql_activation_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlActivationPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Always => serializer.serialize_i32(1),
+                Self::Never => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlActivationPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlActivationPolicy>::new(
+                ".google.cloud.clouddms.v1.CloudSqlSettings.SqlActivationPolicy",
+            ))
         }
     }
 
     /// The storage options for Cloud SQL databases.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlDataDiskType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlDataDiskType {
+        /// Unspecified.
+        Unspecified,
+        /// SSD disk.
+        PdSsd,
+        /// HDD disk.
+        PdHdd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlDataDiskType::value] or
+        /// [SqlDataDiskType::name].
+        UnknownValue(sql_data_disk_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sql_data_disk_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SqlDataDiskType {
-        /// Unspecified.
-        pub const SQL_DATA_DISK_TYPE_UNSPECIFIED: SqlDataDiskType = SqlDataDiskType::new(0);
-
-        /// SSD disk.
-        pub const PD_SSD: SqlDataDiskType = SqlDataDiskType::new(1);
-
-        /// HDD disk.
-        pub const PD_HDD: SqlDataDiskType = SqlDataDiskType::new(2);
-
-        /// Creates a new SqlDataDiskType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PdSsd => std::option::Option::Some(1),
+                Self::PdHdd => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_DATA_DISK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PD_SSD"),
-                2 => std::borrow::Cow::Borrowed("PD_HDD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_DATA_DISK_TYPE_UNSPECIFIED"),
+                Self::PdSsd => std::option::Option::Some("PD_SSD"),
+                Self::PdHdd => std::option::Option::Some("PD_HDD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_DATA_DISK_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SQL_DATA_DISK_TYPE_UNSPECIFIED)
-                }
-                "PD_SSD" => std::option::Option::Some(Self::PD_SSD),
-                "PD_HDD" => std::option::Option::Some(Self::PD_HDD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SqlDataDiskType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlDataDiskType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlDataDiskType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlDataDiskType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PdSsd,
+                2 => Self::PdHdd,
+                _ => Self::UnknownValue(sql_data_disk_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlDataDiskType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_DATA_DISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PD_SSD" => Self::PdSsd,
+                "PD_HDD" => Self::PdHdd,
+                _ => Self::UnknownValue(sql_data_disk_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlDataDiskType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PdSsd => serializer.serialize_i32(1),
+                Self::PdHdd => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlDataDiskType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlDataDiskType>::new(
+                ".google.cloud.clouddms.v1.CloudSqlSettings.SqlDataDiskType",
+            ))
         }
     }
 
     /// The database engine type and version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlDatabaseVersion(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlDatabaseVersion {
+        /// Unspecified version.
+        Unspecified,
+        /// MySQL 5.6.
+        Mysql56,
+        /// MySQL 5.7.
+        Mysql57,
+        /// PostgreSQL 9.6.
+        Postgres96,
+        /// PostgreSQL 11.
+        Postgres11,
+        /// PostgreSQL 10.
+        Postgres10,
+        /// MySQL 8.0.
+        Mysql80,
+        /// PostgreSQL 12.
+        Postgres12,
+        /// PostgreSQL 13.
+        Postgres13,
+        /// PostgreSQL 14.
+        Postgres14,
+        /// PostgreSQL 15.
+        Postgres15,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlDatabaseVersion::value] or
+        /// [SqlDatabaseVersion::name].
+        UnknownValue(sql_database_version::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sql_database_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SqlDatabaseVersion {
-        /// Unspecified version.
-        pub const SQL_DATABASE_VERSION_UNSPECIFIED: SqlDatabaseVersion = SqlDatabaseVersion::new(0);
-
-        /// MySQL 5.6.
-        pub const MYSQL_5_6: SqlDatabaseVersion = SqlDatabaseVersion::new(1);
-
-        /// MySQL 5.7.
-        pub const MYSQL_5_7: SqlDatabaseVersion = SqlDatabaseVersion::new(2);
-
-        /// PostgreSQL 9.6.
-        pub const POSTGRES_9_6: SqlDatabaseVersion = SqlDatabaseVersion::new(3);
-
-        /// PostgreSQL 11.
-        pub const POSTGRES_11: SqlDatabaseVersion = SqlDatabaseVersion::new(4);
-
-        /// PostgreSQL 10.
-        pub const POSTGRES_10: SqlDatabaseVersion = SqlDatabaseVersion::new(5);
-
-        /// MySQL 8.0.
-        pub const MYSQL_8_0: SqlDatabaseVersion = SqlDatabaseVersion::new(6);
-
-        /// PostgreSQL 12.
-        pub const POSTGRES_12: SqlDatabaseVersion = SqlDatabaseVersion::new(7);
-
-        /// PostgreSQL 13.
-        pub const POSTGRES_13: SqlDatabaseVersion = SqlDatabaseVersion::new(8);
-
-        /// PostgreSQL 14.
-        pub const POSTGRES_14: SqlDatabaseVersion = SqlDatabaseVersion::new(17);
-
-        /// PostgreSQL 15.
-        pub const POSTGRES_15: SqlDatabaseVersion = SqlDatabaseVersion::new(18);
-
-        /// Creates a new SqlDatabaseVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Mysql56 => std::option::Option::Some(1),
+                Self::Mysql57 => std::option::Option::Some(2),
+                Self::Postgres96 => std::option::Option::Some(3),
+                Self::Postgres11 => std::option::Option::Some(4),
+                Self::Postgres10 => std::option::Option::Some(5),
+                Self::Mysql80 => std::option::Option::Some(6),
+                Self::Postgres12 => std::option::Option::Some(7),
+                Self::Postgres13 => std::option::Option::Some(8),
+                Self::Postgres14 => std::option::Option::Some(17),
+                Self::Postgres15 => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_DATABASE_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MYSQL_5_6"),
-                2 => std::borrow::Cow::Borrowed("MYSQL_5_7"),
-                3 => std::borrow::Cow::Borrowed("POSTGRES_9_6"),
-                4 => std::borrow::Cow::Borrowed("POSTGRES_11"),
-                5 => std::borrow::Cow::Borrowed("POSTGRES_10"),
-                6 => std::borrow::Cow::Borrowed("MYSQL_8_0"),
-                7 => std::borrow::Cow::Borrowed("POSTGRES_12"),
-                8 => std::borrow::Cow::Borrowed("POSTGRES_13"),
-                17 => std::borrow::Cow::Borrowed("POSTGRES_14"),
-                18 => std::borrow::Cow::Borrowed("POSTGRES_15"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_DATABASE_VERSION_UNSPECIFIED"),
+                Self::Mysql56 => std::option::Option::Some("MYSQL_5_6"),
+                Self::Mysql57 => std::option::Option::Some("MYSQL_5_7"),
+                Self::Postgres96 => std::option::Option::Some("POSTGRES_9_6"),
+                Self::Postgres11 => std::option::Option::Some("POSTGRES_11"),
+                Self::Postgres10 => std::option::Option::Some("POSTGRES_10"),
+                Self::Mysql80 => std::option::Option::Some("MYSQL_8_0"),
+                Self::Postgres12 => std::option::Option::Some("POSTGRES_12"),
+                Self::Postgres13 => std::option::Option::Some("POSTGRES_13"),
+                Self::Postgres14 => std::option::Option::Some("POSTGRES_14"),
+                Self::Postgres15 => std::option::Option::Some("POSTGRES_15"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_DATABASE_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SQL_DATABASE_VERSION_UNSPECIFIED)
-                }
-                "MYSQL_5_6" => std::option::Option::Some(Self::MYSQL_5_6),
-                "MYSQL_5_7" => std::option::Option::Some(Self::MYSQL_5_7),
-                "POSTGRES_9_6" => std::option::Option::Some(Self::POSTGRES_9_6),
-                "POSTGRES_11" => std::option::Option::Some(Self::POSTGRES_11),
-                "POSTGRES_10" => std::option::Option::Some(Self::POSTGRES_10),
-                "MYSQL_8_0" => std::option::Option::Some(Self::MYSQL_8_0),
-                "POSTGRES_12" => std::option::Option::Some(Self::POSTGRES_12),
-                "POSTGRES_13" => std::option::Option::Some(Self::POSTGRES_13),
-                "POSTGRES_14" => std::option::Option::Some(Self::POSTGRES_14),
-                "POSTGRES_15" => std::option::Option::Some(Self::POSTGRES_15),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SqlDatabaseVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlDatabaseVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlDatabaseVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlDatabaseVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Mysql56,
+                2 => Self::Mysql57,
+                3 => Self::Postgres96,
+                4 => Self::Postgres11,
+                5 => Self::Postgres10,
+                6 => Self::Mysql80,
+                7 => Self::Postgres12,
+                8 => Self::Postgres13,
+                17 => Self::Postgres14,
+                18 => Self::Postgres15,
+                _ => Self::UnknownValue(sql_database_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlDatabaseVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_DATABASE_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "MYSQL_5_6" => Self::Mysql56,
+                "MYSQL_5_7" => Self::Mysql57,
+                "POSTGRES_9_6" => Self::Postgres96,
+                "POSTGRES_11" => Self::Postgres11,
+                "POSTGRES_10" => Self::Postgres10,
+                "MYSQL_8_0" => Self::Mysql80,
+                "POSTGRES_12" => Self::Postgres12,
+                "POSTGRES_13" => Self::Postgres13,
+                "POSTGRES_14" => Self::Postgres14,
+                "POSTGRES_15" => Self::Postgres15,
+                _ => Self::UnknownValue(sql_database_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlDatabaseVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Mysql56 => serializer.serialize_i32(1),
+                Self::Mysql57 => serializer.serialize_i32(2),
+                Self::Postgres96 => serializer.serialize_i32(3),
+                Self::Postgres11 => serializer.serialize_i32(4),
+                Self::Postgres10 => serializer.serialize_i32(5),
+                Self::Mysql80 => serializer.serialize_i32(6),
+                Self::Postgres12 => serializer.serialize_i32(7),
+                Self::Postgres13 => serializer.serialize_i32(8),
+                Self::Postgres14 => serializer.serialize_i32(17),
+                Self::Postgres15 => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlDatabaseVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlDatabaseVersion>::new(
+                ".google.cloud.clouddms.v1.CloudSqlSettings.SqlDatabaseVersion",
+            ))
         }
     }
 
     /// The availability type of the given Cloud SQL instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlAvailabilityType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlAvailabilityType {
+        /// This is an unknown Availability type.
+        Unspecified,
+        /// Zonal availablility instance.
+        Zonal,
+        /// Regional availability instance.
+        Regional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlAvailabilityType::value] or
+        /// [SqlAvailabilityType::name].
+        UnknownValue(sql_availability_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sql_availability_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SqlAvailabilityType {
-        /// This is an unknown Availability type.
-        pub const SQL_AVAILABILITY_TYPE_UNSPECIFIED: SqlAvailabilityType =
-            SqlAvailabilityType::new(0);
-
-        /// Zonal availablility instance.
-        pub const ZONAL: SqlAvailabilityType = SqlAvailabilityType::new(1);
-
-        /// Regional availability instance.
-        pub const REGIONAL: SqlAvailabilityType = SqlAvailabilityType::new(2);
-
-        /// Creates a new SqlAvailabilityType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Zonal => std::option::Option::Some(1),
+                Self::Regional => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_AVAILABILITY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ZONAL"),
-                2 => std::borrow::Cow::Borrowed("REGIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_AVAILABILITY_TYPE_UNSPECIFIED"),
+                Self::Zonal => std::option::Option::Some("ZONAL"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_AVAILABILITY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SQL_AVAILABILITY_TYPE_UNSPECIFIED)
-                }
-                "ZONAL" => std::option::Option::Some(Self::ZONAL),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SqlAvailabilityType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SqlAvailabilityType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlAvailabilityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlAvailabilityType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Zonal,
+                2 => Self::Regional,
+                _ => Self::UnknownValue(sql_availability_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlAvailabilityType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_AVAILABILITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ZONAL" => Self::Zonal,
+                "REGIONAL" => Self::Regional,
+                _ => Self::UnknownValue(sql_availability_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlAvailabilityType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Zonal => serializer.serialize_i32(1),
+                Self::Regional => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlAvailabilityType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlAvailabilityType>::new(
+                ".google.cloud.clouddms.v1.CloudSqlSettings.SqlAvailabilityType",
+            ))
         }
     }
 
     /// The edition of the given Cloud SQL instance.
     /// Can be ENTERPRISE or ENTERPRISE_PLUS.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Edition(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Edition {
+        /// The instance did not specify the edition.
+        Unspecified,
+        /// The instance is an enterprise edition.
+        Enterprise,
+        /// The instance is an enterprise plus edition.
+        EnterprisePlus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Edition::value] or
+        /// [Edition::name].
+        UnknownValue(edition::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod edition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Edition {
-        /// The instance did not specify the edition.
-        pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
-
-        /// The instance is an enterprise edition.
-        pub const ENTERPRISE: Edition = Edition::new(2);
-
-        /// The instance is an enterprise plus edition.
-        pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
-
-        /// Creates a new Edition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::EnterprisePlus => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EDITION_UNSPECIFIED"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::EnterprisePlus => std::option::Option::Some("ENTERPRISE_PLUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Edition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Edition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Edition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Edition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Enterprise,
+                3 => Self::EnterprisePlus,
+                _ => Self::UnknownValue(edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Edition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EDITION_UNSPECIFIED" => Self::Unspecified,
+                "ENTERPRISE" => Self::Enterprise,
+                "ENTERPRISE_PLUS" => Self::EnterprisePlus,
+                _ => Self::UnknownValue(edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Edition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::EnterprisePlus => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Edition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Edition>::new(
+                ".google.cloud.clouddms.v1.CloudSqlSettings.Edition",
+            ))
         }
     }
 }
@@ -6718,321 +7151,601 @@ pub mod migration_job {
         use super::*;
 
         /// Describes the parallelism level during initial dump.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DumpParallelLevel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DumpParallelLevel {
+            /// Unknown dump parallel level. Will be defaulted to OPTIMAL.
+            Unspecified,
+            /// Minimal parallel level.
+            Min,
+            /// Optimal parallel level.
+            Optimal,
+            /// Maximum parallel level.
+            Max,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DumpParallelLevel::value] or
+            /// [DumpParallelLevel::name].
+            UnknownValue(dump_parallel_level::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod dump_parallel_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl DumpParallelLevel {
-            /// Unknown dump parallel level. Will be defaulted to OPTIMAL.
-            pub const DUMP_PARALLEL_LEVEL_UNSPECIFIED: DumpParallelLevel =
-                DumpParallelLevel::new(0);
-
-            /// Minimal parallel level.
-            pub const MIN: DumpParallelLevel = DumpParallelLevel::new(1);
-
-            /// Optimal parallel level.
-            pub const OPTIMAL: DumpParallelLevel = DumpParallelLevel::new(2);
-
-            /// Maximum parallel level.
-            pub const MAX: DumpParallelLevel = DumpParallelLevel::new(3);
-
-            /// Creates a new DumpParallelLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Min => std::option::Option::Some(1),
+                    Self::Optimal => std::option::Option::Some(2),
+                    Self::Max => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DUMP_PARALLEL_LEVEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MIN"),
-                    2 => std::borrow::Cow::Borrowed("OPTIMAL"),
-                    3 => std::borrow::Cow::Borrowed("MAX"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DUMP_PARALLEL_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DUMP_PARALLEL_LEVEL_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("DUMP_PARALLEL_LEVEL_UNSPECIFIED")
                     }
-                    "MIN" => std::option::Option::Some(Self::MIN),
-                    "OPTIMAL" => std::option::Option::Some(Self::OPTIMAL),
-                    "MAX" => std::option::Option::Some(Self::MAX),
-                    _ => std::option::Option::None,
+                    Self::Min => std::option::Option::Some("MIN"),
+                    Self::Optimal => std::option::Option::Some("OPTIMAL"),
+                    Self::Max => std::option::Option::Some("MAX"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for DumpParallelLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for DumpParallelLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for DumpParallelLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for DumpParallelLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Min,
+                    2 => Self::Optimal,
+                    3 => Self::Max,
+                    _ => Self::UnknownValue(dump_parallel_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for DumpParallelLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DUMP_PARALLEL_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "MIN" => Self::Min,
+                    "OPTIMAL" => Self::Optimal,
+                    "MAX" => Self::Max,
+                    _ => Self::UnknownValue(dump_parallel_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for DumpParallelLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Min => serializer.serialize_i32(1),
+                    Self::Optimal => serializer.serialize_i32(2),
+                    Self::Max => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for DumpParallelLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DumpParallelLevel>::new(
+                    ".google.cloud.clouddms.v1.MigrationJob.PerformanceConfig.DumpParallelLevel",
+                ))
             }
         }
     }
 
     /// The current migration job states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the migration job is unknown.
+        Unspecified,
+        /// The migration job is down for maintenance.
+        Maintenance,
+        /// The migration job is in draft mode and no resources are created.
+        Draft,
+        /// The migration job is being created.
+        Creating,
+        /// The migration job is created and not started.
+        NotStarted,
+        /// The migration job is running.
+        Running,
+        /// The migration job failed.
+        Failed,
+        /// The migration job has been completed.
+        Completed,
+        /// The migration job is being deleted.
+        Deleting,
+        /// The migration job is being stopped.
+        Stopping,
+        /// The migration job is currently stopped.
+        Stopped,
+        /// The migration job has been deleted.
+        Deleted,
+        /// The migration job is being updated.
+        Updating,
+        /// The migration job is starting.
+        Starting,
+        /// The migration job is restarting.
+        Restarting,
+        /// The migration job is resuming.
+        Resuming,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the migration job is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The migration job is down for maintenance.
-        pub const MAINTENANCE: State = State::new(1);
-
-        /// The migration job is in draft mode and no resources are created.
-        pub const DRAFT: State = State::new(2);
-
-        /// The migration job is being created.
-        pub const CREATING: State = State::new(3);
-
-        /// The migration job is created and not started.
-        pub const NOT_STARTED: State = State::new(4);
-
-        /// The migration job is running.
-        pub const RUNNING: State = State::new(5);
-
-        /// The migration job failed.
-        pub const FAILED: State = State::new(6);
-
-        /// The migration job has been completed.
-        pub const COMPLETED: State = State::new(7);
-
-        /// The migration job is being deleted.
-        pub const DELETING: State = State::new(8);
-
-        /// The migration job is being stopped.
-        pub const STOPPING: State = State::new(9);
-
-        /// The migration job is currently stopped.
-        pub const STOPPED: State = State::new(10);
-
-        /// The migration job has been deleted.
-        pub const DELETED: State = State::new(11);
-
-        /// The migration job is being updated.
-        pub const UPDATING: State = State::new(12);
-
-        /// The migration job is starting.
-        pub const STARTING: State = State::new(13);
-
-        /// The migration job is restarting.
-        pub const RESTARTING: State = State::new(14);
-
-        /// The migration job is resuming.
-        pub const RESUMING: State = State::new(15);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Maintenance => std::option::Option::Some(1),
+                Self::Draft => std::option::Option::Some(2),
+                Self::Creating => std::option::Option::Some(3),
+                Self::NotStarted => std::option::Option::Some(4),
+                Self::Running => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Completed => std::option::Option::Some(7),
+                Self::Deleting => std::option::Option::Some(8),
+                Self::Stopping => std::option::Option::Some(9),
+                Self::Stopped => std::option::Option::Some(10),
+                Self::Deleted => std::option::Option::Some(11),
+                Self::Updating => std::option::Option::Some(12),
+                Self::Starting => std::option::Option::Some(13),
+                Self::Restarting => std::option::Option::Some(14),
+                Self::Resuming => std::option::Option::Some(15),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                2 => std::borrow::Cow::Borrowed("DRAFT"),
-                3 => std::borrow::Cow::Borrowed("CREATING"),
-                4 => std::borrow::Cow::Borrowed("NOT_STARTED"),
-                5 => std::borrow::Cow::Borrowed("RUNNING"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("COMPLETED"),
-                8 => std::borrow::Cow::Borrowed("DELETING"),
-                9 => std::borrow::Cow::Borrowed("STOPPING"),
-                10 => std::borrow::Cow::Borrowed("STOPPED"),
-                11 => std::borrow::Cow::Borrowed("DELETED"),
-                12 => std::borrow::Cow::Borrowed("UPDATING"),
-                13 => std::borrow::Cow::Borrowed("STARTING"),
-                14 => std::borrow::Cow::Borrowed("RESTARTING"),
-                15 => std::borrow::Cow::Borrowed("RESUMING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::NotStarted => std::option::Option::Some("NOT_STARTED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Restarting => std::option::Option::Some("RESTARTING"),
+                Self::Resuming => std::option::Option::Some("RESUMING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
-                "RESUMING" => std::option::Option::Some(Self::RESUMING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Maintenance,
+                2 => Self::Draft,
+                3 => Self::Creating,
+                4 => Self::NotStarted,
+                5 => Self::Running,
+                6 => Self::Failed,
+                7 => Self::Completed,
+                8 => Self::Deleting,
+                9 => Self::Stopping,
+                10 => Self::Stopped,
+                11 => Self::Deleted,
+                12 => Self::Updating,
+                13 => Self::Starting,
+                14 => Self::Restarting,
+                15 => Self::Resuming,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "MAINTENANCE" => Self::Maintenance,
+                "DRAFT" => Self::Draft,
+                "CREATING" => Self::Creating,
+                "NOT_STARTED" => Self::NotStarted,
+                "RUNNING" => Self::Running,
+                "FAILED" => Self::Failed,
+                "COMPLETED" => Self::Completed,
+                "DELETING" => Self::Deleting,
+                "STOPPING" => Self::Stopping,
+                "STOPPED" => Self::Stopped,
+                "DELETED" => Self::Deleted,
+                "UPDATING" => Self::Updating,
+                "STARTING" => Self::Starting,
+                "RESTARTING" => Self::Restarting,
+                "RESUMING" => Self::Resuming,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Maintenance => serializer.serialize_i32(1),
+                Self::Draft => serializer.serialize_i32(2),
+                Self::Creating => serializer.serialize_i32(3),
+                Self::NotStarted => serializer.serialize_i32(4),
+                Self::Running => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Completed => serializer.serialize_i32(7),
+                Self::Deleting => serializer.serialize_i32(8),
+                Self::Stopping => serializer.serialize_i32(9),
+                Self::Stopped => serializer.serialize_i32(10),
+                Self::Deleted => serializer.serialize_i32(11),
+                Self::Updating => serializer.serialize_i32(12),
+                Self::Starting => serializer.serialize_i32(13),
+                Self::Restarting => serializer.serialize_i32(14),
+                Self::Resuming => serializer.serialize_i32(15),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.clouddms.v1.MigrationJob.State",
+            ))
         }
     }
 
     /// The current migration job phase.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Phase(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Phase {
+        /// The phase of the migration job is unknown.
+        Unspecified,
+        /// The migration job is in the full dump phase.
+        FullDump,
+        /// The migration job is CDC phase.
+        Cdc,
+        /// The migration job is running the promote phase.
+        PromoteInProgress,
+        /// Only RDS flow - waiting for source writes to stop
+        WaitingForSourceWritesToStop,
+        /// Only RDS flow - the sources writes stopped, waiting for dump to begin
+        PreparingTheDump,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Phase::value] or
+        /// [Phase::name].
+        UnknownValue(phase::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod phase {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Phase {
-        /// The phase of the migration job is unknown.
-        pub const PHASE_UNSPECIFIED: Phase = Phase::new(0);
-
-        /// The migration job is in the full dump phase.
-        pub const FULL_DUMP: Phase = Phase::new(1);
-
-        /// The migration job is CDC phase.
-        pub const CDC: Phase = Phase::new(2);
-
-        /// The migration job is running the promote phase.
-        pub const PROMOTE_IN_PROGRESS: Phase = Phase::new(3);
-
-        /// Only RDS flow - waiting for source writes to stop
-        pub const WAITING_FOR_SOURCE_WRITES_TO_STOP: Phase = Phase::new(4);
-
-        /// Only RDS flow - the sources writes stopped, waiting for dump to begin
-        pub const PREPARING_THE_DUMP: Phase = Phase::new(5);
-
-        /// Creates a new Phase instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FullDump => std::option::Option::Some(1),
+                Self::Cdc => std::option::Option::Some(2),
+                Self::PromoteInProgress => std::option::Option::Some(3),
+                Self::WaitingForSourceWritesToStop => std::option::Option::Some(4),
+                Self::PreparingTheDump => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PHASE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FULL_DUMP"),
-                2 => std::borrow::Cow::Borrowed("CDC"),
-                3 => std::borrow::Cow::Borrowed("PROMOTE_IN_PROGRESS"),
-                4 => std::borrow::Cow::Borrowed("WAITING_FOR_SOURCE_WRITES_TO_STOP"),
-                5 => std::borrow::Cow::Borrowed("PREPARING_THE_DUMP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PHASE_UNSPECIFIED" => std::option::Option::Some(Self::PHASE_UNSPECIFIED),
-                "FULL_DUMP" => std::option::Option::Some(Self::FULL_DUMP),
-                "CDC" => std::option::Option::Some(Self::CDC),
-                "PROMOTE_IN_PROGRESS" => std::option::Option::Some(Self::PROMOTE_IN_PROGRESS),
-                "WAITING_FOR_SOURCE_WRITES_TO_STOP" => {
-                    std::option::Option::Some(Self::WAITING_FOR_SOURCE_WRITES_TO_STOP)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PHASE_UNSPECIFIED"),
+                Self::FullDump => std::option::Option::Some("FULL_DUMP"),
+                Self::Cdc => std::option::Option::Some("CDC"),
+                Self::PromoteInProgress => std::option::Option::Some("PROMOTE_IN_PROGRESS"),
+                Self::WaitingForSourceWritesToStop => {
+                    std::option::Option::Some("WAITING_FOR_SOURCE_WRITES_TO_STOP")
                 }
-                "PREPARING_THE_DUMP" => std::option::Option::Some(Self::PREPARING_THE_DUMP),
-                _ => std::option::Option::None,
+                Self::PreparingTheDump => std::option::Option::Some("PREPARING_THE_DUMP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Phase {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Phase {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Phase {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Phase {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FullDump,
+                2 => Self::Cdc,
+                3 => Self::PromoteInProgress,
+                4 => Self::WaitingForSourceWritesToStop,
+                5 => Self::PreparingTheDump,
+                _ => Self::UnknownValue(phase::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Phase {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PHASE_UNSPECIFIED" => Self::Unspecified,
+                "FULL_DUMP" => Self::FullDump,
+                "CDC" => Self::Cdc,
+                "PROMOTE_IN_PROGRESS" => Self::PromoteInProgress,
+                "WAITING_FOR_SOURCE_WRITES_TO_STOP" => Self::WaitingForSourceWritesToStop,
+                "PREPARING_THE_DUMP" => Self::PreparingTheDump,
+                _ => Self::UnknownValue(phase::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Phase {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FullDump => serializer.serialize_i32(1),
+                Self::Cdc => serializer.serialize_i32(2),
+                Self::PromoteInProgress => serializer.serialize_i32(3),
+                Self::WaitingForSourceWritesToStop => serializer.serialize_i32(4),
+                Self::PreparingTheDump => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Phase {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Phase>::new(
+                ".google.cloud.clouddms.v1.MigrationJob.Phase",
+            ))
         }
     }
 
     /// The type of migration job (one-time or continuous).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// The type of the migration job is unknown.
+        Unspecified,
+        /// The migration job is a one time migration.
+        OneTime,
+        /// The migration job is a continuous migration.
+        Continuous,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// The type of the migration job is unknown.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// The migration job is a one time migration.
-        pub const ONE_TIME: Type = Type::new(1);
-
-        /// The migration job is a continuous migration.
-        pub const CONTINUOUS: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OneTime => std::option::Option::Some(1),
+                Self::Continuous => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ONE_TIME"),
-                2 => std::borrow::Cow::Borrowed("CONTINUOUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::OneTime => std::option::Option::Some("ONE_TIME"),
+                Self::Continuous => std::option::Option::Some("CONTINUOUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "ONE_TIME" => std::option::Option::Some(Self::ONE_TIME),
-                "CONTINUOUS" => std::option::Option::Some(Self::CONTINUOUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OneTime,
+                2 => Self::Continuous,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ONE_TIME" => Self::OneTime,
+                "CONTINUOUS" => Self::Continuous,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OneTime => serializer.serialize_i32(1),
+                Self::Continuous => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.clouddms.v1.MigrationJob.Type",
+            ))
         }
     }
 
@@ -7410,84 +8123,155 @@ pub mod connection_profile {
     use super::*;
 
     /// The current connection profile state (e.g. DRAFT, READY, or FAILED).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the connection profile is unknown.
+        Unspecified,
+        /// The connection profile is in draft mode and fully editable.
+        Draft,
+        /// The connection profile is being created.
+        Creating,
+        /// The connection profile is ready.
+        Ready,
+        /// The connection profile is being updated.
+        Updating,
+        /// The connection profile is being deleted.
+        Deleting,
+        /// The connection profile has been deleted.
+        Deleted,
+        /// The last action on the connection profile failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the connection profile is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The connection profile is in draft mode and fully editable.
-        pub const DRAFT: State = State::new(1);
-
-        /// The connection profile is being created.
-        pub const CREATING: State = State::new(2);
-
-        /// The connection profile is ready.
-        pub const READY: State = State::new(3);
-
-        /// The connection profile is being updated.
-        pub const UPDATING: State = State::new(4);
-
-        /// The connection profile is being deleted.
-        pub const DELETING: State = State::new(5);
-
-        /// The connection profile has been deleted.
-        pub const DELETED: State = State::new(6);
-
-        /// The last action on the connection profile failed.
-        pub const FAILED: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Ready => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Deleted => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("READY"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("DELETED"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Creating,
+                3 => Self::Ready,
+                4 => Self::Updating,
+                5 => Self::Deleting,
+                6 => Self::Deleted,
+                7 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "DELETED" => Self::Deleted,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Ready => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Deleted => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.clouddms.v1.ConnectionProfile.State",
+            ))
         }
     }
 
@@ -7575,226 +8359,341 @@ pub mod migration_job_verification_error {
     use super::*;
 
     /// A general error code describing the type of error that occurred.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(i32);
-
-    impl ErrorCode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorCode {
         /// An unknown error occurred
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
-
+        Unspecified,
         /// We failed to connect to one of the connection profile.
-        pub const CONNECTION_FAILURE: ErrorCode = ErrorCode::new(1);
-
+        ConnectionFailure,
         /// We failed to authenticate to one of the connection profile.
-        pub const AUTHENTICATION_FAILURE: ErrorCode = ErrorCode::new(2);
-
+        AuthenticationFailure,
         /// One of the involved connection profiles has an invalid configuration.
-        pub const INVALID_CONNECTION_PROFILE_CONFIG: ErrorCode = ErrorCode::new(3);
-
+        InvalidConnectionProfileConfig,
         /// The versions of the source and the destination are incompatible.
-        pub const VERSION_INCOMPATIBILITY: ErrorCode = ErrorCode::new(4);
-
+        VersionIncompatibility,
         /// The types of the source and the destination are incompatible.
-        pub const CONNECTION_PROFILE_TYPES_INCOMPATIBILITY: ErrorCode = ErrorCode::new(5);
-
+        ConnectionProfileTypesIncompatibility,
         /// No pglogical extension installed on databases, applicable for postgres.
-        pub const NO_PGLOGICAL_INSTALLED: ErrorCode = ErrorCode::new(7);
-
+        NoPglogicalInstalled,
         /// pglogical node already exists on databases, applicable for postgres.
-        pub const PGLOGICAL_NODE_ALREADY_EXISTS: ErrorCode = ErrorCode::new(8);
-
+        PglogicalNodeAlreadyExists,
         /// The value of parameter wal_level is not set to logical.
-        pub const INVALID_WAL_LEVEL: ErrorCode = ErrorCode::new(9);
-
+        InvalidWalLevel,
         /// The value of parameter shared_preload_libraries does not include
         /// pglogical.
-        pub const INVALID_SHARED_PRELOAD_LIBRARY: ErrorCode = ErrorCode::new(10);
-
+        InvalidSharedPreloadLibrary,
         /// The value of parameter max_replication_slots is not sufficient.
-        pub const INSUFFICIENT_MAX_REPLICATION_SLOTS: ErrorCode = ErrorCode::new(11);
-
+        InsufficientMaxReplicationSlots,
         /// The value of parameter max_wal_senders is not sufficient.
-        pub const INSUFFICIENT_MAX_WAL_SENDERS: ErrorCode = ErrorCode::new(12);
-
+        InsufficientMaxWalSenders,
         /// The value of parameter max_worker_processes is not sufficient.
-        pub const INSUFFICIENT_MAX_WORKER_PROCESSES: ErrorCode = ErrorCode::new(13);
-
+        InsufficientMaxWorkerProcesses,
         /// Extensions installed are either not supported or having unsupported
         /// versions.
-        pub const UNSUPPORTED_EXTENSIONS: ErrorCode = ErrorCode::new(14);
-
+        UnsupportedExtensions,
         /// Unsupported migration type.
-        pub const UNSUPPORTED_MIGRATION_TYPE: ErrorCode = ErrorCode::new(15);
-
+        UnsupportedMigrationType,
         /// Invalid RDS logical replication.
-        pub const INVALID_RDS_LOGICAL_REPLICATION: ErrorCode = ErrorCode::new(16);
-
+        InvalidRdsLogicalReplication,
         /// The gtid_mode is not supported, applicable for MySQL.
-        pub const UNSUPPORTED_GTID_MODE: ErrorCode = ErrorCode::new(17);
-
+        UnsupportedGtidMode,
         /// The table definition is not support due to missing primary key or replica
         /// identity.
-        pub const UNSUPPORTED_TABLE_DEFINITION: ErrorCode = ErrorCode::new(18);
-
+        UnsupportedTableDefinition,
         /// The definer is not supported.
-        pub const UNSUPPORTED_DEFINER: ErrorCode = ErrorCode::new(19);
-
+        UnsupportedDefiner,
         /// Migration is already running at the time of restart request.
-        pub const CANT_RESTART_RUNNING_MIGRATION: ErrorCode = ErrorCode::new(21);
-
+        CantRestartRunningMigration,
         /// The source already has a replication setup.
-        pub const SOURCE_ALREADY_SETUP: ErrorCode = ErrorCode::new(23);
-
+        SourceAlreadySetup,
         /// The source has tables with limited support.
         /// E.g. PostgreSQL tables without primary keys.
-        pub const TABLES_WITH_LIMITED_SUPPORT: ErrorCode = ErrorCode::new(24);
-
+        TablesWithLimitedSupport,
         /// The source uses an unsupported locale.
-        pub const UNSUPPORTED_DATABASE_LOCALE: ErrorCode = ErrorCode::new(25);
-
+        UnsupportedDatabaseLocale,
         /// The source uses an unsupported Foreign Data Wrapper configuration.
-        pub const UNSUPPORTED_DATABASE_FDW_CONFIG: ErrorCode = ErrorCode::new(26);
-
+        UnsupportedDatabaseFdwConfig,
         /// There was an underlying RDBMS error.
-        pub const ERROR_RDBMS: ErrorCode = ErrorCode::new(27);
-
+        ErrorRdbms,
         /// The source DB size in Bytes exceeds a certain threshold. The migration
         /// might require an increase of quota, or might not be supported.
-        pub const SOURCE_SIZE_EXCEEDS_THRESHOLD: ErrorCode = ErrorCode::new(28);
-
+        SourceSizeExceedsThreshold,
         /// The destination DB contains existing databases that are conflicting with
         /// those in the source DB.
-        pub const EXISTING_CONFLICTING_DATABASES: ErrorCode = ErrorCode::new(29);
-
+        ExistingConflictingDatabases,
         /// Insufficient privilege to enable the parallelism configuration.
-        pub const PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE: ErrorCode = ErrorCode::new(30);
+        ParallelImportInsufficientPrivilege,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorCode::value] or
+        /// [ErrorCode::name].
+        UnknownValue(error_code::UnknownValue),
+    }
 
-        /// Creates a new ErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ErrorCode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConnectionFailure => std::option::Option::Some(1),
+                Self::AuthenticationFailure => std::option::Option::Some(2),
+                Self::InvalidConnectionProfileConfig => std::option::Option::Some(3),
+                Self::VersionIncompatibility => std::option::Option::Some(4),
+                Self::ConnectionProfileTypesIncompatibility => std::option::Option::Some(5),
+                Self::NoPglogicalInstalled => std::option::Option::Some(7),
+                Self::PglogicalNodeAlreadyExists => std::option::Option::Some(8),
+                Self::InvalidWalLevel => std::option::Option::Some(9),
+                Self::InvalidSharedPreloadLibrary => std::option::Option::Some(10),
+                Self::InsufficientMaxReplicationSlots => std::option::Option::Some(11),
+                Self::InsufficientMaxWalSenders => std::option::Option::Some(12),
+                Self::InsufficientMaxWorkerProcesses => std::option::Option::Some(13),
+                Self::UnsupportedExtensions => std::option::Option::Some(14),
+                Self::UnsupportedMigrationType => std::option::Option::Some(15),
+                Self::InvalidRdsLogicalReplication => std::option::Option::Some(16),
+                Self::UnsupportedGtidMode => std::option::Option::Some(17),
+                Self::UnsupportedTableDefinition => std::option::Option::Some(18),
+                Self::UnsupportedDefiner => std::option::Option::Some(19),
+                Self::CantRestartRunningMigration => std::option::Option::Some(21),
+                Self::SourceAlreadySetup => std::option::Option::Some(23),
+                Self::TablesWithLimitedSupport => std::option::Option::Some(24),
+                Self::UnsupportedDatabaseLocale => std::option::Option::Some(25),
+                Self::UnsupportedDatabaseFdwConfig => std::option::Option::Some(26),
+                Self::ErrorRdbms => std::option::Option::Some(27),
+                Self::SourceSizeExceedsThreshold => std::option::Option::Some(28),
+                Self::ExistingConflictingDatabases => std::option::Option::Some(29),
+                Self::ParallelImportInsufficientPrivilege => std::option::Option::Some(30),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONNECTION_FAILURE"),
-                2 => std::borrow::Cow::Borrowed("AUTHENTICATION_FAILURE"),
-                3 => std::borrow::Cow::Borrowed("INVALID_CONNECTION_PROFILE_CONFIG"),
-                4 => std::borrow::Cow::Borrowed("VERSION_INCOMPATIBILITY"),
-                5 => std::borrow::Cow::Borrowed("CONNECTION_PROFILE_TYPES_INCOMPATIBILITY"),
-                7 => std::borrow::Cow::Borrowed("NO_PGLOGICAL_INSTALLED"),
-                8 => std::borrow::Cow::Borrowed("PGLOGICAL_NODE_ALREADY_EXISTS"),
-                9 => std::borrow::Cow::Borrowed("INVALID_WAL_LEVEL"),
-                10 => std::borrow::Cow::Borrowed("INVALID_SHARED_PRELOAD_LIBRARY"),
-                11 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_REPLICATION_SLOTS"),
-                12 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WAL_SENDERS"),
-                13 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WORKER_PROCESSES"),
-                14 => std::borrow::Cow::Borrowed("UNSUPPORTED_EXTENSIONS"),
-                15 => std::borrow::Cow::Borrowed("UNSUPPORTED_MIGRATION_TYPE"),
-                16 => std::borrow::Cow::Borrowed("INVALID_RDS_LOGICAL_REPLICATION"),
-                17 => std::borrow::Cow::Borrowed("UNSUPPORTED_GTID_MODE"),
-                18 => std::borrow::Cow::Borrowed("UNSUPPORTED_TABLE_DEFINITION"),
-                19 => std::borrow::Cow::Borrowed("UNSUPPORTED_DEFINER"),
-                21 => std::borrow::Cow::Borrowed("CANT_RESTART_RUNNING_MIGRATION"),
-                23 => std::borrow::Cow::Borrowed("SOURCE_ALREADY_SETUP"),
-                24 => std::borrow::Cow::Borrowed("TABLES_WITH_LIMITED_SUPPORT"),
-                25 => std::borrow::Cow::Borrowed("UNSUPPORTED_DATABASE_LOCALE"),
-                26 => std::borrow::Cow::Borrowed("UNSUPPORTED_DATABASE_FDW_CONFIG"),
-                27 => std::borrow::Cow::Borrowed("ERROR_RDBMS"),
-                28 => std::borrow::Cow::Borrowed("SOURCE_SIZE_EXCEEDS_THRESHOLD"),
-                29 => std::borrow::Cow::Borrowed("EXISTING_CONFLICTING_DATABASES"),
-                30 => std::borrow::Cow::Borrowed("PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::ConnectionFailure => std::option::Option::Some("CONNECTION_FAILURE"),
+                Self::AuthenticationFailure => std::option::Option::Some("AUTHENTICATION_FAILURE"),
+                Self::InvalidConnectionProfileConfig => {
+                    std::option::Option::Some("INVALID_CONNECTION_PROFILE_CONFIG")
+                }
+                Self::VersionIncompatibility => {
+                    std::option::Option::Some("VERSION_INCOMPATIBILITY")
+                }
+                Self::ConnectionProfileTypesIncompatibility => {
+                    std::option::Option::Some("CONNECTION_PROFILE_TYPES_INCOMPATIBILITY")
+                }
+                Self::NoPglogicalInstalled => std::option::Option::Some("NO_PGLOGICAL_INSTALLED"),
+                Self::PglogicalNodeAlreadyExists => {
+                    std::option::Option::Some("PGLOGICAL_NODE_ALREADY_EXISTS")
+                }
+                Self::InvalidWalLevel => std::option::Option::Some("INVALID_WAL_LEVEL"),
+                Self::InvalidSharedPreloadLibrary => {
+                    std::option::Option::Some("INVALID_SHARED_PRELOAD_LIBRARY")
+                }
+                Self::InsufficientMaxReplicationSlots => {
+                    std::option::Option::Some("INSUFFICIENT_MAX_REPLICATION_SLOTS")
+                }
+                Self::InsufficientMaxWalSenders => {
+                    std::option::Option::Some("INSUFFICIENT_MAX_WAL_SENDERS")
+                }
+                Self::InsufficientMaxWorkerProcesses => {
+                    std::option::Option::Some("INSUFFICIENT_MAX_WORKER_PROCESSES")
+                }
+                Self::UnsupportedExtensions => std::option::Option::Some("UNSUPPORTED_EXTENSIONS"),
+                Self::UnsupportedMigrationType => {
+                    std::option::Option::Some("UNSUPPORTED_MIGRATION_TYPE")
+                }
+                Self::InvalidRdsLogicalReplication => {
+                    std::option::Option::Some("INVALID_RDS_LOGICAL_REPLICATION")
+                }
+                Self::UnsupportedGtidMode => std::option::Option::Some("UNSUPPORTED_GTID_MODE"),
+                Self::UnsupportedTableDefinition => {
+                    std::option::Option::Some("UNSUPPORTED_TABLE_DEFINITION")
+                }
+                Self::UnsupportedDefiner => std::option::Option::Some("UNSUPPORTED_DEFINER"),
+                Self::CantRestartRunningMigration => {
+                    std::option::Option::Some("CANT_RESTART_RUNNING_MIGRATION")
+                }
+                Self::SourceAlreadySetup => std::option::Option::Some("SOURCE_ALREADY_SETUP"),
+                Self::TablesWithLimitedSupport => {
+                    std::option::Option::Some("TABLES_WITH_LIMITED_SUPPORT")
+                }
+                Self::UnsupportedDatabaseLocale => {
+                    std::option::Option::Some("UNSUPPORTED_DATABASE_LOCALE")
+                }
+                Self::UnsupportedDatabaseFdwConfig => {
+                    std::option::Option::Some("UNSUPPORTED_DATABASE_FDW_CONFIG")
+                }
+                Self::ErrorRdbms => std::option::Option::Some("ERROR_RDBMS"),
+                Self::SourceSizeExceedsThreshold => {
+                    std::option::Option::Some("SOURCE_SIZE_EXCEEDS_THRESHOLD")
+                }
+                Self::ExistingConflictingDatabases => {
+                    std::option::Option::Some("EXISTING_CONFLICTING_DATABASES")
+                }
+                Self::ParallelImportInsufficientPrivilege => {
+                    std::option::Option::Some("PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "CONNECTION_FAILURE" => std::option::Option::Some(Self::CONNECTION_FAILURE),
-                "AUTHENTICATION_FAILURE" => std::option::Option::Some(Self::AUTHENTICATION_FAILURE),
-                "INVALID_CONNECTION_PROFILE_CONFIG" => {
-                    std::option::Option::Some(Self::INVALID_CONNECTION_PROFILE_CONFIG)
-                }
-                "VERSION_INCOMPATIBILITY" => {
-                    std::option::Option::Some(Self::VERSION_INCOMPATIBILITY)
-                }
-                "CONNECTION_PROFILE_TYPES_INCOMPATIBILITY" => {
-                    std::option::Option::Some(Self::CONNECTION_PROFILE_TYPES_INCOMPATIBILITY)
-                }
-                "NO_PGLOGICAL_INSTALLED" => std::option::Option::Some(Self::NO_PGLOGICAL_INSTALLED),
-                "PGLOGICAL_NODE_ALREADY_EXISTS" => {
-                    std::option::Option::Some(Self::PGLOGICAL_NODE_ALREADY_EXISTS)
-                }
-                "INVALID_WAL_LEVEL" => std::option::Option::Some(Self::INVALID_WAL_LEVEL),
-                "INVALID_SHARED_PRELOAD_LIBRARY" => {
-                    std::option::Option::Some(Self::INVALID_SHARED_PRELOAD_LIBRARY)
-                }
-                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => {
-                    std::option::Option::Some(Self::INSUFFICIENT_MAX_REPLICATION_SLOTS)
-                }
-                "INSUFFICIENT_MAX_WAL_SENDERS" => {
-                    std::option::Option::Some(Self::INSUFFICIENT_MAX_WAL_SENDERS)
-                }
-                "INSUFFICIENT_MAX_WORKER_PROCESSES" => {
-                    std::option::Option::Some(Self::INSUFFICIENT_MAX_WORKER_PROCESSES)
-                }
-                "UNSUPPORTED_EXTENSIONS" => std::option::Option::Some(Self::UNSUPPORTED_EXTENSIONS),
-                "UNSUPPORTED_MIGRATION_TYPE" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_MIGRATION_TYPE)
-                }
-                "INVALID_RDS_LOGICAL_REPLICATION" => {
-                    std::option::Option::Some(Self::INVALID_RDS_LOGICAL_REPLICATION)
-                }
-                "UNSUPPORTED_GTID_MODE" => std::option::Option::Some(Self::UNSUPPORTED_GTID_MODE),
-                "UNSUPPORTED_TABLE_DEFINITION" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_TABLE_DEFINITION)
-                }
-                "UNSUPPORTED_DEFINER" => std::option::Option::Some(Self::UNSUPPORTED_DEFINER),
-                "CANT_RESTART_RUNNING_MIGRATION" => {
-                    std::option::Option::Some(Self::CANT_RESTART_RUNNING_MIGRATION)
-                }
-                "SOURCE_ALREADY_SETUP" => std::option::Option::Some(Self::SOURCE_ALREADY_SETUP),
-                "TABLES_WITH_LIMITED_SUPPORT" => {
-                    std::option::Option::Some(Self::TABLES_WITH_LIMITED_SUPPORT)
-                }
-                "UNSUPPORTED_DATABASE_LOCALE" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_DATABASE_LOCALE)
-                }
-                "UNSUPPORTED_DATABASE_FDW_CONFIG" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_DATABASE_FDW_CONFIG)
-                }
-                "ERROR_RDBMS" => std::option::Option::Some(Self::ERROR_RDBMS),
-                "SOURCE_SIZE_EXCEEDS_THRESHOLD" => {
-                    std::option::Option::Some(Self::SOURCE_SIZE_EXCEEDS_THRESHOLD)
-                }
-                "EXISTING_CONFLICTING_DATABASES" => {
-                    std::option::Option::Some(Self::EXISTING_CONFLICTING_DATABASES)
-                }
-                "PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => {
-                    std::option::Option::Some(Self::PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConnectionFailure,
+                2 => Self::AuthenticationFailure,
+                3 => Self::InvalidConnectionProfileConfig,
+                4 => Self::VersionIncompatibility,
+                5 => Self::ConnectionProfileTypesIncompatibility,
+                7 => Self::NoPglogicalInstalled,
+                8 => Self::PglogicalNodeAlreadyExists,
+                9 => Self::InvalidWalLevel,
+                10 => Self::InvalidSharedPreloadLibrary,
+                11 => Self::InsufficientMaxReplicationSlots,
+                12 => Self::InsufficientMaxWalSenders,
+                13 => Self::InsufficientMaxWorkerProcesses,
+                14 => Self::UnsupportedExtensions,
+                15 => Self::UnsupportedMigrationType,
+                16 => Self::InvalidRdsLogicalReplication,
+                17 => Self::UnsupportedGtidMode,
+                18 => Self::UnsupportedTableDefinition,
+                19 => Self::UnsupportedDefiner,
+                21 => Self::CantRestartRunningMigration,
+                23 => Self::SourceAlreadySetup,
+                24 => Self::TablesWithLimitedSupport,
+                25 => Self::UnsupportedDatabaseLocale,
+                26 => Self::UnsupportedDatabaseFdwConfig,
+                27 => Self::ErrorRdbms,
+                28 => Self::SourceSizeExceedsThreshold,
+                29 => Self::ExistingConflictingDatabases,
+                30 => Self::ParallelImportInsufficientPrivilege,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "CONNECTION_FAILURE" => Self::ConnectionFailure,
+                "AUTHENTICATION_FAILURE" => Self::AuthenticationFailure,
+                "INVALID_CONNECTION_PROFILE_CONFIG" => Self::InvalidConnectionProfileConfig,
+                "VERSION_INCOMPATIBILITY" => Self::VersionIncompatibility,
+                "CONNECTION_PROFILE_TYPES_INCOMPATIBILITY" => {
+                    Self::ConnectionProfileTypesIncompatibility
+                }
+                "NO_PGLOGICAL_INSTALLED" => Self::NoPglogicalInstalled,
+                "PGLOGICAL_NODE_ALREADY_EXISTS" => Self::PglogicalNodeAlreadyExists,
+                "INVALID_WAL_LEVEL" => Self::InvalidWalLevel,
+                "INVALID_SHARED_PRELOAD_LIBRARY" => Self::InvalidSharedPreloadLibrary,
+                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => Self::InsufficientMaxReplicationSlots,
+                "INSUFFICIENT_MAX_WAL_SENDERS" => Self::InsufficientMaxWalSenders,
+                "INSUFFICIENT_MAX_WORKER_PROCESSES" => Self::InsufficientMaxWorkerProcesses,
+                "UNSUPPORTED_EXTENSIONS" => Self::UnsupportedExtensions,
+                "UNSUPPORTED_MIGRATION_TYPE" => Self::UnsupportedMigrationType,
+                "INVALID_RDS_LOGICAL_REPLICATION" => Self::InvalidRdsLogicalReplication,
+                "UNSUPPORTED_GTID_MODE" => Self::UnsupportedGtidMode,
+                "UNSUPPORTED_TABLE_DEFINITION" => Self::UnsupportedTableDefinition,
+                "UNSUPPORTED_DEFINER" => Self::UnsupportedDefiner,
+                "CANT_RESTART_RUNNING_MIGRATION" => Self::CantRestartRunningMigration,
+                "SOURCE_ALREADY_SETUP" => Self::SourceAlreadySetup,
+                "TABLES_WITH_LIMITED_SUPPORT" => Self::TablesWithLimitedSupport,
+                "UNSUPPORTED_DATABASE_LOCALE" => Self::UnsupportedDatabaseLocale,
+                "UNSUPPORTED_DATABASE_FDW_CONFIG" => Self::UnsupportedDatabaseFdwConfig,
+                "ERROR_RDBMS" => Self::ErrorRdbms,
+                "SOURCE_SIZE_EXCEEDS_THRESHOLD" => Self::SourceSizeExceedsThreshold,
+                "EXISTING_CONFLICTING_DATABASES" => Self::ExistingConflictingDatabases,
+                "PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => {
+                    Self::ParallelImportInsufficientPrivilege
+                }
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConnectionFailure => serializer.serialize_i32(1),
+                Self::AuthenticationFailure => serializer.serialize_i32(2),
+                Self::InvalidConnectionProfileConfig => serializer.serialize_i32(3),
+                Self::VersionIncompatibility => serializer.serialize_i32(4),
+                Self::ConnectionProfileTypesIncompatibility => serializer.serialize_i32(5),
+                Self::NoPglogicalInstalled => serializer.serialize_i32(7),
+                Self::PglogicalNodeAlreadyExists => serializer.serialize_i32(8),
+                Self::InvalidWalLevel => serializer.serialize_i32(9),
+                Self::InvalidSharedPreloadLibrary => serializer.serialize_i32(10),
+                Self::InsufficientMaxReplicationSlots => serializer.serialize_i32(11),
+                Self::InsufficientMaxWalSenders => serializer.serialize_i32(12),
+                Self::InsufficientMaxWorkerProcesses => serializer.serialize_i32(13),
+                Self::UnsupportedExtensions => serializer.serialize_i32(14),
+                Self::UnsupportedMigrationType => serializer.serialize_i32(15),
+                Self::InvalidRdsLogicalReplication => serializer.serialize_i32(16),
+                Self::UnsupportedGtidMode => serializer.serialize_i32(17),
+                Self::UnsupportedTableDefinition => serializer.serialize_i32(18),
+                Self::UnsupportedDefiner => serializer.serialize_i32(19),
+                Self::CantRestartRunningMigration => serializer.serialize_i32(21),
+                Self::SourceAlreadySetup => serializer.serialize_i32(23),
+                Self::TablesWithLimitedSupport => serializer.serialize_i32(24),
+                Self::UnsupportedDatabaseLocale => serializer.serialize_i32(25),
+                Self::UnsupportedDatabaseFdwConfig => serializer.serialize_i32(26),
+                Self::ErrorRdbms => serializer.serialize_i32(27),
+                Self::SourceSizeExceedsThreshold => serializer.serialize_i32(28),
+                Self::ExistingConflictingDatabases => serializer.serialize_i32(29),
+                Self::ParallelImportInsufficientPrivilege => serializer.serialize_i32(30),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                ".google.cloud.clouddms.v1.MigrationJobVerificationError.ErrorCode",
+            ))
         }
     }
 }
@@ -7968,78 +8867,147 @@ pub mod private_connection {
     use super::*;
 
     /// Private Connection state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        Unspecified,
+        /// The private connection is in creation state - creating resources.
+        Creating,
+        /// The private connection has been created with all of its resources.
+        Created,
+        /// The private connection creation has failed.
+        Failed,
+        /// The private connection is being deleted.
+        Deleting,
+        /// Delete request has failed, resource is in invalid state.
+        FailedToDelete,
+        /// The private connection has been deleted.
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The private connection is in creation state - creating resources.
-        pub const CREATING: State = State::new(1);
-
-        /// The private connection has been created with all of its resources.
-        pub const CREATED: State = State::new(2);
-
-        /// The private connection creation has failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The private connection is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Delete request has failed, resource is in invalid state.
-        pub const FAILED_TO_DELETE: State = State::new(5);
-
-        /// The private connection has been deleted.
-        pub const DELETED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Created => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::FailedToDelete => std::option::Option::Some(5),
+                Self::Deleted => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("CREATED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("FAILED_TO_DELETE"),
-                6 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::FailedToDelete => std::option::Option::Some("FAILED_TO_DELETE"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED_TO_DELETE" => std::option::Option::Some(Self::FAILED_TO_DELETE),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Created,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                5 => Self::FailedToDelete,
+                6 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "CREATED" => Self::Created,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "FAILED_TO_DELETE" => Self::FailedToDelete,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Created => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::FailedToDelete => serializer.serialize_i32(5),
+                Self::Deleted => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.clouddms.v1.PrivateConnection.State",
+            ))
         }
     }
 
@@ -8728,62 +9696,121 @@ pub mod background_job_log_entry {
     }
 
     /// Final state after a job completes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobCompletionState(i32);
-
-    impl JobCompletionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JobCompletionState {
         /// The status is not specified. This state is used when job is not yet
         /// finished.
-        pub const JOB_COMPLETION_STATE_UNSPECIFIED: JobCompletionState = JobCompletionState::new(0);
-
+        Unspecified,
         /// Success.
-        pub const SUCCEEDED: JobCompletionState = JobCompletionState::new(1);
-
+        Succeeded,
         /// Error.
-        pub const FAILED: JobCompletionState = JobCompletionState::new(2);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JobCompletionState::value] or
+        /// [JobCompletionState::name].
+        UnknownValue(job_completion_state::UnknownValue),
+    }
 
-        /// Creates a new JobCompletionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod job_completion_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl JobCompletionState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JOB_COMPLETION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("JOB_COMPLETION_STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JOB_COMPLETION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::JOB_COMPLETION_STATE_UNSPECIFIED)
-                }
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JobCompletionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JobCompletionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JobCompletionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JobCompletionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                _ => Self::UnknownValue(job_completion_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JobCompletionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JOB_COMPLETION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(job_completion_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JobCompletionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JobCompletionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobCompletionState>::new(
+                ".google.cloud.clouddms.v1.BackgroundJobLogEntry.JobCompletionState",
+            ))
         }
     }
 
@@ -9391,64 +10418,127 @@ pub mod mapping_rule {
     use super::*;
 
     /// The current mapping rule state such as enabled, disabled or deleted.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the mapping rule is unknown.
+        Unspecified,
+        /// The rule is enabled.
+        Enabled,
+        /// The rule is disabled.
+        Disabled,
+        /// The rule is logically deleted.
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the mapping rule is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The rule is enabled.
-        pub const ENABLED: State = State::new(1);
-
-        /// The rule is disabled.
-        pub const DISABLED: State = State::new(2);
-
-        /// The rule is logically deleted.
-        pub const DELETED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.clouddms.v1.MappingRule.State",
+            ))
         }
     }
 
@@ -11706,64 +12796,127 @@ pub mod database_entity {
     use super::*;
 
     /// The type of database entities tree.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TreeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TreeType {
+        /// Tree type unspecified.
+        Unspecified,
+        /// Tree of entities loaded from a source database.
+        Source,
+        /// Tree of entities converted from the source tree using the mapping rules.
+        Draft,
+        /// Tree of entities observed on the destination database.
+        Destination,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TreeType::value] or
+        /// [TreeType::name].
+        UnknownValue(tree_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tree_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TreeType {
-        /// Tree type unspecified.
-        pub const TREE_TYPE_UNSPECIFIED: TreeType = TreeType::new(0);
-
-        /// Tree of entities loaded from a source database.
-        pub const SOURCE: TreeType = TreeType::new(1);
-
-        /// Tree of entities converted from the source tree using the mapping rules.
-        pub const DRAFT: TreeType = TreeType::new(2);
-
-        /// Tree of entities observed on the destination database.
-        pub const DESTINATION: TreeType = TreeType::new(3);
-
-        /// Creates a new TreeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Source => std::option::Option::Some(1),
+                Self::Draft => std::option::Option::Some(2),
+                Self::Destination => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TREE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SOURCE"),
-                2 => std::borrow::Cow::Borrowed("DRAFT"),
-                3 => std::borrow::Cow::Borrowed("DESTINATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TREE_TYPE_UNSPECIFIED"),
+                Self::Source => std::option::Option::Some("SOURCE"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Destination => std::option::Option::Some("DESTINATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TREE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TREE_TYPE_UNSPECIFIED),
-                "SOURCE" => std::option::Option::Some(Self::SOURCE),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "DESTINATION" => std::option::Option::Some(Self::DESTINATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TreeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TreeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TreeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TreeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Source,
+                2 => Self::Draft,
+                3 => Self::Destination,
+                _ => Self::UnknownValue(tree_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TreeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TREE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SOURCE" => Self::Source,
+                "DRAFT" => Self::Draft,
+                "DESTINATION" => Self::Destination,
+                _ => Self::UnknownValue(tree_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TreeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Source => serializer.serialize_i32(1),
+                Self::Draft => serializer.serialize_i32(2),
+                Self::Destination => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TreeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TreeType>::new(
+                ".google.cloud.clouddms.v1.DatabaseEntity.TreeType",
+            ))
         }
     }
 
@@ -13349,997 +14502,1762 @@ pub mod entity_issue {
     }
 
     /// Type of issue.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IssueType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IssueType {
+        /// Unspecified issue type.
+        Unspecified,
+        /// Issue originated from the DDL
+        Ddl,
+        /// Issue originated during the apply process
+        Apply,
+        /// Issue originated during the convert process
+        Convert,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IssueType::value] or
+        /// [IssueType::name].
+        UnknownValue(issue_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod issue_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IssueType {
-        /// Unspecified issue type.
-        pub const ISSUE_TYPE_UNSPECIFIED: IssueType = IssueType::new(0);
-
-        /// Issue originated from the DDL
-        pub const ISSUE_TYPE_DDL: IssueType = IssueType::new(1);
-
-        /// Issue originated during the apply process
-        pub const ISSUE_TYPE_APPLY: IssueType = IssueType::new(2);
-
-        /// Issue originated during the convert process
-        pub const ISSUE_TYPE_CONVERT: IssueType = IssueType::new(3);
-
-        /// Creates a new IssueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ddl => std::option::Option::Some(1),
+                Self::Apply => std::option::Option::Some(2),
+                Self::Convert => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ISSUE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ISSUE_TYPE_DDL"),
-                2 => std::borrow::Cow::Borrowed("ISSUE_TYPE_APPLY"),
-                3 => std::borrow::Cow::Borrowed("ISSUE_TYPE_CONVERT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ISSUE_TYPE_UNSPECIFIED"),
+                Self::Ddl => std::option::Option::Some("ISSUE_TYPE_DDL"),
+                Self::Apply => std::option::Option::Some("ISSUE_TYPE_APPLY"),
+                Self::Convert => std::option::Option::Some("ISSUE_TYPE_CONVERT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ISSUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ISSUE_TYPE_UNSPECIFIED),
-                "ISSUE_TYPE_DDL" => std::option::Option::Some(Self::ISSUE_TYPE_DDL),
-                "ISSUE_TYPE_APPLY" => std::option::Option::Some(Self::ISSUE_TYPE_APPLY),
-                "ISSUE_TYPE_CONVERT" => std::option::Option::Some(Self::ISSUE_TYPE_CONVERT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IssueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IssueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IssueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IssueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ddl,
+                2 => Self::Apply,
+                3 => Self::Convert,
+                _ => Self::UnknownValue(issue_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IssueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ISSUE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ISSUE_TYPE_DDL" => Self::Ddl,
+                "ISSUE_TYPE_APPLY" => Self::Apply,
+                "ISSUE_TYPE_CONVERT" => Self::Convert,
+                _ => Self::UnknownValue(issue_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IssueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ddl => serializer.serialize_i32(1),
+                Self::Apply => serializer.serialize_i32(2),
+                Self::Convert => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IssueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IssueType>::new(
+                ".google.cloud.clouddms.v1.EntityIssue.IssueType",
+            ))
         }
     }
 
     /// Severity of issue.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IssueSeverity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IssueSeverity {
+        /// Unspecified issue severity
+        Unspecified,
+        /// Info
+        Info,
+        /// Warning
+        Warning,
+        /// Error
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IssueSeverity::value] or
+        /// [IssueSeverity::name].
+        UnknownValue(issue_severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod issue_severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IssueSeverity {
-        /// Unspecified issue severity
-        pub const ISSUE_SEVERITY_UNSPECIFIED: IssueSeverity = IssueSeverity::new(0);
-
-        /// Info
-        pub const ISSUE_SEVERITY_INFO: IssueSeverity = IssueSeverity::new(1);
-
-        /// Warning
-        pub const ISSUE_SEVERITY_WARNING: IssueSeverity = IssueSeverity::new(2);
-
-        /// Error
-        pub const ISSUE_SEVERITY_ERROR: IssueSeverity = IssueSeverity::new(3);
-
-        /// Creates a new IssueSeverity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Info => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_INFO"),
-                2 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_WARNING"),
-                3 => std::borrow::Cow::Borrowed("ISSUE_SEVERITY_ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ISSUE_SEVERITY_UNSPECIFIED"),
+                Self::Info => std::option::Option::Some("ISSUE_SEVERITY_INFO"),
+                Self::Warning => std::option::Option::Some("ISSUE_SEVERITY_WARNING"),
+                Self::Error => std::option::Option::Some("ISSUE_SEVERITY_ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ISSUE_SEVERITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ISSUE_SEVERITY_UNSPECIFIED)
-                }
-                "ISSUE_SEVERITY_INFO" => std::option::Option::Some(Self::ISSUE_SEVERITY_INFO),
-                "ISSUE_SEVERITY_WARNING" => std::option::Option::Some(Self::ISSUE_SEVERITY_WARNING),
-                "ISSUE_SEVERITY_ERROR" => std::option::Option::Some(Self::ISSUE_SEVERITY_ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IssueSeverity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IssueSeverity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IssueSeverity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IssueSeverity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Info,
+                2 => Self::Warning,
+                3 => Self::Error,
+                _ => Self::UnknownValue(issue_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IssueSeverity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ISSUE_SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "ISSUE_SEVERITY_INFO" => Self::Info,
+                "ISSUE_SEVERITY_WARNING" => Self::Warning,
+                "ISSUE_SEVERITY_ERROR" => Self::Error,
+                _ => Self::UnknownValue(issue_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IssueSeverity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Info => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IssueSeverity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IssueSeverity>::new(
+                ".google.cloud.clouddms.v1.EntityIssue.IssueSeverity",
+            ))
         }
     }
 }
 
 /// AIP-157 Partial Response view for Database Entity.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseEntityView(i32);
-
-impl DatabaseEntityView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatabaseEntityView {
     /// Unspecified view. Defaults to basic view.
-    pub const DATABASE_ENTITY_VIEW_UNSPECIFIED: DatabaseEntityView = DatabaseEntityView::new(0);
-
+    Unspecified,
     /// Default view. Does not return DDLs or Issues.
-    pub const DATABASE_ENTITY_VIEW_BASIC: DatabaseEntityView = DatabaseEntityView::new(1);
-
+    Basic,
     /// Return full entity details including mappings, ddl and issues.
-    pub const DATABASE_ENTITY_VIEW_FULL: DatabaseEntityView = DatabaseEntityView::new(2);
-
+    Full,
     /// Top-most (Database, Schema) nodes which are returned contains summary
     /// details for their decendents such as the number of entities per type and
     /// issues rollups. When this view is used, only a single page of result is
     /// returned and the page_size property of the request is ignored. The
     /// returned page will only include the top-most node types.
-    pub const DATABASE_ENTITY_VIEW_ROOT_SUMMARY: DatabaseEntityView = DatabaseEntityView::new(3);
+    RootSummary,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatabaseEntityView::value] or
+    /// [DatabaseEntityView::name].
+    UnknownValue(database_entity_view::UnknownValue),
+}
 
-    /// Creates a new DatabaseEntityView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod database_entity_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DatabaseEntityView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::RootSummary => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_FULL"),
-            3 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_VIEW_ROOT_SUMMARY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATABASE_ENTITY_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("DATABASE_ENTITY_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("DATABASE_ENTITY_VIEW_FULL"),
+            Self::RootSummary => std::option::Option::Some("DATABASE_ENTITY_VIEW_ROOT_SUMMARY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATABASE_ENTITY_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_UNSPECIFIED)
-            }
-            "DATABASE_ENTITY_VIEW_BASIC" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_BASIC)
-            }
-            "DATABASE_ENTITY_VIEW_FULL" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_FULL)
-            }
-            "DATABASE_ENTITY_VIEW_ROOT_SUMMARY" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_VIEW_ROOT_SUMMARY)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatabaseEntityView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseEntityView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NetworkArchitecture(i32);
+impl std::fmt::Display for DatabaseEntityView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatabaseEntityView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            3 => Self::RootSummary,
+            _ => Self::UnknownValue(database_entity_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatabaseEntityView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATABASE_ENTITY_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "DATABASE_ENTITY_VIEW_BASIC" => Self::Basic,
+            "DATABASE_ENTITY_VIEW_FULL" => Self::Full,
+            "DATABASE_ENTITY_VIEW_ROOT_SUMMARY" => Self::RootSummary,
+            _ => Self::UnknownValue(database_entity_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatabaseEntityView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::RootSummary => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatabaseEntityView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEntityView>::new(
+            ".google.cloud.clouddms.v1.DatabaseEntityView",
+        ))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NetworkArchitecture {
+    Unspecified,
+    /// Instance is in Cloud SQL's old producer network architecture.
+    OldCsqlProducer,
+    /// Instance is in Cloud SQL's new producer network architecture.
+    NewCsqlProducer,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NetworkArchitecture::value] or
+    /// [NetworkArchitecture::name].
+    UnknownValue(network_architecture::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod network_architecture {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl NetworkArchitecture {
-    pub const NETWORK_ARCHITECTURE_UNSPECIFIED: NetworkArchitecture = NetworkArchitecture::new(0);
-
-    /// Instance is in Cloud SQL's old producer network architecture.
-    pub const NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER: NetworkArchitecture =
-        NetworkArchitecture::new(1);
-
-    /// Instance is in Cloud SQL's new producer network architecture.
-    pub const NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER: NetworkArchitecture =
-        NetworkArchitecture::new(2);
-
-    /// Creates a new NetworkArchitecture instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::OldCsqlProducer => std::option::Option::Some(1),
+            Self::NewCsqlProducer => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NETWORK_ARCHITECTURE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER"),
-            2 => std::borrow::Cow::Borrowed("NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NETWORK_ARCHITECTURE_UNSPECIFIED"),
+            Self::OldCsqlProducer => {
+                std::option::Option::Some("NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER")
+            }
+            Self::NewCsqlProducer => {
+                std::option::Option::Some("NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NETWORK_ARCHITECTURE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NETWORK_ARCHITECTURE_UNSPECIFIED)
-            }
-            "NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER" => {
-                std::option::Option::Some(Self::NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER)
-            }
-            "NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER" => {
-                std::option::Option::Some(Self::NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NetworkArchitecture {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NetworkArchitecture {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NetworkArchitecture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NetworkArchitecture {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::OldCsqlProducer,
+            2 => Self::NewCsqlProducer,
+            _ => Self::UnknownValue(network_architecture::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NetworkArchitecture {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NETWORK_ARCHITECTURE_UNSPECIFIED" => Self::Unspecified,
+            "NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER" => Self::OldCsqlProducer,
+            "NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER" => Self::NewCsqlProducer,
+            _ => Self::UnknownValue(network_architecture::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NetworkArchitecture {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::OldCsqlProducer => serializer.serialize_i32(1),
+            Self::NewCsqlProducer => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NetworkArchitecture {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NetworkArchitecture>::new(
+            ".google.cloud.clouddms.v1.NetworkArchitecture",
+        ))
     }
 }
 
 /// The database engine types.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseEngine(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatabaseEngine {
+    /// The source database engine of the migration job is unknown.
+    Unspecified,
+    /// The source engine is MySQL.
+    Mysql,
+    /// The source engine is PostgreSQL.
+    Postgresql,
+    /// The source engine is Oracle.
+    Oracle,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatabaseEngine::value] or
+    /// [DatabaseEngine::name].
+    UnknownValue(database_engine::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod database_engine {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DatabaseEngine {
-    /// The source database engine of the migration job is unknown.
-    pub const DATABASE_ENGINE_UNSPECIFIED: DatabaseEngine = DatabaseEngine::new(0);
-
-    /// The source engine is MySQL.
-    pub const MYSQL: DatabaseEngine = DatabaseEngine::new(1);
-
-    /// The source engine is PostgreSQL.
-    pub const POSTGRESQL: DatabaseEngine = DatabaseEngine::new(2);
-
-    /// The source engine is Oracle.
-    pub const ORACLE: DatabaseEngine = DatabaseEngine::new(4);
-
-    /// Creates a new DatabaseEngine instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Mysql => std::option::Option::Some(1),
+            Self::Postgresql => std::option::Option::Some(2),
+            Self::Oracle => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MYSQL"),
-            2 => std::borrow::Cow::Borrowed("POSTGRESQL"),
-            4 => std::borrow::Cow::Borrowed("ORACLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATABASE_ENGINE_UNSPECIFIED"),
+            Self::Mysql => std::option::Option::Some("MYSQL"),
+            Self::Postgresql => std::option::Option::Some("POSTGRESQL"),
+            Self::Oracle => std::option::Option::Some("ORACLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATABASE_ENGINE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATABASE_ENGINE_UNSPECIFIED)
-            }
-            "MYSQL" => std::option::Option::Some(Self::MYSQL),
-            "POSTGRESQL" => std::option::Option::Some(Self::POSTGRESQL),
-            "ORACLE" => std::option::Option::Some(Self::ORACLE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatabaseEngine {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseEngine {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatabaseEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatabaseEngine {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Mysql,
+            2 => Self::Postgresql,
+            4 => Self::Oracle,
+            _ => Self::UnknownValue(database_engine::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatabaseEngine {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATABASE_ENGINE_UNSPECIFIED" => Self::Unspecified,
+            "MYSQL" => Self::Mysql,
+            "POSTGRESQL" => Self::Postgresql,
+            "ORACLE" => Self::Oracle,
+            _ => Self::UnknownValue(database_engine::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatabaseEngine {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Mysql => serializer.serialize_i32(1),
+            Self::Postgresql => serializer.serialize_i32(2),
+            Self::Oracle => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatabaseEngine {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEngine>::new(
+            ".google.cloud.clouddms.v1.DatabaseEngine",
+        ))
     }
 }
 
 /// The database providers.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseProvider(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatabaseProvider {
+    /// The database provider is unknown.
+    Unspecified,
+    /// CloudSQL runs the database.
+    Cloudsql,
+    /// RDS runs the database.
+    Rds,
+    /// Amazon Aurora.
+    Aurora,
+    /// AlloyDB.
+    Alloydb,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatabaseProvider::value] or
+    /// [DatabaseProvider::name].
+    UnknownValue(database_provider::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod database_provider {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DatabaseProvider {
-    /// The database provider is unknown.
-    pub const DATABASE_PROVIDER_UNSPECIFIED: DatabaseProvider = DatabaseProvider::new(0);
-
-    /// CloudSQL runs the database.
-    pub const CLOUDSQL: DatabaseProvider = DatabaseProvider::new(1);
-
-    /// RDS runs the database.
-    pub const RDS: DatabaseProvider = DatabaseProvider::new(2);
-
-    /// Amazon Aurora.
-    pub const AURORA: DatabaseProvider = DatabaseProvider::new(3);
-
-    /// AlloyDB.
-    pub const ALLOYDB: DatabaseProvider = DatabaseProvider::new(4);
-
-    /// Creates a new DatabaseProvider instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Cloudsql => std::option::Option::Some(1),
+            Self::Rds => std::option::Option::Some(2),
+            Self::Aurora => std::option::Option::Some(3),
+            Self::Alloydb => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATABASE_PROVIDER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CLOUDSQL"),
-            2 => std::borrow::Cow::Borrowed("RDS"),
-            3 => std::borrow::Cow::Borrowed("AURORA"),
-            4 => std::borrow::Cow::Borrowed("ALLOYDB"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATABASE_PROVIDER_UNSPECIFIED"),
+            Self::Cloudsql => std::option::Option::Some("CLOUDSQL"),
+            Self::Rds => std::option::Option::Some("RDS"),
+            Self::Aurora => std::option::Option::Some("AURORA"),
+            Self::Alloydb => std::option::Option::Some("ALLOYDB"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATABASE_PROVIDER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATABASE_PROVIDER_UNSPECIFIED)
-            }
-            "CLOUDSQL" => std::option::Option::Some(Self::CLOUDSQL),
-            "RDS" => std::option::Option::Some(Self::RDS),
-            "AURORA" => std::option::Option::Some(Self::AURORA),
-            "ALLOYDB" => std::option::Option::Some(Self::ALLOYDB),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatabaseProvider {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseProvider {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatabaseProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatabaseProvider {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Cloudsql,
+            2 => Self::Rds,
+            3 => Self::Aurora,
+            4 => Self::Alloydb,
+            _ => Self::UnknownValue(database_provider::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatabaseProvider {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATABASE_PROVIDER_UNSPECIFIED" => Self::Unspecified,
+            "CLOUDSQL" => Self::Cloudsql,
+            "RDS" => Self::Rds,
+            "AURORA" => Self::Aurora,
+            "ALLOYDB" => Self::Alloydb,
+            _ => Self::UnknownValue(database_provider::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatabaseProvider {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Cloudsql => serializer.serialize_i32(1),
+            Self::Rds => serializer.serialize_i32(2),
+            Self::Aurora => serializer.serialize_i32(3),
+            Self::Alloydb => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatabaseProvider {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseProvider>::new(
+            ".google.cloud.clouddms.v1.DatabaseProvider",
+        ))
     }
 }
 
 /// Enum used by ValueListFilter to indicate whether the source value is in the
 /// supplied list
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ValuePresentInList(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ValuePresentInList {
+    /// Value present in list unspecified
+    Unspecified,
+    /// If the source value is in the supplied list at value_list
+    IfValueList,
+    /// If the source value is not in the supplied list at value_list
+    IfValueNotList,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ValuePresentInList::value] or
+    /// [ValuePresentInList::name].
+    UnknownValue(value_present_in_list::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod value_present_in_list {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ValuePresentInList {
-    /// Value present in list unspecified
-    pub const VALUE_PRESENT_IN_LIST_UNSPECIFIED: ValuePresentInList = ValuePresentInList::new(0);
-
-    /// If the source value is in the supplied list at value_list
-    pub const VALUE_PRESENT_IN_LIST_IF_VALUE_LIST: ValuePresentInList = ValuePresentInList::new(1);
-
-    /// If the source value is not in the supplied list at value_list
-    pub const VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST: ValuePresentInList =
-        ValuePresentInList::new(2);
-
-    /// Creates a new ValuePresentInList instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::IfValueList => std::option::Option::Some(1),
+            Self::IfValueNotList => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VALUE_PRESENT_IN_LIST_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VALUE_PRESENT_IN_LIST_IF_VALUE_LIST"),
-            2 => std::borrow::Cow::Borrowed("VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VALUE_PRESENT_IN_LIST_UNSPECIFIED"),
+            Self::IfValueList => std::option::Option::Some("VALUE_PRESENT_IN_LIST_IF_VALUE_LIST"),
+            Self::IfValueNotList => {
+                std::option::Option::Some("VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VALUE_PRESENT_IN_LIST_UNSPECIFIED" => {
-                std::option::Option::Some(Self::VALUE_PRESENT_IN_LIST_UNSPECIFIED)
-            }
-            "VALUE_PRESENT_IN_LIST_IF_VALUE_LIST" => {
-                std::option::Option::Some(Self::VALUE_PRESENT_IN_LIST_IF_VALUE_LIST)
-            }
-            "VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST" => {
-                std::option::Option::Some(Self::VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ValuePresentInList {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ValuePresentInList {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ValuePresentInList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ValuePresentInList {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::IfValueList,
+            2 => Self::IfValueNotList,
+            _ => Self::UnknownValue(value_present_in_list::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ValuePresentInList {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VALUE_PRESENT_IN_LIST_UNSPECIFIED" => Self::Unspecified,
+            "VALUE_PRESENT_IN_LIST_IF_VALUE_LIST" => Self::IfValueList,
+            "VALUE_PRESENT_IN_LIST_IF_VALUE_NOT_LIST" => Self::IfValueNotList,
+            _ => Self::UnknownValue(value_present_in_list::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ValuePresentInList {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::IfValueList => serializer.serialize_i32(1),
+            Self::IfValueNotList => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ValuePresentInList {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValuePresentInList>::new(
+            ".google.cloud.clouddms.v1.ValuePresentInList",
+        ))
     }
 }
 
 /// The type of database entities supported,
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseEntityType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatabaseEntityType {
+    /// Unspecified database entity type.
+    Unspecified,
+    /// Schema.
+    Schema,
+    /// Table.
+    Table,
+    /// Column.
+    Column,
+    /// Constraint.
+    Constraint,
+    /// Index.
+    Index,
+    /// Trigger.
+    Trigger,
+    /// View.
+    View,
+    /// Sequence.
+    Sequence,
+    /// Stored Procedure.
+    StoredProcedure,
+    /// Function.
+    Function,
+    /// Synonym.
+    Synonym,
+    /// Package.
+    DatabasePackage,
+    /// UDT.
+    Udt,
+    /// Materialized View.
+    MaterializedView,
+    /// Database.
+    Database,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatabaseEntityType::value] or
+    /// [DatabaseEntityType::name].
+    UnknownValue(database_entity_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod database_entity_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DatabaseEntityType {
-    /// Unspecified database entity type.
-    pub const DATABASE_ENTITY_TYPE_UNSPECIFIED: DatabaseEntityType = DatabaseEntityType::new(0);
-
-    /// Schema.
-    pub const DATABASE_ENTITY_TYPE_SCHEMA: DatabaseEntityType = DatabaseEntityType::new(1);
-
-    /// Table.
-    pub const DATABASE_ENTITY_TYPE_TABLE: DatabaseEntityType = DatabaseEntityType::new(2);
-
-    /// Column.
-    pub const DATABASE_ENTITY_TYPE_COLUMN: DatabaseEntityType = DatabaseEntityType::new(3);
-
-    /// Constraint.
-    pub const DATABASE_ENTITY_TYPE_CONSTRAINT: DatabaseEntityType = DatabaseEntityType::new(4);
-
-    /// Index.
-    pub const DATABASE_ENTITY_TYPE_INDEX: DatabaseEntityType = DatabaseEntityType::new(5);
-
-    /// Trigger.
-    pub const DATABASE_ENTITY_TYPE_TRIGGER: DatabaseEntityType = DatabaseEntityType::new(6);
-
-    /// View.
-    pub const DATABASE_ENTITY_TYPE_VIEW: DatabaseEntityType = DatabaseEntityType::new(7);
-
-    /// Sequence.
-    pub const DATABASE_ENTITY_TYPE_SEQUENCE: DatabaseEntityType = DatabaseEntityType::new(8);
-
-    /// Stored Procedure.
-    pub const DATABASE_ENTITY_TYPE_STORED_PROCEDURE: DatabaseEntityType =
-        DatabaseEntityType::new(9);
-
-    /// Function.
-    pub const DATABASE_ENTITY_TYPE_FUNCTION: DatabaseEntityType = DatabaseEntityType::new(10);
-
-    /// Synonym.
-    pub const DATABASE_ENTITY_TYPE_SYNONYM: DatabaseEntityType = DatabaseEntityType::new(11);
-
-    /// Package.
-    pub const DATABASE_ENTITY_TYPE_DATABASE_PACKAGE: DatabaseEntityType =
-        DatabaseEntityType::new(12);
-
-    /// UDT.
-    pub const DATABASE_ENTITY_TYPE_UDT: DatabaseEntityType = DatabaseEntityType::new(13);
-
-    /// Materialized View.
-    pub const DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW: DatabaseEntityType =
-        DatabaseEntityType::new(14);
-
-    /// Database.
-    pub const DATABASE_ENTITY_TYPE_DATABASE: DatabaseEntityType = DatabaseEntityType::new(15);
-
-    /// Creates a new DatabaseEntityType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Schema => std::option::Option::Some(1),
+            Self::Table => std::option::Option::Some(2),
+            Self::Column => std::option::Option::Some(3),
+            Self::Constraint => std::option::Option::Some(4),
+            Self::Index => std::option::Option::Some(5),
+            Self::Trigger => std::option::Option::Some(6),
+            Self::View => std::option::Option::Some(7),
+            Self::Sequence => std::option::Option::Some(8),
+            Self::StoredProcedure => std::option::Option::Some(9),
+            Self::Function => std::option::Option::Some(10),
+            Self::Synonym => std::option::Option::Some(11),
+            Self::DatabasePackage => std::option::Option::Some(12),
+            Self::Udt => std::option::Option::Some(13),
+            Self::MaterializedView => std::option::Option::Some(14),
+            Self::Database => std::option::Option::Some(15),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_SCHEMA"),
-            2 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_TABLE"),
-            3 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_COLUMN"),
-            4 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_CONSTRAINT"),
-            5 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_INDEX"),
-            6 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_TRIGGER"),
-            7 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_VIEW"),
-            8 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_SEQUENCE"),
-            9 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_STORED_PROCEDURE"),
-            10 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_FUNCTION"),
-            11 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_SYNONYM"),
-            12 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_DATABASE_PACKAGE"),
-            13 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_UDT"),
-            14 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW"),
-            15 => std::borrow::Cow::Borrowed("DATABASE_ENTITY_TYPE_DATABASE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATABASE_ENTITY_TYPE_UNSPECIFIED"),
+            Self::Schema => std::option::Option::Some("DATABASE_ENTITY_TYPE_SCHEMA"),
+            Self::Table => std::option::Option::Some("DATABASE_ENTITY_TYPE_TABLE"),
+            Self::Column => std::option::Option::Some("DATABASE_ENTITY_TYPE_COLUMN"),
+            Self::Constraint => std::option::Option::Some("DATABASE_ENTITY_TYPE_CONSTRAINT"),
+            Self::Index => std::option::Option::Some("DATABASE_ENTITY_TYPE_INDEX"),
+            Self::Trigger => std::option::Option::Some("DATABASE_ENTITY_TYPE_TRIGGER"),
+            Self::View => std::option::Option::Some("DATABASE_ENTITY_TYPE_VIEW"),
+            Self::Sequence => std::option::Option::Some("DATABASE_ENTITY_TYPE_SEQUENCE"),
+            Self::StoredProcedure => {
+                std::option::Option::Some("DATABASE_ENTITY_TYPE_STORED_PROCEDURE")
+            }
+            Self::Function => std::option::Option::Some("DATABASE_ENTITY_TYPE_FUNCTION"),
+            Self::Synonym => std::option::Option::Some("DATABASE_ENTITY_TYPE_SYNONYM"),
+            Self::DatabasePackage => {
+                std::option::Option::Some("DATABASE_ENTITY_TYPE_DATABASE_PACKAGE")
+            }
+            Self::Udt => std::option::Option::Some("DATABASE_ENTITY_TYPE_UDT"),
+            Self::MaterializedView => {
+                std::option::Option::Some("DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW")
+            }
+            Self::Database => std::option::Option::Some("DATABASE_ENTITY_TYPE_DATABASE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATABASE_ENTITY_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_UNSPECIFIED)
-            }
-            "DATABASE_ENTITY_TYPE_SCHEMA" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_SCHEMA)
-            }
-            "DATABASE_ENTITY_TYPE_TABLE" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_TABLE)
-            }
-            "DATABASE_ENTITY_TYPE_COLUMN" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_COLUMN)
-            }
-            "DATABASE_ENTITY_TYPE_CONSTRAINT" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_CONSTRAINT)
-            }
-            "DATABASE_ENTITY_TYPE_INDEX" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_INDEX)
-            }
-            "DATABASE_ENTITY_TYPE_TRIGGER" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_TRIGGER)
-            }
-            "DATABASE_ENTITY_TYPE_VIEW" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_VIEW)
-            }
-            "DATABASE_ENTITY_TYPE_SEQUENCE" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_SEQUENCE)
-            }
-            "DATABASE_ENTITY_TYPE_STORED_PROCEDURE" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_STORED_PROCEDURE)
-            }
-            "DATABASE_ENTITY_TYPE_FUNCTION" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_FUNCTION)
-            }
-            "DATABASE_ENTITY_TYPE_SYNONYM" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_SYNONYM)
-            }
-            "DATABASE_ENTITY_TYPE_DATABASE_PACKAGE" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_DATABASE_PACKAGE)
-            }
-            "DATABASE_ENTITY_TYPE_UDT" => std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_UDT),
-            "DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW)
-            }
-            "DATABASE_ENTITY_TYPE_DATABASE" => {
-                std::option::Option::Some(Self::DATABASE_ENTITY_TYPE_DATABASE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatabaseEntityType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseEntityType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatabaseEntityType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatabaseEntityType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Schema,
+            2 => Self::Table,
+            3 => Self::Column,
+            4 => Self::Constraint,
+            5 => Self::Index,
+            6 => Self::Trigger,
+            7 => Self::View,
+            8 => Self::Sequence,
+            9 => Self::StoredProcedure,
+            10 => Self::Function,
+            11 => Self::Synonym,
+            12 => Self::DatabasePackage,
+            13 => Self::Udt,
+            14 => Self::MaterializedView,
+            15 => Self::Database,
+            _ => Self::UnknownValue(database_entity_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatabaseEntityType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATABASE_ENTITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "DATABASE_ENTITY_TYPE_SCHEMA" => Self::Schema,
+            "DATABASE_ENTITY_TYPE_TABLE" => Self::Table,
+            "DATABASE_ENTITY_TYPE_COLUMN" => Self::Column,
+            "DATABASE_ENTITY_TYPE_CONSTRAINT" => Self::Constraint,
+            "DATABASE_ENTITY_TYPE_INDEX" => Self::Index,
+            "DATABASE_ENTITY_TYPE_TRIGGER" => Self::Trigger,
+            "DATABASE_ENTITY_TYPE_VIEW" => Self::View,
+            "DATABASE_ENTITY_TYPE_SEQUENCE" => Self::Sequence,
+            "DATABASE_ENTITY_TYPE_STORED_PROCEDURE" => Self::StoredProcedure,
+            "DATABASE_ENTITY_TYPE_FUNCTION" => Self::Function,
+            "DATABASE_ENTITY_TYPE_SYNONYM" => Self::Synonym,
+            "DATABASE_ENTITY_TYPE_DATABASE_PACKAGE" => Self::DatabasePackage,
+            "DATABASE_ENTITY_TYPE_UDT" => Self::Udt,
+            "DATABASE_ENTITY_TYPE_MATERIALIZED_VIEW" => Self::MaterializedView,
+            "DATABASE_ENTITY_TYPE_DATABASE" => Self::Database,
+            _ => Self::UnknownValue(database_entity_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatabaseEntityType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Schema => serializer.serialize_i32(1),
+            Self::Table => serializer.serialize_i32(2),
+            Self::Column => serializer.serialize_i32(3),
+            Self::Constraint => serializer.serialize_i32(4),
+            Self::Index => serializer.serialize_i32(5),
+            Self::Trigger => serializer.serialize_i32(6),
+            Self::View => serializer.serialize_i32(7),
+            Self::Sequence => serializer.serialize_i32(8),
+            Self::StoredProcedure => serializer.serialize_i32(9),
+            Self::Function => serializer.serialize_i32(10),
+            Self::Synonym => serializer.serialize_i32(11),
+            Self::DatabasePackage => serializer.serialize_i32(12),
+            Self::Udt => serializer.serialize_i32(13),
+            Self::MaterializedView => serializer.serialize_i32(14),
+            Self::Database => serializer.serialize_i32(15),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatabaseEntityType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEntityType>::new(
+            ".google.cloud.clouddms.v1.DatabaseEntityType",
+        ))
     }
 }
 
 /// Entity Name Transformation Types
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EntityNameTransformation(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EntityNameTransformation {
+    /// Entity name transformation unspecified.
+    Unspecified,
+    /// No transformation.
+    NoTransformation,
+    /// Transform to lower case.
+    LowerCase,
+    /// Transform to upper case.
+    UpperCase,
+    /// Transform to capitalized case.
+    CapitalizedCase,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EntityNameTransformation::value] or
+    /// [EntityNameTransformation::name].
+    UnknownValue(entity_name_transformation::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod entity_name_transformation {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl EntityNameTransformation {
-    /// Entity name transformation unspecified.
-    pub const ENTITY_NAME_TRANSFORMATION_UNSPECIFIED: EntityNameTransformation =
-        EntityNameTransformation::new(0);
-
-    /// No transformation.
-    pub const ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION: EntityNameTransformation =
-        EntityNameTransformation::new(1);
-
-    /// Transform to lower case.
-    pub const ENTITY_NAME_TRANSFORMATION_LOWER_CASE: EntityNameTransformation =
-        EntityNameTransformation::new(2);
-
-    /// Transform to upper case.
-    pub const ENTITY_NAME_TRANSFORMATION_UPPER_CASE: EntityNameTransformation =
-        EntityNameTransformation::new(3);
-
-    /// Transform to capitalized case.
-    pub const ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE: EntityNameTransformation =
-        EntityNameTransformation::new(4);
-
-    /// Creates a new EntityNameTransformation instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NoTransformation => std::option::Option::Some(1),
+            Self::LowerCase => std::option::Option::Some(2),
+            Self::UpperCase => std::option::Option::Some(3),
+            Self::CapitalizedCase => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION"),
-            2 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_LOWER_CASE"),
-            3 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_UPPER_CASE"),
-            4 => std::borrow::Cow::Borrowed("ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("ENTITY_NAME_TRANSFORMATION_UNSPECIFIED")
+            }
+            Self::NoTransformation => {
+                std::option::Option::Some("ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION")
+            }
+            Self::LowerCase => std::option::Option::Some("ENTITY_NAME_TRANSFORMATION_LOWER_CASE"),
+            Self::UpperCase => std::option::Option::Some("ENTITY_NAME_TRANSFORMATION_UPPER_CASE"),
+            Self::CapitalizedCase => {
+                std::option::Option::Some("ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENTITY_NAME_TRANSFORMATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_UNSPECIFIED)
-            }
-            "ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION" => {
-                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION)
-            }
-            "ENTITY_NAME_TRANSFORMATION_LOWER_CASE" => {
-                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_LOWER_CASE)
-            }
-            "ENTITY_NAME_TRANSFORMATION_UPPER_CASE" => {
-                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_UPPER_CASE)
-            }
-            "ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE" => {
-                std::option::Option::Some(Self::ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EntityNameTransformation {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EntityNameTransformation {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EntityNameTransformation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EntityNameTransformation {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NoTransformation,
+            2 => Self::LowerCase,
+            3 => Self::UpperCase,
+            4 => Self::CapitalizedCase,
+            _ => Self::UnknownValue(entity_name_transformation::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EntityNameTransformation {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENTITY_NAME_TRANSFORMATION_UNSPECIFIED" => Self::Unspecified,
+            "ENTITY_NAME_TRANSFORMATION_NO_TRANSFORMATION" => Self::NoTransformation,
+            "ENTITY_NAME_TRANSFORMATION_LOWER_CASE" => Self::LowerCase,
+            "ENTITY_NAME_TRANSFORMATION_UPPER_CASE" => Self::UpperCase,
+            "ENTITY_NAME_TRANSFORMATION_CAPITALIZED_CASE" => Self::CapitalizedCase,
+            _ => Self::UnknownValue(entity_name_transformation::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EntityNameTransformation {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NoTransformation => serializer.serialize_i32(1),
+            Self::LowerCase => serializer.serialize_i32(2),
+            Self::UpperCase => serializer.serialize_i32(3),
+            Self::CapitalizedCase => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EntityNameTransformation {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityNameTransformation>::new(
+            ".google.cloud.clouddms.v1.EntityNameTransformation",
+        ))
     }
 }
 
 /// The types of jobs that can be executed in the background.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackgroundJobType(i32);
-
-impl BackgroundJobType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BackgroundJobType {
     /// Unspecified background job type.
-    pub const BACKGROUND_JOB_TYPE_UNSPECIFIED: BackgroundJobType = BackgroundJobType::new(0);
-
+    Unspecified,
     /// Job to seed from the source database.
-    pub const BACKGROUND_JOB_TYPE_SOURCE_SEED: BackgroundJobType = BackgroundJobType::new(1);
-
+    SourceSeed,
     /// Job to convert the source database into a draft of the destination
     /// database.
-    pub const BACKGROUND_JOB_TYPE_CONVERT: BackgroundJobType = BackgroundJobType::new(2);
-
+    Convert,
     /// Job to apply the draft tree onto the destination.
-    pub const BACKGROUND_JOB_TYPE_APPLY_DESTINATION: BackgroundJobType = BackgroundJobType::new(3);
-
+    ApplyDestination,
     /// Job to import and convert mapping rules from an external source such as an
     /// ora2pg config file.
-    pub const BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE: BackgroundJobType = BackgroundJobType::new(5);
+    ImportRulesFile,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BackgroundJobType::value] or
+    /// [BackgroundJobType::name].
+    UnknownValue(background_job_type::UnknownValue),
+}
 
-    /// Creates a new BackgroundJobType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod background_job_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BackgroundJobType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SourceSeed => std::option::Option::Some(1),
+            Self::Convert => std::option::Option::Some(2),
+            Self::ApplyDestination => std::option::Option::Some(3),
+            Self::ImportRulesFile => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_SOURCE_SEED"),
-            2 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_CONVERT"),
-            3 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_APPLY_DESTINATION"),
-            5 => std::borrow::Cow::Borrowed("BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BACKGROUND_JOB_TYPE_UNSPECIFIED"),
+            Self::SourceSeed => std::option::Option::Some("BACKGROUND_JOB_TYPE_SOURCE_SEED"),
+            Self::Convert => std::option::Option::Some("BACKGROUND_JOB_TYPE_CONVERT"),
+            Self::ApplyDestination => {
+                std::option::Option::Some("BACKGROUND_JOB_TYPE_APPLY_DESTINATION")
+            }
+            Self::ImportRulesFile => {
+                std::option::Option::Some("BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BACKGROUND_JOB_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_UNSPECIFIED)
-            }
-            "BACKGROUND_JOB_TYPE_SOURCE_SEED" => {
-                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_SOURCE_SEED)
-            }
-            "BACKGROUND_JOB_TYPE_CONVERT" => {
-                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_CONVERT)
-            }
-            "BACKGROUND_JOB_TYPE_APPLY_DESTINATION" => {
-                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_APPLY_DESTINATION)
-            }
-            "BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE" => {
-                std::option::Option::Some(Self::BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BackgroundJobType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BackgroundJobType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BackgroundJobType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BackgroundJobType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::SourceSeed,
+            2 => Self::Convert,
+            3 => Self::ApplyDestination,
+            5 => Self::ImportRulesFile,
+            _ => Self::UnknownValue(background_job_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BackgroundJobType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BACKGROUND_JOB_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BACKGROUND_JOB_TYPE_SOURCE_SEED" => Self::SourceSeed,
+            "BACKGROUND_JOB_TYPE_CONVERT" => Self::Convert,
+            "BACKGROUND_JOB_TYPE_APPLY_DESTINATION" => Self::ApplyDestination,
+            "BACKGROUND_JOB_TYPE_IMPORT_RULES_FILE" => Self::ImportRulesFile,
+            _ => Self::UnknownValue(background_job_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BackgroundJobType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SourceSeed => serializer.serialize_i32(1),
+            Self::Convert => serializer.serialize_i32(2),
+            Self::ApplyDestination => serializer.serialize_i32(3),
+            Self::ImportRulesFile => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BackgroundJobType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackgroundJobType>::new(
+            ".google.cloud.clouddms.v1.BackgroundJobType",
+        ))
     }
 }
 
 /// The format for the import rules file.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportRulesFileFormat(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ImportRulesFileFormat {
+    /// Unspecified rules format.
+    Unspecified,
+    /// HarbourBridge session file.
+    HarbourBridgeSessionFile,
+    /// Ora2Pg configuration file.
+    OratopgConfigFile,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ImportRulesFileFormat::value] or
+    /// [ImportRulesFileFormat::name].
+    UnknownValue(import_rules_file_format::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod import_rules_file_format {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ImportRulesFileFormat {
-    /// Unspecified rules format.
-    pub const IMPORT_RULES_FILE_FORMAT_UNSPECIFIED: ImportRulesFileFormat =
-        ImportRulesFileFormat::new(0);
-
-    /// HarbourBridge session file.
-    pub const IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE: ImportRulesFileFormat =
-        ImportRulesFileFormat::new(1);
-
-    /// Ora2Pg configuration file.
-    pub const IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE: ImportRulesFileFormat =
-        ImportRulesFileFormat::new(2);
-
-    /// Creates a new ImportRulesFileFormat instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::HarbourBridgeSessionFile => std::option::Option::Some(1),
+            Self::OratopgConfigFile => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IMPORT_RULES_FILE_FORMAT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE"),
-            2 => std::borrow::Cow::Borrowed("IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IMPORT_RULES_FILE_FORMAT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::IMPORT_RULES_FILE_FORMAT_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("IMPORT_RULES_FILE_FORMAT_UNSPECIFIED"),
+            Self::HarbourBridgeSessionFile => {
+                std::option::Option::Some("IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE")
             }
-            "IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE" => std::option::Option::Some(
-                Self::IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE,
-            ),
-            "IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE" => {
-                std::option::Option::Some(Self::IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE)
+            Self::OratopgConfigFile => {
+                std::option::Option::Some("IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE")
             }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ImportRulesFileFormat {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportRulesFileFormat {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ImportRulesFileFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ImportRulesFileFormat {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::HarbourBridgeSessionFile,
+            2 => Self::OratopgConfigFile,
+            _ => Self::UnknownValue(import_rules_file_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ImportRulesFileFormat {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IMPORT_RULES_FILE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+            "IMPORT_RULES_FILE_FORMAT_HARBOUR_BRIDGE_SESSION_FILE" => {
+                Self::HarbourBridgeSessionFile
+            }
+            "IMPORT_RULES_FILE_FORMAT_ORATOPG_CONFIG_FILE" => Self::OratopgConfigFile,
+            _ => Self::UnknownValue(import_rules_file_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ImportRulesFileFormat {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::HarbourBridgeSessionFile => serializer.serialize_i32(1),
+            Self::OratopgConfigFile => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ImportRulesFileFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportRulesFileFormat>::new(
+            ".google.cloud.clouddms.v1.ImportRulesFileFormat",
+        ))
     }
 }
 
 /// Enum used by IntComparisonFilter and DoubleComparisonFilter to indicate the
 /// relation between source value and compare value.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ValueComparison(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ValueComparison {
+    /// Value comparison unspecified.
+    Unspecified,
+    /// Value is smaller than the Compare value.
+    IfValueSmallerThan,
+    /// Value is smaller or equal than the Compare value.
+    IfValueSmallerEqualThan,
+    /// Value is larger than the Compare value.
+    IfValueLargerThan,
+    /// Value is larger or equal than the Compare value.
+    IfValueLargerEqualThan,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ValueComparison::value] or
+    /// [ValueComparison::name].
+    UnknownValue(value_comparison::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod value_comparison {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ValueComparison {
-    /// Value comparison unspecified.
-    pub const VALUE_COMPARISON_UNSPECIFIED: ValueComparison = ValueComparison::new(0);
-
-    /// Value is smaller than the Compare value.
-    pub const VALUE_COMPARISON_IF_VALUE_SMALLER_THAN: ValueComparison = ValueComparison::new(1);
-
-    /// Value is smaller or equal than the Compare value.
-    pub const VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN: ValueComparison =
-        ValueComparison::new(2);
-
-    /// Value is larger than the Compare value.
-    pub const VALUE_COMPARISON_IF_VALUE_LARGER_THAN: ValueComparison = ValueComparison::new(3);
-
-    /// Value is larger or equal than the Compare value.
-    pub const VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN: ValueComparison =
-        ValueComparison::new(4);
-
-    /// Creates a new ValueComparison instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::IfValueSmallerThan => std::option::Option::Some(1),
+            Self::IfValueSmallerEqualThan => std::option::Option::Some(2),
+            Self::IfValueLargerThan => std::option::Option::Some(3),
+            Self::IfValueLargerEqualThan => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_SMALLER_THAN"),
-            2 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN"),
-            3 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_LARGER_THAN"),
-            4 => std::borrow::Cow::Borrowed("VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VALUE_COMPARISON_UNSPECIFIED"),
+            Self::IfValueSmallerThan => {
+                std::option::Option::Some("VALUE_COMPARISON_IF_VALUE_SMALLER_THAN")
+            }
+            Self::IfValueSmallerEqualThan => {
+                std::option::Option::Some("VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN")
+            }
+            Self::IfValueLargerThan => {
+                std::option::Option::Some("VALUE_COMPARISON_IF_VALUE_LARGER_THAN")
+            }
+            Self::IfValueLargerEqualThan => {
+                std::option::Option::Some("VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VALUE_COMPARISON_UNSPECIFIED" => {
-                std::option::Option::Some(Self::VALUE_COMPARISON_UNSPECIFIED)
-            }
-            "VALUE_COMPARISON_IF_VALUE_SMALLER_THAN" => {
-                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_SMALLER_THAN)
-            }
-            "VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN" => {
-                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN)
-            }
-            "VALUE_COMPARISON_IF_VALUE_LARGER_THAN" => {
-                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_LARGER_THAN)
-            }
-            "VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN" => {
-                std::option::Option::Some(Self::VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ValueComparison {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ValueComparison {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ValueComparison {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ValueComparison {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::IfValueSmallerThan,
+            2 => Self::IfValueSmallerEqualThan,
+            3 => Self::IfValueLargerThan,
+            4 => Self::IfValueLargerEqualThan,
+            _ => Self::UnknownValue(value_comparison::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ValueComparison {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VALUE_COMPARISON_UNSPECIFIED" => Self::Unspecified,
+            "VALUE_COMPARISON_IF_VALUE_SMALLER_THAN" => Self::IfValueSmallerThan,
+            "VALUE_COMPARISON_IF_VALUE_SMALLER_EQUAL_THAN" => Self::IfValueSmallerEqualThan,
+            "VALUE_COMPARISON_IF_VALUE_LARGER_THAN" => Self::IfValueLargerThan,
+            "VALUE_COMPARISON_IF_VALUE_LARGER_EQUAL_THAN" => Self::IfValueLargerEqualThan,
+            _ => Self::UnknownValue(value_comparison::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ValueComparison {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::IfValueSmallerThan => serializer.serialize_i32(1),
+            Self::IfValueSmallerEqualThan => serializer.serialize_i32(2),
+            Self::IfValueLargerThan => serializer.serialize_i32(3),
+            Self::IfValueLargerEqualThan => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ValueComparison {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueComparison>::new(
+            ".google.cloud.clouddms.v1.ValueComparison",
+        ))
     }
 }
 
 /// Specifies the columns on which numeric filter needs to be applied.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NumericFilterOption(i32);
-
-impl NumericFilterOption {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NumericFilterOption {
     /// Numeric filter option unspecified
-    pub const NUMERIC_FILTER_OPTION_UNSPECIFIED: NumericFilterOption = NumericFilterOption::new(0);
-
+    Unspecified,
     /// Numeric filter option that matches all numeric columns.
-    pub const NUMERIC_FILTER_OPTION_ALL: NumericFilterOption = NumericFilterOption::new(1);
-
+    All,
     /// Numeric filter option that matches columns having numeric datatypes with
     /// specified precision and scale within the limited range of filter.
-    pub const NUMERIC_FILTER_OPTION_LIMIT: NumericFilterOption = NumericFilterOption::new(2);
-
+    Limit,
     /// Numeric filter option that matches only the numeric columns with no
     /// precision and scale specified.
-    pub const NUMERIC_FILTER_OPTION_LIMITLESS: NumericFilterOption = NumericFilterOption::new(3);
+    Limitless,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NumericFilterOption::value] or
+    /// [NumericFilterOption::name].
+    UnknownValue(numeric_filter_option::UnknownValue),
+}
 
-    /// Creates a new NumericFilterOption instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod numeric_filter_option {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl NumericFilterOption {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::All => std::option::Option::Some(1),
+            Self::Limit => std::option::Option::Some(2),
+            Self::Limitless => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_ALL"),
-            2 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_LIMIT"),
-            3 => std::borrow::Cow::Borrowed("NUMERIC_FILTER_OPTION_LIMITLESS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NUMERIC_FILTER_OPTION_UNSPECIFIED"),
+            Self::All => std::option::Option::Some("NUMERIC_FILTER_OPTION_ALL"),
+            Self::Limit => std::option::Option::Some("NUMERIC_FILTER_OPTION_LIMIT"),
+            Self::Limitless => std::option::Option::Some("NUMERIC_FILTER_OPTION_LIMITLESS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NUMERIC_FILTER_OPTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_UNSPECIFIED)
-            }
-            "NUMERIC_FILTER_OPTION_ALL" => {
-                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_ALL)
-            }
-            "NUMERIC_FILTER_OPTION_LIMIT" => {
-                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_LIMIT)
-            }
-            "NUMERIC_FILTER_OPTION_LIMITLESS" => {
-                std::option::Option::Some(Self::NUMERIC_FILTER_OPTION_LIMITLESS)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NumericFilterOption {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NumericFilterOption {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NumericFilterOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NumericFilterOption {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::All,
+            2 => Self::Limit,
+            3 => Self::Limitless,
+            _ => Self::UnknownValue(numeric_filter_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NumericFilterOption {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NUMERIC_FILTER_OPTION_UNSPECIFIED" => Self::Unspecified,
+            "NUMERIC_FILTER_OPTION_ALL" => Self::All,
+            "NUMERIC_FILTER_OPTION_LIMIT" => Self::Limit,
+            "NUMERIC_FILTER_OPTION_LIMITLESS" => Self::Limitless,
+            _ => Self::UnknownValue(numeric_filter_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NumericFilterOption {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::All => serializer.serialize_i32(1),
+            Self::Limit => serializer.serialize_i32(2),
+            Self::Limitless => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NumericFilterOption {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NumericFilterOption>::new(
+            ".google.cloud.clouddms.v1.NumericFilterOption",
+        ))
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -865,11 +865,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("tree", &req.tree.value())]);
+        let builder = builder.query(&[("tree", &req.tree)]);
         let builder = builder.query(&[("uncommitted", &req.uncommitted)]);
         let builder = builder.query(&[("commitId", &req.commit_id)]);
         let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -1922,73 +1922,129 @@ pub mod cancel_order_request {
     use super::*;
 
     /// Indicates the cancellation policy the customer uses to cancel the order.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CancellationPolicy(i32);
-
-    impl CancellationPolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CancellationPolicy {
         /// If unspecified, cancellation will try to cancel the order, if order
         /// cannot be immediately cancelled, auto renewal will be turned off.
         /// However, caller should avoid using the value as it will yield a
         /// non-deterministic result. This is still supported mainly to maintain
         /// existing integrated usages and ensure backwards compatibility.
-        pub const CANCELLATION_POLICY_UNSPECIFIED: CancellationPolicy = CancellationPolicy::new(0);
-
+        Unspecified,
         /// Request will cancel the whole order immediately, if order cannot be
         /// immediately cancelled, the request will fail.
-        pub const CANCELLATION_POLICY_CANCEL_IMMEDIATELY: CancellationPolicy =
-            CancellationPolicy::new(1);
-
+        CancelImmediately,
         /// Request will cancel the auto renewal, if order is not subscription based,
         /// the request will fail.
-        pub const CANCELLATION_POLICY_CANCEL_AT_TERM_END: CancellationPolicy =
-            CancellationPolicy::new(2);
+        CancelAtTermEnd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CancellationPolicy::value] or
+        /// [CancellationPolicy::name].
+        UnknownValue(cancellation_policy::UnknownValue),
+    }
 
-        /// Creates a new CancellationPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cancellation_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CancellationPolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CancelImmediately => std::option::Option::Some(1),
+                Self::CancelAtTermEnd => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CANCELLATION_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CANCELLATION_POLICY_CANCEL_IMMEDIATELY"),
-                2 => std::borrow::Cow::Borrowed("CANCELLATION_POLICY_CANCEL_AT_TERM_END"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CANCELLATION_POLICY_UNSPECIFIED"),
+                Self::CancelImmediately => {
+                    std::option::Option::Some("CANCELLATION_POLICY_CANCEL_IMMEDIATELY")
+                }
+                Self::CancelAtTermEnd => {
+                    std::option::Option::Some("CANCELLATION_POLICY_CANCEL_AT_TERM_END")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CANCELLATION_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CANCELLATION_POLICY_UNSPECIFIED)
-                }
-                "CANCELLATION_POLICY_CANCEL_IMMEDIATELY" => {
-                    std::option::Option::Some(Self::CANCELLATION_POLICY_CANCEL_IMMEDIATELY)
-                }
-                "CANCELLATION_POLICY_CANCEL_AT_TERM_END" => {
-                    std::option::Option::Some(Self::CANCELLATION_POLICY_CANCEL_AT_TERM_END)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CancellationPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CancellationPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CancellationPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CancellationPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CancelImmediately,
+                2 => Self::CancelAtTermEnd,
+                _ => Self::UnknownValue(cancellation_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CancellationPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CANCELLATION_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "CANCELLATION_POLICY_CANCEL_IMMEDIATELY" => Self::CancelImmediately,
+                "CANCELLATION_POLICY_CANCEL_AT_TERM_END" => Self::CancelAtTermEnd,
+                _ => Self::UnknownValue(cancellation_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CancellationPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CancelImmediately => serializer.serialize_i32(1),
+                Self::CancelAtTermEnd => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CancellationPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CancellationPolicy>::new(
+                ".google.cloud.commerce.consumer.procurement.v1.CancelOrderRequest.CancellationPolicy"))
         }
     }
 }
@@ -2019,319 +2075,547 @@ impl wkt::message::Message for CancelOrderMetadata {
 }
 
 /// Type of a line item change.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineItemChangeType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LineItemChangeType {
+    /// Sentinel value. Do not use.
+    Unspecified,
+    /// The change is to create a new line item.
+    Create,
+    /// The change is to update an existing line item.
+    Update,
+    /// The change is to cancel an existing line item.
+    Cancel,
+    /// The change is to revert a cancellation.
+    RevertCancellation,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LineItemChangeType::value] or
+    /// [LineItemChangeType::name].
+    UnknownValue(line_item_change_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod line_item_change_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LineItemChangeType {
-    /// Sentinel value. Do not use.
-    pub const LINE_ITEM_CHANGE_TYPE_UNSPECIFIED: LineItemChangeType = LineItemChangeType::new(0);
-
-    /// The change is to create a new line item.
-    pub const LINE_ITEM_CHANGE_TYPE_CREATE: LineItemChangeType = LineItemChangeType::new(1);
-
-    /// The change is to update an existing line item.
-    pub const LINE_ITEM_CHANGE_TYPE_UPDATE: LineItemChangeType = LineItemChangeType::new(2);
-
-    /// The change is to cancel an existing line item.
-    pub const LINE_ITEM_CHANGE_TYPE_CANCEL: LineItemChangeType = LineItemChangeType::new(3);
-
-    /// The change is to revert a cancellation.
-    pub const LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION: LineItemChangeType =
-        LineItemChangeType::new(4);
-
-    /// Creates a new LineItemChangeType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Create => std::option::Option::Some(1),
+            Self::Update => std::option::Option::Some(2),
+            Self::Cancel => std::option::Option::Some(3),
+            Self::RevertCancellation => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_CREATE"),
-            2 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_UPDATE"),
-            3 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_CANCEL"),
-            4 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LINE_ITEM_CHANGE_TYPE_UNSPECIFIED"),
+            Self::Create => std::option::Option::Some("LINE_ITEM_CHANGE_TYPE_CREATE"),
+            Self::Update => std::option::Option::Some("LINE_ITEM_CHANGE_TYPE_UPDATE"),
+            Self::Cancel => std::option::Option::Some("LINE_ITEM_CHANGE_TYPE_CANCEL"),
+            Self::RevertCancellation => {
+                std::option::Option::Some("LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LINE_ITEM_CHANGE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_UNSPECIFIED)
-            }
-            "LINE_ITEM_CHANGE_TYPE_CREATE" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_CREATE)
-            }
-            "LINE_ITEM_CHANGE_TYPE_UPDATE" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_UPDATE)
-            }
-            "LINE_ITEM_CHANGE_TYPE_CANCEL" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_CANCEL)
-            }
-            "LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LineItemChangeType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LineItemChangeType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LineItemChangeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LineItemChangeType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Create,
+            2 => Self::Update,
+            3 => Self::Cancel,
+            4 => Self::RevertCancellation,
+            _ => Self::UnknownValue(line_item_change_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LineItemChangeType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LINE_ITEM_CHANGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "LINE_ITEM_CHANGE_TYPE_CREATE" => Self::Create,
+            "LINE_ITEM_CHANGE_TYPE_UPDATE" => Self::Update,
+            "LINE_ITEM_CHANGE_TYPE_CANCEL" => Self::Cancel,
+            "LINE_ITEM_CHANGE_TYPE_REVERT_CANCELLATION" => Self::RevertCancellation,
+            _ => Self::UnknownValue(line_item_change_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LineItemChangeType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Create => serializer.serialize_i32(1),
+            Self::Update => serializer.serialize_i32(2),
+            Self::Cancel => serializer.serialize_i32(3),
+            Self::RevertCancellation => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LineItemChangeType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LineItemChangeType>::new(
+            ".google.cloud.commerce.consumer.procurement.v1.LineItemChangeType",
+        ))
     }
 }
 
 /// State of a change.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineItemChangeState(i32);
-
-impl LineItemChangeState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LineItemChangeState {
     /// Sentinel value. Do not use.
-    pub const LINE_ITEM_CHANGE_STATE_UNSPECIFIED: LineItemChangeState = LineItemChangeState::new(0);
-
+    Unspecified,
     /// Change is in this state when a change is initiated and waiting for partner
     /// approval. This state is only applicable for pending change.
-    pub const LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL: LineItemChangeState =
-        LineItemChangeState::new(1);
-
+    PendingApproval,
     /// Change is in this state after it's approved by the partner or auto-approved
     /// but before it takes effect. The change can be overwritten or cancelled
     /// depending on the new line item info property (pending Private Offer change
     /// cannot be cancelled and can only be overwritten by another Private Offer).
     /// This state is only applicable for pending change.
-    pub const LINE_ITEM_CHANGE_STATE_APPROVED: LineItemChangeState = LineItemChangeState::new(2);
-
+    Approved,
     /// Change is in this state after it's been activated. This state is only
     /// applicable for change in history.
-    pub const LINE_ITEM_CHANGE_STATE_COMPLETED: LineItemChangeState = LineItemChangeState::new(3);
-
+    Completed,
     /// Change is in this state if it was rejected by the partner. This state is
     /// only applicable for change in history.
-    pub const LINE_ITEM_CHANGE_STATE_REJECTED: LineItemChangeState = LineItemChangeState::new(4);
-
+    Rejected,
     /// Change is in this state if it was abandoned by the user. This state is only
     /// applicable for change in history.
-    pub const LINE_ITEM_CHANGE_STATE_ABANDONED: LineItemChangeState = LineItemChangeState::new(5);
-
+    Abandoned,
     /// Change is in this state if it's currently being provisioned downstream. The
     /// change can't be overwritten or cancelled when it's in this state. This
     /// state is only applicable for pending change.
-    pub const LINE_ITEM_CHANGE_STATE_ACTIVATING: LineItemChangeState = LineItemChangeState::new(6);
+    Activating,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LineItemChangeState::value] or
+    /// [LineItemChangeState::name].
+    UnknownValue(line_item_change_state::UnknownValue),
+}
 
-    /// Creates a new LineItemChangeState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod line_item_change_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LineItemChangeState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PendingApproval => std::option::Option::Some(1),
+            Self::Approved => std::option::Option::Some(2),
+            Self::Completed => std::option::Option::Some(3),
+            Self::Rejected => std::option::Option::Some(4),
+            Self::Abandoned => std::option::Option::Some(5),
+            Self::Activating => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL"),
-            2 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_APPROVED"),
-            3 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_COMPLETED"),
-            4 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REJECTED"),
-            5 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_ABANDONED"),
-            6 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_ACTIVATING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LINE_ITEM_CHANGE_STATE_UNSPECIFIED"),
+            Self::PendingApproval => {
+                std::option::Option::Some("LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL")
+            }
+            Self::Approved => std::option::Option::Some("LINE_ITEM_CHANGE_STATE_APPROVED"),
+            Self::Completed => std::option::Option::Some("LINE_ITEM_CHANGE_STATE_COMPLETED"),
+            Self::Rejected => std::option::Option::Some("LINE_ITEM_CHANGE_STATE_REJECTED"),
+            Self::Abandoned => std::option::Option::Some("LINE_ITEM_CHANGE_STATE_ABANDONED"),
+            Self::Activating => std::option::Option::Some("LINE_ITEM_CHANGE_STATE_ACTIVATING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LINE_ITEM_CHANGE_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_UNSPECIFIED)
-            }
-            "LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL)
-            }
-            "LINE_ITEM_CHANGE_STATE_APPROVED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_APPROVED)
-            }
-            "LINE_ITEM_CHANGE_STATE_COMPLETED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_COMPLETED)
-            }
-            "LINE_ITEM_CHANGE_STATE_REJECTED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REJECTED)
-            }
-            "LINE_ITEM_CHANGE_STATE_ABANDONED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_ABANDONED)
-            }
-            "LINE_ITEM_CHANGE_STATE_ACTIVATING" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_ACTIVATING)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LineItemChangeState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LineItemChangeState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LineItemChangeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LineItemChangeState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PendingApproval,
+            2 => Self::Approved,
+            3 => Self::Completed,
+            4 => Self::Rejected,
+            5 => Self::Abandoned,
+            6 => Self::Activating,
+            _ => Self::UnknownValue(line_item_change_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LineItemChangeState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LINE_ITEM_CHANGE_STATE_UNSPECIFIED" => Self::Unspecified,
+            "LINE_ITEM_CHANGE_STATE_PENDING_APPROVAL" => Self::PendingApproval,
+            "LINE_ITEM_CHANGE_STATE_APPROVED" => Self::Approved,
+            "LINE_ITEM_CHANGE_STATE_COMPLETED" => Self::Completed,
+            "LINE_ITEM_CHANGE_STATE_REJECTED" => Self::Rejected,
+            "LINE_ITEM_CHANGE_STATE_ABANDONED" => Self::Abandoned,
+            "LINE_ITEM_CHANGE_STATE_ACTIVATING" => Self::Activating,
+            _ => Self::UnknownValue(line_item_change_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LineItemChangeState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PendingApproval => serializer.serialize_i32(1),
+            Self::Approved => serializer.serialize_i32(2),
+            Self::Completed => serializer.serialize_i32(3),
+            Self::Rejected => serializer.serialize_i32(4),
+            Self::Abandoned => serializer.serialize_i32(5),
+            Self::Activating => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LineItemChangeState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LineItemChangeState>::new(
+            ".google.cloud.commerce.consumer.procurement.v1.LineItemChangeState",
+        ))
     }
 }
 
 /// Predefined types for line item change state reason.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineItemChangeStateReasonType(i32);
-
-impl LineItemChangeStateReasonType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LineItemChangeStateReasonType {
     /// Default value, indicating there's no predefined type for change state
     /// reason.
-    pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new(0);
-
+    Unspecified,
     /// Change is in current state due to term expiration.
-    pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new(1);
-
+    Expired,
     /// Change is in current state due to user-initiated cancellation.
-    pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new(2);
-
+    UserCancelled,
     /// Change is in current state due to system-initiated cancellation.
-    pub const LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED: LineItemChangeStateReasonType =
-        LineItemChangeStateReasonType::new(3);
+    SystemCancelled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LineItemChangeStateReasonType::value] or
+    /// [LineItemChangeStateReasonType::name].
+    UnknownValue(line_item_change_state_reason_type::UnknownValue),
+}
 
-    /// Creates a new LineItemChangeStateReasonType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod line_item_change_state_reason_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LineItemChangeStateReasonType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Expired => std::option::Option::Some(1),
+            Self::UserCancelled => std::option::Option::Some(2),
+            Self::SystemCancelled => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED"),
-            2 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED"),
-            3 => std::borrow::Cow::Borrowed("LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED")
+            }
+            Self::Expired => {
+                std::option::Option::Some("LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED")
+            }
+            Self::UserCancelled => {
+                std::option::Option::Some("LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED")
+            }
+            Self::SystemCancelled => {
+                std::option::Option::Some("LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED)
-            }
-            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED)
-            }
-            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED)
-            }
-            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED" => {
-                std::option::Option::Some(Self::LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LineItemChangeStateReasonType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LineItemChangeStateReasonType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LineItemChangeStateReasonType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LineItemChangeStateReasonType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Expired,
+            2 => Self::UserCancelled,
+            3 => Self::SystemCancelled,
+            _ => Self::UnknownValue(line_item_change_state_reason_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LineItemChangeStateReasonType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_EXPIRED" => Self::Expired,
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_USER_CANCELLED" => Self::UserCancelled,
+            "LINE_ITEM_CHANGE_STATE_REASON_TYPE_SYSTEM_CANCELLED" => Self::SystemCancelled,
+            _ => Self::UnknownValue(line_item_change_state_reason_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LineItemChangeStateReasonType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Expired => serializer.serialize_i32(1),
+            Self::UserCancelled => serializer.serialize_i32(2),
+            Self::SystemCancelled => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LineItemChangeStateReasonType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<LineItemChangeStateReasonType>::new(
+                ".google.cloud.commerce.consumer.procurement.v1.LineItemChangeStateReasonType",
+            ),
+        )
     }
 }
 
 /// Indicates the auto renewal behavior customer specifies on subscription.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AutoRenewalBehavior(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AutoRenewalBehavior {
+    /// If unspecified, the auto renewal behavior will follow the default config.
+    Unspecified,
+    /// Auto Renewal will be enabled on subscription.
+    Enable,
+    /// Auto Renewal will be disabled on subscription.
+    Disable,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AutoRenewalBehavior::value] or
+    /// [AutoRenewalBehavior::name].
+    UnknownValue(auto_renewal_behavior::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod auto_renewal_behavior {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl AutoRenewalBehavior {
-    /// If unspecified, the auto renewal behavior will follow the default config.
-    pub const AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED: AutoRenewalBehavior = AutoRenewalBehavior::new(0);
-
-    /// Auto Renewal will be enabled on subscription.
-    pub const AUTO_RENEWAL_BEHAVIOR_ENABLE: AutoRenewalBehavior = AutoRenewalBehavior::new(1);
-
-    /// Auto Renewal will be disabled on subscription.
-    pub const AUTO_RENEWAL_BEHAVIOR_DISABLE: AutoRenewalBehavior = AutoRenewalBehavior::new(2);
-
-    /// Creates a new AutoRenewalBehavior instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enable => std::option::Option::Some(1),
+            Self::Disable => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AUTO_RENEWAL_BEHAVIOR_ENABLE"),
-            2 => std::borrow::Cow::Borrowed("AUTO_RENEWAL_BEHAVIOR_DISABLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED"),
+            Self::Enable => std::option::Option::Some("AUTO_RENEWAL_BEHAVIOR_ENABLE"),
+            Self::Disable => std::option::Option::Some("AUTO_RENEWAL_BEHAVIOR_DISABLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED" => {
-                std::option::Option::Some(Self::AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED)
-            }
-            "AUTO_RENEWAL_BEHAVIOR_ENABLE" => {
-                std::option::Option::Some(Self::AUTO_RENEWAL_BEHAVIOR_ENABLE)
-            }
-            "AUTO_RENEWAL_BEHAVIOR_DISABLE" => {
-                std::option::Option::Some(Self::AUTO_RENEWAL_BEHAVIOR_DISABLE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AutoRenewalBehavior {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AutoRenewalBehavior {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AutoRenewalBehavior {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AutoRenewalBehavior {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enable,
+            2 => Self::Disable,
+            _ => Self::UnknownValue(auto_renewal_behavior::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AutoRenewalBehavior {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUTO_RENEWAL_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+            "AUTO_RENEWAL_BEHAVIOR_ENABLE" => Self::Enable,
+            "AUTO_RENEWAL_BEHAVIOR_DISABLE" => Self::Disable,
+            _ => Self::UnknownValue(auto_renewal_behavior::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AutoRenewalBehavior {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enable => serializer.serialize_i32(1),
+            Self::Disable => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AutoRenewalBehavior {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AutoRenewalBehavior>::new(
+            ".google.cloud.commerce.consumer.procurement.v1.AutoRenewalBehavior",
+        ))
     }
 }

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -1155,135 +1155,259 @@ impl wkt::message::Message for ContainerImageSignature {
 }
 
 /// SigningAlgorithm enumerates all the supported signing algorithms.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SigningAlgorithm(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SigningAlgorithm {
+    /// Unspecified signing algorithm.
+    Unspecified,
+    /// RSASSA-PSS with a SHA256 digest.
+    RsassaPssSha256,
+    /// RSASSA-PKCS1 v1.5 with a SHA256 digest.
+    RsassaPkcs1V15Sha256,
+    /// ECDSA on the P-256 Curve with a SHA256 digest.
+    EcdsaP256Sha256,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SigningAlgorithm::value] or
+    /// [SigningAlgorithm::name].
+    UnknownValue(signing_algorithm::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod signing_algorithm {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SigningAlgorithm {
-    /// Unspecified signing algorithm.
-    pub const SIGNING_ALGORITHM_UNSPECIFIED: SigningAlgorithm = SigningAlgorithm::new(0);
-
-    /// RSASSA-PSS with a SHA256 digest.
-    pub const RSASSA_PSS_SHA256: SigningAlgorithm = SigningAlgorithm::new(1);
-
-    /// RSASSA-PKCS1 v1.5 with a SHA256 digest.
-    pub const RSASSA_PKCS1V15_SHA256: SigningAlgorithm = SigningAlgorithm::new(2);
-
-    /// ECDSA on the P-256 Curve with a SHA256 digest.
-    pub const ECDSA_P256_SHA256: SigningAlgorithm = SigningAlgorithm::new(3);
-
-    /// Creates a new SigningAlgorithm instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RsassaPssSha256 => std::option::Option::Some(1),
+            Self::RsassaPkcs1V15Sha256 => std::option::Option::Some(2),
+            Self::EcdsaP256Sha256 => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SIGNING_ALGORITHM_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RSASSA_PSS_SHA256"),
-            2 => std::borrow::Cow::Borrowed("RSASSA_PKCS1V15_SHA256"),
-            3 => std::borrow::Cow::Borrowed("ECDSA_P256_SHA256"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SIGNING_ALGORITHM_UNSPECIFIED"),
+            Self::RsassaPssSha256 => std::option::Option::Some("RSASSA_PSS_SHA256"),
+            Self::RsassaPkcs1V15Sha256 => std::option::Option::Some("RSASSA_PKCS1V15_SHA256"),
+            Self::EcdsaP256Sha256 => std::option::Option::Some("ECDSA_P256_SHA256"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SIGNING_ALGORITHM_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SIGNING_ALGORITHM_UNSPECIFIED)
-            }
-            "RSASSA_PSS_SHA256" => std::option::Option::Some(Self::RSASSA_PSS_SHA256),
-            "RSASSA_PKCS1V15_SHA256" => std::option::Option::Some(Self::RSASSA_PKCS1V15_SHA256),
-            "ECDSA_P256_SHA256" => std::option::Option::Some(Self::ECDSA_P256_SHA256),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SigningAlgorithm {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SigningAlgorithm {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SigningAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SigningAlgorithm {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RsassaPssSha256,
+            2 => Self::RsassaPkcs1V15Sha256,
+            3 => Self::EcdsaP256Sha256,
+            _ => Self::UnknownValue(signing_algorithm::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SigningAlgorithm {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SIGNING_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+            "RSASSA_PSS_SHA256" => Self::RsassaPssSha256,
+            "RSASSA_PKCS1V15_SHA256" => Self::RsassaPkcs1V15Sha256,
+            "ECDSA_P256_SHA256" => Self::EcdsaP256Sha256,
+            _ => Self::UnknownValue(signing_algorithm::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SigningAlgorithm {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RsassaPssSha256 => serializer.serialize_i32(1),
+            Self::RsassaPkcs1V15Sha256 => serializer.serialize_i32(2),
+            Self::EcdsaP256Sha256 => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SigningAlgorithm {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SigningAlgorithm>::new(
+            ".google.cloud.confidentialcomputing.v1.SigningAlgorithm",
+        ))
     }
 }
 
 /// Token type enum contains the different types of token responses Confidential
 /// Space supports
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TokenType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TokenType {
+    /// Unspecified token type
+    Unspecified,
+    /// OpenID Connect (OIDC) token type
+    Oidc,
+    /// Public Key Infrastructure (PKI) token type
+    Pki,
+    /// Limited claim token type for AWS integration
+    LimitedAws,
+    /// Principal-tag-based token for AWS integration
+    AwsPrincipaltags,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TokenType::value] or
+    /// [TokenType::name].
+    UnknownValue(token_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod token_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TokenType {
-    /// Unspecified token type
-    pub const TOKEN_TYPE_UNSPECIFIED: TokenType = TokenType::new(0);
-
-    /// OpenID Connect (OIDC) token type
-    pub const TOKEN_TYPE_OIDC: TokenType = TokenType::new(1);
-
-    /// Public Key Infrastructure (PKI) token type
-    pub const TOKEN_TYPE_PKI: TokenType = TokenType::new(2);
-
-    /// Limited claim token type for AWS integration
-    pub const TOKEN_TYPE_LIMITED_AWS: TokenType = TokenType::new(3);
-
-    /// Principal-tag-based token for AWS integration
-    pub const TOKEN_TYPE_AWS_PRINCIPALTAGS: TokenType = TokenType::new(4);
-
-    /// Creates a new TokenType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Oidc => std::option::Option::Some(1),
+            Self::Pki => std::option::Option::Some(2),
+            Self::LimitedAws => std::option::Option::Some(3),
+            Self::AwsPrincipaltags => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TOKEN_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TOKEN_TYPE_OIDC"),
-            2 => std::borrow::Cow::Borrowed("TOKEN_TYPE_PKI"),
-            3 => std::borrow::Cow::Borrowed("TOKEN_TYPE_LIMITED_AWS"),
-            4 => std::borrow::Cow::Borrowed("TOKEN_TYPE_AWS_PRINCIPALTAGS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TOKEN_TYPE_UNSPECIFIED"),
+            Self::Oidc => std::option::Option::Some("TOKEN_TYPE_OIDC"),
+            Self::Pki => std::option::Option::Some("TOKEN_TYPE_PKI"),
+            Self::LimitedAws => std::option::Option::Some("TOKEN_TYPE_LIMITED_AWS"),
+            Self::AwsPrincipaltags => std::option::Option::Some("TOKEN_TYPE_AWS_PRINCIPALTAGS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TOKEN_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TOKEN_TYPE_UNSPECIFIED),
-            "TOKEN_TYPE_OIDC" => std::option::Option::Some(Self::TOKEN_TYPE_OIDC),
-            "TOKEN_TYPE_PKI" => std::option::Option::Some(Self::TOKEN_TYPE_PKI),
-            "TOKEN_TYPE_LIMITED_AWS" => std::option::Option::Some(Self::TOKEN_TYPE_LIMITED_AWS),
-            "TOKEN_TYPE_AWS_PRINCIPALTAGS" => {
-                std::option::Option::Some(Self::TOKEN_TYPE_AWS_PRINCIPALTAGS)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TokenType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TokenType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TokenType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TokenType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Oidc,
+            2 => Self::Pki,
+            3 => Self::LimitedAws,
+            4 => Self::AwsPrincipaltags,
+            _ => Self::UnknownValue(token_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TokenType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TOKEN_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "TOKEN_TYPE_OIDC" => Self::Oidc,
+            "TOKEN_TYPE_PKI" => Self::Pki,
+            "TOKEN_TYPE_LIMITED_AWS" => Self::LimitedAws,
+            "TOKEN_TYPE_AWS_PRINCIPALTAGS" => Self::AwsPrincipaltags,
+            _ => Self::UnknownValue(token_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TokenType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Oidc => serializer.serialize_i32(1),
+            Self::Pki => serializer.serialize_i32(2),
+            Self::LimitedAws => serializer.serialize_i32(3),
+            Self::AwsPrincipaltags => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TokenType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TokenType>::new(
+            ".google.cloud.confidentialcomputing.v1.TokenType",
+        ))
     }
 }

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -425,250 +425,455 @@ pub mod deployment {
     use super::*;
 
     /// Possible states of a deployment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The deployment is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The deployment is healthy.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The deployment is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The deployment is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The deployment has encountered an unexpected error.
-        pub const FAILED: State = State::new(5);
-
+        Failed,
         /// The deployment is no longer being actively reconciled.
         /// This may be the result of recovering the project after deletion.
-        pub const SUSPENDED: State = State::new(6);
-
+        Suspended,
         /// The deployment has been deleted.
-        pub const DELETED: State = State::new(7);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Suspended => std::option::Option::Some(6),
+                Self::Deleted => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                7 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Failed,
+                6 => Self::Suspended,
+                7 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "SUSPENDED" => Self::Suspended,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Suspended => serializer.serialize_i32(6),
+                Self::Deleted => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.config.v1.Deployment.State",
+            ))
         }
     }
 
     /// Possible errors that can occur with deployments.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(i32);
-
-    impl ErrorCode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorCode {
         /// No error code was specified.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
-
+        Unspecified,
         /// The revision failed. See Revision for more details.
-        pub const REVISION_FAILED: ErrorCode = ErrorCode::new(1);
-
+        RevisionFailed,
         /// Cloud Build failed due to a permission issue.
-        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode = ErrorCode::new(3);
-
+        CloudBuildPermissionDenied,
         /// Cloud Build job associated with a deployment deletion could not be
         /// started.
-        pub const DELETE_BUILD_API_FAILED: ErrorCode = ErrorCode::new(5);
-
+        DeleteBuildApiFailed,
         /// Cloud Build job associated with a deployment deletion was started but
         /// failed.
-        pub const DELETE_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new(6);
-
+        DeleteBuildRunFailed,
         /// Cloud Storage bucket creation failed due to a permission issue.
-        pub const BUCKET_CREATION_PERMISSION_DENIED: ErrorCode = ErrorCode::new(7);
-
+        BucketCreationPermissionDenied,
         /// Cloud Storage bucket creation failed due to an issue unrelated to
         /// permissions.
-        pub const BUCKET_CREATION_FAILED: ErrorCode = ErrorCode::new(8);
+        BucketCreationFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorCode::value] or
+        /// [ErrorCode::name].
+        UnknownValue(error_code::UnknownValue),
+    }
 
-        /// Creates a new ErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ErrorCode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RevisionFailed => std::option::Option::Some(1),
+                Self::CloudBuildPermissionDenied => std::option::Option::Some(3),
+                Self::DeleteBuildApiFailed => std::option::Option::Some(5),
+                Self::DeleteBuildRunFailed => std::option::Option::Some(6),
+                Self::BucketCreationPermissionDenied => std::option::Option::Some(7),
+                Self::BucketCreationFailed => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REVISION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("CLOUD_BUILD_PERMISSION_DENIED"),
-                5 => std::borrow::Cow::Borrowed("DELETE_BUILD_API_FAILED"),
-                6 => std::borrow::Cow::Borrowed("DELETE_BUILD_RUN_FAILED"),
-                7 => std::borrow::Cow::Borrowed("BUCKET_CREATION_PERMISSION_DENIED"),
-                8 => std::borrow::Cow::Borrowed("BUCKET_CREATION_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::RevisionFailed => std::option::Option::Some("REVISION_FAILED"),
+                Self::CloudBuildPermissionDenied => {
+                    std::option::Option::Some("CLOUD_BUILD_PERMISSION_DENIED")
+                }
+                Self::DeleteBuildApiFailed => std::option::Option::Some("DELETE_BUILD_API_FAILED"),
+                Self::DeleteBuildRunFailed => std::option::Option::Some("DELETE_BUILD_RUN_FAILED"),
+                Self::BucketCreationPermissionDenied => {
+                    std::option::Option::Some("BUCKET_CREATION_PERMISSION_DENIED")
+                }
+                Self::BucketCreationFailed => std::option::Option::Some("BUCKET_CREATION_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "REVISION_FAILED" => std::option::Option::Some(Self::REVISION_FAILED),
-                "CLOUD_BUILD_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_PERMISSION_DENIED)
-                }
-                "DELETE_BUILD_API_FAILED" => {
-                    std::option::Option::Some(Self::DELETE_BUILD_API_FAILED)
-                }
-                "DELETE_BUILD_RUN_FAILED" => {
-                    std::option::Option::Some(Self::DELETE_BUILD_RUN_FAILED)
-                }
-                "BUCKET_CREATION_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::BUCKET_CREATION_PERMISSION_DENIED)
-                }
-                "BUCKET_CREATION_FAILED" => std::option::Option::Some(Self::BUCKET_CREATION_FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RevisionFailed,
+                3 => Self::CloudBuildPermissionDenied,
+                5 => Self::DeleteBuildApiFailed,
+                6 => Self::DeleteBuildRunFailed,
+                7 => Self::BucketCreationPermissionDenied,
+                8 => Self::BucketCreationFailed,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "REVISION_FAILED" => Self::RevisionFailed,
+                "CLOUD_BUILD_PERMISSION_DENIED" => Self::CloudBuildPermissionDenied,
+                "DELETE_BUILD_API_FAILED" => Self::DeleteBuildApiFailed,
+                "DELETE_BUILD_RUN_FAILED" => Self::DeleteBuildRunFailed,
+                "BUCKET_CREATION_PERMISSION_DENIED" => Self::BucketCreationPermissionDenied,
+                "BUCKET_CREATION_FAILED" => Self::BucketCreationFailed,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RevisionFailed => serializer.serialize_i32(1),
+                Self::CloudBuildPermissionDenied => serializer.serialize_i32(3),
+                Self::DeleteBuildApiFailed => serializer.serialize_i32(5),
+                Self::DeleteBuildRunFailed => serializer.serialize_i32(6),
+                Self::BucketCreationPermissionDenied => serializer.serialize_i32(7),
+                Self::BucketCreationFailed => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                ".google.cloud.config.v1.Deployment.ErrorCode",
+            ))
         }
     }
 
     /// Possible lock states of a deployment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LockState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LockState {
+        /// The default value. This value is used if the lock state is omitted.
+        Unspecified,
+        /// The deployment is locked.
+        Locked,
+        /// The deployment is unlocked.
+        Unlocked,
+        /// The deployment is being locked.
+        Locking,
+        /// The deployment is being unlocked.
+        Unlocking,
+        /// The deployment has failed to lock.
+        LockFailed,
+        /// The deployment has failed to unlock.
+        UnlockFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LockState::value] or
+        /// [LockState::name].
+        UnknownValue(lock_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod lock_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LockState {
-        /// The default value. This value is used if the lock state is omitted.
-        pub const LOCK_STATE_UNSPECIFIED: LockState = LockState::new(0);
-
-        /// The deployment is locked.
-        pub const LOCKED: LockState = LockState::new(1);
-
-        /// The deployment is unlocked.
-        pub const UNLOCKED: LockState = LockState::new(2);
-
-        /// The deployment is being locked.
-        pub const LOCKING: LockState = LockState::new(3);
-
-        /// The deployment is being unlocked.
-        pub const UNLOCKING: LockState = LockState::new(4);
-
-        /// The deployment has failed to lock.
-        pub const LOCK_FAILED: LockState = LockState::new(5);
-
-        /// The deployment has failed to unlock.
-        pub const UNLOCK_FAILED: LockState = LockState::new(6);
-
-        /// Creates a new LockState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Locked => std::option::Option::Some(1),
+                Self::Unlocked => std::option::Option::Some(2),
+                Self::Locking => std::option::Option::Some(3),
+                Self::Unlocking => std::option::Option::Some(4),
+                Self::LockFailed => std::option::Option::Some(5),
+                Self::UnlockFailed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCK_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOCKED"),
-                2 => std::borrow::Cow::Borrowed("UNLOCKED"),
-                3 => std::borrow::Cow::Borrowed("LOCKING"),
-                4 => std::borrow::Cow::Borrowed("UNLOCKING"),
-                5 => std::borrow::Cow::Borrowed("LOCK_FAILED"),
-                6 => std::borrow::Cow::Borrowed("UNLOCK_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOCK_STATE_UNSPECIFIED"),
+                Self::Locked => std::option::Option::Some("LOCKED"),
+                Self::Unlocked => std::option::Option::Some("UNLOCKED"),
+                Self::Locking => std::option::Option::Some("LOCKING"),
+                Self::Unlocking => std::option::Option::Some("UNLOCKING"),
+                Self::LockFailed => std::option::Option::Some("LOCK_FAILED"),
+                Self::UnlockFailed => std::option::Option::Some("UNLOCK_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCK_STATE_UNSPECIFIED" => std::option::Option::Some(Self::LOCK_STATE_UNSPECIFIED),
-                "LOCKED" => std::option::Option::Some(Self::LOCKED),
-                "UNLOCKED" => std::option::Option::Some(Self::UNLOCKED),
-                "LOCKING" => std::option::Option::Some(Self::LOCKING),
-                "UNLOCKING" => std::option::Option::Some(Self::UNLOCKING),
-                "LOCK_FAILED" => std::option::Option::Some(Self::LOCK_FAILED),
-                "UNLOCK_FAILED" => std::option::Option::Some(Self::UNLOCK_FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LockState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LockState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LockState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LockState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Locked,
+                2 => Self::Unlocked,
+                3 => Self::Locking,
+                4 => Self::Unlocking,
+                5 => Self::LockFailed,
+                6 => Self::UnlockFailed,
+                _ => Self::UnknownValue(lock_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LockState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCK_STATE_UNSPECIFIED" => Self::Unspecified,
+                "LOCKED" => Self::Locked,
+                "UNLOCKED" => Self::Unlocked,
+                "LOCKING" => Self::Locking,
+                "UNLOCKING" => Self::Unlocking,
+                "LOCK_FAILED" => Self::LockFailed,
+                "UNLOCK_FAILED" => Self::UnlockFailed,
+                _ => Self::UnknownValue(lock_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LockState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Locked => serializer.serialize_i32(1),
+                Self::Unlocked => serializer.serialize_i32(2),
+                Self::Locking => serializer.serialize_i32(3),
+                Self::Unlocking => serializer.serialize_i32(4),
+                Self::LockFailed => serializer.serialize_i32(5),
+                Self::UnlockFailed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LockState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LockState>::new(
+                ".google.cloud.config.v1.Deployment.LockState",
+            ))
         }
     }
 
@@ -1622,61 +1827,120 @@ pub mod delete_deployment_request {
     use super::*;
 
     /// Policy on how resources actuated by the deployment should be deleted.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeletePolicy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DeletePolicy {
+        /// Unspecified policy, resources will be deleted.
+        Unspecified,
+        /// Deletes resources actuated by the deployment.
+        Delete,
+        /// Abandons resources and only deletes the deployment and its metadata.
+        Abandon,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DeletePolicy::value] or
+        /// [DeletePolicy::name].
+        UnknownValue(delete_policy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod delete_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DeletePolicy {
-        /// Unspecified policy, resources will be deleted.
-        pub const DELETE_POLICY_UNSPECIFIED: DeletePolicy = DeletePolicy::new(0);
-
-        /// Deletes resources actuated by the deployment.
-        pub const DELETE: DeletePolicy = DeletePolicy::new(1);
-
-        /// Abandons resources and only deletes the deployment and its metadata.
-        pub const ABANDON: DeletePolicy = DeletePolicy::new(2);
-
-        /// Creates a new DeletePolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Delete => std::option::Option::Some(1),
+                Self::Abandon => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DELETE_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DELETE"),
-                2 => std::borrow::Cow::Borrowed("ABANDON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DELETE_POLICY_UNSPECIFIED"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Abandon => std::option::Option::Some("ABANDON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DELETE_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DELETE_POLICY_UNSPECIFIED)
-                }
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "ABANDON" => std::option::Option::Some(Self::ABANDON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DeletePolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DeletePolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DeletePolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DeletePolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Delete,
+                2 => Self::Abandon,
+                _ => Self::UnknownValue(delete_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DeletePolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DELETE_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "DELETE" => Self::Delete,
+                "ABANDON" => Self::Abandon,
+                _ => Self::UnknownValue(delete_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DeletePolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Delete => serializer.serialize_i32(1),
+                Self::Abandon => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DeletePolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeletePolicy>::new(
+                ".google.cloud.config.v1.DeleteDeploymentRequest.DeletePolicy",
+            ))
         }
     }
 }
@@ -2208,200 +2472,389 @@ pub mod revision {
     use super::*;
 
     /// Actions that generate a revision.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// The default value. This value is used if the action is omitted.
+        Unspecified,
+        /// The revision was generated by creating a deployment.
+        Create,
+        /// The revision was generated by updating a deployment.
+        Update,
+        /// The revision was deleted.
+        Delete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// The default value. This value is used if the action is omitted.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// The revision was generated by creating a deployment.
-        pub const CREATE: Action = Action::new(1);
-
-        /// The revision was generated by updating a deployment.
-        pub const UPDATE: Action = Action::new(2);
-
-        /// The revision was deleted.
-        pub const DELETE: Action = Action::new(3);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.cloud.config.v1.Revision.Action",
+            ))
         }
     }
 
     /// Possible states of a revision.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The revision is being applied.
+        Applying,
+        /// The revision was applied successfully.
+        Applied,
+        /// The revision could not be applied successfully.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The revision is being applied.
-        pub const APPLYING: State = State::new(1);
-
-        /// The revision was applied successfully.
-        pub const APPLIED: State = State::new(2);
-
-        /// The revision could not be applied successfully.
-        pub const FAILED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Applying => std::option::Option::Some(1),
+                Self::Applied => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("APPLYING"),
-                2 => std::borrow::Cow::Borrowed("APPLIED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Applying => std::option::Option::Some("APPLYING"),
+                Self::Applied => std::option::Option::Some("APPLIED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "APPLYING" => std::option::Option::Some(Self::APPLYING),
-                "APPLIED" => std::option::Option::Some(Self::APPLIED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Applying,
+                2 => Self::Applied,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "APPLYING" => Self::Applying,
+                "APPLIED" => Self::Applied,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Applying => serializer.serialize_i32(1),
+                Self::Applied => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.config.v1.Revision.State",
+            ))
         }
     }
 
     /// Possible errors if Revision could not be created or updated successfully.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(i32);
-
-    impl ErrorCode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorCode {
         /// No error code was specified.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
-
+        Unspecified,
         /// Cloud Build failed due to a permission issue.
-        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode = ErrorCode::new(1);
-
+        CloudBuildPermissionDenied,
         /// Cloud Build job associated with creating or updating a deployment could
         /// not be started.
-        pub const APPLY_BUILD_API_FAILED: ErrorCode = ErrorCode::new(4);
-
+        ApplyBuildApiFailed,
         /// Cloud Build job associated with creating or updating a deployment was
         /// started but failed.
-        pub const APPLY_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new(5);
-
+        ApplyBuildRunFailed,
         /// quota validation failed for one or more resources in terraform
         /// configuration files.
-        pub const QUOTA_VALIDATION_FAILED: ErrorCode = ErrorCode::new(7);
+        QuotaValidationFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorCode::value] or
+        /// [ErrorCode::name].
+        UnknownValue(error_code::UnknownValue),
+    }
 
-        /// Creates a new ErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ErrorCode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildPermissionDenied => std::option::Option::Some(1),
+                Self::ApplyBuildApiFailed => std::option::Option::Some(4),
+                Self::ApplyBuildRunFailed => std::option::Option::Some(5),
+                Self::QuotaValidationFailed => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_PERMISSION_DENIED"),
-                4 => std::borrow::Cow::Borrowed("APPLY_BUILD_API_FAILED"),
-                5 => std::borrow::Cow::Borrowed("APPLY_BUILD_RUN_FAILED"),
-                7 => std::borrow::Cow::Borrowed("QUOTA_VALIDATION_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "CLOUD_BUILD_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_PERMISSION_DENIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::CloudBuildPermissionDenied => {
+                    std::option::Option::Some("CLOUD_BUILD_PERMISSION_DENIED")
                 }
-                "APPLY_BUILD_API_FAILED" => std::option::Option::Some(Self::APPLY_BUILD_API_FAILED),
-                "APPLY_BUILD_RUN_FAILED" => std::option::Option::Some(Self::APPLY_BUILD_RUN_FAILED),
-                "QUOTA_VALIDATION_FAILED" => {
-                    std::option::Option::Some(Self::QUOTA_VALIDATION_FAILED)
-                }
-                _ => std::option::Option::None,
+                Self::ApplyBuildApiFailed => std::option::Option::Some("APPLY_BUILD_API_FAILED"),
+                Self::ApplyBuildRunFailed => std::option::Option::Some("APPLY_BUILD_RUN_FAILED"),
+                Self::QuotaValidationFailed => std::option::Option::Some("QUOTA_VALIDATION_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildPermissionDenied,
+                4 => Self::ApplyBuildApiFailed,
+                5 => Self::ApplyBuildRunFailed,
+                7 => Self::QuotaValidationFailed,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_PERMISSION_DENIED" => Self::CloudBuildPermissionDenied,
+                "APPLY_BUILD_API_FAILED" => Self::ApplyBuildApiFailed,
+                "APPLY_BUILD_RUN_FAILED" => Self::ApplyBuildRunFailed,
+                "QUOTA_VALIDATION_FAILED" => Self::QuotaValidationFailed,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildPermissionDenied => serializer.serialize_i32(1),
+                Self::ApplyBuildApiFailed => serializer.serialize_i32(4),
+                Self::ApplyBuildRunFailed => serializer.serialize_i32(5),
+                Self::QuotaValidationFailed => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                ".google.cloud.config.v1.Revision.ErrorCode",
+            ))
         }
     }
 
@@ -2632,116 +3085,195 @@ pub mod deployment_operation_metadata {
     use super::*;
 
     /// The possible steps a deployment may be running.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeploymentStep(i32);
-
-    impl DeploymentStep {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DeploymentStep {
         /// Unspecified deployment step
-        pub const DEPLOYMENT_STEP_UNSPECIFIED: DeploymentStep = DeploymentStep::new(0);
-
+        Unspecified,
         /// Infra Manager is creating a Google Cloud Storage bucket to store
         /// artifacts and metadata about the deployment and revision
-        pub const PREPARING_STORAGE_BUCKET: DeploymentStep = DeploymentStep::new(1);
-
+        PreparingStorageBucket,
         /// Downloading the blueprint onto the Google Cloud Storage bucket
-        pub const DOWNLOADING_BLUEPRINT: DeploymentStep = DeploymentStep::new(2);
-
+        DownloadingBlueprint,
         /// Initializing Terraform using `terraform init`
-        pub const RUNNING_TF_INIT: DeploymentStep = DeploymentStep::new(3);
-
+        RunningTfInit,
         /// Running `terraform plan`
-        pub const RUNNING_TF_PLAN: DeploymentStep = DeploymentStep::new(4);
-
+        RunningTfPlan,
         /// Actuating resources using Terraform using `terraform apply`
-        pub const RUNNING_TF_APPLY: DeploymentStep = DeploymentStep::new(5);
-
+        RunningTfApply,
         /// Destroying resources using Terraform using `terraform destroy`
-        pub const RUNNING_TF_DESTROY: DeploymentStep = DeploymentStep::new(6);
-
+        RunningTfDestroy,
         /// Validating the uploaded TF state file when unlocking a deployment
-        pub const RUNNING_TF_VALIDATE: DeploymentStep = DeploymentStep::new(7);
-
+        RunningTfValidate,
         /// Unlocking a deployment
-        pub const UNLOCKING_DEPLOYMENT: DeploymentStep = DeploymentStep::new(8);
-
+        UnlockingDeployment,
         /// Operation was successful
-        pub const SUCCEEDED: DeploymentStep = DeploymentStep::new(9);
-
+        Succeeded,
         /// Operation failed
-        pub const FAILED: DeploymentStep = DeploymentStep::new(10);
-
+        Failed,
         /// Validating the provided repository.
-        pub const VALIDATING_REPOSITORY: DeploymentStep = DeploymentStep::new(11);
-
+        ValidatingRepository,
         /// Running quota validation
-        pub const RUNNING_QUOTA_VALIDATION: DeploymentStep = DeploymentStep::new(12);
+        RunningQuotaValidation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DeploymentStep::value] or
+        /// [DeploymentStep::name].
+        UnknownValue(deployment_step::UnknownValue),
+    }
 
-        /// Creates a new DeploymentStep instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod deployment_step {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DeploymentStep {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PreparingStorageBucket => std::option::Option::Some(1),
+                Self::DownloadingBlueprint => std::option::Option::Some(2),
+                Self::RunningTfInit => std::option::Option::Some(3),
+                Self::RunningTfPlan => std::option::Option::Some(4),
+                Self::RunningTfApply => std::option::Option::Some(5),
+                Self::RunningTfDestroy => std::option::Option::Some(6),
+                Self::RunningTfValidate => std::option::Option::Some(7),
+                Self::UnlockingDeployment => std::option::Option::Some(8),
+                Self::Succeeded => std::option::Option::Some(9),
+                Self::Failed => std::option::Option::Some(10),
+                Self::ValidatingRepository => std::option::Option::Some(11),
+                Self::RunningQuotaValidation => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEPLOYMENT_STEP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PREPARING_STORAGE_BUCKET"),
-                2 => std::borrow::Cow::Borrowed("DOWNLOADING_BLUEPRINT"),
-                3 => std::borrow::Cow::Borrowed("RUNNING_TF_INIT"),
-                4 => std::borrow::Cow::Borrowed("RUNNING_TF_PLAN"),
-                5 => std::borrow::Cow::Borrowed("RUNNING_TF_APPLY"),
-                6 => std::borrow::Cow::Borrowed("RUNNING_TF_DESTROY"),
-                7 => std::borrow::Cow::Borrowed("RUNNING_TF_VALIDATE"),
-                8 => std::borrow::Cow::Borrowed("UNLOCKING_DEPLOYMENT"),
-                9 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                10 => std::borrow::Cow::Borrowed("FAILED"),
-                11 => std::borrow::Cow::Borrowed("VALIDATING_REPOSITORY"),
-                12 => std::borrow::Cow::Borrowed("RUNNING_QUOTA_VALIDATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DEPLOYMENT_STEP_UNSPECIFIED"),
+                Self::PreparingStorageBucket => {
+                    std::option::Option::Some("PREPARING_STORAGE_BUCKET")
+                }
+                Self::DownloadingBlueprint => std::option::Option::Some("DOWNLOADING_BLUEPRINT"),
+                Self::RunningTfInit => std::option::Option::Some("RUNNING_TF_INIT"),
+                Self::RunningTfPlan => std::option::Option::Some("RUNNING_TF_PLAN"),
+                Self::RunningTfApply => std::option::Option::Some("RUNNING_TF_APPLY"),
+                Self::RunningTfDestroy => std::option::Option::Some("RUNNING_TF_DESTROY"),
+                Self::RunningTfValidate => std::option::Option::Some("RUNNING_TF_VALIDATE"),
+                Self::UnlockingDeployment => std::option::Option::Some("UNLOCKING_DEPLOYMENT"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::ValidatingRepository => std::option::Option::Some("VALIDATING_REPOSITORY"),
+                Self::RunningQuotaValidation => {
+                    std::option::Option::Some("RUNNING_QUOTA_VALIDATION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEPLOYMENT_STEP_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DEPLOYMENT_STEP_UNSPECIFIED)
-                }
-                "PREPARING_STORAGE_BUCKET" => {
-                    std::option::Option::Some(Self::PREPARING_STORAGE_BUCKET)
-                }
-                "DOWNLOADING_BLUEPRINT" => std::option::Option::Some(Self::DOWNLOADING_BLUEPRINT),
-                "RUNNING_TF_INIT" => std::option::Option::Some(Self::RUNNING_TF_INIT),
-                "RUNNING_TF_PLAN" => std::option::Option::Some(Self::RUNNING_TF_PLAN),
-                "RUNNING_TF_APPLY" => std::option::Option::Some(Self::RUNNING_TF_APPLY),
-                "RUNNING_TF_DESTROY" => std::option::Option::Some(Self::RUNNING_TF_DESTROY),
-                "RUNNING_TF_VALIDATE" => std::option::Option::Some(Self::RUNNING_TF_VALIDATE),
-                "UNLOCKING_DEPLOYMENT" => std::option::Option::Some(Self::UNLOCKING_DEPLOYMENT),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "VALIDATING_REPOSITORY" => std::option::Option::Some(Self::VALIDATING_REPOSITORY),
-                "RUNNING_QUOTA_VALIDATION" => {
-                    std::option::Option::Some(Self::RUNNING_QUOTA_VALIDATION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DeploymentStep {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DeploymentStep {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DeploymentStep {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DeploymentStep {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PreparingStorageBucket,
+                2 => Self::DownloadingBlueprint,
+                3 => Self::RunningTfInit,
+                4 => Self::RunningTfPlan,
+                5 => Self::RunningTfApply,
+                6 => Self::RunningTfDestroy,
+                7 => Self::RunningTfValidate,
+                8 => Self::UnlockingDeployment,
+                9 => Self::Succeeded,
+                10 => Self::Failed,
+                11 => Self::ValidatingRepository,
+                12 => Self::RunningQuotaValidation,
+                _ => Self::UnknownValue(deployment_step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DeploymentStep {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEPLOYMENT_STEP_UNSPECIFIED" => Self::Unspecified,
+                "PREPARING_STORAGE_BUCKET" => Self::PreparingStorageBucket,
+                "DOWNLOADING_BLUEPRINT" => Self::DownloadingBlueprint,
+                "RUNNING_TF_INIT" => Self::RunningTfInit,
+                "RUNNING_TF_PLAN" => Self::RunningTfPlan,
+                "RUNNING_TF_APPLY" => Self::RunningTfApply,
+                "RUNNING_TF_DESTROY" => Self::RunningTfDestroy,
+                "RUNNING_TF_VALIDATE" => Self::RunningTfValidate,
+                "UNLOCKING_DEPLOYMENT" => Self::UnlockingDeployment,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "VALIDATING_REPOSITORY" => Self::ValidatingRepository,
+                "RUNNING_QUOTA_VALIDATION" => Self::RunningQuotaValidation,
+                _ => Self::UnknownValue(deployment_step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DeploymentStep {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PreparingStorageBucket => serializer.serialize_i32(1),
+                Self::DownloadingBlueprint => serializer.serialize_i32(2),
+                Self::RunningTfInit => serializer.serialize_i32(3),
+                Self::RunningTfPlan => serializer.serialize_i32(4),
+                Self::RunningTfApply => serializer.serialize_i32(5),
+                Self::RunningTfDestroy => serializer.serialize_i32(6),
+                Self::RunningTfValidate => serializer.serialize_i32(7),
+                Self::UnlockingDeployment => serializer.serialize_i32(8),
+                Self::Succeeded => serializer.serialize_i32(9),
+                Self::Failed => serializer.serialize_i32(10),
+                Self::ValidatingRepository => serializer.serialize_i32(11),
+                Self::RunningQuotaValidation => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DeploymentStep {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeploymentStep>::new(
+                ".google.cloud.config.v1.DeploymentOperationMetadata.DeploymentStep",
+            ))
         }
     }
 }
@@ -2842,141 +3374,273 @@ pub mod resource {
     use super::*;
 
     /// Possible intent of the resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Intent(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Intent {
+        /// The default value. This value is used if the intent is omitted.
+        Unspecified,
+        /// Infra Manager will create this Resource.
+        Create,
+        /// Infra Manager will update this Resource.
+        Update,
+        /// Infra Manager will delete this Resource.
+        Delete,
+        /// Infra Manager will destroy and recreate this Resource.
+        Recreate,
+        /// Infra Manager will leave this Resource untouched.
+        Unchanged,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Intent::value] or
+        /// [Intent::name].
+        UnknownValue(intent::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod intent {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Intent {
-        /// The default value. This value is used if the intent is omitted.
-        pub const INTENT_UNSPECIFIED: Intent = Intent::new(0);
-
-        /// Infra Manager will create this Resource.
-        pub const CREATE: Intent = Intent::new(1);
-
-        /// Infra Manager will update this Resource.
-        pub const UPDATE: Intent = Intent::new(2);
-
-        /// Infra Manager will delete this Resource.
-        pub const DELETE: Intent = Intent::new(3);
-
-        /// Infra Manager will destroy and recreate this Resource.
-        pub const RECREATE: Intent = Intent::new(4);
-
-        /// Infra Manager will leave this Resource untouched.
-        pub const UNCHANGED: Intent = Intent::new(5);
-
-        /// Creates a new Intent instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::Recreate => std::option::Option::Some(4),
+                Self::Unchanged => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INTENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                4 => std::borrow::Cow::Borrowed("RECREATE"),
-                5 => std::borrow::Cow::Borrowed("UNCHANGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INTENT_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Recreate => std::option::Option::Some("RECREATE"),
+                Self::Unchanged => std::option::Option::Some("UNCHANGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INTENT_UNSPECIFIED" => std::option::Option::Some(Self::INTENT_UNSPECIFIED),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "RECREATE" => std::option::Option::Some(Self::RECREATE),
-                "UNCHANGED" => std::option::Option::Some(Self::UNCHANGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Intent {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Intent {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Intent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Intent {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                4 => Self::Recreate,
+                5 => Self::Unchanged,
+                _ => Self::UnknownValue(intent::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Intent {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INTENT_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                "RECREATE" => Self::Recreate,
+                "UNCHANGED" => Self::Unchanged,
+                _ => Self::UnknownValue(intent::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Intent {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::Recreate => serializer.serialize_i32(4),
+                Self::Unchanged => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Intent {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Intent>::new(
+                ".google.cloud.config.v1.Resource.Intent",
+            ))
         }
     }
 
     /// Possible states of a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// Resource has been planned for reconcile.
+        Planned,
+        /// Resource is actively reconciling into the intended state.
+        InProgress,
+        /// Resource has reconciled to intended state.
+        Reconciled,
+        /// Resource failed to reconcile.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Resource has been planned for reconcile.
-        pub const PLANNED: State = State::new(1);
-
-        /// Resource is actively reconciling into the intended state.
-        pub const IN_PROGRESS: State = State::new(2);
-
-        /// Resource has reconciled to intended state.
-        pub const RECONCILED: State = State::new(3);
-
-        /// Resource failed to reconcile.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Planned => std::option::Option::Some(1),
+                Self::InProgress => std::option::Option::Some(2),
+                Self::Reconciled => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PLANNED"),
-                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("RECONCILED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Planned => std::option::Option::Some("PLANNED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Reconciled => std::option::Option::Some("RECONCILED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PLANNED" => std::option::Option::Some(Self::PLANNED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "RECONCILED" => std::option::Option::Some(Self::RECONCILED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Planned,
+                2 => Self::InProgress,
+                3 => Self::Reconciled,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PLANNED" => Self::Planned,
+                "IN_PROGRESS" => Self::InProgress,
+                "RECONCILED" => Self::Reconciled,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Planned => serializer.serialize_i32(1),
+                Self::InProgress => serializer.serialize_i32(2),
+                Self::Reconciled => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.config.v1.Resource.State",
+            ))
         }
     }
 }
@@ -4028,232 +4692,431 @@ pub mod preview {
     use super::*;
 
     /// Possible states of a preview.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value is used if the state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The preview is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The preview has succeeded.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// The preview is being applied.
-        pub const APPLYING: State = State::new(3);
-
+        Applying,
         /// The preview is stale. A preview can become stale if a revision has been
         /// applied after this preview was created.
-        pub const STALE: State = State::new(4);
-
+        Stale,
         /// The preview is being deleted.
-        pub const DELETING: State = State::new(5);
-
+        Deleting,
         /// The preview has encountered an unexpected error.
-        pub const FAILED: State = State::new(6);
-
+        Failed,
         /// The preview has been deleted.
-        pub const DELETED: State = State::new(7);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Applying => std::option::Option::Some(3),
+                Self::Stale => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Deleted => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("APPLYING"),
-                4 => std::borrow::Cow::Borrowed("STALE"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Applying => std::option::Option::Some("APPLYING"),
+                Self::Stale => std::option::Option::Some("STALE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "APPLYING" => std::option::Option::Some(Self::APPLYING),
-                "STALE" => std::option::Option::Some(Self::STALE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Succeeded,
+                3 => Self::Applying,
+                4 => Self::Stale,
+                5 => Self::Deleting,
+                6 => Self::Failed,
+                7 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "SUCCEEDED" => Self::Succeeded,
+                "APPLYING" => Self::Applying,
+                "STALE" => Self::Stale,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Applying => serializer.serialize_i32(3),
+                Self::Stale => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Deleted => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.config.v1.Preview.State",
+            ))
         }
     }
 
     /// Preview mode provides options for customizing preview operations.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PreviewMode(i32);
-
-    impl PreviewMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PreviewMode {
         /// Unspecified policy, default mode will be used.
-        pub const PREVIEW_MODE_UNSPECIFIED: PreviewMode = PreviewMode::new(0);
-
+        Unspecified,
         /// DEFAULT mode generates an execution plan for reconciling current resource
         /// state into expected resource state.
-        pub const DEFAULT: PreviewMode = PreviewMode::new(1);
-
+        Default,
         /// DELETE mode generates as execution plan for destroying current resources.
-        pub const DELETE: PreviewMode = PreviewMode::new(2);
+        Delete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PreviewMode::value] or
+        /// [PreviewMode::name].
+        UnknownValue(preview_mode::UnknownValue),
+    }
 
-        /// Creates a new PreviewMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod preview_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PreviewMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::Delete => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PREVIEW_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PREVIEW_MODE_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PREVIEW_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PREVIEW_MODE_UNSPECIFIED)
-                }
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PreviewMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PreviewMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PreviewMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PreviewMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::Delete,
+                _ => Self::UnknownValue(preview_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PreviewMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PREVIEW_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "DELETE" => Self::Delete,
+                _ => Self::UnknownValue(preview_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PreviewMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::Delete => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PreviewMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PreviewMode>::new(
+                ".google.cloud.config.v1.Preview.PreviewMode",
+            ))
         }
     }
 
     /// Possible errors that can occur with previews.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorCode {
+        /// No error code was specified.
+        Unspecified,
+        /// Cloud Build failed due to a permissions issue.
+        CloudBuildPermissionDenied,
+        /// Cloud Storage bucket failed to create due to a permissions issue.
+        BucketCreationPermissionDenied,
+        /// Cloud Storage bucket failed for a non-permissions-related issue.
+        BucketCreationFailed,
+        /// Acquiring lock on provided deployment reference failed.
+        DeploymentLockAcquireFailed,
+        /// Preview encountered an error when trying to access Cloud Build API.
+        PreviewBuildApiFailed,
+        /// Preview created a build but build failed and logs were generated.
+        PreviewBuildRunFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorCode::value] or
+        /// [ErrorCode::name].
+        UnknownValue(error_code::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ErrorCode {
-        /// No error code was specified.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
-
-        /// Cloud Build failed due to a permissions issue.
-        pub const CLOUD_BUILD_PERMISSION_DENIED: ErrorCode = ErrorCode::new(1);
-
-        /// Cloud Storage bucket failed to create due to a permissions issue.
-        pub const BUCKET_CREATION_PERMISSION_DENIED: ErrorCode = ErrorCode::new(2);
-
-        /// Cloud Storage bucket failed for a non-permissions-related issue.
-        pub const BUCKET_CREATION_FAILED: ErrorCode = ErrorCode::new(3);
-
-        /// Acquiring lock on provided deployment reference failed.
-        pub const DEPLOYMENT_LOCK_ACQUIRE_FAILED: ErrorCode = ErrorCode::new(4);
-
-        /// Preview encountered an error when trying to access Cloud Build API.
-        pub const PREVIEW_BUILD_API_FAILED: ErrorCode = ErrorCode::new(5);
-
-        /// Preview created a build but build failed and logs were generated.
-        pub const PREVIEW_BUILD_RUN_FAILED: ErrorCode = ErrorCode::new(6);
-
-        /// Creates a new ErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildPermissionDenied => std::option::Option::Some(1),
+                Self::BucketCreationPermissionDenied => std::option::Option::Some(2),
+                Self::BucketCreationFailed => std::option::Option::Some(3),
+                Self::DeploymentLockAcquireFailed => std::option::Option::Some(4),
+                Self::PreviewBuildApiFailed => std::option::Option::Some(5),
+                Self::PreviewBuildRunFailed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_PERMISSION_DENIED"),
-                2 => std::borrow::Cow::Borrowed("BUCKET_CREATION_PERMISSION_DENIED"),
-                3 => std::borrow::Cow::Borrowed("BUCKET_CREATION_FAILED"),
-                4 => std::borrow::Cow::Borrowed("DEPLOYMENT_LOCK_ACQUIRE_FAILED"),
-                5 => std::borrow::Cow::Borrowed("PREVIEW_BUILD_API_FAILED"),
-                6 => std::borrow::Cow::Borrowed("PREVIEW_BUILD_RUN_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::CloudBuildPermissionDenied => {
+                    std::option::Option::Some("CLOUD_BUILD_PERMISSION_DENIED")
+                }
+                Self::BucketCreationPermissionDenied => {
+                    std::option::Option::Some("BUCKET_CREATION_PERMISSION_DENIED")
+                }
+                Self::BucketCreationFailed => std::option::Option::Some("BUCKET_CREATION_FAILED"),
+                Self::DeploymentLockAcquireFailed => {
+                    std::option::Option::Some("DEPLOYMENT_LOCK_ACQUIRE_FAILED")
+                }
+                Self::PreviewBuildApiFailed => {
+                    std::option::Option::Some("PREVIEW_BUILD_API_FAILED")
+                }
+                Self::PreviewBuildRunFailed => {
+                    std::option::Option::Some("PREVIEW_BUILD_RUN_FAILED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "CLOUD_BUILD_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_PERMISSION_DENIED)
-                }
-                "BUCKET_CREATION_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::BUCKET_CREATION_PERMISSION_DENIED)
-                }
-                "BUCKET_CREATION_FAILED" => std::option::Option::Some(Self::BUCKET_CREATION_FAILED),
-                "DEPLOYMENT_LOCK_ACQUIRE_FAILED" => {
-                    std::option::Option::Some(Self::DEPLOYMENT_LOCK_ACQUIRE_FAILED)
-                }
-                "PREVIEW_BUILD_API_FAILED" => {
-                    std::option::Option::Some(Self::PREVIEW_BUILD_API_FAILED)
-                }
-                "PREVIEW_BUILD_RUN_FAILED" => {
-                    std::option::Option::Some(Self::PREVIEW_BUILD_RUN_FAILED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildPermissionDenied,
+                2 => Self::BucketCreationPermissionDenied,
+                3 => Self::BucketCreationFailed,
+                4 => Self::DeploymentLockAcquireFailed,
+                5 => Self::PreviewBuildApiFailed,
+                6 => Self::PreviewBuildRunFailed,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_PERMISSION_DENIED" => Self::CloudBuildPermissionDenied,
+                "BUCKET_CREATION_PERMISSION_DENIED" => Self::BucketCreationPermissionDenied,
+                "BUCKET_CREATION_FAILED" => Self::BucketCreationFailed,
+                "DEPLOYMENT_LOCK_ACQUIRE_FAILED" => Self::DeploymentLockAcquireFailed,
+                "PREVIEW_BUILD_API_FAILED" => Self::PreviewBuildApiFailed,
+                "PREVIEW_BUILD_RUN_FAILED" => Self::PreviewBuildRunFailed,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildPermissionDenied => serializer.serialize_i32(1),
+                Self::BucketCreationPermissionDenied => serializer.serialize_i32(2),
+                Self::BucketCreationFailed => serializer.serialize_i32(3),
+                Self::DeploymentLockAcquireFailed => serializer.serialize_i32(4),
+                Self::PreviewBuildApiFailed => serializer.serialize_i32(5),
+                Self::PreviewBuildRunFailed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                ".google.cloud.config.v1.Preview.ErrorCode",
+            ))
         }
     }
 
@@ -4344,104 +5207,179 @@ pub mod preview_operation_metadata {
     use super::*;
 
     /// The possible steps a preview may be running.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PreviewStep(i32);
-
-    impl PreviewStep {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PreviewStep {
         /// Unspecified preview step.
-        pub const PREVIEW_STEP_UNSPECIFIED: PreviewStep = PreviewStep::new(0);
-
+        Unspecified,
         /// Infra Manager is creating a Google Cloud Storage bucket to store
         /// artifacts and metadata about the preview.
-        pub const PREPARING_STORAGE_BUCKET: PreviewStep = PreviewStep::new(1);
-
+        PreparingStorageBucket,
         /// Downloading the blueprint onto the Google Cloud Storage bucket.
-        pub const DOWNLOADING_BLUEPRINT: PreviewStep = PreviewStep::new(2);
-
+        DownloadingBlueprint,
         /// Initializing Terraform using `terraform init`.
-        pub const RUNNING_TF_INIT: PreviewStep = PreviewStep::new(3);
-
+        RunningTfInit,
         /// Running `terraform plan`.
-        pub const RUNNING_TF_PLAN: PreviewStep = PreviewStep::new(4);
-
+        RunningTfPlan,
         /// Fetching a deployment.
-        pub const FETCHING_DEPLOYMENT: PreviewStep = PreviewStep::new(5);
-
+        FetchingDeployment,
         /// Locking a deployment.
-        pub const LOCKING_DEPLOYMENT: PreviewStep = PreviewStep::new(6);
-
+        LockingDeployment,
         /// Unlocking a deployment.
-        pub const UNLOCKING_DEPLOYMENT: PreviewStep = PreviewStep::new(7);
-
+        UnlockingDeployment,
         /// Operation was successful.
-        pub const SUCCEEDED: PreviewStep = PreviewStep::new(8);
-
+        Succeeded,
         /// Operation failed.
-        pub const FAILED: PreviewStep = PreviewStep::new(9);
-
+        Failed,
         /// Validating the provided repository.
-        pub const VALIDATING_REPOSITORY: PreviewStep = PreviewStep::new(10);
+        ValidatingRepository,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PreviewStep::value] or
+        /// [PreviewStep::name].
+        UnknownValue(preview_step::UnknownValue),
+    }
 
-        /// Creates a new PreviewStep instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod preview_step {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PreviewStep {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PreparingStorageBucket => std::option::Option::Some(1),
+                Self::DownloadingBlueprint => std::option::Option::Some(2),
+                Self::RunningTfInit => std::option::Option::Some(3),
+                Self::RunningTfPlan => std::option::Option::Some(4),
+                Self::FetchingDeployment => std::option::Option::Some(5),
+                Self::LockingDeployment => std::option::Option::Some(6),
+                Self::UnlockingDeployment => std::option::Option::Some(7),
+                Self::Succeeded => std::option::Option::Some(8),
+                Self::Failed => std::option::Option::Some(9),
+                Self::ValidatingRepository => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PREVIEW_STEP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PREPARING_STORAGE_BUCKET"),
-                2 => std::borrow::Cow::Borrowed("DOWNLOADING_BLUEPRINT"),
-                3 => std::borrow::Cow::Borrowed("RUNNING_TF_INIT"),
-                4 => std::borrow::Cow::Borrowed("RUNNING_TF_PLAN"),
-                5 => std::borrow::Cow::Borrowed("FETCHING_DEPLOYMENT"),
-                6 => std::borrow::Cow::Borrowed("LOCKING_DEPLOYMENT"),
-                7 => std::borrow::Cow::Borrowed("UNLOCKING_DEPLOYMENT"),
-                8 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                9 => std::borrow::Cow::Borrowed("FAILED"),
-                10 => std::borrow::Cow::Borrowed("VALIDATING_REPOSITORY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PREVIEW_STEP_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PREVIEW_STEP_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PREVIEW_STEP_UNSPECIFIED"),
+                Self::PreparingStorageBucket => {
+                    std::option::Option::Some("PREPARING_STORAGE_BUCKET")
                 }
-                "PREPARING_STORAGE_BUCKET" => {
-                    std::option::Option::Some(Self::PREPARING_STORAGE_BUCKET)
-                }
-                "DOWNLOADING_BLUEPRINT" => std::option::Option::Some(Self::DOWNLOADING_BLUEPRINT),
-                "RUNNING_TF_INIT" => std::option::Option::Some(Self::RUNNING_TF_INIT),
-                "RUNNING_TF_PLAN" => std::option::Option::Some(Self::RUNNING_TF_PLAN),
-                "FETCHING_DEPLOYMENT" => std::option::Option::Some(Self::FETCHING_DEPLOYMENT),
-                "LOCKING_DEPLOYMENT" => std::option::Option::Some(Self::LOCKING_DEPLOYMENT),
-                "UNLOCKING_DEPLOYMENT" => std::option::Option::Some(Self::UNLOCKING_DEPLOYMENT),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "VALIDATING_REPOSITORY" => std::option::Option::Some(Self::VALIDATING_REPOSITORY),
-                _ => std::option::Option::None,
+                Self::DownloadingBlueprint => std::option::Option::Some("DOWNLOADING_BLUEPRINT"),
+                Self::RunningTfInit => std::option::Option::Some("RUNNING_TF_INIT"),
+                Self::RunningTfPlan => std::option::Option::Some("RUNNING_TF_PLAN"),
+                Self::FetchingDeployment => std::option::Option::Some("FETCHING_DEPLOYMENT"),
+                Self::LockingDeployment => std::option::Option::Some("LOCKING_DEPLOYMENT"),
+                Self::UnlockingDeployment => std::option::Option::Some("UNLOCKING_DEPLOYMENT"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::ValidatingRepository => std::option::Option::Some("VALIDATING_REPOSITORY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PreviewStep {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PreviewStep {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PreviewStep {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PreviewStep {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PreparingStorageBucket,
+                2 => Self::DownloadingBlueprint,
+                3 => Self::RunningTfInit,
+                4 => Self::RunningTfPlan,
+                5 => Self::FetchingDeployment,
+                6 => Self::LockingDeployment,
+                7 => Self::UnlockingDeployment,
+                8 => Self::Succeeded,
+                9 => Self::Failed,
+                10 => Self::ValidatingRepository,
+                _ => Self::UnknownValue(preview_step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PreviewStep {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PREVIEW_STEP_UNSPECIFIED" => Self::Unspecified,
+                "PREPARING_STORAGE_BUCKET" => Self::PreparingStorageBucket,
+                "DOWNLOADING_BLUEPRINT" => Self::DownloadingBlueprint,
+                "RUNNING_TF_INIT" => Self::RunningTfInit,
+                "RUNNING_TF_PLAN" => Self::RunningTfPlan,
+                "FETCHING_DEPLOYMENT" => Self::FetchingDeployment,
+                "LOCKING_DEPLOYMENT" => Self::LockingDeployment,
+                "UNLOCKING_DEPLOYMENT" => Self::UnlockingDeployment,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "VALIDATING_REPOSITORY" => Self::ValidatingRepository,
+                _ => Self::UnknownValue(preview_step::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PreviewStep {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PreparingStorageBucket => serializer.serialize_i32(1),
+                Self::DownloadingBlueprint => serializer.serialize_i32(2),
+                Self::RunningTfInit => serializer.serialize_i32(3),
+                Self::RunningTfPlan => serializer.serialize_i32(4),
+                Self::FetchingDeployment => serializer.serialize_i32(5),
+                Self::LockingDeployment => serializer.serialize_i32(6),
+                Self::UnlockingDeployment => serializer.serialize_i32(7),
+                Self::Succeeded => serializer.serialize_i32(8),
+                Self::Failed => serializer.serialize_i32(9),
+                Self::ValidatingRepository => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PreviewStep {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PreviewStep>::new(
+                ".google.cloud.config.v1.PreviewOperationMetadata.PreviewStep",
+            ))
         }
     }
 }
@@ -5238,128 +6176,250 @@ pub mod terraform_version {
     use super::*;
 
     /// Possible states of a TerraformVersion.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The version is actively supported.
+        Active,
+        /// The version is deprecated.
+        Deprecated,
+        /// The version is obsolete.
+        Obsolete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The version is actively supported.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The version is deprecated.
-        pub const DEPRECATED: State = State::new(2);
-
-        /// The version is obsolete.
-        pub const OBSOLETE: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Deprecated => std::option::Option::Some(2),
+                Self::Obsolete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                3 => std::borrow::Cow::Borrowed("OBSOLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::Obsolete => std::option::Option::Some("OBSOLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                "OBSOLETE" => std::option::Option::Some(Self::OBSOLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Deprecated,
+                3 => Self::Obsolete,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DEPRECATED" => Self::Deprecated,
+                "OBSOLETE" => Self::Obsolete,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Deprecated => serializer.serialize_i32(2),
+                Self::Obsolete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.config.v1.TerraformVersion.State",
+            ))
         }
     }
 }
 
 /// Enum values to control quota checks for resources in terraform
 /// configuration files.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct QuotaValidation(i32);
-
-impl QuotaValidation {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum QuotaValidation {
     /// The default value.
     /// QuotaValidation on terraform configuration files will be disabled in
     /// this case.
-    pub const QUOTA_VALIDATION_UNSPECIFIED: QuotaValidation = QuotaValidation::new(0);
-
+    Unspecified,
     /// Enable computing quotas for resources in terraform configuration files to
     /// get visibility on resources with insufficient quotas.
-    pub const ENABLED: QuotaValidation = QuotaValidation::new(1);
-
+    Enabled,
     /// Enforce quota checks so deployment fails if there isn't sufficient quotas
     /// available to deploy resources in terraform configuration files.
-    pub const ENFORCED: QuotaValidation = QuotaValidation::new(2);
+    Enforced,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [QuotaValidation::value] or
+    /// [QuotaValidation::name].
+    UnknownValue(quota_validation::UnknownValue),
+}
 
-    /// Creates a new QuotaValidation instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod quota_validation {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl QuotaValidation {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enabled => std::option::Option::Some(1),
+            Self::Enforced => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("QUOTA_VALIDATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENABLED"),
-            2 => std::borrow::Cow::Borrowed("ENFORCED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("QUOTA_VALIDATION_UNSPECIFIED"),
+            Self::Enabled => std::option::Option::Some("ENABLED"),
+            Self::Enforced => std::option::Option::Some("ENFORCED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "QUOTA_VALIDATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::QUOTA_VALIDATION_UNSPECIFIED)
-            }
-            "ENABLED" => std::option::Option::Some(Self::ENABLED),
-            "ENFORCED" => std::option::Option::Some(Self::ENFORCED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for QuotaValidation {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for QuotaValidation {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for QuotaValidation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for QuotaValidation {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enabled,
+            2 => Self::Enforced,
+            _ => Self::UnknownValue(quota_validation::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for QuotaValidation {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "QUOTA_VALIDATION_UNSPECIFIED" => Self::Unspecified,
+            "ENABLED" => Self::Enabled,
+            "ENFORCED" => Self::Enforced,
+            _ => Self::UnknownValue(quota_validation::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for QuotaValidation {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enabled => serializer.serialize_i32(1),
+            Self::Enforced => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for QuotaValidation {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<QuotaValidation>::new(
+            ".google.cloud.config.v1.QuotaValidation",
+        ))
     }
 }

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -160,7 +160,7 @@ impl super::stub::Config for Config {
             );
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("force", &req.force)]);
-        let builder = builder.query(&[("deletePolicy", &req.delete_policy.value())]);
+        let builder = builder.query(&[("deletePolicy", &req.delete_policy)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -858,136 +858,266 @@ pub mod config_variable_template {
     use super::*;
 
     /// ValueType indicates the data type of the value.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ValueType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ValueType {
+        /// Value type is not specified.
+        Unspecified,
+        /// Value type is string.
+        String,
+        /// Value type is integer.
+        Int,
+        /// Value type is boolean.
+        Bool,
+        /// Value type is secret.
+        Secret,
+        /// Value type is enum.
+        Enum,
+        /// Value type is authorization code.
+        AuthorizationCode,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ValueType::value] or
+        /// [ValueType::name].
+        UnknownValue(value_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod value_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ValueType {
-        /// Value type is not specified.
-        pub const VALUE_TYPE_UNSPECIFIED: ValueType = ValueType::new(0);
-
-        /// Value type is string.
-        pub const STRING: ValueType = ValueType::new(1);
-
-        /// Value type is integer.
-        pub const INT: ValueType = ValueType::new(2);
-
-        /// Value type is boolean.
-        pub const BOOL: ValueType = ValueType::new(3);
-
-        /// Value type is secret.
-        pub const SECRET: ValueType = ValueType::new(4);
-
-        /// Value type is enum.
-        pub const ENUM: ValueType = ValueType::new(5);
-
-        /// Value type is authorization code.
-        pub const AUTHORIZATION_CODE: ValueType = ValueType::new(6);
-
-        /// Creates a new ValueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::String => std::option::Option::Some(1),
+                Self::Int => std::option::Option::Some(2),
+                Self::Bool => std::option::Option::Some(3),
+                Self::Secret => std::option::Option::Some(4),
+                Self::Enum => std::option::Option::Some(5),
+                Self::AuthorizationCode => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VALUE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STRING"),
-                2 => std::borrow::Cow::Borrowed("INT"),
-                3 => std::borrow::Cow::Borrowed("BOOL"),
-                4 => std::borrow::Cow::Borrowed("SECRET"),
-                5 => std::borrow::Cow::Borrowed("ENUM"),
-                6 => std::borrow::Cow::Borrowed("AUTHORIZATION_CODE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VALUE_TYPE_UNSPECIFIED"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Int => std::option::Option::Some("INT"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::Secret => std::option::Option::Some("SECRET"),
+                Self::Enum => std::option::Option::Some("ENUM"),
+                Self::AuthorizationCode => std::option::Option::Some("AUTHORIZATION_CODE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VALUE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::VALUE_TYPE_UNSPECIFIED),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "INT" => std::option::Option::Some(Self::INT),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "SECRET" => std::option::Option::Some(Self::SECRET),
-                "ENUM" => std::option::Option::Some(Self::ENUM),
-                "AUTHORIZATION_CODE" => std::option::Option::Some(Self::AUTHORIZATION_CODE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ValueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ValueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ValueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ValueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::String,
+                2 => Self::Int,
+                3 => Self::Bool,
+                4 => Self::Secret,
+                5 => Self::Enum,
+                6 => Self::AuthorizationCode,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ValueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VALUE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STRING" => Self::String,
+                "INT" => Self::Int,
+                "BOOL" => Self::Bool,
+                "SECRET" => Self::Secret,
+                "ENUM" => Self::Enum,
+                "AUTHORIZATION_CODE" => Self::AuthorizationCode,
+                _ => Self::UnknownValue(value_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ValueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::String => serializer.serialize_i32(1),
+                Self::Int => serializer.serialize_i32(2),
+                Self::Bool => serializer.serialize_i32(3),
+                Self::Secret => serializer.serialize_i32(4),
+                Self::Enum => serializer.serialize_i32(5),
+                Self::AuthorizationCode => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ValueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValueType>::new(
+                ".google.cloud.connectors.v1.ConfigVariableTemplate.ValueType",
+            ))
         }
     }
 
     /// Indicates the state of the config variable.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Status is unspecified.
+        Unspecified,
+        /// Config variable is active
+        Active,
+        /// Config variable is deprecated.
+        Deprecated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Status is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Config variable is active
-        pub const ACTIVE: State = State::new(1);
-
-        /// Config variable is deprecated.
-        pub const DEPRECATED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Deprecated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Deprecated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DEPRECATED" => Self::Deprecated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Deprecated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.connectors.v1.ConfigVariableTemplate.State",
+            ))
         }
     }
 }
@@ -1372,128 +1502,255 @@ pub mod role_grant {
         use super::*;
 
         /// Resource Type definition.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Value type is not specified.
+            Unspecified,
+            /// GCP Project Resource.
+            GcpProject,
+            /// Any GCP Resource which is identified uniquely by IAM.
+            GcpResource,
+            /// GCP Secret Resource.
+            GcpSecretmanagerSecret,
+            /// GCP Secret Version Resource.
+            GcpSecretmanagerSecretVersion,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Value type is not specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// GCP Project Resource.
-            pub const GCP_PROJECT: Type = Type::new(1);
-
-            /// Any GCP Resource which is identified uniquely by IAM.
-            pub const GCP_RESOURCE: Type = Type::new(2);
-
-            /// GCP Secret Resource.
-            pub const GCP_SECRETMANAGER_SECRET: Type = Type::new(3);
-
-            /// GCP Secret Version Resource.
-            pub const GCP_SECRETMANAGER_SECRET_VERSION: Type = Type::new(4);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::GcpProject => std::option::Option::Some(1),
+                    Self::GcpResource => std::option::Option::Some(2),
+                    Self::GcpSecretmanagerSecret => std::option::Option::Some(3),
+                    Self::GcpSecretmanagerSecretVersion => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("GCP_PROJECT"),
-                    2 => std::borrow::Cow::Borrowed("GCP_RESOURCE"),
-                    3 => std::borrow::Cow::Borrowed("GCP_SECRETMANAGER_SECRET"),
-                    4 => std::borrow::Cow::Borrowed("GCP_SECRETMANAGER_SECRET_VERSION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "GCP_PROJECT" => std::option::Option::Some(Self::GCP_PROJECT),
-                    "GCP_RESOURCE" => std::option::Option::Some(Self::GCP_RESOURCE),
-                    "GCP_SECRETMANAGER_SECRET" => {
-                        std::option::Option::Some(Self::GCP_SECRETMANAGER_SECRET)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::GcpProject => std::option::Option::Some("GCP_PROJECT"),
+                    Self::GcpResource => std::option::Option::Some("GCP_RESOURCE"),
+                    Self::GcpSecretmanagerSecret => {
+                        std::option::Option::Some("GCP_SECRETMANAGER_SECRET")
                     }
-                    "GCP_SECRETMANAGER_SECRET_VERSION" => {
-                        std::option::Option::Some(Self::GCP_SECRETMANAGER_SECRET_VERSION)
+                    Self::GcpSecretmanagerSecretVersion => {
+                        std::option::Option::Some("GCP_SECRETMANAGER_SECRET_VERSION")
                     }
-                    _ => std::option::Option::None,
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::GcpProject,
+                    2 => Self::GcpResource,
+                    3 => Self::GcpSecretmanagerSecret,
+                    4 => Self::GcpSecretmanagerSecretVersion,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "GCP_PROJECT" => Self::GcpProject,
+                    "GCP_RESOURCE" => Self::GcpResource,
+                    "GCP_SECRETMANAGER_SECRET" => Self::GcpSecretmanagerSecret,
+                    "GCP_SECRETMANAGER_SECRET_VERSION" => Self::GcpSecretmanagerSecretVersion,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::GcpProject => serializer.serialize_i32(1),
+                    Self::GcpResource => serializer.serialize_i32(2),
+                    Self::GcpSecretmanagerSecret => serializer.serialize_i32(3),
+                    Self::GcpSecretmanagerSecretVersion => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.connectors.v1.RoleGrant.Resource.Type",
+                ))
             }
         }
     }
 
     /// Supported Principal values.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Principal(i32);
-
-    impl Principal {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Principal {
         /// Value type is not specified.
-        pub const PRINCIPAL_UNSPECIFIED: Principal = Principal::new(0);
-
+        Unspecified,
         /// Service Account used for Connector workload identity
         /// This is either the default service account if unspecified or Service
         /// Account provided by Customers through BYOSA.
-        pub const CONNECTOR_SA: Principal = Principal::new(1);
+        ConnectorSa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Principal::value] or
+        /// [Principal::name].
+        UnknownValue(principal::UnknownValue),
+    }
 
-        /// Creates a new Principal instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod principal {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Principal {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConnectorSa => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRINCIPAL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONNECTOR_SA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRINCIPAL_UNSPECIFIED"),
+                Self::ConnectorSa => std::option::Option::Some("CONNECTOR_SA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRINCIPAL_UNSPECIFIED" => std::option::Option::Some(Self::PRINCIPAL_UNSPECIFIED),
-                "CONNECTOR_SA" => std::option::Option::Some(Self::CONNECTOR_SA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Principal {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Principal {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Principal {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Principal {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConnectorSa,
+                _ => Self::UnknownValue(principal::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Principal {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRINCIPAL_UNSPECIFIED" => Self::Unspecified,
+                "CONNECTOR_SA" => Self::ConnectorSa,
+                _ => Self::UnknownValue(principal::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Principal {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConnectorSa => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Principal {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Principal>::new(
+                ".google.cloud.connectors.v1.RoleGrant.Principal",
+            ))
         }
     }
 }
@@ -1987,59 +2244,120 @@ pub mod connection_schema_metadata {
     use super::*;
 
     /// State of connection runtime schema.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default state.
+        Unspecified,
+        /// Schema refresh is in progress.
+        Refreshing,
+        /// Schema has been updated.
+        Updated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Schema refresh is in progress.
-        pub const REFRESHING: State = State::new(1);
-
-        /// Schema has been updated.
-        pub const UPDATED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Refreshing => std::option::Option::Some(1),
+                Self::Updated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REFRESHING"),
-                2 => std::borrow::Cow::Borrowed("UPDATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Refreshing => std::option::Option::Some("REFRESHING"),
+                Self::Updated => std::option::Option::Some("UPDATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "REFRESHING" => std::option::Option::Some(Self::REFRESHING),
-                "UPDATED" => std::option::Option::Some(Self::UPDATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Refreshing,
+                2 => Self::Updated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "REFRESHING" => Self::Refreshing,
+                "UPDATED" => Self::Updated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Refreshing => serializer.serialize_i32(1),
+                Self::Updated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.connectors.v1.ConnectionSchemaMetadata.State",
+            ))
         }
     }
 }
@@ -3206,85 +3524,156 @@ pub mod connection_status {
     use super::*;
 
     /// All the possible Connection State.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Connection does not have a state yet.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Connection is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Connection is running and ready for requests.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// Connection is stopped.
-        pub const INACTIVE: State = State::new(3);
-
+        Inactive,
         /// Connection is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Connection is being updated.
-        pub const UPDATING: State = State::new(5);
-
+        Updating,
         /// Connection is not running due to an error.
-        pub const ERROR: State = State::new(6);
-
+        Error,
         /// Connection is not running due to an auth error for the Oauth2 Auth Code
         /// based connector.
-        pub const AUTHORIZATION_REQUIRED: State = State::new(7);
+        AuthorizationRequired,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Inactive => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::AuthorizationRequired => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("INACTIVE"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("AUTHORIZATION_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::AuthorizationRequired => std::option::Option::Some("AUTHORIZATION_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "AUTHORIZATION_REQUIRED" => std::option::Option::Some(Self::AUTHORIZATION_REQUIRED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Inactive,
+                4 => Self::Deleting,
+                5 => Self::Updating,
+                6 => Self::Error,
+                7 => Self::AuthorizationRequired,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "INACTIVE" => Self::Inactive,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "ERROR" => Self::Error,
+                "AUTHORIZATION_REQUIRED" => Self::AuthorizationRequired,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Inactive => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::AuthorizationRequired => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.connectors.v1.ConnectionStatus.State",
+            ))
         }
     }
 }
@@ -4319,56 +4708,113 @@ pub mod extraction_rule {
     }
 
     /// Supported Source types for extraction.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SourceType {
+        /// Default SOURCE.
+        Unspecified,
+        /// Config Variable source type.
+        ConfigVariable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SourceType::value] or
+        /// [SourceType::name].
+        UnknownValue(source_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SourceType {
-        /// Default SOURCE.
-        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
-
-        /// Config Variable source type.
-        pub const CONFIG_VARIABLE: SourceType = SourceType::new(1);
-
-        /// Creates a new SourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConfigVariable => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFIG_VARIABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SOURCE_TYPE_UNSPECIFIED"),
+                Self::ConfigVariable => std::option::Option::Some("CONFIG_VARIABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
-                }
-                "CONFIG_VARIABLE" => std::option::Option::Some(Self::CONFIG_VARIABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConfigVariable,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CONFIG_VARIABLE" => Self::ConfigVariable,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConfigVariable => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceType>::new(
+                ".google.cloud.connectors.v1.ExtractionRule.SourceType",
+            ))
         }
     }
 }
@@ -5036,79 +5482,148 @@ pub mod runtime_config {
     use super::*;
 
     /// State of the location.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// STATE_UNSPECIFIED.
+        Unspecified,
+        /// INACTIVE.
+        Inactive,
+        /// ACTIVATING.
+        Activating,
+        /// ACTIVE.
+        Active,
+        /// CREATING.
+        Creating,
+        /// DELETING.
+        Deleting,
+        /// UPDATING.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// STATE_UNSPECIFIED.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// INACTIVE.
-        pub const INACTIVE: State = State::new(1);
-
-        /// ACTIVATING.
-        pub const ACTIVATING: State = State::new(2);
-
-        /// ACTIVE.
-        pub const ACTIVE: State = State::new(3);
-
-        /// CREATING.
-        pub const CREATING: State = State::new(4);
-
-        /// DELETING.
-        pub const DELETING: State = State::new(5);
-
-        /// UPDATING.
-        pub const UPDATING: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Inactive => std::option::Option::Some(1),
+                Self::Activating => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::Creating => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Updating => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INACTIVE"),
-                2 => std::borrow::Cow::Borrowed("ACTIVATING"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("CREATING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Activating => std::option::Option::Some("ACTIVATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Inactive,
+                2 => Self::Activating,
+                3 => Self::Active,
+                4 => Self::Creating,
+                5 => Self::Deleting,
+                6 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INACTIVE" => Self::Inactive,
+                "ACTIVATING" => Self::Activating,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Inactive => serializer.serialize_i32(1),
+                Self::Activating => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::Creating => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Updating => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.connectors.v1.RuntimeConfig.State",
+            ))
         }
     }
 }
@@ -5444,705 +5959,1272 @@ pub mod ssl_config {
     use super::*;
 
     /// Enum for Ttust Model
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrustModel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TrustModel {
+        /// Public Trust Model. Takes the Default Java trust store.
+        Public,
+        /// Private Trust Model. Takes custom/private trust store.
+        Private,
+        /// Insecure Trust Model. Accept all certificates.
+        Insecure,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TrustModel::value] or
+        /// [TrustModel::name].
+        UnknownValue(trust_model::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod trust_model {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TrustModel {
-        /// Public Trust Model. Takes the Default Java trust store.
-        pub const PUBLIC: TrustModel = TrustModel::new(0);
-
-        /// Private Trust Model. Takes custom/private trust store.
-        pub const PRIVATE: TrustModel = TrustModel::new(1);
-
-        /// Insecure Trust Model. Accept all certificates.
-        pub const INSECURE: TrustModel = TrustModel::new(2);
-
-        /// Creates a new TrustModel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Public => std::option::Option::Some(0),
+                Self::Private => std::option::Option::Some(1),
+                Self::Insecure => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PUBLIC"),
-                1 => std::borrow::Cow::Borrowed("PRIVATE"),
-                2 => std::borrow::Cow::Borrowed("INSECURE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Public => std::option::Option::Some("PUBLIC"),
+                Self::Private => std::option::Option::Some("PRIVATE"),
+                Self::Insecure => std::option::Option::Some("INSECURE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PUBLIC" => std::option::Option::Some(Self::PUBLIC),
-                "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
-                "INSECURE" => std::option::Option::Some(Self::INSECURE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TrustModel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TrustModel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TrustModel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TrustModel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Public,
+                1 => Self::Private,
+                2 => Self::Insecure,
+                _ => Self::UnknownValue(trust_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TrustModel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PUBLIC" => Self::Public,
+                "PRIVATE" => Self::Private,
+                "INSECURE" => Self::Insecure,
+                _ => Self::UnknownValue(trust_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TrustModel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Public => serializer.serialize_i32(0),
+                Self::Private => serializer.serialize_i32(1),
+                Self::Insecure => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TrustModel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TrustModel>::new(
+                ".google.cloud.connectors.v1.SslConfig.TrustModel",
+            ))
         }
     }
 }
 
 /// AuthType defines different authentication types.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthType(i32);
-
-impl AuthType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AuthType {
     /// Authentication type not specified.
-    pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new(0);
-
+    Unspecified,
     /// Username and Password Authentication.
-    pub const USER_PASSWORD: AuthType = AuthType::new(1);
-
+    UserPassword,
     /// JSON Web Token (JWT) Profile for Oauth 2.0
     /// Authorization Grant based authentication
-    pub const OAUTH2_JWT_BEARER: AuthType = AuthType::new(2);
-
+    Oauth2JwtBearer,
     /// Oauth 2.0 Client Credentials Grant Authentication
-    pub const OAUTH2_CLIENT_CREDENTIALS: AuthType = AuthType::new(3);
-
+    Oauth2ClientCredentials,
     /// SSH Public Key Authentication
-    pub const SSH_PUBLIC_KEY: AuthType = AuthType::new(4);
-
+    SshPublicKey,
     /// Oauth 2.0 Authorization Code Flow
-    pub const OAUTH2_AUTH_CODE_FLOW: AuthType = AuthType::new(5);
+    Oauth2AuthCodeFlow,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AuthType::value] or
+    /// [AuthType::name].
+    UnknownValue(auth_type::UnknownValue),
+}
 
-    /// Creates a new AuthType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod auth_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AuthType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::UserPassword => std::option::Option::Some(1),
+            Self::Oauth2JwtBearer => std::option::Option::Some(2),
+            Self::Oauth2ClientCredentials => std::option::Option::Some(3),
+            Self::SshPublicKey => std::option::Option::Some(4),
+            Self::Oauth2AuthCodeFlow => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUTH_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("USER_PASSWORD"),
-            2 => std::borrow::Cow::Borrowed("OAUTH2_JWT_BEARER"),
-            3 => std::borrow::Cow::Borrowed("OAUTH2_CLIENT_CREDENTIALS"),
-            4 => std::borrow::Cow::Borrowed("SSH_PUBLIC_KEY"),
-            5 => std::borrow::Cow::Borrowed("OAUTH2_AUTH_CODE_FLOW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AUTH_TYPE_UNSPECIFIED"),
+            Self::UserPassword => std::option::Option::Some("USER_PASSWORD"),
+            Self::Oauth2JwtBearer => std::option::Option::Some("OAUTH2_JWT_BEARER"),
+            Self::Oauth2ClientCredentials => std::option::Option::Some("OAUTH2_CLIENT_CREDENTIALS"),
+            Self::SshPublicKey => std::option::Option::Some("SSH_PUBLIC_KEY"),
+            Self::Oauth2AuthCodeFlow => std::option::Option::Some("OAUTH2_AUTH_CODE_FLOW"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUTH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::AUTH_TYPE_UNSPECIFIED),
-            "USER_PASSWORD" => std::option::Option::Some(Self::USER_PASSWORD),
-            "OAUTH2_JWT_BEARER" => std::option::Option::Some(Self::OAUTH2_JWT_BEARER),
-            "OAUTH2_CLIENT_CREDENTIALS" => {
-                std::option::Option::Some(Self::OAUTH2_CLIENT_CREDENTIALS)
-            }
-            "SSH_PUBLIC_KEY" => std::option::Option::Some(Self::SSH_PUBLIC_KEY),
-            "OAUTH2_AUTH_CODE_FLOW" => std::option::Option::Some(Self::OAUTH2_AUTH_CODE_FLOW),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AuthType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AuthType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AuthType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::UserPassword,
+            2 => Self::Oauth2JwtBearer,
+            3 => Self::Oauth2ClientCredentials,
+            4 => Self::SshPublicKey,
+            5 => Self::Oauth2AuthCodeFlow,
+            _ => Self::UnknownValue(auth_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AuthType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUTH_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "USER_PASSWORD" => Self::UserPassword,
+            "OAUTH2_JWT_BEARER" => Self::Oauth2JwtBearer,
+            "OAUTH2_CLIENT_CREDENTIALS" => Self::Oauth2ClientCredentials,
+            "SSH_PUBLIC_KEY" => Self::SshPublicKey,
+            "OAUTH2_AUTH_CODE_FLOW" => Self::Oauth2AuthCodeFlow,
+            _ => Self::UnknownValue(auth_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AuthType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::UserPassword => serializer.serialize_i32(1),
+            Self::Oauth2JwtBearer => serializer.serialize_i32(2),
+            Self::Oauth2ClientCredentials => serializer.serialize_i32(3),
+            Self::SshPublicKey => serializer.serialize_i32(4),
+            Self::Oauth2AuthCodeFlow => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AuthType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthType>::new(
+            ".google.cloud.connectors.v1.AuthType",
+        ))
     }
 }
 
 /// LaunchStage is a enum to indicate launch stage:
 /// PREVIEW, GA, DEPRECATED, PRIVATE_PREVIEW.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LaunchStage(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LaunchStage {
+    /// LAUNCH_STAGE_UNSPECIFIED.
+    Unspecified,
+    /// PREVIEW.
+    Preview,
+    /// GA.
+    Ga,
+    /// DEPRECATED.
+    Deprecated,
+    /// PRIVATE_PREVIEW.
+    PrivatePreview,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LaunchStage::value] or
+    /// [LaunchStage::name].
+    UnknownValue(launch_stage::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod launch_stage {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LaunchStage {
-    /// LAUNCH_STAGE_UNSPECIFIED.
-    pub const LAUNCH_STAGE_UNSPECIFIED: LaunchStage = LaunchStage::new(0);
-
-    /// PREVIEW.
-    pub const PREVIEW: LaunchStage = LaunchStage::new(1);
-
-    /// GA.
-    pub const GA: LaunchStage = LaunchStage::new(2);
-
-    /// DEPRECATED.
-    pub const DEPRECATED: LaunchStage = LaunchStage::new(3);
-
-    /// PRIVATE_PREVIEW.
-    pub const PRIVATE_PREVIEW: LaunchStage = LaunchStage::new(5);
-
-    /// Creates a new LaunchStage instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Preview => std::option::Option::Some(1),
+            Self::Ga => std::option::Option::Some(2),
+            Self::Deprecated => std::option::Option::Some(3),
+            Self::PrivatePreview => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LAUNCH_STAGE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PREVIEW"),
-            2 => std::borrow::Cow::Borrowed("GA"),
-            3 => std::borrow::Cow::Borrowed("DEPRECATED"),
-            5 => std::borrow::Cow::Borrowed("PRIVATE_PREVIEW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LAUNCH_STAGE_UNSPECIFIED"),
+            Self::Preview => std::option::Option::Some("PREVIEW"),
+            Self::Ga => std::option::Option::Some("GA"),
+            Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+            Self::PrivatePreview => std::option::Option::Some("PRIVATE_PREVIEW"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LAUNCH_STAGE_UNSPECIFIED" => std::option::Option::Some(Self::LAUNCH_STAGE_UNSPECIFIED),
-            "PREVIEW" => std::option::Option::Some(Self::PREVIEW),
-            "GA" => std::option::Option::Some(Self::GA),
-            "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-            "PRIVATE_PREVIEW" => std::option::Option::Some(Self::PRIVATE_PREVIEW),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LaunchStage {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LaunchStage {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LaunchStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LaunchStage {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Preview,
+            2 => Self::Ga,
+            3 => Self::Deprecated,
+            5 => Self::PrivatePreview,
+            _ => Self::UnknownValue(launch_stage::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LaunchStage {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LAUNCH_STAGE_UNSPECIFIED" => Self::Unspecified,
+            "PREVIEW" => Self::Preview,
+            "GA" => Self::Ga,
+            "DEPRECATED" => Self::Deprecated,
+            "PRIVATE_PREVIEW" => Self::PrivatePreview,
+            _ => Self::UnknownValue(launch_stage::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LaunchStage {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Preview => serializer.serialize_i32(1),
+            Self::Ga => serializer.serialize_i32(2),
+            Self::Deprecated => serializer.serialize_i32(3),
+            Self::PrivatePreview => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LaunchStage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LaunchStage>::new(
+            ".google.cloud.connectors.v1.LaunchStage",
+        ))
     }
 }
 
 /// All possible data types of a entity or action field.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DataType {
+    /// Data type is not specified.
+    Unspecified,
+    /// DEPRECATED! Use DATA_TYPE_INTEGER.
+    Int,
+    /// Short integer(int16) data type.
+    Smallint,
+    /// Double data type.
+    Double,
+    /// Date data type.
+    Date,
+    /// DEPRECATED! Use DATA_TYPE_TIMESTAMP.
+    Datetime,
+    /// Time data type.
+    Time,
+    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
+    String,
+    /// DEPRECATED! Use DATA_TYPE_BIGINT.
+    Long,
+    /// Boolean data type.
+    Boolean,
+    /// Decimal data type.
+    Decimal,
+    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
+    Uuid,
+    /// UNSUPPORTED! Binary data type.
+    Blob,
+    /// Bit data type.
+    Bit,
+    /// Small integer(int8) data type.
+    Tinyint,
+    /// Integer(int32) data type.
+    Integer,
+    /// Long integer(int64) data type.
+    Bigint,
+    /// Float data type.
+    Float,
+    /// Real data type.
+    Real,
+    /// Numeric data type.
+    Numeric,
+    /// Char data type.
+    Char,
+    /// Varchar data type.
+    Varchar,
+    /// Longvarchar data type.
+    Longvarchar,
+    /// Timestamp data type.
+    Timestamp,
+    /// Nchar data type.
+    Nchar,
+    /// Nvarchar data type.
+    Nvarchar,
+    /// Longnvarchar data type.
+    Longnvarchar,
+    /// Null data type.
+    Null,
+    /// UNSUPPORTED! Binary data type.
+    Other,
+    /// UNSUPPORTED! Binary data type.
+    JavaObject,
+    /// UNSUPPORTED! Binary data type.
+    Distinct,
+    /// UNSUPPORTED! Binary data type.
+    Struct,
+    /// UNSUPPORTED! Binary data type.
+    Array,
+    /// UNSUPPORTED! Binary data type.
+    Clob,
+    /// UNSUPPORTED! Binary data type.
+    Ref,
+    /// UNSUPPORTED! Binary data type.
+    Datalink,
+    /// UNSUPPORTED! Row id data type.
+    Rowid,
+    /// UNSUPPORTED! Binary data type.
+    Binary,
+    /// UNSUPPORTED! Variable binary data type.
+    Varbinary,
+    /// UNSUPPORTED! Long variable binary data type.
+    Longvarbinary,
+    /// UNSUPPORTED! NCLOB data type.
+    Nclob,
+    /// UNSUPPORTED! SQL XML data type is not supported.
+    Sqlxml,
+    /// UNSUPPORTED! Cursor reference type is not supported.
+    RefCursor,
+    /// UNSUPPORTED! Use TIME or TIMESTAMP instead.
+    TimeWithTimezone,
+    /// UNSUPPORTED! Use TIMESTAMP instead.
+    TimestampWithTimezone,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DataType::value] or
+    /// [DataType::name].
+    UnknownValue(data_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod data_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DataType {
-    /// Data type is not specified.
-    pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
-
-    /// DEPRECATED! Use DATA_TYPE_INTEGER.
-    pub const DATA_TYPE_INT: DataType = DataType::new(1);
-
-    /// Short integer(int16) data type.
-    pub const DATA_TYPE_SMALLINT: DataType = DataType::new(2);
-
-    /// Double data type.
-    pub const DATA_TYPE_DOUBLE: DataType = DataType::new(3);
-
-    /// Date data type.
-    pub const DATA_TYPE_DATE: DataType = DataType::new(4);
-
-    /// DEPRECATED! Use DATA_TYPE_TIMESTAMP.
-    pub const DATA_TYPE_DATETIME: DataType = DataType::new(5);
-
-    /// Time data type.
-    pub const DATA_TYPE_TIME: DataType = DataType::new(6);
-
-    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
-    pub const DATA_TYPE_STRING: DataType = DataType::new(7);
-
-    /// DEPRECATED! Use DATA_TYPE_BIGINT.
-    pub const DATA_TYPE_LONG: DataType = DataType::new(8);
-
-    /// Boolean data type.
-    pub const DATA_TYPE_BOOLEAN: DataType = DataType::new(9);
-
-    /// Decimal data type.
-    pub const DATA_TYPE_DECIMAL: DataType = DataType::new(10);
-
-    /// DEPRECATED! Use DATA_TYPE_VARCHAR.
-    pub const DATA_TYPE_UUID: DataType = DataType::new(11);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_BLOB: DataType = DataType::new(12);
-
-    /// Bit data type.
-    pub const DATA_TYPE_BIT: DataType = DataType::new(13);
-
-    /// Small integer(int8) data type.
-    pub const DATA_TYPE_TINYINT: DataType = DataType::new(14);
-
-    /// Integer(int32) data type.
-    pub const DATA_TYPE_INTEGER: DataType = DataType::new(15);
-
-    /// Long integer(int64) data type.
-    pub const DATA_TYPE_BIGINT: DataType = DataType::new(16);
-
-    /// Float data type.
-    pub const DATA_TYPE_FLOAT: DataType = DataType::new(17);
-
-    /// Real data type.
-    pub const DATA_TYPE_REAL: DataType = DataType::new(18);
-
-    /// Numeric data type.
-    pub const DATA_TYPE_NUMERIC: DataType = DataType::new(19);
-
-    /// Char data type.
-    pub const DATA_TYPE_CHAR: DataType = DataType::new(20);
-
-    /// Varchar data type.
-    pub const DATA_TYPE_VARCHAR: DataType = DataType::new(21);
-
-    /// Longvarchar data type.
-    pub const DATA_TYPE_LONGVARCHAR: DataType = DataType::new(22);
-
-    /// Timestamp data type.
-    pub const DATA_TYPE_TIMESTAMP: DataType = DataType::new(23);
-
-    /// Nchar data type.
-    pub const DATA_TYPE_NCHAR: DataType = DataType::new(24);
-
-    /// Nvarchar data type.
-    pub const DATA_TYPE_NVARCHAR: DataType = DataType::new(25);
-
-    /// Longnvarchar data type.
-    pub const DATA_TYPE_LONGNVARCHAR: DataType = DataType::new(26);
-
-    /// Null data type.
-    pub const DATA_TYPE_NULL: DataType = DataType::new(27);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_OTHER: DataType = DataType::new(28);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_JAVA_OBJECT: DataType = DataType::new(29);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_DISTINCT: DataType = DataType::new(30);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_STRUCT: DataType = DataType::new(31);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_ARRAY: DataType = DataType::new(32);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_CLOB: DataType = DataType::new(33);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_REF: DataType = DataType::new(34);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_DATALINK: DataType = DataType::new(35);
-
-    /// UNSUPPORTED! Row id data type.
-    pub const DATA_TYPE_ROWID: DataType = DataType::new(36);
-
-    /// UNSUPPORTED! Binary data type.
-    pub const DATA_TYPE_BINARY: DataType = DataType::new(37);
-
-    /// UNSUPPORTED! Variable binary data type.
-    pub const DATA_TYPE_VARBINARY: DataType = DataType::new(38);
-
-    /// UNSUPPORTED! Long variable binary data type.
-    pub const DATA_TYPE_LONGVARBINARY: DataType = DataType::new(39);
-
-    /// UNSUPPORTED! NCLOB data type.
-    pub const DATA_TYPE_NCLOB: DataType = DataType::new(40);
-
-    /// UNSUPPORTED! SQL XML data type is not supported.
-    pub const DATA_TYPE_SQLXML: DataType = DataType::new(41);
-
-    /// UNSUPPORTED! Cursor reference type is not supported.
-    pub const DATA_TYPE_REF_CURSOR: DataType = DataType::new(42);
-
-    /// UNSUPPORTED! Use TIME or TIMESTAMP instead.
-    pub const DATA_TYPE_TIME_WITH_TIMEZONE: DataType = DataType::new(43);
-
-    /// UNSUPPORTED! Use TIMESTAMP instead.
-    pub const DATA_TYPE_TIMESTAMP_WITH_TIMEZONE: DataType = DataType::new(44);
-
-    /// Creates a new DataType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Int => std::option::Option::Some(1),
+            Self::Smallint => std::option::Option::Some(2),
+            Self::Double => std::option::Option::Some(3),
+            Self::Date => std::option::Option::Some(4),
+            Self::Datetime => std::option::Option::Some(5),
+            Self::Time => std::option::Option::Some(6),
+            Self::String => std::option::Option::Some(7),
+            Self::Long => std::option::Option::Some(8),
+            Self::Boolean => std::option::Option::Some(9),
+            Self::Decimal => std::option::Option::Some(10),
+            Self::Uuid => std::option::Option::Some(11),
+            Self::Blob => std::option::Option::Some(12),
+            Self::Bit => std::option::Option::Some(13),
+            Self::Tinyint => std::option::Option::Some(14),
+            Self::Integer => std::option::Option::Some(15),
+            Self::Bigint => std::option::Option::Some(16),
+            Self::Float => std::option::Option::Some(17),
+            Self::Real => std::option::Option::Some(18),
+            Self::Numeric => std::option::Option::Some(19),
+            Self::Char => std::option::Option::Some(20),
+            Self::Varchar => std::option::Option::Some(21),
+            Self::Longvarchar => std::option::Option::Some(22),
+            Self::Timestamp => std::option::Option::Some(23),
+            Self::Nchar => std::option::Option::Some(24),
+            Self::Nvarchar => std::option::Option::Some(25),
+            Self::Longnvarchar => std::option::Option::Some(26),
+            Self::Null => std::option::Option::Some(27),
+            Self::Other => std::option::Option::Some(28),
+            Self::JavaObject => std::option::Option::Some(29),
+            Self::Distinct => std::option::Option::Some(30),
+            Self::Struct => std::option::Option::Some(31),
+            Self::Array => std::option::Option::Some(32),
+            Self::Clob => std::option::Option::Some(33),
+            Self::Ref => std::option::Option::Some(34),
+            Self::Datalink => std::option::Option::Some(35),
+            Self::Rowid => std::option::Option::Some(36),
+            Self::Binary => std::option::Option::Some(37),
+            Self::Varbinary => std::option::Option::Some(38),
+            Self::Longvarbinary => std::option::Option::Some(39),
+            Self::Nclob => std::option::Option::Some(40),
+            Self::Sqlxml => std::option::Option::Some(41),
+            Self::RefCursor => std::option::Option::Some(42),
+            Self::TimeWithTimezone => std::option::Option::Some(43),
+            Self::TimestampWithTimezone => std::option::Option::Some(44),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DATA_TYPE_INT"),
-            2 => std::borrow::Cow::Borrowed("DATA_TYPE_SMALLINT"),
-            3 => std::borrow::Cow::Borrowed("DATA_TYPE_DOUBLE"),
-            4 => std::borrow::Cow::Borrowed("DATA_TYPE_DATE"),
-            5 => std::borrow::Cow::Borrowed("DATA_TYPE_DATETIME"),
-            6 => std::borrow::Cow::Borrowed("DATA_TYPE_TIME"),
-            7 => std::borrow::Cow::Borrowed("DATA_TYPE_STRING"),
-            8 => std::borrow::Cow::Borrowed("DATA_TYPE_LONG"),
-            9 => std::borrow::Cow::Borrowed("DATA_TYPE_BOOLEAN"),
-            10 => std::borrow::Cow::Borrowed("DATA_TYPE_DECIMAL"),
-            11 => std::borrow::Cow::Borrowed("DATA_TYPE_UUID"),
-            12 => std::borrow::Cow::Borrowed("DATA_TYPE_BLOB"),
-            13 => std::borrow::Cow::Borrowed("DATA_TYPE_BIT"),
-            14 => std::borrow::Cow::Borrowed("DATA_TYPE_TINYINT"),
-            15 => std::borrow::Cow::Borrowed("DATA_TYPE_INTEGER"),
-            16 => std::borrow::Cow::Borrowed("DATA_TYPE_BIGINT"),
-            17 => std::borrow::Cow::Borrowed("DATA_TYPE_FLOAT"),
-            18 => std::borrow::Cow::Borrowed("DATA_TYPE_REAL"),
-            19 => std::borrow::Cow::Borrowed("DATA_TYPE_NUMERIC"),
-            20 => std::borrow::Cow::Borrowed("DATA_TYPE_CHAR"),
-            21 => std::borrow::Cow::Borrowed("DATA_TYPE_VARCHAR"),
-            22 => std::borrow::Cow::Borrowed("DATA_TYPE_LONGVARCHAR"),
-            23 => std::borrow::Cow::Borrowed("DATA_TYPE_TIMESTAMP"),
-            24 => std::borrow::Cow::Borrowed("DATA_TYPE_NCHAR"),
-            25 => std::borrow::Cow::Borrowed("DATA_TYPE_NVARCHAR"),
-            26 => std::borrow::Cow::Borrowed("DATA_TYPE_LONGNVARCHAR"),
-            27 => std::borrow::Cow::Borrowed("DATA_TYPE_NULL"),
-            28 => std::borrow::Cow::Borrowed("DATA_TYPE_OTHER"),
-            29 => std::borrow::Cow::Borrowed("DATA_TYPE_JAVA_OBJECT"),
-            30 => std::borrow::Cow::Borrowed("DATA_TYPE_DISTINCT"),
-            31 => std::borrow::Cow::Borrowed("DATA_TYPE_STRUCT"),
-            32 => std::borrow::Cow::Borrowed("DATA_TYPE_ARRAY"),
-            33 => std::borrow::Cow::Borrowed("DATA_TYPE_CLOB"),
-            34 => std::borrow::Cow::Borrowed("DATA_TYPE_REF"),
-            35 => std::borrow::Cow::Borrowed("DATA_TYPE_DATALINK"),
-            36 => std::borrow::Cow::Borrowed("DATA_TYPE_ROWID"),
-            37 => std::borrow::Cow::Borrowed("DATA_TYPE_BINARY"),
-            38 => std::borrow::Cow::Borrowed("DATA_TYPE_VARBINARY"),
-            39 => std::borrow::Cow::Borrowed("DATA_TYPE_LONGVARBINARY"),
-            40 => std::borrow::Cow::Borrowed("DATA_TYPE_NCLOB"),
-            41 => std::borrow::Cow::Borrowed("DATA_TYPE_SQLXML"),
-            42 => std::borrow::Cow::Borrowed("DATA_TYPE_REF_CURSOR"),
-            43 => std::borrow::Cow::Borrowed("DATA_TYPE_TIME_WITH_TIMEZONE"),
-            44 => std::borrow::Cow::Borrowed("DATA_TYPE_TIMESTAMP_WITH_TIMEZONE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
-            "DATA_TYPE_INT" => std::option::Option::Some(Self::DATA_TYPE_INT),
-            "DATA_TYPE_SMALLINT" => std::option::Option::Some(Self::DATA_TYPE_SMALLINT),
-            "DATA_TYPE_DOUBLE" => std::option::Option::Some(Self::DATA_TYPE_DOUBLE),
-            "DATA_TYPE_DATE" => std::option::Option::Some(Self::DATA_TYPE_DATE),
-            "DATA_TYPE_DATETIME" => std::option::Option::Some(Self::DATA_TYPE_DATETIME),
-            "DATA_TYPE_TIME" => std::option::Option::Some(Self::DATA_TYPE_TIME),
-            "DATA_TYPE_STRING" => std::option::Option::Some(Self::DATA_TYPE_STRING),
-            "DATA_TYPE_LONG" => std::option::Option::Some(Self::DATA_TYPE_LONG),
-            "DATA_TYPE_BOOLEAN" => std::option::Option::Some(Self::DATA_TYPE_BOOLEAN),
-            "DATA_TYPE_DECIMAL" => std::option::Option::Some(Self::DATA_TYPE_DECIMAL),
-            "DATA_TYPE_UUID" => std::option::Option::Some(Self::DATA_TYPE_UUID),
-            "DATA_TYPE_BLOB" => std::option::Option::Some(Self::DATA_TYPE_BLOB),
-            "DATA_TYPE_BIT" => std::option::Option::Some(Self::DATA_TYPE_BIT),
-            "DATA_TYPE_TINYINT" => std::option::Option::Some(Self::DATA_TYPE_TINYINT),
-            "DATA_TYPE_INTEGER" => std::option::Option::Some(Self::DATA_TYPE_INTEGER),
-            "DATA_TYPE_BIGINT" => std::option::Option::Some(Self::DATA_TYPE_BIGINT),
-            "DATA_TYPE_FLOAT" => std::option::Option::Some(Self::DATA_TYPE_FLOAT),
-            "DATA_TYPE_REAL" => std::option::Option::Some(Self::DATA_TYPE_REAL),
-            "DATA_TYPE_NUMERIC" => std::option::Option::Some(Self::DATA_TYPE_NUMERIC),
-            "DATA_TYPE_CHAR" => std::option::Option::Some(Self::DATA_TYPE_CHAR),
-            "DATA_TYPE_VARCHAR" => std::option::Option::Some(Self::DATA_TYPE_VARCHAR),
-            "DATA_TYPE_LONGVARCHAR" => std::option::Option::Some(Self::DATA_TYPE_LONGVARCHAR),
-            "DATA_TYPE_TIMESTAMP" => std::option::Option::Some(Self::DATA_TYPE_TIMESTAMP),
-            "DATA_TYPE_NCHAR" => std::option::Option::Some(Self::DATA_TYPE_NCHAR),
-            "DATA_TYPE_NVARCHAR" => std::option::Option::Some(Self::DATA_TYPE_NVARCHAR),
-            "DATA_TYPE_LONGNVARCHAR" => std::option::Option::Some(Self::DATA_TYPE_LONGNVARCHAR),
-            "DATA_TYPE_NULL" => std::option::Option::Some(Self::DATA_TYPE_NULL),
-            "DATA_TYPE_OTHER" => std::option::Option::Some(Self::DATA_TYPE_OTHER),
-            "DATA_TYPE_JAVA_OBJECT" => std::option::Option::Some(Self::DATA_TYPE_JAVA_OBJECT),
-            "DATA_TYPE_DISTINCT" => std::option::Option::Some(Self::DATA_TYPE_DISTINCT),
-            "DATA_TYPE_STRUCT" => std::option::Option::Some(Self::DATA_TYPE_STRUCT),
-            "DATA_TYPE_ARRAY" => std::option::Option::Some(Self::DATA_TYPE_ARRAY),
-            "DATA_TYPE_CLOB" => std::option::Option::Some(Self::DATA_TYPE_CLOB),
-            "DATA_TYPE_REF" => std::option::Option::Some(Self::DATA_TYPE_REF),
-            "DATA_TYPE_DATALINK" => std::option::Option::Some(Self::DATA_TYPE_DATALINK),
-            "DATA_TYPE_ROWID" => std::option::Option::Some(Self::DATA_TYPE_ROWID),
-            "DATA_TYPE_BINARY" => std::option::Option::Some(Self::DATA_TYPE_BINARY),
-            "DATA_TYPE_VARBINARY" => std::option::Option::Some(Self::DATA_TYPE_VARBINARY),
-            "DATA_TYPE_LONGVARBINARY" => std::option::Option::Some(Self::DATA_TYPE_LONGVARBINARY),
-            "DATA_TYPE_NCLOB" => std::option::Option::Some(Self::DATA_TYPE_NCLOB),
-            "DATA_TYPE_SQLXML" => std::option::Option::Some(Self::DATA_TYPE_SQLXML),
-            "DATA_TYPE_REF_CURSOR" => std::option::Option::Some(Self::DATA_TYPE_REF_CURSOR),
-            "DATA_TYPE_TIME_WITH_TIMEZONE" => {
-                std::option::Option::Some(Self::DATA_TYPE_TIME_WITH_TIMEZONE)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATA_TYPE_UNSPECIFIED"),
+            Self::Int => std::option::Option::Some("DATA_TYPE_INT"),
+            Self::Smallint => std::option::Option::Some("DATA_TYPE_SMALLINT"),
+            Self::Double => std::option::Option::Some("DATA_TYPE_DOUBLE"),
+            Self::Date => std::option::Option::Some("DATA_TYPE_DATE"),
+            Self::Datetime => std::option::Option::Some("DATA_TYPE_DATETIME"),
+            Self::Time => std::option::Option::Some("DATA_TYPE_TIME"),
+            Self::String => std::option::Option::Some("DATA_TYPE_STRING"),
+            Self::Long => std::option::Option::Some("DATA_TYPE_LONG"),
+            Self::Boolean => std::option::Option::Some("DATA_TYPE_BOOLEAN"),
+            Self::Decimal => std::option::Option::Some("DATA_TYPE_DECIMAL"),
+            Self::Uuid => std::option::Option::Some("DATA_TYPE_UUID"),
+            Self::Blob => std::option::Option::Some("DATA_TYPE_BLOB"),
+            Self::Bit => std::option::Option::Some("DATA_TYPE_BIT"),
+            Self::Tinyint => std::option::Option::Some("DATA_TYPE_TINYINT"),
+            Self::Integer => std::option::Option::Some("DATA_TYPE_INTEGER"),
+            Self::Bigint => std::option::Option::Some("DATA_TYPE_BIGINT"),
+            Self::Float => std::option::Option::Some("DATA_TYPE_FLOAT"),
+            Self::Real => std::option::Option::Some("DATA_TYPE_REAL"),
+            Self::Numeric => std::option::Option::Some("DATA_TYPE_NUMERIC"),
+            Self::Char => std::option::Option::Some("DATA_TYPE_CHAR"),
+            Self::Varchar => std::option::Option::Some("DATA_TYPE_VARCHAR"),
+            Self::Longvarchar => std::option::Option::Some("DATA_TYPE_LONGVARCHAR"),
+            Self::Timestamp => std::option::Option::Some("DATA_TYPE_TIMESTAMP"),
+            Self::Nchar => std::option::Option::Some("DATA_TYPE_NCHAR"),
+            Self::Nvarchar => std::option::Option::Some("DATA_TYPE_NVARCHAR"),
+            Self::Longnvarchar => std::option::Option::Some("DATA_TYPE_LONGNVARCHAR"),
+            Self::Null => std::option::Option::Some("DATA_TYPE_NULL"),
+            Self::Other => std::option::Option::Some("DATA_TYPE_OTHER"),
+            Self::JavaObject => std::option::Option::Some("DATA_TYPE_JAVA_OBJECT"),
+            Self::Distinct => std::option::Option::Some("DATA_TYPE_DISTINCT"),
+            Self::Struct => std::option::Option::Some("DATA_TYPE_STRUCT"),
+            Self::Array => std::option::Option::Some("DATA_TYPE_ARRAY"),
+            Self::Clob => std::option::Option::Some("DATA_TYPE_CLOB"),
+            Self::Ref => std::option::Option::Some("DATA_TYPE_REF"),
+            Self::Datalink => std::option::Option::Some("DATA_TYPE_DATALINK"),
+            Self::Rowid => std::option::Option::Some("DATA_TYPE_ROWID"),
+            Self::Binary => std::option::Option::Some("DATA_TYPE_BINARY"),
+            Self::Varbinary => std::option::Option::Some("DATA_TYPE_VARBINARY"),
+            Self::Longvarbinary => std::option::Option::Some("DATA_TYPE_LONGVARBINARY"),
+            Self::Nclob => std::option::Option::Some("DATA_TYPE_NCLOB"),
+            Self::Sqlxml => std::option::Option::Some("DATA_TYPE_SQLXML"),
+            Self::RefCursor => std::option::Option::Some("DATA_TYPE_REF_CURSOR"),
+            Self::TimeWithTimezone => std::option::Option::Some("DATA_TYPE_TIME_WITH_TIMEZONE"),
+            Self::TimestampWithTimezone => {
+                std::option::Option::Some("DATA_TYPE_TIMESTAMP_WITH_TIMEZONE")
             }
-            "DATA_TYPE_TIMESTAMP_WITH_TIMEZONE" => {
-                std::option::Option::Some(Self::DATA_TYPE_TIMESTAMP_WITH_TIMEZONE)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for DataType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DataType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DataType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Int,
+            2 => Self::Smallint,
+            3 => Self::Double,
+            4 => Self::Date,
+            5 => Self::Datetime,
+            6 => Self::Time,
+            7 => Self::String,
+            8 => Self::Long,
+            9 => Self::Boolean,
+            10 => Self::Decimal,
+            11 => Self::Uuid,
+            12 => Self::Blob,
+            13 => Self::Bit,
+            14 => Self::Tinyint,
+            15 => Self::Integer,
+            16 => Self::Bigint,
+            17 => Self::Float,
+            18 => Self::Real,
+            19 => Self::Numeric,
+            20 => Self::Char,
+            21 => Self::Varchar,
+            22 => Self::Longvarchar,
+            23 => Self::Timestamp,
+            24 => Self::Nchar,
+            25 => Self::Nvarchar,
+            26 => Self::Longnvarchar,
+            27 => Self::Null,
+            28 => Self::Other,
+            29 => Self::JavaObject,
+            30 => Self::Distinct,
+            31 => Self::Struct,
+            32 => Self::Array,
+            33 => Self::Clob,
+            34 => Self::Ref,
+            35 => Self::Datalink,
+            36 => Self::Rowid,
+            37 => Self::Binary,
+            38 => Self::Varbinary,
+            39 => Self::Longvarbinary,
+            40 => Self::Nclob,
+            41 => Self::Sqlxml,
+            42 => Self::RefCursor,
+            43 => Self::TimeWithTimezone,
+            44 => Self::TimestampWithTimezone,
+            _ => Self::UnknownValue(data_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DataType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATA_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "DATA_TYPE_INT" => Self::Int,
+            "DATA_TYPE_SMALLINT" => Self::Smallint,
+            "DATA_TYPE_DOUBLE" => Self::Double,
+            "DATA_TYPE_DATE" => Self::Date,
+            "DATA_TYPE_DATETIME" => Self::Datetime,
+            "DATA_TYPE_TIME" => Self::Time,
+            "DATA_TYPE_STRING" => Self::String,
+            "DATA_TYPE_LONG" => Self::Long,
+            "DATA_TYPE_BOOLEAN" => Self::Boolean,
+            "DATA_TYPE_DECIMAL" => Self::Decimal,
+            "DATA_TYPE_UUID" => Self::Uuid,
+            "DATA_TYPE_BLOB" => Self::Blob,
+            "DATA_TYPE_BIT" => Self::Bit,
+            "DATA_TYPE_TINYINT" => Self::Tinyint,
+            "DATA_TYPE_INTEGER" => Self::Integer,
+            "DATA_TYPE_BIGINT" => Self::Bigint,
+            "DATA_TYPE_FLOAT" => Self::Float,
+            "DATA_TYPE_REAL" => Self::Real,
+            "DATA_TYPE_NUMERIC" => Self::Numeric,
+            "DATA_TYPE_CHAR" => Self::Char,
+            "DATA_TYPE_VARCHAR" => Self::Varchar,
+            "DATA_TYPE_LONGVARCHAR" => Self::Longvarchar,
+            "DATA_TYPE_TIMESTAMP" => Self::Timestamp,
+            "DATA_TYPE_NCHAR" => Self::Nchar,
+            "DATA_TYPE_NVARCHAR" => Self::Nvarchar,
+            "DATA_TYPE_LONGNVARCHAR" => Self::Longnvarchar,
+            "DATA_TYPE_NULL" => Self::Null,
+            "DATA_TYPE_OTHER" => Self::Other,
+            "DATA_TYPE_JAVA_OBJECT" => Self::JavaObject,
+            "DATA_TYPE_DISTINCT" => Self::Distinct,
+            "DATA_TYPE_STRUCT" => Self::Struct,
+            "DATA_TYPE_ARRAY" => Self::Array,
+            "DATA_TYPE_CLOB" => Self::Clob,
+            "DATA_TYPE_REF" => Self::Ref,
+            "DATA_TYPE_DATALINK" => Self::Datalink,
+            "DATA_TYPE_ROWID" => Self::Rowid,
+            "DATA_TYPE_BINARY" => Self::Binary,
+            "DATA_TYPE_VARBINARY" => Self::Varbinary,
+            "DATA_TYPE_LONGVARBINARY" => Self::Longvarbinary,
+            "DATA_TYPE_NCLOB" => Self::Nclob,
+            "DATA_TYPE_SQLXML" => Self::Sqlxml,
+            "DATA_TYPE_REF_CURSOR" => Self::RefCursor,
+            "DATA_TYPE_TIME_WITH_TIMEZONE" => Self::TimeWithTimezone,
+            "DATA_TYPE_TIMESTAMP_WITH_TIMEZONE" => Self::TimestampWithTimezone,
+            _ => Self::UnknownValue(data_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DataType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Int => serializer.serialize_i32(1),
+            Self::Smallint => serializer.serialize_i32(2),
+            Self::Double => serializer.serialize_i32(3),
+            Self::Date => serializer.serialize_i32(4),
+            Self::Datetime => serializer.serialize_i32(5),
+            Self::Time => serializer.serialize_i32(6),
+            Self::String => serializer.serialize_i32(7),
+            Self::Long => serializer.serialize_i32(8),
+            Self::Boolean => serializer.serialize_i32(9),
+            Self::Decimal => serializer.serialize_i32(10),
+            Self::Uuid => serializer.serialize_i32(11),
+            Self::Blob => serializer.serialize_i32(12),
+            Self::Bit => serializer.serialize_i32(13),
+            Self::Tinyint => serializer.serialize_i32(14),
+            Self::Integer => serializer.serialize_i32(15),
+            Self::Bigint => serializer.serialize_i32(16),
+            Self::Float => serializer.serialize_i32(17),
+            Self::Real => serializer.serialize_i32(18),
+            Self::Numeric => serializer.serialize_i32(19),
+            Self::Char => serializer.serialize_i32(20),
+            Self::Varchar => serializer.serialize_i32(21),
+            Self::Longvarchar => serializer.serialize_i32(22),
+            Self::Timestamp => serializer.serialize_i32(23),
+            Self::Nchar => serializer.serialize_i32(24),
+            Self::Nvarchar => serializer.serialize_i32(25),
+            Self::Longnvarchar => serializer.serialize_i32(26),
+            Self::Null => serializer.serialize_i32(27),
+            Self::Other => serializer.serialize_i32(28),
+            Self::JavaObject => serializer.serialize_i32(29),
+            Self::Distinct => serializer.serialize_i32(30),
+            Self::Struct => serializer.serialize_i32(31),
+            Self::Array => serializer.serialize_i32(32),
+            Self::Clob => serializer.serialize_i32(33),
+            Self::Ref => serializer.serialize_i32(34),
+            Self::Datalink => serializer.serialize_i32(35),
+            Self::Rowid => serializer.serialize_i32(36),
+            Self::Binary => serializer.serialize_i32(37),
+            Self::Varbinary => serializer.serialize_i32(38),
+            Self::Longvarbinary => serializer.serialize_i32(39),
+            Self::Nclob => serializer.serialize_i32(40),
+            Self::Sqlxml => serializer.serialize_i32(41),
+            Self::RefCursor => serializer.serialize_i32(42),
+            Self::TimeWithTimezone => serializer.serialize_i32(43),
+            Self::TimestampWithTimezone => serializer.serialize_i32(44),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DataType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataType>::new(
+            ".google.cloud.connectors.v1.DataType",
+        ))
     }
 }
 
 /// Enum to control which fields should be included in the response.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectionView {
+    /// CONNECTION_UNSPECIFIED.
+    Unspecified,
+    /// Do not include runtime required configs.
+    Basic,
+    /// Include runtime required configs.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConnectionView::value] or
+    /// [ConnectionView::name].
+    UnknownValue(connection_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod connection_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ConnectionView {
-    /// CONNECTION_UNSPECIFIED.
-    pub const CONNECTION_VIEW_UNSPECIFIED: ConnectionView = ConnectionView::new(0);
-
-    /// Do not include runtime required configs.
-    pub const BASIC: ConnectionView = ConnectionView::new(1);
-
-    /// Include runtime required configs.
-    pub const FULL: ConnectionView = ConnectionView::new(2);
-
-    /// Creates a new ConnectionView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONNECTION_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONNECTION_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONNECTION_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONNECTION_VIEW_UNSPECIFIED)
-            }
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConnectionView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConnectionView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConnectionView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(connection_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConnectionView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONNECTION_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(connection_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConnectionView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConnectionView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionView>::new(
+            ".google.cloud.connectors.v1.ConnectionView",
+        ))
     }
 }
 
 /// Enum to control which fields should be included in the response.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectorVersionView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectorVersionView {
+    /// CONNECTOR_VERSION_VIEW_UNSPECIFIED.
+    Unspecified,
+    /// Do not include role grant configs.
+    Basic,
+    /// Include role grant configs.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConnectorVersionView::value] or
+    /// [ConnectorVersionView::name].
+    UnknownValue(connector_version_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod connector_version_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ConnectorVersionView {
-    /// CONNECTOR_VERSION_VIEW_UNSPECIFIED.
-    pub const CONNECTOR_VERSION_VIEW_UNSPECIFIED: ConnectorVersionView =
-        ConnectorVersionView::new(0);
-
-    /// Do not include role grant configs.
-    pub const CONNECTOR_VERSION_VIEW_BASIC: ConnectorVersionView = ConnectorVersionView::new(1);
-
-    /// Include role grant configs.
-    pub const CONNECTOR_VERSION_VIEW_FULL: ConnectorVersionView = ConnectorVersionView::new(2);
-
-    /// Creates a new ConnectorVersionView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONNECTOR_VERSION_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CONNECTOR_VERSION_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("CONNECTOR_VERSION_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONNECTOR_VERSION_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("CONNECTOR_VERSION_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("CONNECTOR_VERSION_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONNECTOR_VERSION_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONNECTOR_VERSION_VIEW_UNSPECIFIED)
-            }
-            "CONNECTOR_VERSION_VIEW_BASIC" => {
-                std::option::Option::Some(Self::CONNECTOR_VERSION_VIEW_BASIC)
-            }
-            "CONNECTOR_VERSION_VIEW_FULL" => {
-                std::option::Option::Some(Self::CONNECTOR_VERSION_VIEW_FULL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConnectorVersionView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectorVersionView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConnectorVersionView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConnectorVersionView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(connector_version_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConnectorVersionView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONNECTOR_VERSION_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "CONNECTOR_VERSION_VIEW_BASIC" => Self::Basic,
+            "CONNECTOR_VERSION_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(connector_version_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConnectorVersionView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConnectorVersionView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectorVersionView>::new(
+            ".google.cloud.connectors.v1.ConnectorVersionView",
+        ))
     }
 }
 
 /// Enum for controlling the SSL Type (TLS/MTLS)
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SslType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SslType {
+    /// No SSL configuration required.
+    Unspecified,
+    /// TLS Handshake
+    Tls,
+    /// mutual TLS (MTLS) Handshake
+    Mtls,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SslType::value] or
+    /// [SslType::name].
+    UnknownValue(ssl_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod ssl_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SslType {
-    /// No SSL configuration required.
-    pub const SSL_TYPE_UNSPECIFIED: SslType = SslType::new(0);
-
-    /// TLS Handshake
-    pub const TLS: SslType = SslType::new(1);
-
-    /// mutual TLS (MTLS) Handshake
-    pub const MTLS: SslType = SslType::new(2);
-
-    /// Creates a new SslType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Tls => std::option::Option::Some(1),
+            Self::Mtls => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SSL_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TLS"),
-            2 => std::borrow::Cow::Borrowed("MTLS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SSL_TYPE_UNSPECIFIED"),
+            Self::Tls => std::option::Option::Some("TLS"),
+            Self::Mtls => std::option::Option::Some("MTLS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SSL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_TYPE_UNSPECIFIED),
-            "TLS" => std::option::Option::Some(Self::TLS),
-            "MTLS" => std::option::Option::Some(Self::MTLS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SslType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SslType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SslType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SslType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Tls,
+            2 => Self::Mtls,
+            _ => Self::UnknownValue(ssl_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SslType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SSL_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "TLS" => Self::Tls,
+            "MTLS" => Self::Mtls,
+            _ => Self::UnknownValue(ssl_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SslType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Tls => serializer.serialize_i32(1),
+            Self::Mtls => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SslType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SslType>::new(
+            ".google.cloud.connectors.v1.SslType",
+        ))
     }
 }
 
 /// Enum for Cert Types
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CertType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CertType {
+    /// Cert type unspecified.
+    Unspecified,
+    /// Privacy Enhanced Mail (PEM) Type
+    Pem,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CertType::value] or
+    /// [CertType::name].
+    UnknownValue(cert_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod cert_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CertType {
-    /// Cert type unspecified.
-    pub const CERT_TYPE_UNSPECIFIED: CertType = CertType::new(0);
-
-    /// Privacy Enhanced Mail (PEM) Type
-    pub const PEM: CertType = CertType::new(1);
-
-    /// Creates a new CertType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Pem => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CERT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PEM"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CERT_TYPE_UNSPECIFIED"),
+            Self::Pem => std::option::Option::Some("PEM"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CERT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::CERT_TYPE_UNSPECIFIED),
-            "PEM" => std::option::Option::Some(Self::PEM),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CertType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CertType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CertType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CertType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Pem,
+            _ => Self::UnknownValue(cert_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CertType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CERT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PEM" => Self::Pem,
+            _ => Self::UnknownValue(cert_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CertType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Pem => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CertType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CertType>::new(
+            ".google.cloud.connectors.v1.CertType",
+        ))
     }
 }

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -61,7 +61,7 @@ impl super::stub::Connectors for Connectors {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -81,7 +81,7 @@ impl super::stub::Connectors for Connectors {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -265,7 +265,7 @@ impl super::stub::Connectors for Connectors {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -285,7 +285,7 @@ impl super::stub::Connectors for Connectors {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -1274,61 +1274,124 @@ pub mod ingest_conversations_request {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BucketObjectType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum BucketObjectType {
+            /// The object type is unspecified and will default to `TRANSCRIPT`.
+            Unspecified,
+            /// The object is a transcript.
+            Transcript,
+            /// The object is an audio file.
+            Audio,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [BucketObjectType::value] or
+            /// [BucketObjectType::name].
+            UnknownValue(bucket_object_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod bucket_object_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl BucketObjectType {
-            /// The object type is unspecified and will default to `TRANSCRIPT`.
-            pub const BUCKET_OBJECT_TYPE_UNSPECIFIED: BucketObjectType = BucketObjectType::new(0);
-
-            /// The object is a transcript.
-            pub const TRANSCRIPT: BucketObjectType = BucketObjectType::new(1);
-
-            /// The object is an audio file.
-            pub const AUDIO: BucketObjectType = BucketObjectType::new(2);
-
-            /// Creates a new BucketObjectType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Transcript => std::option::Option::Some(1),
+                    Self::Audio => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("BUCKET_OBJECT_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TRANSCRIPT"),
-                    2 => std::borrow::Cow::Borrowed("AUDIO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "BUCKET_OBJECT_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::BUCKET_OBJECT_TYPE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("BUCKET_OBJECT_TYPE_UNSPECIFIED")
                     }
-                    "TRANSCRIPT" => std::option::Option::Some(Self::TRANSCRIPT),
-                    "AUDIO" => std::option::Option::Some(Self::AUDIO),
-                    _ => std::option::Option::None,
+                    Self::Transcript => std::option::Option::Some("TRANSCRIPT"),
+                    Self::Audio => std::option::Option::Some("AUDIO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for BucketObjectType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for BucketObjectType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for BucketObjectType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for BucketObjectType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Transcript,
+                    2 => Self::Audio,
+                    _ => Self::UnknownValue(bucket_object_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for BucketObjectType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "BUCKET_OBJECT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "TRANSCRIPT" => Self::Transcript,
+                    "AUDIO" => Self::Audio,
+                    _ => Self::UnknownValue(bucket_object_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for BucketObjectType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Transcript => serializer.serialize_i32(1),
+                    Self::Audio => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for BucketObjectType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<BucketObjectType>::new(
+                    ".google.cloud.contactcenterinsights.v1.IngestConversationsRequest.GcsSource.BucketObjectType"))
             }
         }
     }
@@ -2457,62 +2520,121 @@ pub mod export_insights_data_request {
     }
 
     /// Specifies the action that occurs if the destination table already exists.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WriteDisposition(i32);
-
-    impl WriteDisposition {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WriteDisposition {
         /// Write disposition is not specified. Defaults to WRITE_TRUNCATE.
-        pub const WRITE_DISPOSITION_UNSPECIFIED: WriteDisposition = WriteDisposition::new(0);
-
+        Unspecified,
         /// If the table already exists, BigQuery will overwrite the table data and
         /// use the schema from the load.
-        pub const WRITE_TRUNCATE: WriteDisposition = WriteDisposition::new(1);
-
+        WriteTruncate,
         /// If the table already exists, BigQuery will append data to the table.
-        pub const WRITE_APPEND: WriteDisposition = WriteDisposition::new(2);
+        WriteAppend,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WriteDisposition::value] or
+        /// [WriteDisposition::name].
+        UnknownValue(write_disposition::UnknownValue),
+    }
 
-        /// Creates a new WriteDisposition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod write_disposition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl WriteDisposition {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::WriteTruncate => std::option::Option::Some(1),
+                Self::WriteAppend => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WRITE_DISPOSITION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WRITE_TRUNCATE"),
-                2 => std::borrow::Cow::Borrowed("WRITE_APPEND"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WRITE_DISPOSITION_UNSPECIFIED"),
+                Self::WriteTruncate => std::option::Option::Some("WRITE_TRUNCATE"),
+                Self::WriteAppend => std::option::Option::Some("WRITE_APPEND"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WRITE_DISPOSITION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WRITE_DISPOSITION_UNSPECIFIED)
-                }
-                "WRITE_TRUNCATE" => std::option::Option::Some(Self::WRITE_TRUNCATE),
-                "WRITE_APPEND" => std::option::Option::Some(Self::WRITE_APPEND),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WriteDisposition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WriteDisposition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WriteDisposition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WriteDisposition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::WriteTruncate,
+                2 => Self::WriteAppend,
+                _ => Self::UnknownValue(write_disposition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WriteDisposition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WRITE_DISPOSITION_UNSPECIFIED" => Self::Unspecified,
+                "WRITE_TRUNCATE" => Self::WriteTruncate,
+                "WRITE_APPEND" => Self::WriteAppend,
+                _ => Self::UnknownValue(write_disposition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WriteDisposition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::WriteTruncate => serializer.serialize_i32(1),
+                Self::WriteAppend => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WriteDisposition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WriteDisposition>::new(
+                ".google.cloud.contactcenterinsights.v1.ExportInsightsDataRequest.WriteDisposition",
+            ))
         }
     }
 
@@ -5465,92 +5587,157 @@ pub mod dimension {
     }
 
     /// The key of the dimension.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DimensionKey(i32);
-
-    impl DimensionKey {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DimensionKey {
         /// The key of the dimension is unspecified.
-        pub const DIMENSION_KEY_UNSPECIFIED: DimensionKey = DimensionKey::new(0);
-
+        Unspecified,
         /// The dimension is keyed by issues.
-        pub const ISSUE: DimensionKey = DimensionKey::new(1);
-
+        Issue,
         /// The dimension is keyed by agents.
-        pub const AGENT: DimensionKey = DimensionKey::new(2);
-
+        Agent,
         /// The dimension is keyed by agent teams.
-        pub const AGENT_TEAM: DimensionKey = DimensionKey::new(3);
-
+        AgentTeam,
         /// The dimension is keyed by QaQuestionIds.
         /// Note that: We only group by the QuestionId and not the revision-id of the
         /// scorecard this question is a part of. This allows for showing stats for
         /// the same question across different scorecard revisions.
-        pub const QA_QUESTION_ID: DimensionKey = DimensionKey::new(4);
-
+        QaQuestionId,
         /// The dimension is keyed by QaQuestionIds-Answer value pairs.
         /// Note that: We only group by the QuestionId and not the revision-id of the
         /// scorecard this question is a part of. This allows for showing
         /// distribution of answers per question across different scorecard
         /// revisions.
-        pub const QA_QUESTION_ANSWER_VALUE: DimensionKey = DimensionKey::new(5);
-
+        QaQuestionAnswerValue,
         /// The dimension is keyed by the conversation profile ID.
-        pub const CONVERSATION_PROFILE_ID: DimensionKey = DimensionKey::new(6);
+        ConversationProfileId,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DimensionKey::value] or
+        /// [DimensionKey::name].
+        UnknownValue(dimension_key::UnknownValue),
+    }
 
-        /// Creates a new DimensionKey instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod dimension_key {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DimensionKey {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Issue => std::option::Option::Some(1),
+                Self::Agent => std::option::Option::Some(2),
+                Self::AgentTeam => std::option::Option::Some(3),
+                Self::QaQuestionId => std::option::Option::Some(4),
+                Self::QaQuestionAnswerValue => std::option::Option::Some(5),
+                Self::ConversationProfileId => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIMENSION_KEY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ISSUE"),
-                2 => std::borrow::Cow::Borrowed("AGENT"),
-                3 => std::borrow::Cow::Borrowed("AGENT_TEAM"),
-                4 => std::borrow::Cow::Borrowed("QA_QUESTION_ID"),
-                5 => std::borrow::Cow::Borrowed("QA_QUESTION_ANSWER_VALUE"),
-                6 => std::borrow::Cow::Borrowed("CONVERSATION_PROFILE_ID"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIMENSION_KEY_UNSPECIFIED"),
+                Self::Issue => std::option::Option::Some("ISSUE"),
+                Self::Agent => std::option::Option::Some("AGENT"),
+                Self::AgentTeam => std::option::Option::Some("AGENT_TEAM"),
+                Self::QaQuestionId => std::option::Option::Some("QA_QUESTION_ID"),
+                Self::QaQuestionAnswerValue => {
+                    std::option::Option::Some("QA_QUESTION_ANSWER_VALUE")
+                }
+                Self::ConversationProfileId => std::option::Option::Some("CONVERSATION_PROFILE_ID"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIMENSION_KEY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DIMENSION_KEY_UNSPECIFIED)
-                }
-                "ISSUE" => std::option::Option::Some(Self::ISSUE),
-                "AGENT" => std::option::Option::Some(Self::AGENT),
-                "AGENT_TEAM" => std::option::Option::Some(Self::AGENT_TEAM),
-                "QA_QUESTION_ID" => std::option::Option::Some(Self::QA_QUESTION_ID),
-                "QA_QUESTION_ANSWER_VALUE" => {
-                    std::option::Option::Some(Self::QA_QUESTION_ANSWER_VALUE)
-                }
-                "CONVERSATION_PROFILE_ID" => {
-                    std::option::Option::Some(Self::CONVERSATION_PROFILE_ID)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DimensionKey {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DimensionKey {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DimensionKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DimensionKey {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Issue,
+                2 => Self::Agent,
+                3 => Self::AgentTeam,
+                4 => Self::QaQuestionId,
+                5 => Self::QaQuestionAnswerValue,
+                6 => Self::ConversationProfileId,
+                _ => Self::UnknownValue(dimension_key::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DimensionKey {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIMENSION_KEY_UNSPECIFIED" => Self::Unspecified,
+                "ISSUE" => Self::Issue,
+                "AGENT" => Self::Agent,
+                "AGENT_TEAM" => Self::AgentTeam,
+                "QA_QUESTION_ID" => Self::QaQuestionId,
+                "QA_QUESTION_ANSWER_VALUE" => Self::QaQuestionAnswerValue,
+                "CONVERSATION_PROFILE_ID" => Self::ConversationProfileId,
+                _ => Self::UnknownValue(dimension_key::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DimensionKey {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Issue => serializer.serialize_i32(1),
+                Self::Agent => serializer.serialize_i32(2),
+                Self::AgentTeam => serializer.serialize_i32(3),
+                Self::QaQuestionId => serializer.serialize_i32(4),
+                Self::QaQuestionAnswerValue => serializer.serialize_i32(5),
+                Self::ConversationProfileId => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DimensionKey {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DimensionKey>::new(
+                ".google.cloud.contactcenterinsights.v1.Dimension.DimensionKey",
+            ))
         }
     }
 
@@ -5681,87 +5868,154 @@ pub mod query_metrics_request {
     /// A time granularity divides the time line into discrete time periods.
     /// This is useful for defining buckets over which filtering and aggregation
     /// should be performed.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeGranularity(i32);
-
-    impl TimeGranularity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimeGranularity {
         /// The time granularity is unspecified and will default to NONE.
-        pub const TIME_GRANULARITY_UNSPECIFIED: TimeGranularity = TimeGranularity::new(0);
-
+        Unspecified,
         /// No time granularity. The response won't contain a time series.
         /// This is the default value if no time granularity is specified.
-        pub const NONE: TimeGranularity = TimeGranularity::new(1);
-
+        None,
         /// Data points in the time series will aggregate at a daily granularity.
         /// 1 day means [midnight to midnight).
-        pub const DAILY: TimeGranularity = TimeGranularity::new(2);
-
+        Daily,
         /// Data points in the time series will aggregate at a daily granularity.
         /// 1 HOUR means [01:00 to 02:00).
-        pub const HOURLY: TimeGranularity = TimeGranularity::new(3);
-
+        Hourly,
         /// Data points in the time series will aggregate at a daily granularity.
         /// PER_MINUTE means [01:00 to 01:01).
-        pub const PER_MINUTE: TimeGranularity = TimeGranularity::new(4);
-
+        PerMinute,
         /// Data points in the time series will aggregate at a 1 minute  granularity.
         /// PER_5_MINUTES means [01:00 to 01:05).
-        pub const PER_5_MINUTES: TimeGranularity = TimeGranularity::new(5);
-
+        Per5Minutes,
         /// Data points in the time series will aggregate at a monthly granularity.
         /// 1 MONTH means [01st of the month to 1st of the next month).
-        pub const MONTHLY: TimeGranularity = TimeGranularity::new(6);
+        Monthly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimeGranularity::value] or
+        /// [TimeGranularity::name].
+        UnknownValue(time_granularity::UnknownValue),
+    }
 
-        /// Creates a new TimeGranularity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod time_granularity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TimeGranularity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Daily => std::option::Option::Some(2),
+                Self::Hourly => std::option::Option::Some(3),
+                Self::PerMinute => std::option::Option::Some(4),
+                Self::Per5Minutes => std::option::Option::Some(5),
+                Self::Monthly => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIME_GRANULARITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("DAILY"),
-                3 => std::borrow::Cow::Borrowed("HOURLY"),
-                4 => std::borrow::Cow::Borrowed("PER_MINUTE"),
-                5 => std::borrow::Cow::Borrowed("PER_5_MINUTES"),
-                6 => std::borrow::Cow::Borrowed("MONTHLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIME_GRANULARITY_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Hourly => std::option::Option::Some("HOURLY"),
+                Self::PerMinute => std::option::Option::Some("PER_MINUTE"),
+                Self::Per5Minutes => std::option::Option::Some("PER_5_MINUTES"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIME_GRANULARITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TIME_GRANULARITY_UNSPECIFIED)
-                }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "HOURLY" => std::option::Option::Some(Self::HOURLY),
-                "PER_MINUTE" => std::option::Option::Some(Self::PER_MINUTE),
-                "PER_5_MINUTES" => std::option::Option::Some(Self::PER_5_MINUTES),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TimeGranularity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeGranularity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimeGranularity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimeGranularity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Daily,
+                3 => Self::Hourly,
+                4 => Self::PerMinute,
+                5 => Self::Per5Minutes,
+                6 => Self::Monthly,
+                _ => Self::UnknownValue(time_granularity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimeGranularity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIME_GRANULARITY_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "DAILY" => Self::Daily,
+                "HOURLY" => Self::Hourly,
+                "PER_MINUTE" => Self::PerMinute,
+                "PER_5_MINUTES" => Self::Per5Minutes,
+                "MONTHLY" => Self::Monthly,
+                _ => Self::UnknownValue(time_granularity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimeGranularity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Daily => serializer.serialize_i32(2),
+                Self::Hourly => serializer.serialize_i32(3),
+                Self::PerMinute => serializer.serialize_i32(4),
+                Self::Per5Minutes => serializer.serialize_i32(5),
+                Self::Monthly => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimeGranularity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimeGranularity>::new(
+                ".google.cloud.contactcenterinsights.v1.QueryMetricsRequest.TimeGranularity",
+            ))
         }
     }
 }
@@ -8252,59 +8506,122 @@ pub mod bulk_upload_feedback_labels_request {
         use super::*;
 
         /// All permissible file formats.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Format(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Format {
+            /// Unspecified format.
+            Unspecified,
+            /// CSV format.
+            Csv,
+            /// JSON format.
+            Json,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Format::value] or
+            /// [Format::name].
+            UnknownValue(format::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Format {
-            /// Unspecified format.
-            pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
-
-            /// CSV format.
-            pub const CSV: Format = Format::new(1);
-
-            /// JSON format.
-            pub const JSON: Format = Format::new(2);
-
-            /// Creates a new Format instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Csv => std::option::Option::Some(1),
+                    Self::Json => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CSV"),
-                    2 => std::borrow::Cow::Borrowed("JSON"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("FORMAT_UNSPECIFIED"),
+                    Self::Csv => std::option::Option::Some("CSV"),
+                    Self::Json => std::option::Option::Some("JSON"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
-                    "CSV" => std::option::Option::Some(Self::CSV),
-                    "JSON" => std::option::Option::Some(Self::JSON),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Format {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Format {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Format {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Format {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Csv,
+                    2 => Self::Json,
+                    _ => Self::UnknownValue(format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Format {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "CSV" => Self::Csv,
+                    "JSON" => Self::Json,
+                    _ => Self::UnknownValue(format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Format {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Csv => serializer.serialize_i32(1),
+                    Self::Json => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Format {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Format>::new(
+                    ".google.cloud.contactcenterinsights.v1.BulkUploadFeedbackLabelsRequest.GcsSource.Format"))
             }
         }
     }
@@ -8776,122 +9093,243 @@ pub mod bulk_download_feedback_labels_request {
         /// All permissible file formats.
         /// See `records_per_file_count` to override the default number of records
         /// per file.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Format(i32);
-
-        impl Format {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Format {
             /// Unspecified format.
-            pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
-
+            Unspecified,
             /// CSV format.
             /// 1,000 labels are stored per CSV file by default.
-            pub const CSV: Format = Format::new(1);
-
+            Csv,
             /// JSON format.
             /// 1 label stored per JSON file by default.
-            pub const JSON: Format = Format::new(2);
+            Json,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Format::value] or
+            /// [Format::name].
+            UnknownValue(format::UnknownValue),
+        }
 
-            /// Creates a new Format instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Format {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Csv => std::option::Option::Some(1),
+                    Self::Json => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CSV"),
-                    2 => std::borrow::Cow::Borrowed("JSON"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("FORMAT_UNSPECIFIED"),
+                    Self::Csv => std::option::Option::Some("CSV"),
+                    Self::Json => std::option::Option::Some("JSON"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
-                    "CSV" => std::option::Option::Some(Self::CSV),
-                    "JSON" => std::option::Option::Some(Self::JSON),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Format {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Format {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Format {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Format {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Csv,
+                    2 => Self::Json,
+                    _ => Self::UnknownValue(format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Format {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "CSV" => Self::Csv,
+                    "JSON" => Self::Json,
+                    _ => Self::UnknownValue(format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Format {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Csv => serializer.serialize_i32(1),
+                    Self::Json => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Format {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Format>::new(
+                    ".google.cloud.contactcenterinsights.v1.BulkDownloadFeedbackLabelsRequest.GcsDestination.Format"))
             }
         }
     }
 
     /// Possible feedback label types that will be downloaded.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FeedbackLabelType(i32);
-
-    impl FeedbackLabelType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FeedbackLabelType {
         /// Unspecified format
-        pub const FEEDBACK_LABEL_TYPE_UNSPECIFIED: FeedbackLabelType = FeedbackLabelType::new(0);
-
+        Unspecified,
         /// Downloaded file will contain all Quality AI labels from the latest
         /// scorecard revision.
-        pub const QUALITY_AI: FeedbackLabelType = FeedbackLabelType::new(1);
-
+        QualityAi,
         /// Downloaded file will contain only Topic Modeling labels.
-        pub const TOPIC_MODELING: FeedbackLabelType = FeedbackLabelType::new(2);
+        TopicModeling,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FeedbackLabelType::value] or
+        /// [FeedbackLabelType::name].
+        UnknownValue(feedback_label_type::UnknownValue),
+    }
 
-        /// Creates a new FeedbackLabelType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod feedback_label_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FeedbackLabelType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::QualityAi => std::option::Option::Some(1),
+                Self::TopicModeling => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FEEDBACK_LABEL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("QUALITY_AI"),
-                2 => std::borrow::Cow::Borrowed("TOPIC_MODELING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FEEDBACK_LABEL_TYPE_UNSPECIFIED"),
+                Self::QualityAi => std::option::Option::Some("QUALITY_AI"),
+                Self::TopicModeling => std::option::Option::Some("TOPIC_MODELING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FEEDBACK_LABEL_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FEEDBACK_LABEL_TYPE_UNSPECIFIED)
-                }
-                "QUALITY_AI" => std::option::Option::Some(Self::QUALITY_AI),
-                "TOPIC_MODELING" => std::option::Option::Some(Self::TOPIC_MODELING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FeedbackLabelType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FeedbackLabelType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FeedbackLabelType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FeedbackLabelType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::QualityAi,
+                2 => Self::TopicModeling,
+                _ => Self::UnknownValue(feedback_label_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FeedbackLabelType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FEEDBACK_LABEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "QUALITY_AI" => Self::QualityAi,
+                "TOPIC_MODELING" => Self::TopicModeling,
+                _ => Self::UnknownValue(feedback_label_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FeedbackLabelType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::QualityAi => serializer.serialize_i32(1),
+                Self::TopicModeling => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FeedbackLabelType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FeedbackLabelType>::new(
+                ".google.cloud.contactcenterinsights.v1.BulkDownloadFeedbackLabelsRequest.FeedbackLabelType"))
         }
     }
 
@@ -10020,59 +10458,120 @@ pub mod conversation {
     }
 
     /// Possible media for the conversation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Medium(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Medium {
+        /// Default value, if unspecified will default to PHONE_CALL.
+        Unspecified,
+        /// The format for conversations that took place over the phone.
+        PhoneCall,
+        /// The format for conversations that took place over chat.
+        Chat,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Medium::value] or
+        /// [Medium::name].
+        UnknownValue(medium::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod medium {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Medium {
-        /// Default value, if unspecified will default to PHONE_CALL.
-        pub const MEDIUM_UNSPECIFIED: Medium = Medium::new(0);
-
-        /// The format for conversations that took place over the phone.
-        pub const PHONE_CALL: Medium = Medium::new(1);
-
-        /// The format for conversations that took place over chat.
-        pub const CHAT: Medium = Medium::new(2);
-
-        /// Creates a new Medium instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PhoneCall => std::option::Option::Some(1),
+                Self::Chat => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MEDIUM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PHONE_CALL"),
-                2 => std::borrow::Cow::Borrowed("CHAT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MEDIUM_UNSPECIFIED"),
+                Self::PhoneCall => std::option::Option::Some("PHONE_CALL"),
+                Self::Chat => std::option::Option::Some("CHAT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MEDIUM_UNSPECIFIED" => std::option::Option::Some(Self::MEDIUM_UNSPECIFIED),
-                "PHONE_CALL" => std::option::Option::Some(Self::PHONE_CALL),
-                "CHAT" => std::option::Option::Some(Self::CHAT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Medium {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Medium {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Medium {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Medium {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PhoneCall,
+                2 => Self::Chat,
+                _ => Self::UnknownValue(medium::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Medium {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MEDIUM_UNSPECIFIED" => Self::Unspecified,
+                "PHONE_CALL" => Self::PhoneCall,
+                "CHAT" => Self::Chat,
+                _ => Self::UnknownValue(medium::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Medium {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PhoneCall => serializer.serialize_i32(1),
+                Self::Chat => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Medium {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Medium>::new(
+                ".google.cloud.contactcenterinsights.v1.Conversation.Medium",
+            ))
         }
     }
 
@@ -11547,34 +12046,25 @@ pub mod entity {
     /// Wikipedia URL (`wikipedia_url`) and Knowledge Graph MID (`mid`). The table
     /// below lists the associated fields for entities that have different
     /// metadata.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Person.
-        pub const PERSON: Type = Type::new(1);
-
+        Person,
         /// Location.
-        pub const LOCATION: Type = Type::new(2);
-
+        Location,
         /// Organization.
-        pub const ORGANIZATION: Type = Type::new(3);
-
+        Organization,
         /// Event.
-        pub const EVENT: Type = Type::new(4);
-
+        Event,
         /// Artwork.
-        pub const WORK_OF_ART: Type = Type::new(5);
-
+        WorkOfArt,
         /// Consumer product.
-        pub const CONSUMER_GOOD: Type = Type::new(6);
-
+        ConsumerGood,
         /// Other types of entities.
-        pub const OTHER: Type = Type::new(7);
-
+        Other,
         /// Phone number.
         ///
         /// The metadata lists the phone number (formatted according to local
@@ -11586,8 +12076,7 @@ pub mod entity {
         /// * `area_code` - Region or area code, if detected.
         /// * `extension` - Phone extension (to be dialed after connection), if
         ///   detected.
-        pub const PHONE_NUMBER: Type = Type::new(9);
-
+        PhoneNumber,
         /// Address.
         ///
         /// The metadata identifies the street number and locality plus whichever
@@ -11603,8 +12092,7 @@ pub mod entity {
         ///   detected.
         /// * `sublocality` - Used in Asian addresses to demark a district within a
         ///   city, if detected.
-        pub const ADDRESS: Type = Type::new(10);
-
+        Address,
         /// Date.
         ///
         /// The metadata identifies the components of the date:
@@ -11612,78 +12100,170 @@ pub mod entity {
         /// * `year` - Four digit year, if detected.
         /// * `month` - Two digit month number, if detected.
         /// * `day` - Two digit day number, if detected.
-        pub const DATE: Type = Type::new(11);
-
+        Date,
         /// Number.
         ///
         /// The metadata is the number itself.
-        pub const NUMBER: Type = Type::new(12);
-
+        Number,
         /// Price.
         ///
         /// The metadata identifies the `value` and `currency`.
-        pub const PRICE: Type = Type::new(13);
+        Price,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Person => std::option::Option::Some(1),
+                Self::Location => std::option::Option::Some(2),
+                Self::Organization => std::option::Option::Some(3),
+                Self::Event => std::option::Option::Some(4),
+                Self::WorkOfArt => std::option::Option::Some(5),
+                Self::ConsumerGood => std::option::Option::Some(6),
+                Self::Other => std::option::Option::Some(7),
+                Self::PhoneNumber => std::option::Option::Some(9),
+                Self::Address => std::option::Option::Some(10),
+                Self::Date => std::option::Option::Some(11),
+                Self::Number => std::option::Option::Some(12),
+                Self::Price => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PERSON"),
-                2 => std::borrow::Cow::Borrowed("LOCATION"),
-                3 => std::borrow::Cow::Borrowed("ORGANIZATION"),
-                4 => std::borrow::Cow::Borrowed("EVENT"),
-                5 => std::borrow::Cow::Borrowed("WORK_OF_ART"),
-                6 => std::borrow::Cow::Borrowed("CONSUMER_GOOD"),
-                7 => std::borrow::Cow::Borrowed("OTHER"),
-                9 => std::borrow::Cow::Borrowed("PHONE_NUMBER"),
-                10 => std::borrow::Cow::Borrowed("ADDRESS"),
-                11 => std::borrow::Cow::Borrowed("DATE"),
-                12 => std::borrow::Cow::Borrowed("NUMBER"),
-                13 => std::borrow::Cow::Borrowed("PRICE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Person => std::option::Option::Some("PERSON"),
+                Self::Location => std::option::Option::Some("LOCATION"),
+                Self::Organization => std::option::Option::Some("ORGANIZATION"),
+                Self::Event => std::option::Option::Some("EVENT"),
+                Self::WorkOfArt => std::option::Option::Some("WORK_OF_ART"),
+                Self::ConsumerGood => std::option::Option::Some("CONSUMER_GOOD"),
+                Self::Other => std::option::Option::Some("OTHER"),
+                Self::PhoneNumber => std::option::Option::Some("PHONE_NUMBER"),
+                Self::Address => std::option::Option::Some("ADDRESS"),
+                Self::Date => std::option::Option::Some("DATE"),
+                Self::Number => std::option::Option::Some("NUMBER"),
+                Self::Price => std::option::Option::Some("PRICE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PERSON" => std::option::Option::Some(Self::PERSON),
-                "LOCATION" => std::option::Option::Some(Self::LOCATION),
-                "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
-                "EVENT" => std::option::Option::Some(Self::EVENT),
-                "WORK_OF_ART" => std::option::Option::Some(Self::WORK_OF_ART),
-                "CONSUMER_GOOD" => std::option::Option::Some(Self::CONSUMER_GOOD),
-                "OTHER" => std::option::Option::Some(Self::OTHER),
-                "PHONE_NUMBER" => std::option::Option::Some(Self::PHONE_NUMBER),
-                "ADDRESS" => std::option::Option::Some(Self::ADDRESS),
-                "DATE" => std::option::Option::Some(Self::DATE),
-                "NUMBER" => std::option::Option::Some(Self::NUMBER),
-                "PRICE" => std::option::Option::Some(Self::PRICE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Person,
+                2 => Self::Location,
+                3 => Self::Organization,
+                4 => Self::Event,
+                5 => Self::WorkOfArt,
+                6 => Self::ConsumerGood,
+                7 => Self::Other,
+                9 => Self::PhoneNumber,
+                10 => Self::Address,
+                11 => Self::Date,
+                12 => Self::Number,
+                13 => Self::Price,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PERSON" => Self::Person,
+                "LOCATION" => Self::Location,
+                "ORGANIZATION" => Self::Organization,
+                "EVENT" => Self::Event,
+                "WORK_OF_ART" => Self::WorkOfArt,
+                "CONSUMER_GOOD" => Self::ConsumerGood,
+                "OTHER" => Self::Other,
+                "PHONE_NUMBER" => Self::PhoneNumber,
+                "ADDRESS" => Self::Address,
+                "DATE" => Self::Date,
+                "NUMBER" => Self::Number,
+                "PRICE" => Self::Price,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Person => serializer.serialize_i32(1),
+                Self::Location => serializer.serialize_i32(2),
+                Self::Organization => serializer.serialize_i32(3),
+                Self::Event => serializer.serialize_i32(4),
+                Self::WorkOfArt => serializer.serialize_i32(5),
+                Self::ConsumerGood => serializer.serialize_i32(6),
+                Self::Other => serializer.serialize_i32(7),
+                Self::PhoneNumber => serializer.serialize_i32(9),
+                Self::Address => serializer.serialize_i32(10),
+                Self::Date => serializer.serialize_i32(11),
+                Self::Number => serializer.serialize_i32(12),
+                Self::Price => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.contactcenterinsights.v1.Entity.Type",
+            ))
         }
     }
 }
@@ -11944,61 +12524,120 @@ pub mod entity_mention_data {
     use super::*;
 
     /// The supported types of mentions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MentionType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MentionType {
+        /// Unspecified.
+        Unspecified,
+        /// Proper noun.
+        Proper,
+        /// Common noun (or noun compound).
+        Common,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MentionType::value] or
+        /// [MentionType::name].
+        UnknownValue(mention_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mention_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MentionType {
-        /// Unspecified.
-        pub const MENTION_TYPE_UNSPECIFIED: MentionType = MentionType::new(0);
-
-        /// Proper noun.
-        pub const PROPER: MentionType = MentionType::new(1);
-
-        /// Common noun (or noun compound).
-        pub const COMMON: MentionType = MentionType::new(2);
-
-        /// Creates a new MentionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Proper => std::option::Option::Some(1),
+                Self::Common => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MENTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROPER"),
-                2 => std::borrow::Cow::Borrowed("COMMON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MENTION_TYPE_UNSPECIFIED"),
+                Self::Proper => std::option::Option::Some("PROPER"),
+                Self::Common => std::option::Option::Some("COMMON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MENTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MENTION_TYPE_UNSPECIFIED)
-                }
-                "PROPER" => std::option::Option::Some(Self::PROPER),
-                "COMMON" => std::option::Option::Some(Self::COMMON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MentionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MentionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MentionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MentionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Proper,
+                2 => Self::Common,
+                _ => Self::UnknownValue(mention_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MentionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MENTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PROPER" => Self::Proper,
+                "COMMON" => Self::Common,
+                _ => Self::UnknownValue(mention_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MentionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Proper => serializer.serialize_i32(1),
+                Self::Common => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MentionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MentionType>::new(
+                ".google.cloud.contactcenterinsights.v1.EntityMentionData.MentionType",
+            ))
         }
     }
 }
@@ -12335,132 +12974,260 @@ pub mod issue_model {
     }
 
     /// State of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Model is not deployed but is ready to deploy.
-        pub const UNDEPLOYED: State = State::new(1);
-
+        Undeployed,
         /// Model is being deployed.
-        pub const DEPLOYING: State = State::new(2);
-
+        Deploying,
         /// Model is deployed and is ready to be used. A model can only be used in
         /// analysis if it's in this state.
-        pub const DEPLOYED: State = State::new(3);
-
+        Deployed,
         /// Model is being undeployed.
-        pub const UNDEPLOYING: State = State::new(4);
-
+        Undeploying,
         /// Model is being deleted.
-        pub const DELETING: State = State::new(5);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Undeployed => std::option::Option::Some(1),
+                Self::Deploying => std::option::Option::Some(2),
+                Self::Deployed => std::option::Option::Some(3),
+                Self::Undeploying => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNDEPLOYED"),
-                2 => std::borrow::Cow::Borrowed("DEPLOYING"),
-                3 => std::borrow::Cow::Borrowed("DEPLOYED"),
-                4 => std::borrow::Cow::Borrowed("UNDEPLOYING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Undeployed => std::option::Option::Some("UNDEPLOYED"),
+                Self::Deploying => std::option::Option::Some("DEPLOYING"),
+                Self::Deployed => std::option::Option::Some("DEPLOYED"),
+                Self::Undeploying => std::option::Option::Some("UNDEPLOYING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "UNDEPLOYED" => std::option::Option::Some(Self::UNDEPLOYED),
-                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
-                "DEPLOYED" => std::option::Option::Some(Self::DEPLOYED),
-                "UNDEPLOYING" => std::option::Option::Some(Self::UNDEPLOYING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Undeployed,
+                2 => Self::Deploying,
+                3 => Self::Deployed,
+                4 => Self::Undeploying,
+                5 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "UNDEPLOYED" => Self::Undeployed,
+                "DEPLOYING" => Self::Deploying,
+                "DEPLOYED" => Self::Deployed,
+                "UNDEPLOYING" => Self::Undeploying,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Undeployed => serializer.serialize_i32(1),
+                Self::Deploying => serializer.serialize_i32(2),
+                Self::Deployed => serializer.serialize_i32(3),
+                Self::Undeploying => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.contactcenterinsights.v1.IssueModel.State",
+            ))
         }
     }
 
     /// Type of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelType {
+        /// Unspecified model type.
+        Unspecified,
+        /// Type V1.
+        TypeV1,
+        /// Type V2.
+        TypeV2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelType::value] or
+        /// [ModelType::name].
+        UnknownValue(model_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod model_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ModelType {
-        /// Unspecified model type.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
-
-        /// Type V1.
-        pub const TYPE_V1: ModelType = ModelType::new(1);
-
-        /// Type V2.
-        pub const TYPE_V2: ModelType = ModelType::new(2);
-
-        /// Creates a new ModelType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TypeV1 => std::option::Option::Some(1),
+                Self::TypeV2 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TYPE_V1"),
-                2 => std::borrow::Cow::Borrowed("TYPE_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_TYPE_UNSPECIFIED"),
+                Self::TypeV1 => std::option::Option::Some("TYPE_V1"),
+                Self::TypeV2 => std::option::Option::Some("TYPE_V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
-                "TYPE_V1" => std::option::Option::Some(Self::TYPE_V1),
-                "TYPE_V2" => std::option::Option::Some(Self::TYPE_V2),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TypeV1,
+                2 => Self::TypeV2,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TYPE_V1" => Self::TypeV1,
+                "TYPE_V2" => Self::TypeV2,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TypeV1 => serializer.serialize_i32(1),
+                Self::TypeV2 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelType>::new(
+                ".google.cloud.contactcenterinsights.v1.IssueModel.ModelType",
+            ))
         }
     }
 }
@@ -12865,61 +13632,120 @@ pub mod phrase_matcher {
 
     /// Specifies how to combine each phrase match rule group to determine whether
     /// there is a match.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PhraseMatcherType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PhraseMatcherType {
+        /// Unspecified.
+        Unspecified,
+        /// Must meet all phrase match rule groups or there is no match.
+        AllOf,
+        /// If any of the phrase match rule groups are met, there is a match.
+        AnyOf,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PhraseMatcherType::value] or
+        /// [PhraseMatcherType::name].
+        UnknownValue(phrase_matcher_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod phrase_matcher_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PhraseMatcherType {
-        /// Unspecified.
-        pub const PHRASE_MATCHER_TYPE_UNSPECIFIED: PhraseMatcherType = PhraseMatcherType::new(0);
-
-        /// Must meet all phrase match rule groups or there is no match.
-        pub const ALL_OF: PhraseMatcherType = PhraseMatcherType::new(1);
-
-        /// If any of the phrase match rule groups are met, there is a match.
-        pub const ANY_OF: PhraseMatcherType = PhraseMatcherType::new(2);
-
-        /// Creates a new PhraseMatcherType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllOf => std::option::Option::Some(1),
+                Self::AnyOf => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PHRASE_MATCHER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_OF"),
-                2 => std::borrow::Cow::Borrowed("ANY_OF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PHRASE_MATCHER_TYPE_UNSPECIFIED"),
+                Self::AllOf => std::option::Option::Some("ALL_OF"),
+                Self::AnyOf => std::option::Option::Some("ANY_OF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PHRASE_MATCHER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PHRASE_MATCHER_TYPE_UNSPECIFIED)
-                }
-                "ALL_OF" => std::option::Option::Some(Self::ALL_OF),
-                "ANY_OF" => std::option::Option::Some(Self::ANY_OF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PhraseMatcherType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PhraseMatcherType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PhraseMatcherType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PhraseMatcherType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllOf,
+                2 => Self::AnyOf,
+                _ => Self::UnknownValue(phrase_matcher_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PhraseMatcherType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PHRASE_MATCHER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALL_OF" => Self::AllOf,
+                "ANY_OF" => Self::AnyOf,
+                _ => Self::UnknownValue(phrase_matcher_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PhraseMatcherType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllOf => serializer.serialize_i32(1),
+                Self::AnyOf => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PhraseMatcherType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PhraseMatcherType>::new(
+                ".google.cloud.contactcenterinsights.v1.PhraseMatcher.PhraseMatcherType",
+            ))
         }
     }
 }
@@ -12983,62 +13809,121 @@ pub mod phrase_match_rule_group {
 
     /// Specifies how to combine each phrase match rule for whether there is a
     /// match.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PhraseMatchRuleGroupType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PhraseMatchRuleGroupType {
+        /// Unspecified.
+        Unspecified,
+        /// Must meet all phrase match rules or there is no match.
+        AllOf,
+        /// If any of the phrase match rules are met, there is a match.
+        AnyOf,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PhraseMatchRuleGroupType::value] or
+        /// [PhraseMatchRuleGroupType::name].
+        UnknownValue(phrase_match_rule_group_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod phrase_match_rule_group_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PhraseMatchRuleGroupType {
-        /// Unspecified.
-        pub const PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED: PhraseMatchRuleGroupType =
-            PhraseMatchRuleGroupType::new(0);
-
-        /// Must meet all phrase match rules or there is no match.
-        pub const ALL_OF: PhraseMatchRuleGroupType = PhraseMatchRuleGroupType::new(1);
-
-        /// If any of the phrase match rules are met, there is a match.
-        pub const ANY_OF: PhraseMatchRuleGroupType = PhraseMatchRuleGroupType::new(2);
-
-        /// Creates a new PhraseMatchRuleGroupType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllOf => std::option::Option::Some(1),
+                Self::AnyOf => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_OF"),
-                2 => std::borrow::Cow::Borrowed("ANY_OF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED")
                 }
-                "ALL_OF" => std::option::Option::Some(Self::ALL_OF),
-                "ANY_OF" => std::option::Option::Some(Self::ANY_OF),
-                _ => std::option::Option::None,
+                Self::AllOf => std::option::Option::Some("ALL_OF"),
+                Self::AnyOf => std::option::Option::Some("ANY_OF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PhraseMatchRuleGroupType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PhraseMatchRuleGroupType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PhraseMatchRuleGroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PhraseMatchRuleGroupType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllOf,
+                2 => Self::AnyOf,
+                _ => Self::UnknownValue(phrase_match_rule_group_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PhraseMatchRuleGroupType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PHRASE_MATCH_RULE_GROUP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALL_OF" => Self::AllOf,
+                "ANY_OF" => Self::AnyOf,
+                _ => Self::UnknownValue(phrase_match_rule_group_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PhraseMatchRuleGroupType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllOf => serializer.serialize_i32(1),
+                Self::AnyOf => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PhraseMatchRuleGroupType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PhraseMatchRuleGroupType>::new(
+                ".google.cloud.contactcenterinsights.v1.PhraseMatchRuleGroup.PhraseMatchRuleGroupType"))
         }
     }
 }
@@ -14132,62 +15017,123 @@ pub mod runtime_annotation {
         use super::*;
 
         /// The source of the query.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct QuerySource(i32);
-
-        impl QuerySource {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum QuerySource {
             /// Unknown query source.
-            pub const QUERY_SOURCE_UNSPECIFIED: QuerySource = QuerySource::new(0);
-
+            Unspecified,
             /// The query is from agents.
-            pub const AGENT_QUERY: QuerySource = QuerySource::new(1);
-
+            AgentQuery,
             /// The query is a query from previous suggestions, e.g. from a preceding
             /// SuggestKnowledgeAssist response.
-            pub const SUGGESTED_QUERY: QuerySource = QuerySource::new(2);
+            SuggestedQuery,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [QuerySource::value] or
+            /// [QuerySource::name].
+            UnknownValue(query_source::UnknownValue),
+        }
 
-            /// Creates a new QuerySource instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod query_source {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl QuerySource {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::AgentQuery => std::option::Option::Some(1),
+                    Self::SuggestedQuery => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("QUERY_SOURCE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AGENT_QUERY"),
-                    2 => std::borrow::Cow::Borrowed("SUGGESTED_QUERY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("QUERY_SOURCE_UNSPECIFIED"),
+                    Self::AgentQuery => std::option::Option::Some("AGENT_QUERY"),
+                    Self::SuggestedQuery => std::option::Option::Some("SUGGESTED_QUERY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "QUERY_SOURCE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::QUERY_SOURCE_UNSPECIFIED)
-                    }
-                    "AGENT_QUERY" => std::option::Option::Some(Self::AGENT_QUERY),
-                    "SUGGESTED_QUERY" => std::option::Option::Some(Self::SUGGESTED_QUERY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for QuerySource {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for QuerySource {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for QuerySource {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for QuerySource {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::AgentQuery,
+                    2 => Self::SuggestedQuery,
+                    _ => Self::UnknownValue(query_source::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for QuerySource {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "QUERY_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                    "AGENT_QUERY" => Self::AgentQuery,
+                    "SUGGESTED_QUERY" => Self::SuggestedQuery,
+                    _ => Self::UnknownValue(query_source::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for QuerySource {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::AgentQuery => serializer.serialize_i32(1),
+                    Self::SuggestedQuery => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for QuerySource {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<QuerySource>::new(
+                    ".google.cloud.contactcenterinsights.v1.RuntimeAnnotation.UserInput.QuerySource"))
             }
         }
     }
@@ -14278,66 +15224,127 @@ pub mod answer_feedback {
     use super::*;
 
     /// The correctness level of an answer.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CorrectnessLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CorrectnessLevel {
+        /// Correctness level unspecified.
+        Unspecified,
+        /// Answer is totally wrong.
+        NotCorrect,
+        /// Answer is partially correct.
+        PartiallyCorrect,
+        /// Answer is fully correct.
+        FullyCorrect,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CorrectnessLevel::value] or
+        /// [CorrectnessLevel::name].
+        UnknownValue(correctness_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod correctness_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CorrectnessLevel {
-        /// Correctness level unspecified.
-        pub const CORRECTNESS_LEVEL_UNSPECIFIED: CorrectnessLevel = CorrectnessLevel::new(0);
-
-        /// Answer is totally wrong.
-        pub const NOT_CORRECT: CorrectnessLevel = CorrectnessLevel::new(1);
-
-        /// Answer is partially correct.
-        pub const PARTIALLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(2);
-
-        /// Answer is fully correct.
-        pub const FULLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(3);
-
-        /// Creates a new CorrectnessLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotCorrect => std::option::Option::Some(1),
+                Self::PartiallyCorrect => std::option::Option::Some(2),
+                Self::FullyCorrect => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CORRECTNESS_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_CORRECT"),
-                2 => std::borrow::Cow::Borrowed("PARTIALLY_CORRECT"),
-                3 => std::borrow::Cow::Borrowed("FULLY_CORRECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CORRECTNESS_LEVEL_UNSPECIFIED"),
+                Self::NotCorrect => std::option::Option::Some("NOT_CORRECT"),
+                Self::PartiallyCorrect => std::option::Option::Some("PARTIALLY_CORRECT"),
+                Self::FullyCorrect => std::option::Option::Some("FULLY_CORRECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CORRECTNESS_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CORRECTNESS_LEVEL_UNSPECIFIED)
-                }
-                "NOT_CORRECT" => std::option::Option::Some(Self::NOT_CORRECT),
-                "PARTIALLY_CORRECT" => std::option::Option::Some(Self::PARTIALLY_CORRECT),
-                "FULLY_CORRECT" => std::option::Option::Some(Self::FULLY_CORRECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CorrectnessLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CorrectnessLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CorrectnessLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CorrectnessLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotCorrect,
+                2 => Self::PartiallyCorrect,
+                3 => Self::FullyCorrect,
+                _ => Self::UnknownValue(correctness_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CorrectnessLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CORRECTNESS_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "NOT_CORRECT" => Self::NotCorrect,
+                "PARTIALLY_CORRECT" => Self::PartiallyCorrect,
+                "FULLY_CORRECT" => Self::FullyCorrect,
+                _ => Self::UnknownValue(correctness_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CorrectnessLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotCorrect => serializer.serialize_i32(1),
+                Self::PartiallyCorrect => serializer.serialize_i32(2),
+                Self::FullyCorrect => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CorrectnessLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CorrectnessLevel>::new(
+                ".google.cloud.contactcenterinsights.v1.AnswerFeedback.CorrectnessLevel",
+            ))
         }
     }
 }
@@ -14971,69 +15978,134 @@ pub mod conversation_participant {
     use super::*;
 
     /// The role of the participant.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
+        /// Participant's role is not set.
+        Unspecified,
+        /// Participant is a human agent.
+        HumanAgent,
+        /// Participant is an automated agent.
+        AutomatedAgent,
+        /// Participant is an end user who conversed with the contact center.
+        EndUser,
+        /// Participant is either a human or automated agent.
+        AnyAgent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Role {
-        /// Participant's role is not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
-        /// Participant is a human agent.
-        pub const HUMAN_AGENT: Role = Role::new(1);
-
-        /// Participant is an automated agent.
-        pub const AUTOMATED_AGENT: Role = Role::new(2);
-
-        /// Participant is an end user who conversed with the contact center.
-        pub const END_USER: Role = Role::new(3);
-
-        /// Participant is either a human or automated agent.
-        pub const ANY_AGENT: Role = Role::new(4);
-
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HumanAgent => std::option::Option::Some(1),
+                Self::AutomatedAgent => std::option::Option::Some(2),
+                Self::EndUser => std::option::Option::Some(3),
+                Self::AnyAgent => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HUMAN_AGENT"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT"),
-                3 => std::borrow::Cow::Borrowed("END_USER"),
-                4 => std::borrow::Cow::Borrowed("ANY_AGENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::HumanAgent => std::option::Option::Some("HUMAN_AGENT"),
+                Self::AutomatedAgent => std::option::Option::Some("AUTOMATED_AGENT"),
+                Self::EndUser => std::option::Option::Some("END_USER"),
+                Self::AnyAgent => std::option::Option::Some("ANY_AGENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "HUMAN_AGENT" => std::option::Option::Some(Self::HUMAN_AGENT),
-                "AUTOMATED_AGENT" => std::option::Option::Some(Self::AUTOMATED_AGENT),
-                "END_USER" => std::option::Option::Some(Self::END_USER),
-                "ANY_AGENT" => std::option::Option::Some(Self::ANY_AGENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HumanAgent,
+                2 => Self::AutomatedAgent,
+                3 => Self::EndUser,
+                4 => Self::AnyAgent,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "HUMAN_AGENT" => Self::HumanAgent,
+                "AUTOMATED_AGENT" => Self::AutomatedAgent,
+                "END_USER" => Self::EndUser,
+                "ANY_AGENT" => Self::AnyAgent,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HumanAgent => serializer.serialize_i32(1),
+                Self::AutomatedAgent => serializer.serialize_i32(2),
+                Self::EndUser => serializer.serialize_i32(3),
+                Self::AnyAgent => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.contactcenterinsights.v1.ConversationParticipant.Role",
+            ))
         }
     }
 
@@ -15435,62 +16507,124 @@ pub mod annotator_selector {
         use super::*;
 
         /// Summarization model to use, if `conversation_profile` is not used.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SummarizationModel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SummarizationModel {
+            /// Unspecified summarization model.
+            Unspecified,
+            /// The CCAI baseline model.
+            BaselineModel,
+            /// The CCAI baseline model, V2.0.
+            BaselineModelV20,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SummarizationModel::value] or
+            /// [SummarizationModel::name].
+            UnknownValue(summarization_model::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod summarization_model {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SummarizationModel {
-            /// Unspecified summarization model.
-            pub const SUMMARIZATION_MODEL_UNSPECIFIED: SummarizationModel =
-                SummarizationModel::new(0);
-
-            /// The CCAI baseline model.
-            pub const BASELINE_MODEL: SummarizationModel = SummarizationModel::new(1);
-
-            /// The CCAI baseline model, V2.0.
-            pub const BASELINE_MODEL_V2_0: SummarizationModel = SummarizationModel::new(2);
-
-            /// Creates a new SummarizationModel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::BaselineModel => std::option::Option::Some(1),
+                    Self::BaselineModelV20 => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SUMMARIZATION_MODEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("BASELINE_MODEL"),
-                    2 => std::borrow::Cow::Borrowed("BASELINE_MODEL_V2_0"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SUMMARIZATION_MODEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SUMMARIZATION_MODEL_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SUMMARIZATION_MODEL_UNSPECIFIED")
                     }
-                    "BASELINE_MODEL" => std::option::Option::Some(Self::BASELINE_MODEL),
-                    "BASELINE_MODEL_V2_0" => std::option::Option::Some(Self::BASELINE_MODEL_V2_0),
-                    _ => std::option::Option::None,
+                    Self::BaselineModel => std::option::Option::Some("BASELINE_MODEL"),
+                    Self::BaselineModelV20 => std::option::Option::Some("BASELINE_MODEL_V2_0"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for SummarizationModel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SummarizationModel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SummarizationModel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SummarizationModel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::BaselineModel,
+                    2 => Self::BaselineModelV20,
+                    _ => Self::UnknownValue(summarization_model::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SummarizationModel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SUMMARIZATION_MODEL_UNSPECIFIED" => Self::Unspecified,
+                    "BASELINE_MODEL" => Self::BaselineModel,
+                    "BASELINE_MODEL_V2_0" => Self::BaselineModelV20,
+                    _ => Self::UnknownValue(summarization_model::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SummarizationModel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::BaselineModel => serializer.serialize_i32(1),
+                    Self::BaselineModelV20 => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SummarizationModel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SummarizationModel>::new(
+                    ".google.cloud.contactcenterinsights.v1.AnnotatorSelector.SummarizationConfig.SummarizationModel"))
             }
         }
 
@@ -16291,79 +17425,148 @@ pub mod qa_scorecard_revision {
     use super::*;
 
     /// Enum representing the set of states a scorecard revision may be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified.
+        Unspecified,
+        /// The scorecard revision can be edited.
+        Editable,
+        /// Scorecard model training is in progress.
+        Training,
+        /// Scorecard revision model training failed.
+        TrainingFailed,
+        /// The revision can be used in analysis.
+        Ready,
+        /// Scorecard is being deleted.
+        Deleting,
+        /// Scorecard model training was explicitly cancelled by the user.
+        TrainingCancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The scorecard revision can be edited.
-        pub const EDITABLE: State = State::new(12);
-
-        /// Scorecard model training is in progress.
-        pub const TRAINING: State = State::new(2);
-
-        /// Scorecard revision model training failed.
-        pub const TRAINING_FAILED: State = State::new(9);
-
-        /// The revision can be used in analysis.
-        pub const READY: State = State::new(11);
-
-        /// Scorecard is being deleted.
-        pub const DELETING: State = State::new(7);
-
-        /// Scorecard model training was explicitly cancelled by the user.
-        pub const TRAINING_CANCELLED: State = State::new(14);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Editable => std::option::Option::Some(12),
+                Self::Training => std::option::Option::Some(2),
+                Self::TrainingFailed => std::option::Option::Some(9),
+                Self::Ready => std::option::Option::Some(11),
+                Self::Deleting => std::option::Option::Some(7),
+                Self::TrainingCancelled => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("TRAINING"),
-                7 => std::borrow::Cow::Borrowed("DELETING"),
-                9 => std::borrow::Cow::Borrowed("TRAINING_FAILED"),
-                11 => std::borrow::Cow::Borrowed("READY"),
-                12 => std::borrow::Cow::Borrowed("EDITABLE"),
-                14 => std::borrow::Cow::Borrowed("TRAINING_CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Editable => std::option::Option::Some("EDITABLE"),
+                Self::Training => std::option::Option::Some("TRAINING"),
+                Self::TrainingFailed => std::option::Option::Some("TRAINING_FAILED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::TrainingCancelled => std::option::Option::Some("TRAINING_CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "EDITABLE" => std::option::Option::Some(Self::EDITABLE),
-                "TRAINING" => std::option::Option::Some(Self::TRAINING),
-                "TRAINING_FAILED" => std::option::Option::Some(Self::TRAINING_FAILED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "TRAINING_CANCELLED" => std::option::Option::Some(Self::TRAINING_CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Training,
+                7 => Self::Deleting,
+                9 => Self::TrainingFailed,
+                11 => Self::Ready,
+                12 => Self::Editable,
+                14 => Self::TrainingCancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "EDITABLE" => Self::Editable,
+                "TRAINING" => Self::Training,
+                "TRAINING_FAILED" => Self::TrainingFailed,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "TRAINING_CANCELLED" => Self::TrainingCancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Editable => serializer.serialize_i32(12),
+                Self::Training => serializer.serialize_i32(2),
+                Self::TrainingFailed => serializer.serialize_i32(9),
+                Self::Ready => serializer.serialize_i32(11),
+                Self::Deleting => serializer.serialize_i32(7),
+                Self::TrainingCancelled => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.contactcenterinsights.v1.QaScorecardRevision.State",
+            ))
         }
     }
 }
@@ -16746,61 +17949,123 @@ pub mod qa_answer {
         use super::*;
 
         /// What created the answer.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SourceType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SourceType {
+            /// Source type is unspecified.
+            Unspecified,
+            /// Answer was system-generated; created during an Insights analysis.
+            SystemGenerated,
+            /// Answer was created by a human via manual edit.
+            ManualEdit,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SourceType::value] or
+            /// [SourceType::name].
+            UnknownValue(source_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod source_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SourceType {
-            /// Source type is unspecified.
-            pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
-
-            /// Answer was system-generated; created during an Insights analysis.
-            pub const SYSTEM_GENERATED: SourceType = SourceType::new(1);
-
-            /// Answer was created by a human via manual edit.
-            pub const MANUAL_EDIT: SourceType = SourceType::new(2);
-
-            /// Creates a new SourceType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SystemGenerated => std::option::Option::Some(1),
+                    Self::ManualEdit => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SYSTEM_GENERATED"),
-                    2 => std::borrow::Cow::Borrowed("MANUAL_EDIT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SOURCE_TYPE_UNSPECIFIED"),
+                    Self::SystemGenerated => std::option::Option::Some("SYSTEM_GENERATED"),
+                    Self::ManualEdit => std::option::Option::Some("MANUAL_EDIT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SOURCE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
-                    }
-                    "SYSTEM_GENERATED" => std::option::Option::Some(Self::SYSTEM_GENERATED),
-                    "MANUAL_EDIT" => std::option::Option::Some(Self::MANUAL_EDIT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SourceType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SourceType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SourceType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SourceType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SystemGenerated,
+                    2 => Self::ManualEdit,
+                    _ => Self::UnknownValue(source_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SourceType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SYSTEM_GENERATED" => Self::SystemGenerated,
+                    "MANUAL_EDIT" => Self::ManualEdit,
+                    _ => Self::UnknownValue(source_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SourceType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SystemGenerated => serializer.serialize_i32(1),
+                    Self::ManualEdit => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SourceType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceType>::new(
+                    ".google.cloud.contactcenterinsights.v1.QaAnswer.AnswerSource.SourceType",
+                ))
             }
         }
     }
@@ -17140,215 +18405,391 @@ pub mod qa_scorecard_result {
         use super::*;
 
         /// What created the score.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SourceType(i32);
-
-        impl SourceType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SourceType {
             /// Source type is unspecified.
-            pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
-
+            Unspecified,
             /// Score is derived only from system-generated answers.
-            pub const SYSTEM_GENERATED_ONLY: SourceType = SourceType::new(1);
-
+            SystemGeneratedOnly,
             /// Score is derived from both system-generated answers, and includes
             /// any manual edits if they exist.
-            pub const INCLUDES_MANUAL_EDITS: SourceType = SourceType::new(2);
+            IncludesManualEdits,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SourceType::value] or
+            /// [SourceType::name].
+            UnknownValue(source_type::UnknownValue),
+        }
 
-            /// Creates a new SourceType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod source_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SourceType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SystemGeneratedOnly => std::option::Option::Some(1),
+                    Self::IncludesManualEdits => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SYSTEM_GENERATED_ONLY"),
-                    2 => std::borrow::Cow::Borrowed("INCLUDES_MANUAL_EDITS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SOURCE_TYPE_UNSPECIFIED"),
+                    Self::SystemGeneratedOnly => std::option::Option::Some("SYSTEM_GENERATED_ONLY"),
+                    Self::IncludesManualEdits => std::option::Option::Some("INCLUDES_MANUAL_EDITS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SOURCE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
-                    }
-                    "SYSTEM_GENERATED_ONLY" => {
-                        std::option::Option::Some(Self::SYSTEM_GENERATED_ONLY)
-                    }
-                    "INCLUDES_MANUAL_EDITS" => {
-                        std::option::Option::Some(Self::INCLUDES_MANUAL_EDITS)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SourceType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SourceType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SourceType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SourceType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SystemGeneratedOnly,
+                    2 => Self::IncludesManualEdits,
+                    _ => Self::UnknownValue(source_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SourceType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SYSTEM_GENERATED_ONLY" => Self::SystemGeneratedOnly,
+                    "INCLUDES_MANUAL_EDITS" => Self::IncludesManualEdits,
+                    _ => Self::UnknownValue(source_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SourceType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SystemGeneratedOnly => serializer.serialize_i32(1),
+                    Self::IncludesManualEdits => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SourceType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceType>::new(
+                    ".google.cloud.contactcenterinsights.v1.QaScorecardResult.ScoreSource.SourceType"))
             }
         }
     }
 }
 
 /// Represents the options for viewing a conversation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConversationView(i32);
-
-impl ConversationView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConversationView {
     /// The conversation view is not specified.
     ///
     /// * Defaults to `FULL` in `GetConversationRequest`.
     /// * Defaults to `BASIC` in `ListConversationsRequest`.
-    pub const CONVERSATION_VIEW_UNSPECIFIED: ConversationView = ConversationView::new(0);
-
+    Unspecified,
     /// Populates all fields in the conversation.
-    pub const FULL: ConversationView = ConversationView::new(2);
-
+    Full,
     /// Populates all fields in the conversation except the transcript.
-    pub const BASIC: ConversationView = ConversationView::new(1);
+    Basic,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConversationView::value] or
+    /// [ConversationView::name].
+    UnknownValue(conversation_view::UnknownValue),
+}
 
-    /// Creates a new ConversationView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod conversation_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ConversationView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Full => std::option::Option::Some(2),
+            Self::Basic => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONVERSATION_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONVERSATION_VIEW_UNSPECIFIED"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONVERSATION_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONVERSATION_VIEW_UNSPECIFIED)
-            }
-            "FULL" => std::option::Option::Some(Self::FULL),
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConversationView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConversationView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConversationView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConversationView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(conversation_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConversationView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONVERSATION_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "FULL" => Self::Full,
+            "BASIC" => Self::Basic,
+            _ => Self::UnknownValue(conversation_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConversationView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Full => serializer.serialize_i32(2),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConversationView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConversationView>::new(
+            ".google.cloud.contactcenterinsights.v1.ConversationView",
+        ))
     }
 }
 
 /// Enum for the different types of issues a tuning dataset can have.
 /// These warnings are currentlyraised when trying to validate a dataset for
 /// tuning a scorecard.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatasetValidationWarning(i32);
-
-impl DatasetValidationWarning {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatasetValidationWarning {
     /// Unspecified data validation warning.
-    pub const DATASET_VALIDATION_WARNING_UNSPECIFIED: DatasetValidationWarning =
-        DatasetValidationWarning::new(0);
-
+    Unspecified,
     /// A non-trivial percentage of the feedback labels are invalid.
-    pub const TOO_MANY_INVALID_FEEDBACK_LABELS: DatasetValidationWarning =
-        DatasetValidationWarning::new(1);
-
+    TooManyInvalidFeedbackLabels,
     /// The quantity of valid feedback labels provided is less than the
     /// recommended minimum.
-    pub const INSUFFICIENT_FEEDBACK_LABELS: DatasetValidationWarning =
-        DatasetValidationWarning::new(2);
-
+    InsufficientFeedbackLabels,
     /// One or more of the answers have less than the recommended minimum of
     /// feedback labels.
-    pub const INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER: DatasetValidationWarning =
-        DatasetValidationWarning::new(3);
-
+    InsufficientFeedbackLabelsPerAnswer,
     /// All the labels in the dataset come from a single answer choice.
-    pub const ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER: DatasetValidationWarning =
-        DatasetValidationWarning::new(4);
+    AllFeedbackLabelsHaveTheSameAnswer,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatasetValidationWarning::value] or
+    /// [DatasetValidationWarning::name].
+    UnknownValue(dataset_validation_warning::UnknownValue),
+}
 
-    /// Creates a new DatasetValidationWarning instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod dataset_validation_warning {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DatasetValidationWarning {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::TooManyInvalidFeedbackLabels => std::option::Option::Some(1),
+            Self::InsufficientFeedbackLabels => std::option::Option::Some(2),
+            Self::InsufficientFeedbackLabelsPerAnswer => std::option::Option::Some(3),
+            Self::AllFeedbackLabelsHaveTheSameAnswer => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATASET_VALIDATION_WARNING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TOO_MANY_INVALID_FEEDBACK_LABELS"),
-            2 => std::borrow::Cow::Borrowed("INSUFFICIENT_FEEDBACK_LABELS"),
-            3 => std::borrow::Cow::Borrowed("INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER"),
-            4 => std::borrow::Cow::Borrowed("ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("DATASET_VALIDATION_WARNING_UNSPECIFIED")
+            }
+            Self::TooManyInvalidFeedbackLabels => {
+                std::option::Option::Some("TOO_MANY_INVALID_FEEDBACK_LABELS")
+            }
+            Self::InsufficientFeedbackLabels => {
+                std::option::Option::Some("INSUFFICIENT_FEEDBACK_LABELS")
+            }
+            Self::InsufficientFeedbackLabelsPerAnswer => {
+                std::option::Option::Some("INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER")
+            }
+            Self::AllFeedbackLabelsHaveTheSameAnswer => {
+                std::option::Option::Some("ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATASET_VALIDATION_WARNING_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATASET_VALIDATION_WARNING_UNSPECIFIED)
-            }
-            "TOO_MANY_INVALID_FEEDBACK_LABELS" => {
-                std::option::Option::Some(Self::TOO_MANY_INVALID_FEEDBACK_LABELS)
-            }
-            "INSUFFICIENT_FEEDBACK_LABELS" => {
-                std::option::Option::Some(Self::INSUFFICIENT_FEEDBACK_LABELS)
-            }
-            "INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER" => {
-                std::option::Option::Some(Self::INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER)
-            }
-            "ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER" => {
-                std::option::Option::Some(Self::ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatasetValidationWarning {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatasetValidationWarning {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatasetValidationWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatasetValidationWarning {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::TooManyInvalidFeedbackLabels,
+            2 => Self::InsufficientFeedbackLabels,
+            3 => Self::InsufficientFeedbackLabelsPerAnswer,
+            4 => Self::AllFeedbackLabelsHaveTheSameAnswer,
+            _ => Self::UnknownValue(dataset_validation_warning::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatasetValidationWarning {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATASET_VALIDATION_WARNING_UNSPECIFIED" => Self::Unspecified,
+            "TOO_MANY_INVALID_FEEDBACK_LABELS" => Self::TooManyInvalidFeedbackLabels,
+            "INSUFFICIENT_FEEDBACK_LABELS" => Self::InsufficientFeedbackLabels,
+            "INSUFFICIENT_FEEDBACK_LABELS_PER_ANSWER" => Self::InsufficientFeedbackLabelsPerAnswer,
+            "ALL_FEEDBACK_LABELS_HAVE_THE_SAME_ANSWER" => Self::AllFeedbackLabelsHaveTheSameAnswer,
+            _ => Self::UnknownValue(dataset_validation_warning::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatasetValidationWarning {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::TooManyInvalidFeedbackLabels => serializer.serialize_i32(1),
+            Self::InsufficientFeedbackLabels => serializer.serialize_i32(2),
+            Self::InsufficientFeedbackLabelsPerAnswer => serializer.serialize_i32(3),
+            Self::AllFeedbackLabelsHaveTheSameAnswer => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatasetValidationWarning {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatasetValidationWarning>::new(
+            ".google.cloud.contactcenterinsights.v1.DatasetValidationWarning",
+        ))
     }
 }

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -131,7 +131,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -158,7 +158,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -222,70 +222,135 @@ pub mod run {
     use super::*;
 
     /// The current state of the run.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unknown. The true state may be any of the below or a
         /// different state that is not supported here explicitly.
-        pub const UNKNOWN: State = State::new(0);
-
+        Unknown,
         /// The run is still executing.
-        pub const STARTED: State = State::new(1);
-
+        Started,
         /// The run completed.
-        pub const COMPLETED: State = State::new(2);
-
+        Completed,
         /// The run failed.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// The run aborted.
-        pub const ABORTED: State = State::new(4);
+        Aborted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Started => std::option::Option::Some(1),
+                Self::Completed => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Aborted => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("STARTED"),
-                2 => std::borrow::Cow::Borrowed("COMPLETED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("ABORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Started => std::option::Option::Some("STARTED"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "STARTED" => std::option::Option::Some(Self::STARTED),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Started,
+                2 => Self::Completed,
+                3 => Self::Failed,
+                4 => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "STARTED" => Self::Started,
+                "COMPLETED" => Self::Completed,
+                "FAILED" => Self::Failed,
+                "ABORTED" => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Started => serializer.serialize_i32(1),
+                Self::Completed => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Aborted => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datacatalog.lineage.v1.Run.State",
+            ))
         }
     }
 }
@@ -559,126 +624,252 @@ pub mod operation_metadata {
     use super::*;
 
     /// An enum with the state of the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unused.
+        Unspecified,
+        /// The operation has been created but is not yet started.
+        Pending,
+        /// The operation is underway.
+        Running,
+        /// The operation completed successfully.
+        Succeeded,
+        /// The operation is no longer running and did not succeed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The operation has been created but is not yet started.
-        pub const PENDING: State = State::new(1);
-
-        /// The operation is underway.
-        pub const RUNNING: State = State::new(2);
-
-        /// The operation completed successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// The operation is no longer running and did not succeed.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datacatalog.lineage.v1.OperationMetadata.State",
+            ))
         }
     }
 
     /// Type of the long running operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unused.
+        Unspecified,
+        /// The resource deletion operation.
+        Delete,
+        /// The resource creation operation.
+        Create,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// The resource deletion operation.
-        pub const DELETE: Type = Type::new(1);
-
-        /// The resource creation operation.
-        pub const CREATE: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Delete => std::option::Option::Some(1),
+                Self::Create => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DELETE"),
-                2 => std::borrow::Cow::Borrowed("CREATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Delete,
+                2 => Self::Create,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DELETE" => Self::Delete,
+                "CREATE" => Self::Create,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Delete => serializer.serialize_i32(1),
+                Self::Create => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.datacatalog.lineage.v1.OperationMetadata.Type",
+            ))
         }
     }
 }
@@ -2342,81 +2533,148 @@ pub mod origin {
     use super::*;
 
     /// Type of the source of a process.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SourceType {
+        /// Source is Unspecified
+        Unspecified,
+        /// A custom source
+        Custom,
+        /// BigQuery
+        Bigquery,
+        /// Data Fusion
+        DataFusion,
+        /// Composer
+        Composer,
+        /// Looker Studio
+        LookerStudio,
+        /// Dataproc
+        Dataproc,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SourceType::value] or
+        /// [SourceType::name].
+        UnknownValue(source_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SourceType {
-        /// Source is Unspecified
-        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
-
-        /// A custom source
-        pub const CUSTOM: SourceType = SourceType::new(1);
-
-        /// BigQuery
-        pub const BIGQUERY: SourceType = SourceType::new(2);
-
-        /// Data Fusion
-        pub const DATA_FUSION: SourceType = SourceType::new(3);
-
-        /// Composer
-        pub const COMPOSER: SourceType = SourceType::new(4);
-
-        /// Looker Studio
-        pub const LOOKER_STUDIO: SourceType = SourceType::new(5);
-
-        /// Dataproc
-        pub const DATAPROC: SourceType = SourceType::new(6);
-
-        /// Creates a new SourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Custom => std::option::Option::Some(1),
+                Self::Bigquery => std::option::Option::Some(2),
+                Self::DataFusion => std::option::Option::Some(3),
+                Self::Composer => std::option::Option::Some(4),
+                Self::LookerStudio => std::option::Option::Some(5),
+                Self::Dataproc => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CUSTOM"),
-                2 => std::borrow::Cow::Borrowed("BIGQUERY"),
-                3 => std::borrow::Cow::Borrowed("DATA_FUSION"),
-                4 => std::borrow::Cow::Borrowed("COMPOSER"),
-                5 => std::borrow::Cow::Borrowed("LOOKER_STUDIO"),
-                6 => std::borrow::Cow::Borrowed("DATAPROC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SOURCE_TYPE_UNSPECIFIED"),
+                Self::Custom => std::option::Option::Some("CUSTOM"),
+                Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+                Self::DataFusion => std::option::Option::Some("DATA_FUSION"),
+                Self::Composer => std::option::Option::Some("COMPOSER"),
+                Self::LookerStudio => std::option::Option::Some("LOOKER_STUDIO"),
+                Self::Dataproc => std::option::Option::Some("DATAPROC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
-                }
-                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-                "DATA_FUSION" => std::option::Option::Some(Self::DATA_FUSION),
-                "COMPOSER" => std::option::Option::Some(Self::COMPOSER),
-                "LOOKER_STUDIO" => std::option::Option::Some(Self::LOOKER_STUDIO),
-                "DATAPROC" => std::option::Option::Some(Self::DATAPROC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Custom,
+                2 => Self::Bigquery,
+                3 => Self::DataFusion,
+                4 => Self::Composer,
+                5 => Self::LookerStudio,
+                6 => Self::Dataproc,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CUSTOM" => Self::Custom,
+                "BIGQUERY" => Self::Bigquery,
+                "DATA_FUSION" => Self::DataFusion,
+                "COMPOSER" => Self::Composer,
+                "LOOKER_STUDIO" => Self::LookerStudio,
+                "DATAPROC" => Self::Dataproc,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Custom => serializer.serialize_i32(1),
+                Self::Bigquery => serializer.serialize_i32(2),
+                Self::DataFusion => serializer.serialize_i32(3),
+                Self::Composer => serializer.serialize_i32(4),
+                Self::LookerStudio => serializer.serialize_i32(5),
+                Self::Dataproc => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceType>::new(
+                ".google.cloud.datacatalog.lineage.v1.Origin.SourceType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -139,56 +139,113 @@ pub mod big_query_connection_spec {
     use super::*;
 
     /// The type of the BigQuery connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectionType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConnectionType {
+        /// Unspecified type.
+        Unspecified,
+        /// Cloud SQL connection.
+        CloudSql,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConnectionType::value] or
+        /// [ConnectionType::name].
+        UnknownValue(connection_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod connection_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConnectionType {
-        /// Unspecified type.
-        pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
-
-        /// Cloud SQL connection.
-        pub const CLOUD_SQL: ConnectionType = ConnectionType::new(1);
-
-        /// Creates a new ConnectionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudSql => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_SQL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONNECTION_TYPE_UNSPECIFIED"),
+                Self::CloudSql => std::option::Option::Some("CLOUD_SQL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONNECTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
-                }
-                "CLOUD_SQL" => std::option::Option::Some(Self::CLOUD_SQL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConnectionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConnectionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConnectionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudSql,
+                _ => Self::UnknownValue(connection_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConnectionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONNECTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_SQL" => Self::CloudSql,
+                _ => Self::UnknownValue(connection_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConnectionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudSql => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConnectionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionType>::new(
+                ".google.cloud.datacatalog.v1.BigQueryConnectionSpec.ConnectionType",
+            ))
         }
     }
 
@@ -264,61 +321,120 @@ pub mod cloud_sql_big_query_connection_spec {
     use super::*;
 
     /// Supported Cloud SQL database types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseType {
+        /// Unspecified database type.
+        Unspecified,
+        /// Cloud SQL for PostgreSQL.
+        Postgres,
+        /// Cloud SQL for MySQL.
+        Mysql,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseType::value] or
+        /// [DatabaseType::name].
+        UnknownValue(database_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseType {
-        /// Unspecified database type.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
-
-        /// Cloud SQL for PostgreSQL.
-        pub const POSTGRES: DatabaseType = DatabaseType::new(1);
-
-        /// Cloud SQL for MySQL.
-        pub const MYSQL: DatabaseType = DatabaseType::new(2);
-
-        /// Creates a new DatabaseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Postgres => std::option::Option::Some(1),
+                Self::Mysql => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("POSTGRES"),
-                2 => std::borrow::Cow::Borrowed("MYSQL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_TYPE_UNSPECIFIED"),
+                Self::Postgres => std::option::Option::Some("POSTGRES"),
+                Self::Mysql => std::option::Option::Some("MYSQL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
-                }
-                "POSTGRES" => std::option::Option::Some(Self::POSTGRES),
-                "MYSQL" => std::option::Option::Some(Self::MYSQL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Postgres,
+                2 => Self::Mysql,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "POSTGRES" => Self::Postgres,
+                "MYSQL" => Self::Mysql,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Postgres => serializer.serialize_i32(1),
+                Self::Mysql => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseType>::new(
+                ".google.cloud.datacatalog.v1.CloudSqlBigQueryConnectionSpec.DatabaseType",
+            ))
         }
     }
 }
@@ -516,59 +632,120 @@ pub mod data_source {
     use super::*;
 
     /// Name of a service that stores the data.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Service(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Service {
+        /// Default unknown service.
+        Unspecified,
+        /// Google Cloud Storage service.
+        CloudStorage,
+        /// BigQuery service.
+        Bigquery,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Service::value] or
+        /// [Service::name].
+        UnknownValue(service::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod service {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Service {
-        /// Default unknown service.
-        pub const SERVICE_UNSPECIFIED: Service = Service::new(0);
-
-        /// Google Cloud Storage service.
-        pub const CLOUD_STORAGE: Service = Service::new(1);
-
-        /// BigQuery service.
-        pub const BIGQUERY: Service = Service::new(2);
-
-        /// Creates a new Service instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudStorage => std::option::Option::Some(1),
+                Self::Bigquery => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SERVICE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_STORAGE"),
-                2 => std::borrow::Cow::Borrowed("BIGQUERY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SERVICE_UNSPECIFIED"),
+                Self::CloudStorage => std::option::Option::Some("CLOUD_STORAGE"),
+                Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SERVICE_UNSPECIFIED" => std::option::Option::Some(Self::SERVICE_UNSPECIFIED),
-                "CLOUD_STORAGE" => std::option::Option::Some(Self::CLOUD_STORAGE),
-                "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Service {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Service {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Service {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Service {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudStorage,
+                2 => Self::Bigquery,
+                _ => Self::UnknownValue(service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Service {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SERVICE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_STORAGE" => Self::CloudStorage,
+                "BIGQUERY" => Self::Bigquery,
+                _ => Self::UnknownValue(service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Service {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudStorage => serializer.serialize_i32(1),
+                Self::Bigquery => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Service {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Service>::new(
+                ".google.cloud.datacatalog.v1.DataSource.Service",
+            ))
         }
     }
 
@@ -2892,61 +3069,123 @@ pub mod database_table_spec {
         use super::*;
 
         /// Concrete type of the view.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ViewType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ViewType {
+            /// Default unknown view type.
+            Unspecified,
+            /// Standard view.
+            StandardView,
+            /// Materialized view.
+            MaterializedView,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ViewType::value] or
+            /// [ViewType::name].
+            UnknownValue(view_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod view_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ViewType {
-            /// Default unknown view type.
-            pub const VIEW_TYPE_UNSPECIFIED: ViewType = ViewType::new(0);
-
-            /// Standard view.
-            pub const STANDARD_VIEW: ViewType = ViewType::new(1);
-
-            /// Materialized view.
-            pub const MATERIALIZED_VIEW: ViewType = ViewType::new(2);
-
-            /// Creates a new ViewType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::StandardView => std::option::Option::Some(1),
+                    Self::MaterializedView => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("VIEW_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("STANDARD_VIEW"),
-                    2 => std::borrow::Cow::Borrowed("MATERIALIZED_VIEW"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("VIEW_TYPE_UNSPECIFIED"),
+                    Self::StandardView => std::option::Option::Some("STANDARD_VIEW"),
+                    Self::MaterializedView => std::option::Option::Some("MATERIALIZED_VIEW"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "VIEW_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::VIEW_TYPE_UNSPECIFIED)
-                    }
-                    "STANDARD_VIEW" => std::option::Option::Some(Self::STANDARD_VIEW),
-                    "MATERIALIZED_VIEW" => std::option::Option::Some(Self::MATERIALIZED_VIEW),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ViewType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ViewType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ViewType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ViewType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::StandardView,
+                    2 => Self::MaterializedView,
+                    _ => Self::UnknownValue(view_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ViewType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "VIEW_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "STANDARD_VIEW" => Self::StandardView,
+                    "MATERIALIZED_VIEW" => Self::MaterializedView,
+                    _ => Self::UnknownValue(view_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ViewType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::StandardView => serializer.serialize_i32(1),
+                    Self::MaterializedView => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ViewType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ViewType>::new(
+                    ".google.cloud.datacatalog.v1.DatabaseTableSpec.DatabaseViewSpec.ViewType",
+                ))
             }
         }
 
@@ -2963,59 +3202,120 @@ pub mod database_table_spec {
     }
 
     /// Type of the table.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TableType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TableType {
+        /// Default unknown table type.
+        Unspecified,
+        /// Native table.
+        Native,
+        /// External table.
+        External,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TableType::value] or
+        /// [TableType::name].
+        UnknownValue(table_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod table_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TableType {
-        /// Default unknown table type.
-        pub const TABLE_TYPE_UNSPECIFIED: TableType = TableType::new(0);
-
-        /// Native table.
-        pub const NATIVE: TableType = TableType::new(1);
-
-        /// External table.
-        pub const EXTERNAL: TableType = TableType::new(2);
-
-        /// Creates a new TableType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Native => std::option::Option::Some(1),
+                Self::External => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TABLE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NATIVE"),
-                2 => std::borrow::Cow::Borrowed("EXTERNAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TABLE_TYPE_UNSPECIFIED"),
+                Self::Native => std::option::Option::Some("NATIVE"),
+                Self::External => std::option::Option::Some("EXTERNAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TABLE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TABLE_TYPE_UNSPECIFIED),
-                "NATIVE" => std::option::Option::Some(Self::NATIVE),
-                "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TableType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TableType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TableType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TableType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Native,
+                2 => Self::External,
+                _ => Self::UnknownValue(table_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TableType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TABLE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NATIVE" => Self::Native,
+                "EXTERNAL" => Self::External,
+                _ => Self::UnknownValue(table_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TableType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Native => serializer.serialize_i32(1),
+                Self::External => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TableType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableType>::new(
+                ".google.cloud.datacatalog.v1.DatabaseTableSpec.TableType",
+            ))
         }
     }
 }
@@ -3302,124 +3602,249 @@ pub mod routine_spec {
         use super::*;
 
         /// The input or output mode of the argument.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Mode {
+            /// Unspecified mode.
+            Unspecified,
+            /// The argument is input-only.
+            In,
+            /// The argument is output-only.
+            Out,
+            /// The argument is both an input and an output.
+            Inout,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Mode::value] or
+            /// [Mode::name].
+            UnknownValue(mode::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Mode {
-            /// Unspecified mode.
-            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-            /// The argument is input-only.
-            pub const IN: Mode = Mode::new(1);
-
-            /// The argument is output-only.
-            pub const OUT: Mode = Mode::new(2);
-
-            /// The argument is both an input and an output.
-            pub const INOUT: Mode = Mode::new(3);
-
-            /// Creates a new Mode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::In => std::option::Option::Some(1),
+                    Self::Out => std::option::Option::Some(2),
+                    Self::Inout => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IN"),
-                    2 => std::borrow::Cow::Borrowed("OUT"),
-                    3 => std::borrow::Cow::Borrowed("INOUT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                    Self::In => std::option::Option::Some("IN"),
+                    Self::Out => std::option::Option::Some("OUT"),
+                    Self::Inout => std::option::Option::Some("INOUT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                    "IN" => std::option::Option::Some(Self::IN),
-                    "OUT" => std::option::Option::Some(Self::OUT),
-                    "INOUT" => std::option::Option::Some(Self::INOUT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Mode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Mode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::In,
+                    2 => Self::Out,
+                    3 => Self::Inout,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Mode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODE_UNSPECIFIED" => Self::Unspecified,
+                    "IN" => Self::In,
+                    "OUT" => Self::Out,
+                    "INOUT" => Self::Inout,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Mode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::In => serializer.serialize_i32(1),
+                    Self::Out => serializer.serialize_i32(2),
+                    Self::Inout => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Mode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                    ".google.cloud.datacatalog.v1.RoutineSpec.Argument.Mode",
+                ))
             }
         }
     }
 
     /// The fine-grained type of the routine.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutineType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoutineType {
+        /// Unspecified type.
+        Unspecified,
+        /// Non-builtin permanent scalar function.
+        ScalarFunction,
+        /// Stored procedure.
+        Procedure,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoutineType::value] or
+        /// [RoutineType::name].
+        UnknownValue(routine_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod routine_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RoutineType {
-        /// Unspecified type.
-        pub const ROUTINE_TYPE_UNSPECIFIED: RoutineType = RoutineType::new(0);
-
-        /// Non-builtin permanent scalar function.
-        pub const SCALAR_FUNCTION: RoutineType = RoutineType::new(1);
-
-        /// Stored procedure.
-        pub const PROCEDURE: RoutineType = RoutineType::new(2);
-
-        /// Creates a new RoutineType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ScalarFunction => std::option::Option::Some(1),
+                Self::Procedure => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUTINE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCALAR_FUNCTION"),
-                2 => std::borrow::Cow::Borrowed("PROCEDURE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUTINE_TYPE_UNSPECIFIED"),
+                Self::ScalarFunction => std::option::Option::Some("SCALAR_FUNCTION"),
+                Self::Procedure => std::option::Option::Some("PROCEDURE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUTINE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROUTINE_TYPE_UNSPECIFIED)
-                }
-                "SCALAR_FUNCTION" => std::option::Option::Some(Self::SCALAR_FUNCTION),
-                "PROCEDURE" => std::option::Option::Some(Self::PROCEDURE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RoutineType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutineType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoutineType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoutineType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ScalarFunction,
+                2 => Self::Procedure,
+                _ => Self::UnknownValue(routine_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoutineType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUTINE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCALAR_FUNCTION" => Self::ScalarFunction,
+                "PROCEDURE" => Self::Procedure,
+                _ => Self::UnknownValue(routine_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoutineType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ScalarFunction => serializer.serialize_i32(1),
+                Self::Procedure => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoutineType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoutineType>::new(
+                ".google.cloud.datacatalog.v1.RoutineSpec.RoutineType",
+            ))
         }
     }
 
@@ -3988,86 +4413,155 @@ pub mod vertex_model_source_info {
     use super::*;
 
     /// Source of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelSourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelSourceType {
+        /// Should not be used.
+        Unspecified,
+        /// The Model is uploaded by automl training pipeline.
+        Automl,
+        /// The Model is uploaded by user or custom training pipeline.
+        Custom,
+        /// The Model is registered and sync'ed from BigQuery ML.
+        Bqml,
+        /// The Model is saved or tuned from Model Garden.
+        ModelGarden,
+        /// The Model is saved or tuned from Genie.
+        Genie,
+        /// The Model is uploaded by text embedding finetuning pipeline.
+        CustomTextEmbedding,
+        /// The Model is saved or tuned from Marketplace.
+        Marketplace,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelSourceType::value] or
+        /// [ModelSourceType::name].
+        UnknownValue(model_source_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod model_source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ModelSourceType {
-        /// Should not be used.
-        pub const MODEL_SOURCE_TYPE_UNSPECIFIED: ModelSourceType = ModelSourceType::new(0);
-
-        /// The Model is uploaded by automl training pipeline.
-        pub const AUTOML: ModelSourceType = ModelSourceType::new(1);
-
-        /// The Model is uploaded by user or custom training pipeline.
-        pub const CUSTOM: ModelSourceType = ModelSourceType::new(2);
-
-        /// The Model is registered and sync'ed from BigQuery ML.
-        pub const BQML: ModelSourceType = ModelSourceType::new(3);
-
-        /// The Model is saved or tuned from Model Garden.
-        pub const MODEL_GARDEN: ModelSourceType = ModelSourceType::new(4);
-
-        /// The Model is saved or tuned from Genie.
-        pub const GENIE: ModelSourceType = ModelSourceType::new(5);
-
-        /// The Model is uploaded by text embedding finetuning pipeline.
-        pub const CUSTOM_TEXT_EMBEDDING: ModelSourceType = ModelSourceType::new(6);
-
-        /// The Model is saved or tuned from Marketplace.
-        pub const MARKETPLACE: ModelSourceType = ModelSourceType::new(7);
-
-        /// Creates a new ModelSourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automl => std::option::Option::Some(1),
+                Self::Custom => std::option::Option::Some(2),
+                Self::Bqml => std::option::Option::Some(3),
+                Self::ModelGarden => std::option::Option::Some(4),
+                Self::Genie => std::option::Option::Some(5),
+                Self::CustomTextEmbedding => std::option::Option::Some(6),
+                Self::Marketplace => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOML"),
-                2 => std::borrow::Cow::Borrowed("CUSTOM"),
-                3 => std::borrow::Cow::Borrowed("BQML"),
-                4 => std::borrow::Cow::Borrowed("MODEL_GARDEN"),
-                5 => std::borrow::Cow::Borrowed("GENIE"),
-                6 => std::borrow::Cow::Borrowed("CUSTOM_TEXT_EMBEDDING"),
-                7 => std::borrow::Cow::Borrowed("MARKETPLACE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_SOURCE_TYPE_UNSPECIFIED"),
+                Self::Automl => std::option::Option::Some("AUTOML"),
+                Self::Custom => std::option::Option::Some("CUSTOM"),
+                Self::Bqml => std::option::Option::Some("BQML"),
+                Self::ModelGarden => std::option::Option::Some("MODEL_GARDEN"),
+                Self::Genie => std::option::Option::Some("GENIE"),
+                Self::CustomTextEmbedding => std::option::Option::Some("CUSTOM_TEXT_EMBEDDING"),
+                Self::Marketplace => std::option::Option::Some("MARKETPLACE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MODEL_SOURCE_TYPE_UNSPECIFIED)
-                }
-                "AUTOML" => std::option::Option::Some(Self::AUTOML),
-                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                "BQML" => std::option::Option::Some(Self::BQML),
-                "MODEL_GARDEN" => std::option::Option::Some(Self::MODEL_GARDEN),
-                "GENIE" => std::option::Option::Some(Self::GENIE),
-                "CUSTOM_TEXT_EMBEDDING" => std::option::Option::Some(Self::CUSTOM_TEXT_EMBEDDING),
-                "MARKETPLACE" => std::option::Option::Some(Self::MARKETPLACE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelSourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelSourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelSourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelSourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automl,
+                2 => Self::Custom,
+                3 => Self::Bqml,
+                4 => Self::ModelGarden,
+                5 => Self::Genie,
+                6 => Self::CustomTextEmbedding,
+                7 => Self::Marketplace,
+                _ => Self::UnknownValue(model_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelSourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOML" => Self::Automl,
+                "CUSTOM" => Self::Custom,
+                "BQML" => Self::Bqml,
+                "MODEL_GARDEN" => Self::ModelGarden,
+                "GENIE" => Self::Genie,
+                "CUSTOM_TEXT_EMBEDDING" => Self::CustomTextEmbedding,
+                "MARKETPLACE" => Self::Marketplace,
+                _ => Self::UnknownValue(model_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelSourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automl => serializer.serialize_i32(1),
+                Self::Custom => serializer.serialize_i32(2),
+                Self::Bqml => serializer.serialize_i32(3),
+                Self::ModelGarden => serializer.serialize_i32(4),
+                Self::Genie => serializer.serialize_i32(5),
+                Self::CustomTextEmbedding => serializer.serialize_i32(6),
+                Self::Marketplace => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelSourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelSourceType>::new(
+                ".google.cloud.datacatalog.v1.VertexModelSourceInfo.ModelSourceType",
+            ))
         }
     }
 }
@@ -4214,115 +4708,196 @@ pub mod vertex_dataset_spec {
     use super::*;
 
     /// Type of data stored in the dataset.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataType(i32);
-
-    impl DataType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataType {
         /// Should not be used.
-        pub const DATA_TYPE_UNSPECIFIED: DataType = DataType::new(0);
-
+        Unspecified,
         /// Structured data dataset.
-        pub const TABLE: DataType = DataType::new(1);
-
+        Table,
         /// Image dataset which supports ImageClassification, ImageObjectDetection
         /// and ImageSegmentation problems.
-        pub const IMAGE: DataType = DataType::new(2);
-
+        Image,
         /// Document dataset which supports TextClassification, TextExtraction and
         /// TextSentiment problems.
-        pub const TEXT: DataType = DataType::new(3);
-
+        Text,
         /// Video dataset which supports VideoClassification, VideoObjectTracking and
         /// VideoActionRecognition problems.
-        pub const VIDEO: DataType = DataType::new(4);
-
+        Video,
         /// Conversation dataset which supports conversation problems.
-        pub const CONVERSATION: DataType = DataType::new(5);
-
+        Conversation,
         /// TimeSeries dataset.
-        pub const TIME_SERIES: DataType = DataType::new(6);
-
+        TimeSeries,
         /// Document dataset which supports DocumentAnnotation problems.
-        pub const DOCUMENT: DataType = DataType::new(7);
-
+        Document,
         /// TextToSpeech dataset which supports TextToSpeech problems.
-        pub const TEXT_TO_SPEECH: DataType = DataType::new(8);
-
+        TextToSpeech,
         /// Translation dataset which supports Translation problems.
-        pub const TRANSLATION: DataType = DataType::new(9);
-
+        Translation,
         /// Store Vision dataset which is used for HITL integration.
-        pub const STORE_VISION: DataType = DataType::new(10);
-
+        StoreVision,
         /// Enterprise Knowledge Graph dataset which is used for HITL labeling
         /// integration.
-        pub const ENTERPRISE_KNOWLEDGE_GRAPH: DataType = DataType::new(11);
-
+        EnterpriseKnowledgeGraph,
         /// Text prompt dataset which supports Large Language Models.
-        pub const TEXT_PROMPT: DataType = DataType::new(12);
+        TextPrompt,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataType::value] or
+        /// [DataType::name].
+        UnknownValue(data_type::UnknownValue),
+    }
 
-        /// Creates a new DataType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Table => std::option::Option::Some(1),
+                Self::Image => std::option::Option::Some(2),
+                Self::Text => std::option::Option::Some(3),
+                Self::Video => std::option::Option::Some(4),
+                Self::Conversation => std::option::Option::Some(5),
+                Self::TimeSeries => std::option::Option::Some(6),
+                Self::Document => std::option::Option::Some(7),
+                Self::TextToSpeech => std::option::Option::Some(8),
+                Self::Translation => std::option::Option::Some(9),
+                Self::StoreVision => std::option::Option::Some(10),
+                Self::EnterpriseKnowledgeGraph => std::option::Option::Some(11),
+                Self::TextPrompt => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TABLE"),
-                2 => std::borrow::Cow::Borrowed("IMAGE"),
-                3 => std::borrow::Cow::Borrowed("TEXT"),
-                4 => std::borrow::Cow::Borrowed("VIDEO"),
-                5 => std::borrow::Cow::Borrowed("CONVERSATION"),
-                6 => std::borrow::Cow::Borrowed("TIME_SERIES"),
-                7 => std::borrow::Cow::Borrowed("DOCUMENT"),
-                8 => std::borrow::Cow::Borrowed("TEXT_TO_SPEECH"),
-                9 => std::borrow::Cow::Borrowed("TRANSLATION"),
-                10 => std::borrow::Cow::Borrowed("STORE_VISION"),
-                11 => std::borrow::Cow::Borrowed("ENTERPRISE_KNOWLEDGE_GRAPH"),
-                12 => std::borrow::Cow::Borrowed("TEXT_PROMPT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_TYPE_UNSPECIFIED),
-                "TABLE" => std::option::Option::Some(Self::TABLE),
-                "IMAGE" => std::option::Option::Some(Self::IMAGE),
-                "TEXT" => std::option::Option::Some(Self::TEXT),
-                "VIDEO" => std::option::Option::Some(Self::VIDEO),
-                "CONVERSATION" => std::option::Option::Some(Self::CONVERSATION),
-                "TIME_SERIES" => std::option::Option::Some(Self::TIME_SERIES),
-                "DOCUMENT" => std::option::Option::Some(Self::DOCUMENT),
-                "TEXT_TO_SPEECH" => std::option::Option::Some(Self::TEXT_TO_SPEECH),
-                "TRANSLATION" => std::option::Option::Some(Self::TRANSLATION),
-                "STORE_VISION" => std::option::Option::Some(Self::STORE_VISION),
-                "ENTERPRISE_KNOWLEDGE_GRAPH" => {
-                    std::option::Option::Some(Self::ENTERPRISE_KNOWLEDGE_GRAPH)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_TYPE_UNSPECIFIED"),
+                Self::Table => std::option::Option::Some("TABLE"),
+                Self::Image => std::option::Option::Some("IMAGE"),
+                Self::Text => std::option::Option::Some("TEXT"),
+                Self::Video => std::option::Option::Some("VIDEO"),
+                Self::Conversation => std::option::Option::Some("CONVERSATION"),
+                Self::TimeSeries => std::option::Option::Some("TIME_SERIES"),
+                Self::Document => std::option::Option::Some("DOCUMENT"),
+                Self::TextToSpeech => std::option::Option::Some("TEXT_TO_SPEECH"),
+                Self::Translation => std::option::Option::Some("TRANSLATION"),
+                Self::StoreVision => std::option::Option::Some("STORE_VISION"),
+                Self::EnterpriseKnowledgeGraph => {
+                    std::option::Option::Some("ENTERPRISE_KNOWLEDGE_GRAPH")
                 }
-                "TEXT_PROMPT" => std::option::Option::Some(Self::TEXT_PROMPT),
-                _ => std::option::Option::None,
+                Self::TextPrompt => std::option::Option::Some("TEXT_PROMPT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DataType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Table,
+                2 => Self::Image,
+                3 => Self::Text,
+                4 => Self::Video,
+                5 => Self::Conversation,
+                6 => Self::TimeSeries,
+                7 => Self::Document,
+                8 => Self::TextToSpeech,
+                9 => Self::Translation,
+                10 => Self::StoreVision,
+                11 => Self::EnterpriseKnowledgeGraph,
+                12 => Self::TextPrompt,
+                _ => Self::UnknownValue(data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TABLE" => Self::Table,
+                "IMAGE" => Self::Image,
+                "TEXT" => Self::Text,
+                "VIDEO" => Self::Video,
+                "CONVERSATION" => Self::Conversation,
+                "TIME_SERIES" => Self::TimeSeries,
+                "DOCUMENT" => Self::Document,
+                "TEXT_TO_SPEECH" => Self::TextToSpeech,
+                "TRANSLATION" => Self::Translation,
+                "STORE_VISION" => Self::StoreVision,
+                "ENTERPRISE_KNOWLEDGE_GRAPH" => Self::EnterpriseKnowledgeGraph,
+                "TEXT_PROMPT" => Self::TextPrompt,
+                _ => Self::UnknownValue(data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Table => serializer.serialize_i32(1),
+                Self::Image => serializer.serialize_i32(2),
+                Self::Text => serializer.serialize_i32(3),
+                Self::Video => serializer.serialize_i32(4),
+                Self::Conversation => serializer.serialize_i32(5),
+                Self::TimeSeries => serializer.serialize_i32(6),
+                Self::Document => serializer.serialize_i32(7),
+                Self::TextToSpeech => serializer.serialize_i32(8),
+                Self::Translation => serializer.serialize_i32(9),
+                Self::StoreVision => serializer.serialize_i32(10),
+                Self::EnterpriseKnowledgeGraph => serializer.serialize_i32(11),
+                Self::TextPrompt => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataType>::new(
+                ".google.cloud.datacatalog.v1.VertexDatasetSpec.DataType",
+            ))
         }
     }
 }
@@ -4458,61 +5033,120 @@ pub mod feature_online_store_spec {
     use super::*;
 
     /// Type of underlying storage type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StorageType {
+        /// Should not be used.
+        Unspecified,
+        /// Underlsying storgae is Bigtable.
+        Bigtable,
+        /// Underlying is optimized online server (Lightning).
+        Optimized,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StorageType::value] or
+        /// [StorageType::name].
+        UnknownValue(storage_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod storage_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StorageType {
-        /// Should not be used.
-        pub const STORAGE_TYPE_UNSPECIFIED: StorageType = StorageType::new(0);
-
-        /// Underlsying storgae is Bigtable.
-        pub const BIGTABLE: StorageType = StorageType::new(1);
-
-        /// Underlying is optimized online server (Lightning).
-        pub const OPTIMIZED: StorageType = StorageType::new(2);
-
-        /// Creates a new StorageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bigtable => std::option::Option::Some(1),
+                Self::Optimized => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STORAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BIGTABLE"),
-                2 => std::borrow::Cow::Borrowed("OPTIMIZED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STORAGE_TYPE_UNSPECIFIED"),
+                Self::Bigtable => std::option::Option::Some("BIGTABLE"),
+                Self::Optimized => std::option::Option::Some("OPTIMIZED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STORAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STORAGE_TYPE_UNSPECIFIED)
-                }
-                "BIGTABLE" => std::option::Option::Some(Self::BIGTABLE),
-                "OPTIMIZED" => std::option::Option::Some(Self::OPTIMIZED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StorageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StorageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StorageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bigtable,
+                2 => Self::Optimized,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StorageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STORAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BIGTABLE" => Self::Bigtable,
+                "OPTIMIZED" => Self::Optimized,
+                _ => Self::UnknownValue(storage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StorageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bigtable => serializer.serialize_i32(1),
+                Self::Optimized => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StorageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageType>::new(
+                ".google.cloud.datacatalog.v1.FeatureOnlineStoreSpec.StorageType",
+            ))
         }
     }
 }
@@ -5763,69 +6397,129 @@ pub mod reconcile_tags_metadata {
     use super::*;
 
     /// Enum holding possible states of the reconciliation operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReconciliationState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReconciliationState {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// The reconciliation has been queued and awaits for execution.
+        ReconciliationQueued,
+        /// The reconciliation is in progress.
+        ReconciliationInProgress,
+        /// The reconciliation has been finished.
+        ReconciliationDone,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReconciliationState::value] or
+        /// [ReconciliationState::name].
+        UnknownValue(reconciliation_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod reconciliation_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ReconciliationState {
-        /// Default value. This value is unused.
-        pub const RECONCILIATION_STATE_UNSPECIFIED: ReconciliationState =
-            ReconciliationState::new(0);
-
-        /// The reconciliation has been queued and awaits for execution.
-        pub const RECONCILIATION_QUEUED: ReconciliationState = ReconciliationState::new(1);
-
-        /// The reconciliation is in progress.
-        pub const RECONCILIATION_IN_PROGRESS: ReconciliationState = ReconciliationState::new(2);
-
-        /// The reconciliation has been finished.
-        pub const RECONCILIATION_DONE: ReconciliationState = ReconciliationState::new(3);
-
-        /// Creates a new ReconciliationState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReconciliationQueued => std::option::Option::Some(1),
+                Self::ReconciliationInProgress => std::option::Option::Some(2),
+                Self::ReconciliationDone => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RECONCILIATION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RECONCILIATION_QUEUED"),
-                2 => std::borrow::Cow::Borrowed("RECONCILIATION_IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("RECONCILIATION_DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RECONCILIATION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RECONCILIATION_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RECONCILIATION_STATE_UNSPECIFIED"),
+                Self::ReconciliationQueued => std::option::Option::Some("RECONCILIATION_QUEUED"),
+                Self::ReconciliationInProgress => {
+                    std::option::Option::Some("RECONCILIATION_IN_PROGRESS")
                 }
-                "RECONCILIATION_QUEUED" => std::option::Option::Some(Self::RECONCILIATION_QUEUED),
-                "RECONCILIATION_IN_PROGRESS" => {
-                    std::option::Option::Some(Self::RECONCILIATION_IN_PROGRESS)
-                }
-                "RECONCILIATION_DONE" => std::option::Option::Some(Self::RECONCILIATION_DONE),
-                _ => std::option::Option::None,
+                Self::ReconciliationDone => std::option::Option::Some("RECONCILIATION_DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ReconciliationState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReconciliationState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReconciliationState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReconciliationState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReconciliationQueued,
+                2 => Self::ReconciliationInProgress,
+                3 => Self::ReconciliationDone,
+                _ => Self::UnknownValue(reconciliation_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReconciliationState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RECONCILIATION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "RECONCILIATION_QUEUED" => Self::ReconciliationQueued,
+                "RECONCILIATION_IN_PROGRESS" => Self::ReconciliationInProgress,
+                "RECONCILIATION_DONE" => Self::ReconciliationDone,
+                _ => Self::UnknownValue(reconciliation_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReconciliationState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReconciliationQueued => serializer.serialize_i32(1),
+                Self::ReconciliationInProgress => serializer.serialize_i32(2),
+                Self::ReconciliationDone => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReconciliationState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReconciliationState>::new(
+                ".google.cloud.datacatalog.v1.ReconcileTagsMetadata.ReconciliationState",
+            ))
         }
     }
 }
@@ -6317,71 +7011,134 @@ pub mod import_entries_metadata {
     use super::*;
 
     /// Enum holding possible states of the import operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ImportState {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// The dump with entries has been queued for import.
+        ImportQueued,
+        /// The import of entries is in progress.
+        ImportInProgress,
+        /// The import of entries has been finished.
+        ImportDone,
+        /// The import of entries has been abandoned in favor of a newer request.
+        ImportObsolete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ImportState::value] or
+        /// [ImportState::name].
+        UnknownValue(import_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod import_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ImportState {
-        /// Default value. This value is unused.
-        pub const IMPORT_STATE_UNSPECIFIED: ImportState = ImportState::new(0);
-
-        /// The dump with entries has been queued for import.
-        pub const IMPORT_QUEUED: ImportState = ImportState::new(1);
-
-        /// The import of entries is in progress.
-        pub const IMPORT_IN_PROGRESS: ImportState = ImportState::new(2);
-
-        /// The import of entries has been finished.
-        pub const IMPORT_DONE: ImportState = ImportState::new(3);
-
-        /// The import of entries has been abandoned in favor of a newer request.
-        pub const IMPORT_OBSOLETE: ImportState = ImportState::new(4);
-
-        /// Creates a new ImportState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ImportQueued => std::option::Option::Some(1),
+                Self::ImportInProgress => std::option::Option::Some(2),
+                Self::ImportDone => std::option::Option::Some(3),
+                Self::ImportObsolete => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPORT_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPORT_QUEUED"),
-                2 => std::borrow::Cow::Borrowed("IMPORT_IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("IMPORT_DONE"),
-                4 => std::borrow::Cow::Borrowed("IMPORT_OBSOLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPORT_STATE_UNSPECIFIED"),
+                Self::ImportQueued => std::option::Option::Some("IMPORT_QUEUED"),
+                Self::ImportInProgress => std::option::Option::Some("IMPORT_IN_PROGRESS"),
+                Self::ImportDone => std::option::Option::Some("IMPORT_DONE"),
+                Self::ImportObsolete => std::option::Option::Some("IMPORT_OBSOLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPORT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IMPORT_STATE_UNSPECIFIED)
-                }
-                "IMPORT_QUEUED" => std::option::Option::Some(Self::IMPORT_QUEUED),
-                "IMPORT_IN_PROGRESS" => std::option::Option::Some(Self::IMPORT_IN_PROGRESS),
-                "IMPORT_DONE" => std::option::Option::Some(Self::IMPORT_DONE),
-                "IMPORT_OBSOLETE" => std::option::Option::Some(Self::IMPORT_OBSOLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ImportState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ImportState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ImportState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ImportQueued,
+                2 => Self::ImportInProgress,
+                3 => Self::ImportDone,
+                4 => Self::ImportObsolete,
+                _ => Self::UnknownValue(import_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ImportState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPORT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "IMPORT_QUEUED" => Self::ImportQueued,
+                "IMPORT_IN_PROGRESS" => Self::ImportInProgress,
+                "IMPORT_DONE" => Self::ImportDone,
+                "IMPORT_OBSOLETE" => Self::ImportObsolete,
+                _ => Self::UnknownValue(import_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ImportState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ImportQueued => serializer.serialize_i32(1),
+                Self::ImportInProgress => serializer.serialize_i32(2),
+                Self::ImportDone => serializer.serialize_i32(3),
+                Self::ImportObsolete => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ImportState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportState>::new(
+                ".google.cloud.datacatalog.v1.ImportEntriesMetadata.ImportState",
+            ))
         }
     }
 }
@@ -7974,59 +8731,116 @@ pub mod taxonomy {
     }
 
     /// Defines policy types where the policy tags can be used for.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyType(i32);
-
-    impl PolicyType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PolicyType {
         /// Unspecified policy type.
-        pub const POLICY_TYPE_UNSPECIFIED: PolicyType = PolicyType::new(0);
-
+        Unspecified,
         /// Fine-grained access control policy that enables access control on
         /// tagged sub-resources.
-        pub const FINE_GRAINED_ACCESS_CONTROL: PolicyType = PolicyType::new(1);
+        FineGrainedAccessControl,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PolicyType::value] or
+        /// [PolicyType::name].
+        UnknownValue(policy_type::UnknownValue),
+    }
 
-        /// Creates a new PolicyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod policy_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PolicyType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FineGrainedAccessControl => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POLICY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FINE_GRAINED_ACCESS_CONTROL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POLICY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POLICY_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POLICY_TYPE_UNSPECIFIED"),
+                Self::FineGrainedAccessControl => {
+                    std::option::Option::Some("FINE_GRAINED_ACCESS_CONTROL")
                 }
-                "FINE_GRAINED_ACCESS_CONTROL" => {
-                    std::option::Option::Some(Self::FINE_GRAINED_ACCESS_CONTROL)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PolicyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PolicyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PolicyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FineGrainedAccessControl,
+                _ => Self::UnknownValue(policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PolicyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POLICY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FINE_GRAINED_ACCESS_CONTROL" => Self::FineGrainedAccessControl,
+                _ => Self::UnknownValue(policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PolicyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FineGrainedAccessControl => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PolicyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PolicyType>::new(
+                ".google.cloud.datacatalog.v1.Taxonomy.PolicyType",
+            ))
         }
     }
 }
@@ -9640,76 +10454,146 @@ pub mod column_schema {
         use super::*;
 
         /// Column type in Looker.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LookerColumnType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum LookerColumnType {
+            /// Unspecified.
+            Unspecified,
+            /// Dimension.
+            Dimension,
+            /// Dimension group - parent for Dimension.
+            DimensionGroup,
+            /// Filter.
+            Filter,
+            /// Measure.
+            Measure,
+            /// Parameter.
+            Parameter,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [LookerColumnType::value] or
+            /// [LookerColumnType::name].
+            UnknownValue(looker_column_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod looker_column_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl LookerColumnType {
-            /// Unspecified.
-            pub const LOOKER_COLUMN_TYPE_UNSPECIFIED: LookerColumnType = LookerColumnType::new(0);
-
-            /// Dimension.
-            pub const DIMENSION: LookerColumnType = LookerColumnType::new(1);
-
-            /// Dimension group - parent for Dimension.
-            pub const DIMENSION_GROUP: LookerColumnType = LookerColumnType::new(2);
-
-            /// Filter.
-            pub const FILTER: LookerColumnType = LookerColumnType::new(3);
-
-            /// Measure.
-            pub const MEASURE: LookerColumnType = LookerColumnType::new(4);
-
-            /// Parameter.
-            pub const PARAMETER: LookerColumnType = LookerColumnType::new(5);
-
-            /// Creates a new LookerColumnType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Dimension => std::option::Option::Some(1),
+                    Self::DimensionGroup => std::option::Option::Some(2),
+                    Self::Filter => std::option::Option::Some(3),
+                    Self::Measure => std::option::Option::Some(4),
+                    Self::Parameter => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("LOOKER_COLUMN_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DIMENSION"),
-                    2 => std::borrow::Cow::Borrowed("DIMENSION_GROUP"),
-                    3 => std::borrow::Cow::Borrowed("FILTER"),
-                    4 => std::borrow::Cow::Borrowed("MEASURE"),
-                    5 => std::borrow::Cow::Borrowed("PARAMETER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "LOOKER_COLUMN_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::LOOKER_COLUMN_TYPE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("LOOKER_COLUMN_TYPE_UNSPECIFIED")
                     }
-                    "DIMENSION" => std::option::Option::Some(Self::DIMENSION),
-                    "DIMENSION_GROUP" => std::option::Option::Some(Self::DIMENSION_GROUP),
-                    "FILTER" => std::option::Option::Some(Self::FILTER),
-                    "MEASURE" => std::option::Option::Some(Self::MEASURE),
-                    "PARAMETER" => std::option::Option::Some(Self::PARAMETER),
-                    _ => std::option::Option::None,
+                    Self::Dimension => std::option::Option::Some("DIMENSION"),
+                    Self::DimensionGroup => std::option::Option::Some("DIMENSION_GROUP"),
+                    Self::Filter => std::option::Option::Some("FILTER"),
+                    Self::Measure => std::option::Option::Some("MEASURE"),
+                    Self::Parameter => std::option::Option::Some("PARAMETER"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for LookerColumnType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for LookerColumnType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for LookerColumnType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for LookerColumnType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Dimension,
+                    2 => Self::DimensionGroup,
+                    3 => Self::Filter,
+                    4 => Self::Measure,
+                    5 => Self::Parameter,
+                    _ => Self::UnknownValue(looker_column_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for LookerColumnType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "LOOKER_COLUMN_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "DIMENSION" => Self::Dimension,
+                    "DIMENSION_GROUP" => Self::DimensionGroup,
+                    "FILTER" => Self::Filter,
+                    "MEASURE" => Self::Measure,
+                    "PARAMETER" => Self::Parameter,
+                    _ => Self::UnknownValue(looker_column_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for LookerColumnType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Dimension => serializer.serialize_i32(1),
+                    Self::DimensionGroup => serializer.serialize_i32(2),
+                    Self::Filter => serializer.serialize_i32(3),
+                    Self::Measure => serializer.serialize_i32(4),
+                    Self::Parameter => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for LookerColumnType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<LookerColumnType>::new(
+                    ".google.cloud.datacatalog.v1.ColumnSchema.LookerColumnSpec.LookerColumnType",
+                ))
             }
         }
     }
@@ -9751,75 +10635,134 @@ pub mod column_schema {
     }
 
     /// Specifies inclusion of the column in an index
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexingType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IndexingType {
+        /// Unspecified.
+        Unspecified,
+        /// Column not a part of an index.
+        None,
+        /// Column Part of non unique index.
+        NonUnique,
+        /// Column part of unique index.
+        Unique,
+        /// Column part of the primary key.
+        PrimaryKey,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IndexingType::value] or
+        /// [IndexingType::name].
+        UnknownValue(indexing_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod indexing_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IndexingType {
-        /// Unspecified.
-        pub const INDEXING_TYPE_UNSPECIFIED: IndexingType = IndexingType::new(0);
-
-        /// Column not a part of an index.
-        pub const INDEXING_TYPE_NONE: IndexingType = IndexingType::new(1);
-
-        /// Column Part of non unique index.
-        pub const INDEXING_TYPE_NON_UNIQUE: IndexingType = IndexingType::new(2);
-
-        /// Column part of unique index.
-        pub const INDEXING_TYPE_UNIQUE: IndexingType = IndexingType::new(3);
-
-        /// Column part of the primary key.
-        pub const INDEXING_TYPE_PRIMARY_KEY: IndexingType = IndexingType::new(4);
-
-        /// Creates a new IndexingType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::NonUnique => std::option::Option::Some(2),
+                Self::Unique => std::option::Option::Some(3),
+                Self::PrimaryKey => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INDEXING_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INDEXING_TYPE_NONE"),
-                2 => std::borrow::Cow::Borrowed("INDEXING_TYPE_NON_UNIQUE"),
-                3 => std::borrow::Cow::Borrowed("INDEXING_TYPE_UNIQUE"),
-                4 => std::borrow::Cow::Borrowed("INDEXING_TYPE_PRIMARY_KEY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INDEXING_TYPE_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("INDEXING_TYPE_NONE"),
+                Self::NonUnique => std::option::Option::Some("INDEXING_TYPE_NON_UNIQUE"),
+                Self::Unique => std::option::Option::Some("INDEXING_TYPE_UNIQUE"),
+                Self::PrimaryKey => std::option::Option::Some("INDEXING_TYPE_PRIMARY_KEY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INDEXING_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INDEXING_TYPE_UNSPECIFIED)
-                }
-                "INDEXING_TYPE_NONE" => std::option::Option::Some(Self::INDEXING_TYPE_NONE),
-                "INDEXING_TYPE_NON_UNIQUE" => {
-                    std::option::Option::Some(Self::INDEXING_TYPE_NON_UNIQUE)
-                }
-                "INDEXING_TYPE_UNIQUE" => std::option::Option::Some(Self::INDEXING_TYPE_UNIQUE),
-                "INDEXING_TYPE_PRIMARY_KEY" => {
-                    std::option::Option::Some(Self::INDEXING_TYPE_PRIMARY_KEY)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IndexingType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexingType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IndexingType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IndexingType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::NonUnique,
+                3 => Self::Unique,
+                4 => Self::PrimaryKey,
+                _ => Self::UnknownValue(indexing_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IndexingType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INDEXING_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INDEXING_TYPE_NONE" => Self::None,
+                "INDEXING_TYPE_NON_UNIQUE" => Self::NonUnique,
+                "INDEXING_TYPE_UNIQUE" => Self::Unique,
+                "INDEXING_TYPE_PRIMARY_KEY" => Self::PrimaryKey,
+                _ => Self::UnknownValue(indexing_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IndexingType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::NonUnique => serializer.serialize_i32(2),
+                Self::Unique => serializer.serialize_i32(3),
+                Self::PrimaryKey => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IndexingType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndexingType>::new(
+                ".google.cloud.datacatalog.v1.ColumnSchema.IndexingType",
+            ))
         }
     }
 
@@ -10920,67 +11863,127 @@ pub mod tag_template {
     use super::*;
 
     /// This enum describes TagTemplate transfer status to Dataplex service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataplexTransferStatus(i32);
-
-    impl DataplexTransferStatus {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataplexTransferStatus {
         /// Default value. TagTemplate and its tags are only visible and editable in
         /// DataCatalog.
-        pub const DATAPLEX_TRANSFER_STATUS_UNSPECIFIED: DataplexTransferStatus =
-            DataplexTransferStatus::new(0);
-
+        Unspecified,
         /// TagTemplate and its tags are auto-copied to Dataplex service.
         /// Visible in both services. Editable in DataCatalog, read-only in Dataplex.
         /// Deprecated: Individual TagTemplate migration is deprecated in favor of
         /// organization or project wide TagTemplate migration opt-in.
-        pub const MIGRATED: DataplexTransferStatus = DataplexTransferStatus::new(1);
-
+        Migrated,
         /// TagTemplate and its tags are auto-copied to Dataplex service.
         /// Visible in both services. Editable in Dataplex, read-only in DataCatalog.
-        pub const TRANSFERRED: DataplexTransferStatus = DataplexTransferStatus::new(2);
+        Transferred,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataplexTransferStatus::value] or
+        /// [DataplexTransferStatus::name].
+        UnknownValue(dataplex_transfer_status::UnknownValue),
+    }
 
-        /// Creates a new DataplexTransferStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod dataplex_transfer_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataplexTransferStatus {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Migrated => std::option::Option::Some(1),
+                Self::Transferred => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATAPLEX_TRANSFER_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MIGRATED"),
-                2 => std::borrow::Cow::Borrowed("TRANSFERRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATAPLEX_TRANSFER_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATAPLEX_TRANSFER_STATUS_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DATAPLEX_TRANSFER_STATUS_UNSPECIFIED")
                 }
-                "MIGRATED" => std::option::Option::Some(Self::MIGRATED),
-                "TRANSFERRED" => std::option::Option::Some(Self::TRANSFERRED),
-                _ => std::option::Option::None,
+                Self::Migrated => std::option::Option::Some("MIGRATED"),
+                Self::Transferred => std::option::Option::Some("TRANSFERRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DataplexTransferStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataplexTransferStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataplexTransferStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataplexTransferStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Migrated,
+                2 => Self::Transferred,
+                _ => Self::UnknownValue(dataplex_transfer_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataplexTransferStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATAPLEX_TRANSFER_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "MIGRATED" => Self::Migrated,
+                "TRANSFERRED" => Self::Transferred,
+                _ => Self::UnknownValue(dataplex_transfer_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataplexTransferStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Migrated => serializer.serialize_i32(1),
+                Self::Transferred => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataplexTransferStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataplexTransferStatus>::new(
+                ".google.cloud.datacatalog.v1.TagTemplate.DataplexTransferStatus",
+            ))
         }
     }
 }
@@ -11277,76 +12280,141 @@ pub mod field_type {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrimitiveType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PrimitiveType {
+        /// The default invalid value for a type.
+        Unspecified,
+        /// A double precision number.
+        Double,
+        /// An UTF-8 string.
+        String,
+        /// A boolean value.
+        Bool,
+        /// A timestamp.
+        Timestamp,
+        /// A Richtext description.
+        Richtext,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PrimitiveType::value] or
+        /// [PrimitiveType::name].
+        UnknownValue(primitive_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod primitive_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PrimitiveType {
-        /// The default invalid value for a type.
-        pub const PRIMITIVE_TYPE_UNSPECIFIED: PrimitiveType = PrimitiveType::new(0);
-
-        /// A double precision number.
-        pub const DOUBLE: PrimitiveType = PrimitiveType::new(1);
-
-        /// An UTF-8 string.
-        pub const STRING: PrimitiveType = PrimitiveType::new(2);
-
-        /// A boolean value.
-        pub const BOOL: PrimitiveType = PrimitiveType::new(3);
-
-        /// A timestamp.
-        pub const TIMESTAMP: PrimitiveType = PrimitiveType::new(4);
-
-        /// A Richtext description.
-        pub const RICHTEXT: PrimitiveType = PrimitiveType::new(5);
-
-        /// Creates a new PrimitiveType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Double => std::option::Option::Some(1),
+                Self::String => std::option::Option::Some(2),
+                Self::Bool => std::option::Option::Some(3),
+                Self::Timestamp => std::option::Option::Some(4),
+                Self::Richtext => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIMITIVE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DOUBLE"),
-                2 => std::borrow::Cow::Borrowed("STRING"),
-                3 => std::borrow::Cow::Borrowed("BOOL"),
-                4 => std::borrow::Cow::Borrowed("TIMESTAMP"),
-                5 => std::borrow::Cow::Borrowed("RICHTEXT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIMITIVE_TYPE_UNSPECIFIED"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Bool => std::option::Option::Some("BOOL"),
+                Self::Timestamp => std::option::Option::Some("TIMESTAMP"),
+                Self::Richtext => std::option::Option::Some("RICHTEXT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIMITIVE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIMITIVE_TYPE_UNSPECIFIED)
-                }
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "BOOL" => std::option::Option::Some(Self::BOOL),
-                "TIMESTAMP" => std::option::Option::Some(Self::TIMESTAMP),
-                "RICHTEXT" => std::option::Option::Some(Self::RICHTEXT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PrimitiveType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PrimitiveType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PrimitiveType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PrimitiveType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Double,
+                2 => Self::String,
+                3 => Self::Bool,
+                4 => Self::Timestamp,
+                5 => Self::Richtext,
+                _ => Self::UnknownValue(primitive_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PrimitiveType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIMITIVE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DOUBLE" => Self::Double,
+                "STRING" => Self::String,
+                "BOOL" => Self::Bool,
+                "TIMESTAMP" => Self::Timestamp,
+                "RICHTEXT" => Self::Richtext,
+                _ => Self::UnknownValue(primitive_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PrimitiveType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Double => serializer.serialize_i32(1),
+                Self::String => serializer.serialize_i32(2),
+                Self::Bool => serializer.serialize_i32(3),
+                Self::Timestamp => serializer.serialize_i32(4),
+                Self::Richtext => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PrimitiveType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PrimitiveType>::new(
+                ".google.cloud.datacatalog.v1.FieldType.PrimitiveType",
+            ))
         }
     }
 
@@ -11633,156 +12701,288 @@ impl wkt::message::Message for UsageSignal {
 }
 
 /// This enum lists all the systems that Data Catalog integrates with.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IntegratedSystem(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IntegratedSystem {
+    /// Default unknown system.
+    Unspecified,
+    /// BigQuery.
+    Bigquery,
+    /// Cloud Pub/Sub.
+    CloudPubsub,
+    /// Dataproc Metastore.
+    DataprocMetastore,
+    /// Dataplex.
+    Dataplex,
+    /// Cloud Spanner
+    CloudSpanner,
+    /// Cloud Bigtable
+    CloudBigtable,
+    /// Cloud Sql
+    CloudSql,
+    /// Looker
+    Looker,
+    /// Vertex AI
+    VertexAi,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IntegratedSystem::value] or
+    /// [IntegratedSystem::name].
+    UnknownValue(integrated_system::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod integrated_system {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl IntegratedSystem {
-    /// Default unknown system.
-    pub const INTEGRATED_SYSTEM_UNSPECIFIED: IntegratedSystem = IntegratedSystem::new(0);
-
-    /// BigQuery.
-    pub const BIGQUERY: IntegratedSystem = IntegratedSystem::new(1);
-
-    /// Cloud Pub/Sub.
-    pub const CLOUD_PUBSUB: IntegratedSystem = IntegratedSystem::new(2);
-
-    /// Dataproc Metastore.
-    pub const DATAPROC_METASTORE: IntegratedSystem = IntegratedSystem::new(3);
-
-    /// Dataplex.
-    pub const DATAPLEX: IntegratedSystem = IntegratedSystem::new(4);
-
-    /// Cloud Spanner
-    pub const CLOUD_SPANNER: IntegratedSystem = IntegratedSystem::new(6);
-
-    /// Cloud Bigtable
-    pub const CLOUD_BIGTABLE: IntegratedSystem = IntegratedSystem::new(7);
-
-    /// Cloud Sql
-    pub const CLOUD_SQL: IntegratedSystem = IntegratedSystem::new(8);
-
-    /// Looker
-    pub const LOOKER: IntegratedSystem = IntegratedSystem::new(9);
-
-    /// Vertex AI
-    pub const VERTEX_AI: IntegratedSystem = IntegratedSystem::new(10);
-
-    /// Creates a new IntegratedSystem instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Bigquery => std::option::Option::Some(1),
+            Self::CloudPubsub => std::option::Option::Some(2),
+            Self::DataprocMetastore => std::option::Option::Some(3),
+            Self::Dataplex => std::option::Option::Some(4),
+            Self::CloudSpanner => std::option::Option::Some(6),
+            Self::CloudBigtable => std::option::Option::Some(7),
+            Self::CloudSql => std::option::Option::Some(8),
+            Self::Looker => std::option::Option::Some(9),
+            Self::VertexAi => std::option::Option::Some(10),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INTEGRATED_SYSTEM_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BIGQUERY"),
-            2 => std::borrow::Cow::Borrowed("CLOUD_PUBSUB"),
-            3 => std::borrow::Cow::Borrowed("DATAPROC_METASTORE"),
-            4 => std::borrow::Cow::Borrowed("DATAPLEX"),
-            6 => std::borrow::Cow::Borrowed("CLOUD_SPANNER"),
-            7 => std::borrow::Cow::Borrowed("CLOUD_BIGTABLE"),
-            8 => std::borrow::Cow::Borrowed("CLOUD_SQL"),
-            9 => std::borrow::Cow::Borrowed("LOOKER"),
-            10 => std::borrow::Cow::Borrowed("VERTEX_AI"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INTEGRATED_SYSTEM_UNSPECIFIED"),
+            Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+            Self::CloudPubsub => std::option::Option::Some("CLOUD_PUBSUB"),
+            Self::DataprocMetastore => std::option::Option::Some("DATAPROC_METASTORE"),
+            Self::Dataplex => std::option::Option::Some("DATAPLEX"),
+            Self::CloudSpanner => std::option::Option::Some("CLOUD_SPANNER"),
+            Self::CloudBigtable => std::option::Option::Some("CLOUD_BIGTABLE"),
+            Self::CloudSql => std::option::Option::Some("CLOUD_SQL"),
+            Self::Looker => std::option::Option::Some("LOOKER"),
+            Self::VertexAi => std::option::Option::Some("VERTEX_AI"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INTEGRATED_SYSTEM_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INTEGRATED_SYSTEM_UNSPECIFIED)
-            }
-            "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-            "CLOUD_PUBSUB" => std::option::Option::Some(Self::CLOUD_PUBSUB),
-            "DATAPROC_METASTORE" => std::option::Option::Some(Self::DATAPROC_METASTORE),
-            "DATAPLEX" => std::option::Option::Some(Self::DATAPLEX),
-            "CLOUD_SPANNER" => std::option::Option::Some(Self::CLOUD_SPANNER),
-            "CLOUD_BIGTABLE" => std::option::Option::Some(Self::CLOUD_BIGTABLE),
-            "CLOUD_SQL" => std::option::Option::Some(Self::CLOUD_SQL),
-            "LOOKER" => std::option::Option::Some(Self::LOOKER),
-            "VERTEX_AI" => std::option::Option::Some(Self::VERTEX_AI),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IntegratedSystem {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IntegratedSystem {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IntegratedSystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IntegratedSystem {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Bigquery,
+            2 => Self::CloudPubsub,
+            3 => Self::DataprocMetastore,
+            4 => Self::Dataplex,
+            6 => Self::CloudSpanner,
+            7 => Self::CloudBigtable,
+            8 => Self::CloudSql,
+            9 => Self::Looker,
+            10 => Self::VertexAi,
+            _ => Self::UnknownValue(integrated_system::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IntegratedSystem {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INTEGRATED_SYSTEM_UNSPECIFIED" => Self::Unspecified,
+            "BIGQUERY" => Self::Bigquery,
+            "CLOUD_PUBSUB" => Self::CloudPubsub,
+            "DATAPROC_METASTORE" => Self::DataprocMetastore,
+            "DATAPLEX" => Self::Dataplex,
+            "CLOUD_SPANNER" => Self::CloudSpanner,
+            "CLOUD_BIGTABLE" => Self::CloudBigtable,
+            "CLOUD_SQL" => Self::CloudSql,
+            "LOOKER" => Self::Looker,
+            "VERTEX_AI" => Self::VertexAi,
+            _ => Self::UnknownValue(integrated_system::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IntegratedSystem {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Bigquery => serializer.serialize_i32(1),
+            Self::CloudPubsub => serializer.serialize_i32(2),
+            Self::DataprocMetastore => serializer.serialize_i32(3),
+            Self::Dataplex => serializer.serialize_i32(4),
+            Self::CloudSpanner => serializer.serialize_i32(6),
+            Self::CloudBigtable => serializer.serialize_i32(7),
+            Self::CloudSql => serializer.serialize_i32(8),
+            Self::Looker => serializer.serialize_i32(9),
+            Self::VertexAi => serializer.serialize_i32(10),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IntegratedSystem {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IntegratedSystem>::new(
+            ".google.cloud.datacatalog.v1.IntegratedSystem",
+        ))
     }
 }
 
 /// This enum describes all the systems that manage
 /// Taxonomy and PolicyTag resources in DataCatalog.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ManagingSystem(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ManagingSystem {
+    /// Default value
+    Unspecified,
+    /// Dataplex.
+    Dataplex,
+    /// Other
+    Other,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ManagingSystem::value] or
+    /// [ManagingSystem::name].
+    UnknownValue(managing_system::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod managing_system {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ManagingSystem {
-    /// Default value
-    pub const MANAGING_SYSTEM_UNSPECIFIED: ManagingSystem = ManagingSystem::new(0);
-
-    /// Dataplex.
-    pub const MANAGING_SYSTEM_DATAPLEX: ManagingSystem = ManagingSystem::new(1);
-
-    /// Other
-    pub const MANAGING_SYSTEM_OTHER: ManagingSystem = ManagingSystem::new(2);
-
-    /// Creates a new ManagingSystem instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Dataplex => std::option::Option::Some(1),
+            Self::Other => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MANAGING_SYSTEM_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MANAGING_SYSTEM_DATAPLEX"),
-            2 => std::borrow::Cow::Borrowed("MANAGING_SYSTEM_OTHER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MANAGING_SYSTEM_UNSPECIFIED"),
+            Self::Dataplex => std::option::Option::Some("MANAGING_SYSTEM_DATAPLEX"),
+            Self::Other => std::option::Option::Some("MANAGING_SYSTEM_OTHER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MANAGING_SYSTEM_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MANAGING_SYSTEM_UNSPECIFIED)
-            }
-            "MANAGING_SYSTEM_DATAPLEX" => std::option::Option::Some(Self::MANAGING_SYSTEM_DATAPLEX),
-            "MANAGING_SYSTEM_OTHER" => std::option::Option::Some(Self::MANAGING_SYSTEM_OTHER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ManagingSystem {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ManagingSystem {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ManagingSystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ManagingSystem {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Dataplex,
+            2 => Self::Other,
+            _ => Self::UnknownValue(managing_system::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ManagingSystem {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MANAGING_SYSTEM_UNSPECIFIED" => Self::Unspecified,
+            "MANAGING_SYSTEM_DATAPLEX" => Self::Dataplex,
+            "MANAGING_SYSTEM_OTHER" => Self::Other,
+            _ => Self::UnknownValue(managing_system::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ManagingSystem {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Dataplex => serializer.serialize_i32(1),
+            Self::Other => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ManagingSystem {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ManagingSystem>::new(
+            ".google.cloud.datacatalog.v1.ManagingSystem",
+        ))
     }
 }
 
@@ -11798,415 +12998,739 @@ impl std::default::Default for ManagingSystem {
 /// [Surface files from Cloud Storage with fileset
 /// entries](/data-catalog/docs/how-to/filesets) or [Create custom entries for
 /// your data sources](/data-catalog/docs/how-to/custom-entries).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EntryType(i32);
-
-impl EntryType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EntryType {
     /// Default unknown type.
-    pub const ENTRY_TYPE_UNSPECIFIED: EntryType = EntryType::new(0);
-
+    Unspecified,
     /// The entry type that has a GoogleSQL schema, including
     /// logical views.
-    pub const TABLE: EntryType = EntryType::new(2);
-
+    Table,
     /// The type of models.
     ///
     /// For more information, see [Supported models in BigQuery
     /// ML](/bigquery/docs/bqml-introduction#supported_models).
-    pub const MODEL: EntryType = EntryType::new(5);
-
+    Model,
     /// An entry type for streaming entries. For example, a Pub/Sub topic.
-    pub const DATA_STREAM: EntryType = EntryType::new(3);
-
+    DataStream,
     /// An entry type for a set of files or objects. For example, a
     /// Cloud Storage fileset.
-    pub const FILESET: EntryType = EntryType::new(4);
-
+    Fileset,
     /// A group of servers that work together. For example, a Kafka cluster.
-    pub const CLUSTER: EntryType = EntryType::new(6);
-
+    Cluster,
     /// A database.
-    pub const DATABASE: EntryType = EntryType::new(7);
-
+    Database,
     /// Connection to a data source. For example, a BigQuery
     /// connection.
-    pub const DATA_SOURCE_CONNECTION: EntryType = EntryType::new(8);
-
+    DataSourceConnection,
     /// Routine, for example, a BigQuery routine.
-    pub const ROUTINE: EntryType = EntryType::new(9);
-
+    Routine,
     /// A Dataplex lake.
-    pub const LAKE: EntryType = EntryType::new(10);
-
+    Lake,
     /// A Dataplex zone.
-    pub const ZONE: EntryType = EntryType::new(11);
-
+    Zone,
     /// A service, for example, a Dataproc Metastore service.
-    pub const SERVICE: EntryType = EntryType::new(14);
-
+    Service,
     /// Schema within a relational database.
-    pub const DATABASE_SCHEMA: EntryType = EntryType::new(15);
-
+    DatabaseSchema,
     /// A Dashboard, for example from Looker.
-    pub const DASHBOARD: EntryType = EntryType::new(16);
-
+    Dashboard,
     /// A Looker Explore.
     ///
     /// For more information, see [Looker Explore API]
     /// (<https://developers.looker.com/api/explorer/4.0/methods/LookmlModel/lookml_model_explore>).
-    pub const EXPLORE: EntryType = EntryType::new(17);
-
+    Explore,
     /// A Looker Look.
     ///
     /// For more information, see [Looker Look API]
     /// (<https://developers.looker.com/api/explorer/4.0/methods/Look>).
-    pub const LOOK: EntryType = EntryType::new(18);
-
+    Look,
     /// Feature Online Store resource in Vertex AI Feature Store.
-    pub const FEATURE_ONLINE_STORE: EntryType = EntryType::new(19);
-
+    FeatureOnlineStore,
     /// Feature View resource in Vertex AI Feature Store.
-    pub const FEATURE_VIEW: EntryType = EntryType::new(20);
-
+    FeatureView,
     /// Feature Group resource in Vertex AI Feature Store.
-    pub const FEATURE_GROUP: EntryType = EntryType::new(21);
+    FeatureGroup,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EntryType::value] or
+    /// [EntryType::name].
+    UnknownValue(entry_type::UnknownValue),
+}
 
-    /// Creates a new EntryType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod entry_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl EntryType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Table => std::option::Option::Some(2),
+            Self::Model => std::option::Option::Some(5),
+            Self::DataStream => std::option::Option::Some(3),
+            Self::Fileset => std::option::Option::Some(4),
+            Self::Cluster => std::option::Option::Some(6),
+            Self::Database => std::option::Option::Some(7),
+            Self::DataSourceConnection => std::option::Option::Some(8),
+            Self::Routine => std::option::Option::Some(9),
+            Self::Lake => std::option::Option::Some(10),
+            Self::Zone => std::option::Option::Some(11),
+            Self::Service => std::option::Option::Some(14),
+            Self::DatabaseSchema => std::option::Option::Some(15),
+            Self::Dashboard => std::option::Option::Some(16),
+            Self::Explore => std::option::Option::Some(17),
+            Self::Look => std::option::Option::Some(18),
+            Self::FeatureOnlineStore => std::option::Option::Some(19),
+            Self::FeatureView => std::option::Option::Some(20),
+            Self::FeatureGroup => std::option::Option::Some(21),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENTRY_TYPE_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("TABLE"),
-            3 => std::borrow::Cow::Borrowed("DATA_STREAM"),
-            4 => std::borrow::Cow::Borrowed("FILESET"),
-            5 => std::borrow::Cow::Borrowed("MODEL"),
-            6 => std::borrow::Cow::Borrowed("CLUSTER"),
-            7 => std::borrow::Cow::Borrowed("DATABASE"),
-            8 => std::borrow::Cow::Borrowed("DATA_SOURCE_CONNECTION"),
-            9 => std::borrow::Cow::Borrowed("ROUTINE"),
-            10 => std::borrow::Cow::Borrowed("LAKE"),
-            11 => std::borrow::Cow::Borrowed("ZONE"),
-            14 => std::borrow::Cow::Borrowed("SERVICE"),
-            15 => std::borrow::Cow::Borrowed("DATABASE_SCHEMA"),
-            16 => std::borrow::Cow::Borrowed("DASHBOARD"),
-            17 => std::borrow::Cow::Borrowed("EXPLORE"),
-            18 => std::borrow::Cow::Borrowed("LOOK"),
-            19 => std::borrow::Cow::Borrowed("FEATURE_ONLINE_STORE"),
-            20 => std::borrow::Cow::Borrowed("FEATURE_VIEW"),
-            21 => std::borrow::Cow::Borrowed("FEATURE_GROUP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENTRY_TYPE_UNSPECIFIED"),
+            Self::Table => std::option::Option::Some("TABLE"),
+            Self::Model => std::option::Option::Some("MODEL"),
+            Self::DataStream => std::option::Option::Some("DATA_STREAM"),
+            Self::Fileset => std::option::Option::Some("FILESET"),
+            Self::Cluster => std::option::Option::Some("CLUSTER"),
+            Self::Database => std::option::Option::Some("DATABASE"),
+            Self::DataSourceConnection => std::option::Option::Some("DATA_SOURCE_CONNECTION"),
+            Self::Routine => std::option::Option::Some("ROUTINE"),
+            Self::Lake => std::option::Option::Some("LAKE"),
+            Self::Zone => std::option::Option::Some("ZONE"),
+            Self::Service => std::option::Option::Some("SERVICE"),
+            Self::DatabaseSchema => std::option::Option::Some("DATABASE_SCHEMA"),
+            Self::Dashboard => std::option::Option::Some("DASHBOARD"),
+            Self::Explore => std::option::Option::Some("EXPLORE"),
+            Self::Look => std::option::Option::Some("LOOK"),
+            Self::FeatureOnlineStore => std::option::Option::Some("FEATURE_ONLINE_STORE"),
+            Self::FeatureView => std::option::Option::Some("FEATURE_VIEW"),
+            Self::FeatureGroup => std::option::Option::Some("FEATURE_GROUP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENTRY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ENTRY_TYPE_UNSPECIFIED),
-            "TABLE" => std::option::Option::Some(Self::TABLE),
-            "MODEL" => std::option::Option::Some(Self::MODEL),
-            "DATA_STREAM" => std::option::Option::Some(Self::DATA_STREAM),
-            "FILESET" => std::option::Option::Some(Self::FILESET),
-            "CLUSTER" => std::option::Option::Some(Self::CLUSTER),
-            "DATABASE" => std::option::Option::Some(Self::DATABASE),
-            "DATA_SOURCE_CONNECTION" => std::option::Option::Some(Self::DATA_SOURCE_CONNECTION),
-            "ROUTINE" => std::option::Option::Some(Self::ROUTINE),
-            "LAKE" => std::option::Option::Some(Self::LAKE),
-            "ZONE" => std::option::Option::Some(Self::ZONE),
-            "SERVICE" => std::option::Option::Some(Self::SERVICE),
-            "DATABASE_SCHEMA" => std::option::Option::Some(Self::DATABASE_SCHEMA),
-            "DASHBOARD" => std::option::Option::Some(Self::DASHBOARD),
-            "EXPLORE" => std::option::Option::Some(Self::EXPLORE),
-            "LOOK" => std::option::Option::Some(Self::LOOK),
-            "FEATURE_ONLINE_STORE" => std::option::Option::Some(Self::FEATURE_ONLINE_STORE),
-            "FEATURE_VIEW" => std::option::Option::Some(Self::FEATURE_VIEW),
-            "FEATURE_GROUP" => std::option::Option::Some(Self::FEATURE_GROUP),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EntryType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EntryType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EntryType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EntryType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::Table,
+            3 => Self::DataStream,
+            4 => Self::Fileset,
+            5 => Self::Model,
+            6 => Self::Cluster,
+            7 => Self::Database,
+            8 => Self::DataSourceConnection,
+            9 => Self::Routine,
+            10 => Self::Lake,
+            11 => Self::Zone,
+            14 => Self::Service,
+            15 => Self::DatabaseSchema,
+            16 => Self::Dashboard,
+            17 => Self::Explore,
+            18 => Self::Look,
+            19 => Self::FeatureOnlineStore,
+            20 => Self::FeatureView,
+            21 => Self::FeatureGroup,
+            _ => Self::UnknownValue(entry_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EntryType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENTRY_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "TABLE" => Self::Table,
+            "MODEL" => Self::Model,
+            "DATA_STREAM" => Self::DataStream,
+            "FILESET" => Self::Fileset,
+            "CLUSTER" => Self::Cluster,
+            "DATABASE" => Self::Database,
+            "DATA_SOURCE_CONNECTION" => Self::DataSourceConnection,
+            "ROUTINE" => Self::Routine,
+            "LAKE" => Self::Lake,
+            "ZONE" => Self::Zone,
+            "SERVICE" => Self::Service,
+            "DATABASE_SCHEMA" => Self::DatabaseSchema,
+            "DASHBOARD" => Self::Dashboard,
+            "EXPLORE" => Self::Explore,
+            "LOOK" => Self::Look,
+            "FEATURE_ONLINE_STORE" => Self::FeatureOnlineStore,
+            "FEATURE_VIEW" => Self::FeatureView,
+            "FEATURE_GROUP" => Self::FeatureGroup,
+            _ => Self::UnknownValue(entry_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EntryType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Table => serializer.serialize_i32(2),
+            Self::Model => serializer.serialize_i32(5),
+            Self::DataStream => serializer.serialize_i32(3),
+            Self::Fileset => serializer.serialize_i32(4),
+            Self::Cluster => serializer.serialize_i32(6),
+            Self::Database => serializer.serialize_i32(7),
+            Self::DataSourceConnection => serializer.serialize_i32(8),
+            Self::Routine => serializer.serialize_i32(9),
+            Self::Lake => serializer.serialize_i32(10),
+            Self::Zone => serializer.serialize_i32(11),
+            Self::Service => serializer.serialize_i32(14),
+            Self::DatabaseSchema => serializer.serialize_i32(15),
+            Self::Dashboard => serializer.serialize_i32(16),
+            Self::Explore => serializer.serialize_i32(17),
+            Self::Look => serializer.serialize_i32(18),
+            Self::FeatureOnlineStore => serializer.serialize_i32(19),
+            Self::FeatureView => serializer.serialize_i32(20),
+            Self::FeatureGroup => serializer.serialize_i32(21),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EntryType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntryType>::new(
+            ".google.cloud.datacatalog.v1.EntryType",
+        ))
     }
 }
 
 /// Configuration related to the opt-in status for the migration of TagTemplates
 /// to Dataplex.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TagTemplateMigration(i32);
-
-impl TagTemplateMigration {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TagTemplateMigration {
     /// Default value. Migration of Tag Templates from Data Catalog to Dataplex is
     /// not performed.
-    pub const TAG_TEMPLATE_MIGRATION_UNSPECIFIED: TagTemplateMigration =
-        TagTemplateMigration::new(0);
-
+    Unspecified,
     /// Migration of Tag Templates from Data Catalog to Dataplex is enabled.
-    pub const TAG_TEMPLATE_MIGRATION_ENABLED: TagTemplateMigration = TagTemplateMigration::new(1);
-
+    Enabled,
     /// Migration of Tag Templates from Data Catalog to Dataplex is disabled.
-    pub const TAG_TEMPLATE_MIGRATION_DISABLED: TagTemplateMigration = TagTemplateMigration::new(2);
+    Disabled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TagTemplateMigration::value] or
+    /// [TagTemplateMigration::name].
+    UnknownValue(tag_template_migration::UnknownValue),
+}
 
-    /// Creates a new TagTemplateMigration instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod tag_template_migration {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl TagTemplateMigration {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enabled => std::option::Option::Some(1),
+            Self::Disabled => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TAG_TEMPLATE_MIGRATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TAG_TEMPLATE_MIGRATION_ENABLED"),
-            2 => std::borrow::Cow::Borrowed("TAG_TEMPLATE_MIGRATION_DISABLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TAG_TEMPLATE_MIGRATION_UNSPECIFIED"),
+            Self::Enabled => std::option::Option::Some("TAG_TEMPLATE_MIGRATION_ENABLED"),
+            Self::Disabled => std::option::Option::Some("TAG_TEMPLATE_MIGRATION_DISABLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TAG_TEMPLATE_MIGRATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TAG_TEMPLATE_MIGRATION_UNSPECIFIED)
-            }
-            "TAG_TEMPLATE_MIGRATION_ENABLED" => {
-                std::option::Option::Some(Self::TAG_TEMPLATE_MIGRATION_ENABLED)
-            }
-            "TAG_TEMPLATE_MIGRATION_DISABLED" => {
-                std::option::Option::Some(Self::TAG_TEMPLATE_MIGRATION_DISABLED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TagTemplateMigration {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TagTemplateMigration {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TagTemplateMigration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TagTemplateMigration {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enabled,
+            2 => Self::Disabled,
+            _ => Self::UnknownValue(tag_template_migration::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TagTemplateMigration {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TAG_TEMPLATE_MIGRATION_UNSPECIFIED" => Self::Unspecified,
+            "TAG_TEMPLATE_MIGRATION_ENABLED" => Self::Enabled,
+            "TAG_TEMPLATE_MIGRATION_DISABLED" => Self::Disabled,
+            _ => Self::UnknownValue(tag_template_migration::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TagTemplateMigration {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enabled => serializer.serialize_i32(1),
+            Self::Disabled => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TagTemplateMigration {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TagTemplateMigration>::new(
+            ".google.cloud.datacatalog.v1.TagTemplateMigration",
+        ))
     }
 }
 
 /// Configuration related to the opt-in status for the UI switch to Dataplex.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CatalogUIExperience(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CatalogUIExperience {
+    /// Default value. The default UI is Dataplex.
+    Unspecified,
+    /// The UI is Dataplex.
+    Enabled,
+    /// The UI is Data Catalog.
+    Disabled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CatalogUIExperience::value] or
+    /// [CatalogUIExperience::name].
+    UnknownValue(catalog_ui_experience::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod catalog_ui_experience {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CatalogUIExperience {
-    /// Default value. The default UI is Dataplex.
-    pub const CATALOG_UI_EXPERIENCE_UNSPECIFIED: CatalogUIExperience = CatalogUIExperience::new(0);
-
-    /// The UI is Dataplex.
-    pub const CATALOG_UI_EXPERIENCE_ENABLED: CatalogUIExperience = CatalogUIExperience::new(1);
-
-    /// The UI is Data Catalog.
-    pub const CATALOG_UI_EXPERIENCE_DISABLED: CatalogUIExperience = CatalogUIExperience::new(2);
-
-    /// Creates a new CatalogUIExperience instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enabled => std::option::Option::Some(1),
+            Self::Disabled => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CATALOG_UI_EXPERIENCE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CATALOG_UI_EXPERIENCE_ENABLED"),
-            2 => std::borrow::Cow::Borrowed("CATALOG_UI_EXPERIENCE_DISABLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CATALOG_UI_EXPERIENCE_UNSPECIFIED"),
+            Self::Enabled => std::option::Option::Some("CATALOG_UI_EXPERIENCE_ENABLED"),
+            Self::Disabled => std::option::Option::Some("CATALOG_UI_EXPERIENCE_DISABLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CATALOG_UI_EXPERIENCE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CATALOG_UI_EXPERIENCE_UNSPECIFIED)
-            }
-            "CATALOG_UI_EXPERIENCE_ENABLED" => {
-                std::option::Option::Some(Self::CATALOG_UI_EXPERIENCE_ENABLED)
-            }
-            "CATALOG_UI_EXPERIENCE_DISABLED" => {
-                std::option::Option::Some(Self::CATALOG_UI_EXPERIENCE_DISABLED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CatalogUIExperience {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CatalogUIExperience {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CatalogUIExperience {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CatalogUIExperience {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enabled,
+            2 => Self::Disabled,
+            _ => Self::UnknownValue(catalog_ui_experience::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CatalogUIExperience {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CATALOG_UI_EXPERIENCE_UNSPECIFIED" => Self::Unspecified,
+            "CATALOG_UI_EXPERIENCE_ENABLED" => Self::Enabled,
+            "CATALOG_UI_EXPERIENCE_DISABLED" => Self::Disabled,
+            _ => Self::UnknownValue(catalog_ui_experience::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CatalogUIExperience {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enabled => serializer.serialize_i32(1),
+            Self::Disabled => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CatalogUIExperience {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CatalogUIExperience>::new(
+            ".google.cloud.datacatalog.v1.CatalogUIExperience",
+        ))
     }
 }
 
 /// The resource types that can be returned in search results.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchResultType(i32);
-
-impl SearchResultType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SearchResultType {
     /// Default unknown type.
-    pub const SEARCH_RESULT_TYPE_UNSPECIFIED: SearchResultType = SearchResultType::new(0);
-
+    Unspecified,
     /// An [Entry][google.cloud.datacatalog.v1.Entry].
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
-    pub const ENTRY: SearchResultType = SearchResultType::new(1);
-
+    Entry,
     /// A [TagTemplate][google.cloud.datacatalog.v1.TagTemplate].
     ///
     /// [google.cloud.datacatalog.v1.TagTemplate]: crate::model::TagTemplate
-    pub const TAG_TEMPLATE: SearchResultType = SearchResultType::new(2);
-
+    TagTemplate,
     /// An [EntryGroup][google.cloud.datacatalog.v1.EntryGroup].
     ///
     /// [google.cloud.datacatalog.v1.EntryGroup]: crate::model::EntryGroup
-    pub const ENTRY_GROUP: SearchResultType = SearchResultType::new(3);
+    EntryGroup,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SearchResultType::value] or
+    /// [SearchResultType::name].
+    UnknownValue(search_result_type::UnknownValue),
+}
 
-    /// Creates a new SearchResultType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod search_result_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SearchResultType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Entry => std::option::Option::Some(1),
+            Self::TagTemplate => std::option::Option::Some(2),
+            Self::EntryGroup => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEARCH_RESULT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENTRY"),
-            2 => std::borrow::Cow::Borrowed("TAG_TEMPLATE"),
-            3 => std::borrow::Cow::Borrowed("ENTRY_GROUP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEARCH_RESULT_TYPE_UNSPECIFIED"),
+            Self::Entry => std::option::Option::Some("ENTRY"),
+            Self::TagTemplate => std::option::Option::Some("TAG_TEMPLATE"),
+            Self::EntryGroup => std::option::Option::Some("ENTRY_GROUP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEARCH_RESULT_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SEARCH_RESULT_TYPE_UNSPECIFIED)
-            }
-            "ENTRY" => std::option::Option::Some(Self::ENTRY),
-            "TAG_TEMPLATE" => std::option::Option::Some(Self::TAG_TEMPLATE),
-            "ENTRY_GROUP" => std::option::Option::Some(Self::ENTRY_GROUP),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SearchResultType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchResultType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SearchResultType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SearchResultType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Entry,
+            2 => Self::TagTemplate,
+            3 => Self::EntryGroup,
+            _ => Self::UnknownValue(search_result_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SearchResultType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEARCH_RESULT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ENTRY" => Self::Entry,
+            "TAG_TEMPLATE" => Self::TagTemplate,
+            "ENTRY_GROUP" => Self::EntryGroup,
+            _ => Self::UnknownValue(search_result_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SearchResultType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Entry => serializer.serialize_i32(1),
+            Self::TagTemplate => serializer.serialize_i32(2),
+            Self::EntryGroup => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SearchResultType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchResultType>::new(
+            ".google.cloud.datacatalog.v1.SearchResultType",
+        ))
     }
 }
 
 /// Table source type.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TableSourceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TableSourceType {
+    /// Default unknown type.
+    Unspecified,
+    /// Table view.
+    BigqueryView,
+    /// BigQuery native table.
+    BigqueryTable,
+    /// BigQuery materialized view.
+    BigqueryMaterializedView,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TableSourceType::value] or
+    /// [TableSourceType::name].
+    UnknownValue(table_source_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod table_source_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TableSourceType {
-    /// Default unknown type.
-    pub const TABLE_SOURCE_TYPE_UNSPECIFIED: TableSourceType = TableSourceType::new(0);
-
-    /// Table view.
-    pub const BIGQUERY_VIEW: TableSourceType = TableSourceType::new(2);
-
-    /// BigQuery native table.
-    pub const BIGQUERY_TABLE: TableSourceType = TableSourceType::new(5);
-
-    /// BigQuery materialized view.
-    pub const BIGQUERY_MATERIALIZED_VIEW: TableSourceType = TableSourceType::new(7);
-
-    /// Creates a new TableSourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::BigqueryView => std::option::Option::Some(2),
+            Self::BigqueryTable => std::option::Option::Some(5),
+            Self::BigqueryMaterializedView => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TABLE_SOURCE_TYPE_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("BIGQUERY_VIEW"),
-            5 => std::borrow::Cow::Borrowed("BIGQUERY_TABLE"),
-            7 => std::borrow::Cow::Borrowed("BIGQUERY_MATERIALIZED_VIEW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TABLE_SOURCE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TABLE_SOURCE_TYPE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TABLE_SOURCE_TYPE_UNSPECIFIED"),
+            Self::BigqueryView => std::option::Option::Some("BIGQUERY_VIEW"),
+            Self::BigqueryTable => std::option::Option::Some("BIGQUERY_TABLE"),
+            Self::BigqueryMaterializedView => {
+                std::option::Option::Some("BIGQUERY_MATERIALIZED_VIEW")
             }
-            "BIGQUERY_VIEW" => std::option::Option::Some(Self::BIGQUERY_VIEW),
-            "BIGQUERY_TABLE" => std::option::Option::Some(Self::BIGQUERY_TABLE),
-            "BIGQUERY_MATERIALIZED_VIEW" => {
-                std::option::Option::Some(Self::BIGQUERY_MATERIALIZED_VIEW)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for TableSourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TableSourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TableSourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TableSourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::BigqueryView,
+            5 => Self::BigqueryTable,
+            7 => Self::BigqueryMaterializedView,
+            _ => Self::UnknownValue(table_source_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TableSourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TABLE_SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BIGQUERY_VIEW" => Self::BigqueryView,
+            "BIGQUERY_TABLE" => Self::BigqueryTable,
+            "BIGQUERY_MATERIALIZED_VIEW" => Self::BigqueryMaterializedView,
+            _ => Self::UnknownValue(table_source_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TableSourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::BigqueryView => serializer.serialize_i32(2),
+            Self::BigqueryTable => serializer.serialize_i32(5),
+            Self::BigqueryMaterializedView => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TableSourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableSourceType>::new(
+            ".google.cloud.datacatalog.v1.TableSourceType",
+        ))
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -158,61 +158,120 @@ pub mod version {
     use super::*;
 
     /// Each type represents the release availability of a CDF version
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Version does not have availability yet
+        Unspecified,
+        /// Version is under development and not considered stable
+        Preview,
+        /// Version is available for public use
+        GeneralAvailability,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Version does not have availability yet
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Version is under development and not considered stable
-        pub const TYPE_PREVIEW: Type = Type::new(1);
-
-        /// Version is available for public use
-        pub const TYPE_GENERAL_AVAILABILITY: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Preview => std::option::Option::Some(1),
+                Self::GeneralAvailability => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TYPE_PREVIEW"),
-                2 => std::borrow::Cow::Borrowed("TYPE_GENERAL_AVAILABILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Preview => std::option::Option::Some("TYPE_PREVIEW"),
+                Self::GeneralAvailability => std::option::Option::Some("TYPE_GENERAL_AVAILABILITY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TYPE_PREVIEW" => std::option::Option::Some(Self::TYPE_PREVIEW),
-                "TYPE_GENERAL_AVAILABILITY" => {
-                    std::option::Option::Some(Self::TYPE_GENERAL_AVAILABILITY)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Preview,
+                2 => Self::GeneralAvailability,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TYPE_PREVIEW" => Self::Preview,
+                "TYPE_GENERAL_AVAILABILITY" => Self::GeneralAvailability,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Preview => serializer.serialize_i32(1),
+                Self::GeneralAvailability => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.datafusion.v1.Version.Type",
+            ))
         }
     }
 }
@@ -272,132 +331,256 @@ pub mod accelerator {
 
     /// Each type represents an Accelerator (Add-On) supported by Cloud Data Fusion
     /// service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AcceleratorType(i32);
-
-    impl AcceleratorType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AcceleratorType {
         /// Default value, if unspecified.
-        pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType = AcceleratorType::new(0);
-
+        Unspecified,
         /// Change Data Capture accelerator for CDF.
-        pub const CDC: AcceleratorType = AcceleratorType::new(1);
-
+        Cdc,
         /// Cloud Healthcare accelerator for CDF. This accelerator is to enable Cloud
         /// Healthcare specific CDF plugins developed by Healthcare team.
-        pub const HEALTHCARE: AcceleratorType = AcceleratorType::new(2);
-
+        Healthcare,
         /// Contact Center AI Insights
         /// This accelerator is used to enable import and export pipelines
         /// custom built to streamline CCAI Insights processing.
-        pub const CCAI_INSIGHTS: AcceleratorType = AcceleratorType::new(3);
+        CcaiInsights,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AcceleratorType::value] or
+        /// [AcceleratorType::name].
+        UnknownValue(accelerator_type::UnknownValue),
+    }
 
-        /// Creates a new AcceleratorType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod accelerator_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AcceleratorType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Cdc => std::option::Option::Some(1),
+                Self::Healthcare => std::option::Option::Some(2),
+                Self::CcaiInsights => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCELERATOR_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CDC"),
-                2 => std::borrow::Cow::Borrowed("HEALTHCARE"),
-                3 => std::borrow::Cow::Borrowed("CCAI_INSIGHTS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCELERATOR_TYPE_UNSPECIFIED"),
+                Self::Cdc => std::option::Option::Some("CDC"),
+                Self::Healthcare => std::option::Option::Some("HEALTHCARE"),
+                Self::CcaiInsights => std::option::Option::Some("CCAI_INSIGHTS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCELERATOR_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCELERATOR_TYPE_UNSPECIFIED)
-                }
-                "CDC" => std::option::Option::Some(Self::CDC),
-                "HEALTHCARE" => std::option::Option::Some(Self::HEALTHCARE),
-                "CCAI_INSIGHTS" => std::option::Option::Some(Self::CCAI_INSIGHTS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AcceleratorType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AcceleratorType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AcceleratorType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AcceleratorType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Cdc,
+                2 => Self::Healthcare,
+                3 => Self::CcaiInsights,
+                _ => Self::UnknownValue(accelerator_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AcceleratorType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCELERATOR_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CDC" => Self::Cdc,
+                "HEALTHCARE" => Self::Healthcare,
+                "CCAI_INSIGHTS" => Self::CcaiInsights,
+                _ => Self::UnknownValue(accelerator_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AcceleratorType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Cdc => serializer.serialize_i32(1),
+                Self::Healthcare => serializer.serialize_i32(2),
+                Self::CcaiInsights => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AcceleratorType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AcceleratorType>::new(
+                ".google.cloud.datafusion.v1.Accelerator.AcceleratorType",
+            ))
         }
     }
 
     /// Different values possible for the state of an accelerator
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value, do not use
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Indicates that the accelerator is enabled and available to use
-        pub const ENABLED: State = State::new(1);
-
+        Enabled,
         /// Indicates that the accelerator is disabled and not available to use
-        pub const DISABLED: State = State::new(2);
-
+        Disabled,
         /// Indicates that accelerator state is currently unknown.
         /// Requests for enable, disable could be retried while in this state
-        pub const UNKNOWN: State = State::new(3);
+        Unknown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Unknown => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "UNKNOWN" => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Unknown => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datafusion.v1.Accelerator.State",
+            ))
         }
     }
 }
@@ -815,224 +998,421 @@ pub mod instance {
 
     /// Represents the type of Data Fusion instance. Each type is configured with
     /// the default settings for processing and memory.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// No type specified. The instance creation will fail.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Basic Data Fusion instance. In Basic type, the user will be able to
         /// create data pipelines using point and click UI. However, there are
         /// certain limitations, such as fewer number of concurrent pipelines, no
         /// support for streaming pipelines, etc.
-        pub const BASIC: Type = Type::new(1);
-
+        Basic,
         /// Enterprise Data Fusion instance. In Enterprise type, the user will have
         /// all features available, such as support for streaming pipelines, higher
         /// number of concurrent pipelines, etc.
-        pub const ENTERPRISE: Type = Type::new(2);
-
+        Enterprise,
         /// Developer Data Fusion instance. In Developer type, the user will have all
         /// features available but with restrictive capabilities. This is to help
         /// enterprises design and develop their data ingestion and integration
         /// pipelines at low cost.
-        pub const DEVELOPER: Type = Type::new(3);
+        Developer,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::Developer => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                3 => std::borrow::Cow::Borrowed("DEVELOPER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::Developer => std::option::Option::Some("DEVELOPER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                "DEVELOPER" => std::option::Option::Some(Self::DEVELOPER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Enterprise,
+                3 => Self::Developer,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "ENTERPRISE" => Self::Enterprise,
+                "DEVELOPER" => Self::Developer,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::Developer => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.datafusion.v1.Instance.Type",
+            ))
         }
     }
 
     /// Represents the state of a Data Fusion instance
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Instance does not have a state yet
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Instance is being created
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Instance is active and ready for requests. This corresponds to 'RUNNING'
         /// in datafusion.v1beta1.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// Instance creation failed
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// Instance is being deleted
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Instance is being upgraded
-        pub const UPGRADING: State = State::new(5);
-
+        Upgrading,
         /// Instance is being restarted
-        pub const RESTARTING: State = State::new(6);
-
+        Restarting,
         /// Instance is being updated on customer request
-        pub const UPDATING: State = State::new(7);
-
+        Updating,
         /// Instance is being auto-updated
-        pub const AUTO_UPDATING: State = State::new(8);
-
+        AutoUpdating,
         /// Instance is being auto-upgraded
-        pub const AUTO_UPGRADING: State = State::new(9);
-
+        AutoUpgrading,
         /// Instance is disabled
-        pub const DISABLED: State = State::new(10);
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Upgrading => std::option::Option::Some(5),
+                Self::Restarting => std::option::Option::Some(6),
+                Self::Updating => std::option::Option::Some(7),
+                Self::AutoUpdating => std::option::Option::Some(8),
+                Self::AutoUpgrading => std::option::Option::Some(9),
+                Self::Disabled => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UPGRADING"),
-                6 => std::borrow::Cow::Borrowed("RESTARTING"),
-                7 => std::borrow::Cow::Borrowed("UPDATING"),
-                8 => std::borrow::Cow::Borrowed("AUTO_UPDATING"),
-                9 => std::borrow::Cow::Borrowed("AUTO_UPGRADING"),
-                10 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Upgrading => std::option::Option::Some("UPGRADING"),
+                Self::Restarting => std::option::Option::Some("RESTARTING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::AutoUpdating => std::option::Option::Some("AUTO_UPDATING"),
+                Self::AutoUpgrading => std::option::Option::Some("AUTO_UPGRADING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
-                "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "AUTO_UPDATING" => std::option::Option::Some(Self::AUTO_UPDATING),
-                "AUTO_UPGRADING" => std::option::Option::Some(Self::AUTO_UPGRADING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                5 => Self::Upgrading,
+                6 => Self::Restarting,
+                7 => Self::Updating,
+                8 => Self::AutoUpdating,
+                9 => Self::AutoUpgrading,
+                10 => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "UPGRADING" => Self::Upgrading,
+                "RESTARTING" => Self::Restarting,
+                "UPDATING" => Self::Updating,
+                "AUTO_UPDATING" => Self::AutoUpdating,
+                "AUTO_UPGRADING" => Self::AutoUpgrading,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Upgrading => serializer.serialize_i32(5),
+                Self::Restarting => serializer.serialize_i32(6),
+                Self::Updating => serializer.serialize_i32(7),
+                Self::AutoUpdating => serializer.serialize_i32(8),
+                Self::AutoUpgrading => serializer.serialize_i32(9),
+                Self::Disabled => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datafusion.v1.Instance.State",
+            ))
         }
     }
 
     /// The reason for disabling the instance if the state is DISABLED.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DisabledReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DisabledReason {
+        /// This is an unknown reason for disabling.
+        Unspecified,
+        /// The KMS key used by the instance is either revoked or denied access to
+        KmsKeyIssue,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DisabledReason::value] or
+        /// [DisabledReason::name].
+        UnknownValue(disabled_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod disabled_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DisabledReason {
-        /// This is an unknown reason for disabling.
-        pub const DISABLED_REASON_UNSPECIFIED: DisabledReason = DisabledReason::new(0);
-
-        /// The KMS key used by the instance is either revoked or denied access to
-        pub const KMS_KEY_ISSUE: DisabledReason = DisabledReason::new(1);
-
-        /// Creates a new DisabledReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::KmsKeyIssue => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISABLED_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KMS_KEY_ISSUE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISABLED_REASON_UNSPECIFIED"),
+                Self::KmsKeyIssue => std::option::Option::Some("KMS_KEY_ISSUE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISABLED_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISABLED_REASON_UNSPECIFIED)
-                }
-                "KMS_KEY_ISSUE" => std::option::Option::Some(Self::KMS_KEY_ISSUE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DisabledReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DisabledReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DisabledReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DisabledReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::KmsKeyIssue,
+                _ => Self::UnknownValue(disabled_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DisabledReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISABLED_REASON_UNSPECIFIED" => Self::Unspecified,
+                "KMS_KEY_ISSUE" => Self::KmsKeyIssue,
+                _ => Self::UnknownValue(disabled_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DisabledReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::KmsKeyIssue => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DisabledReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DisabledReason>::new(
+                ".google.cloud.datafusion.v1.Instance.DisabledReason",
+            ))
         }
     }
 }

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -916,56 +916,116 @@ pub mod content {
         use super::*;
 
         /// Query Engine Type of the SQL Script.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct QueryEngine(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum QueryEngine {
+            /// Value was unspecified.
+            Unspecified,
+            /// Spark SQL Query.
+            Spark,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [QueryEngine::value] or
+            /// [QueryEngine::name].
+            UnknownValue(query_engine::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod query_engine {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl QueryEngine {
-            /// Value was unspecified.
-            pub const QUERY_ENGINE_UNSPECIFIED: QueryEngine = QueryEngine::new(0);
-
-            /// Spark SQL Query.
-            pub const SPARK: QueryEngine = QueryEngine::new(2);
-
-            /// Creates a new QueryEngine instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Spark => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("QUERY_ENGINE_UNSPECIFIED"),
-                    2 => std::borrow::Cow::Borrowed("SPARK"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("QUERY_ENGINE_UNSPECIFIED"),
+                    Self::Spark => std::option::Option::Some("SPARK"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "QUERY_ENGINE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::QUERY_ENGINE_UNSPECIFIED)
-                    }
-                    "SPARK" => std::option::Option::Some(Self::SPARK),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for QueryEngine {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for QueryEngine {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for QueryEngine {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for QueryEngine {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    2 => Self::Spark,
+                    _ => Self::UnknownValue(query_engine::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for QueryEngine {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "QUERY_ENGINE_UNSPECIFIED" => Self::Unspecified,
+                    "SPARK" => Self::Spark,
+                    _ => Self::UnknownValue(query_engine::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for QueryEngine {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Spark => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for QueryEngine {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<QueryEngine>::new(
+                    ".google.cloud.dataplex.v1.Content.SqlScript.QueryEngine",
+                ))
             }
         }
     }
@@ -1012,56 +1072,116 @@ pub mod content {
         use super::*;
 
         /// Kernel Type of the Jupyter notebook.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct KernelType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum KernelType {
+            /// Kernel Type unspecified.
+            Unspecified,
+            /// Python 3 Kernel.
+            Python3,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [KernelType::value] or
+            /// [KernelType::name].
+            UnknownValue(kernel_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod kernel_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl KernelType {
-            /// Kernel Type unspecified.
-            pub const KERNEL_TYPE_UNSPECIFIED: KernelType = KernelType::new(0);
-
-            /// Python 3 Kernel.
-            pub const PYTHON3: KernelType = KernelType::new(1);
-
-            /// Creates a new KernelType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Python3 => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("KERNEL_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PYTHON3"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("KERNEL_TYPE_UNSPECIFIED"),
+                    Self::Python3 => std::option::Option::Some("PYTHON3"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "KERNEL_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::KERNEL_TYPE_UNSPECIFIED)
-                    }
-                    "PYTHON3" => std::option::Option::Some(Self::PYTHON3),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for KernelType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for KernelType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for KernelType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for KernelType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Python3,
+                    _ => Self::UnknownValue(kernel_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for KernelType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "KERNEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "PYTHON3" => Self::Python3,
+                    _ => Self::UnknownValue(kernel_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for KernelType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Python3 => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for KernelType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<KernelType>::new(
+                    ".google.cloud.dataplex.v1.Content.Notebook.KernelType",
+                ))
             }
         }
     }
@@ -5644,90 +5764,152 @@ pub mod metadata_job {
         /// Specifies how the entries and aspects in a metadata job are updated. For
         /// more information, see [Sync
         /// mode](https://cloud.google.com/dataplex/docs/import-metadata#sync-mode).
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SyncMode(i32);
-
-        impl SyncMode {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SyncMode {
             /// Sync mode unspecified.
-            pub const SYNC_MODE_UNSPECIFIED: SyncMode = SyncMode::new(0);
-
+            Unspecified,
             /// All resources in the job's scope are modified. If a resource exists in
             /// Dataplex but isn't included in the metadata import file, the resource
             /// is deleted when you run the metadata job. Use this mode to perform a
             /// full sync of the set of entries in the job scope.
             ///
             /// This sync mode is supported for entries.
-            pub const FULL: SyncMode = SyncMode::new(1);
-
+            Full,
             /// Only the resources that are explicitly included in the
             /// metadata import file are modified. Use this mode to modify a subset of
             /// resources while leaving unreferenced resources unchanged.
             ///
             /// This sync mode is supported for aspects.
-            pub const INCREMENTAL: SyncMode = SyncMode::new(2);
-
+            Incremental,
             /// If entry sync mode is `NONE`, then aspects are modified according
             /// to the aspect sync mode. Other metadata that belongs to entries in the
             /// job's scope isn't modified.
             ///
             /// This sync mode is supported for entries.
-            pub const NONE: SyncMode = SyncMode::new(3);
+            None,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SyncMode::value] or
+            /// [SyncMode::name].
+            UnknownValue(sync_mode::UnknownValue),
+        }
 
-            /// Creates a new SyncMode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod sync_mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SyncMode {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Full => std::option::Option::Some(1),
+                    Self::Incremental => std::option::Option::Some(2),
+                    Self::None => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SYNC_MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("FULL"),
-                    2 => std::borrow::Cow::Borrowed("INCREMENTAL"),
-                    3 => std::borrow::Cow::Borrowed("NONE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SYNC_MODE_UNSPECIFIED"),
+                    Self::Full => std::option::Option::Some("FULL"),
+                    Self::Incremental => std::option::Option::Some("INCREMENTAL"),
+                    Self::None => std::option::Option::Some("NONE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SYNC_MODE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SYNC_MODE_UNSPECIFIED)
-                    }
-                    "FULL" => std::option::Option::Some(Self::FULL),
-                    "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
-                    "NONE" => std::option::Option::Some(Self::NONE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SyncMode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SyncMode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SyncMode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SyncMode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Full,
+                    2 => Self::Incremental,
+                    3 => Self::None,
+                    _ => Self::UnknownValue(sync_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SyncMode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SYNC_MODE_UNSPECIFIED" => Self::Unspecified,
+                    "FULL" => Self::Full,
+                    "INCREMENTAL" => Self::Incremental,
+                    "NONE" => Self::None,
+                    _ => Self::UnknownValue(sync_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SyncMode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Full => serializer.serialize_i32(1),
+                    Self::Incremental => serializer.serialize_i32(2),
+                    Self::None => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SyncMode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SyncMode>::new(
+                    ".google.cloud.dataplex.v1.MetadataJob.ImportJobSpec.SyncMode",
+                ))
             }
         }
 
         /// The level of logs to write to Cloud Logging for this job.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LogLevel(i32);
-
-        impl LogLevel {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum LogLevel {
             /// Log level unspecified.
-            pub const LOG_LEVEL_UNSPECIFIED: LogLevel = LogLevel::new(0);
-
+            Unspecified,
             /// Debug-level logging. Captures detailed logs for each import item. Use
             /// debug-level logging to troubleshoot issues with specific import items.
             /// For example, use debug-level logging to identify resources that are
@@ -5738,55 +5920,119 @@ pub mod metadata_job {
             /// Depending on the size of your metadata job and the number of logs that
             /// are generated, debug-level logging might incur
             /// [additional costs](https://cloud.google.com/stackdriver/pricing).
-            pub const DEBUG: LogLevel = LogLevel::new(1);
-
+            Debug,
             /// Info-level logging. Captures logs at the overall job level. Includes
             /// aggregate logs about import items, but doesn't specify which import
             /// item has an error.
-            pub const INFO: LogLevel = LogLevel::new(2);
+            Info,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [LogLevel::value] or
+            /// [LogLevel::name].
+            UnknownValue(log_level::UnknownValue),
+        }
 
-            /// Creates a new LogLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod log_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl LogLevel {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Debug => std::option::Option::Some(1),
+                    Self::Info => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("LOG_LEVEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DEBUG"),
-                    2 => std::borrow::Cow::Borrowed("INFO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("LOG_LEVEL_UNSPECIFIED"),
+                    Self::Debug => std::option::Option::Some("DEBUG"),
+                    Self::Info => std::option::Option::Some("INFO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "LOG_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::LOG_LEVEL_UNSPECIFIED)
-                    }
-                    "DEBUG" => std::option::Option::Some(Self::DEBUG),
-                    "INFO" => std::option::Option::Some(Self::INFO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for LogLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for LogLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for LogLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for LogLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Debug,
+                    2 => Self::Info,
+                    _ => Self::UnknownValue(log_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for LogLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "LOG_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "DEBUG" => Self::Debug,
+                    "INFO" => Self::Info,
+                    _ => Self::UnknownValue(log_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for LogLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Debug => serializer.serialize_i32(1),
+                    Self::Info => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for LogLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogLevel>::new(
+                    ".google.cloud.dataplex.v1.MetadataJob.ImportJobSpec.LogLevel",
+                ))
             }
         }
     }
@@ -6045,144 +6291,277 @@ pub mod metadata_job {
         use super::*;
 
         /// State of a metadata job.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// State unspecified.
+            Unspecified,
+            /// The job is queued.
+            Queued,
+            /// The job is running.
+            Running,
+            /// The job is being canceled.
+            Canceling,
+            /// The job is canceled.
+            Canceled,
+            /// The job succeeded.
+            Succeeded,
+            /// The job failed.
+            Failed,
+            /// The job completed with some errors.
+            SucceededWithErrors,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// State unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// The job is queued.
-            pub const QUEUED: State = State::new(1);
-
-            /// The job is running.
-            pub const RUNNING: State = State::new(2);
-
-            /// The job is being canceled.
-            pub const CANCELING: State = State::new(3);
-
-            /// The job is canceled.
-            pub const CANCELED: State = State::new(4);
-
-            /// The job succeeded.
-            pub const SUCCEEDED: State = State::new(5);
-
-            /// The job failed.
-            pub const FAILED: State = State::new(6);
-
-            /// The job completed with some errors.
-            pub const SUCCEEDED_WITH_ERRORS: State = State::new(7);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Queued => std::option::Option::Some(1),
+                    Self::Running => std::option::Option::Some(2),
+                    Self::Canceling => std::option::Option::Some(3),
+                    Self::Canceled => std::option::Option::Some(4),
+                    Self::Succeeded => std::option::Option::Some(5),
+                    Self::Failed => std::option::Option::Some(6),
+                    Self::SucceededWithErrors => std::option::Option::Some(7),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("QUEUED"),
-                    2 => std::borrow::Cow::Borrowed("RUNNING"),
-                    3 => std::borrow::Cow::Borrowed("CANCELING"),
-                    4 => std::borrow::Cow::Borrowed("CANCELED"),
-                    5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                    6 => std::borrow::Cow::Borrowed("FAILED"),
-                    7 => std::borrow::Cow::Borrowed("SUCCEEDED_WITH_ERRORS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Queued => std::option::Option::Some("QUEUED"),
+                    Self::Running => std::option::Option::Some("RUNNING"),
+                    Self::Canceling => std::option::Option::Some("CANCELING"),
+                    Self::Canceled => std::option::Option::Some("CANCELED"),
+                    Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::SucceededWithErrors => std::option::Option::Some("SUCCEEDED_WITH_ERRORS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "QUEUED" => std::option::Option::Some(Self::QUEUED),
-                    "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                    "CANCELING" => std::option::Option::Some(Self::CANCELING),
-                    "CANCELED" => std::option::Option::Some(Self::CANCELED),
-                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "SUCCEEDED_WITH_ERRORS" => {
-                        std::option::Option::Some(Self::SUCCEEDED_WITH_ERRORS)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Queued,
+                    2 => Self::Running,
+                    3 => Self::Canceling,
+                    4 => Self::Canceled,
+                    5 => Self::Succeeded,
+                    6 => Self::Failed,
+                    7 => Self::SucceededWithErrors,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "QUEUED" => Self::Queued,
+                    "RUNNING" => Self::Running,
+                    "CANCELING" => Self::Canceling,
+                    "CANCELED" => Self::Canceled,
+                    "SUCCEEDED" => Self::Succeeded,
+                    "FAILED" => Self::Failed,
+                    "SUCCEEDED_WITH_ERRORS" => Self::SucceededWithErrors,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Queued => serializer.serialize_i32(1),
+                    Self::Running => serializer.serialize_i32(2),
+                    Self::Canceling => serializer.serialize_i32(3),
+                    Self::Canceled => serializer.serialize_i32(4),
+                    Self::Succeeded => serializer.serialize_i32(5),
+                    Self::Failed => serializer.serialize_i32(6),
+                    Self::SucceededWithErrors => serializer.serialize_i32(7),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.dataplex.v1.MetadataJob.Status.State",
+                ))
             }
         }
     }
 
     /// Metadata job type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified.
+        Unspecified,
+        /// Import job.
+        Import,
+        /// Export job type.
+        Export,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Import job.
-        pub const IMPORT: Type = Type::new(1);
-
-        /// Export job type.
-        pub const EXPORT: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Import => std::option::Option::Some(1),
+                Self::Export => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPORT"),
-                2 => std::borrow::Cow::Borrowed("EXPORT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Import => std::option::Option::Some("IMPORT"),
+                Self::Export => std::option::Option::Some("EXPORT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "IMPORT" => std::option::Option::Some(Self::IMPORT),
-                "EXPORT" => std::option::Option::Some(Self::EXPORT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Import,
+                2 => Self::Export,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMPORT" => Self::Import,
+                "EXPORT" => Self::Export,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Import => serializer.serialize_i32(1),
+                Self::Export => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dataplex.v1.MetadataJob.Type",
+            ))
         }
     }
 
@@ -6381,129 +6760,254 @@ pub mod encryption_config {
         use super::*;
 
         /// Error code for the failure if anything related to Cmek db fails.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ErrorCode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ErrorCode {
+            /// The error code is not specified
+            Unknown,
+            /// Error because of internal server error, will be retried automatically..
+            InternalError,
+            /// User action is required to resolve the error.
+            RequireUserAction,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ErrorCode::value] or
+            /// [ErrorCode::name].
+            UnknownValue(error_code::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod error_code {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ErrorCode {
-            /// The error code is not specified
-            pub const UNKNOWN: ErrorCode = ErrorCode::new(0);
-
-            /// Error because of internal server error, will be retried automatically..
-            pub const INTERNAL_ERROR: ErrorCode = ErrorCode::new(1);
-
-            /// User action is required to resolve the error.
-            pub const REQUIRE_USER_ACTION: ErrorCode = ErrorCode::new(2);
-
-            /// Creates a new ErrorCode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unknown => std::option::Option::Some(0),
+                    Self::InternalError => std::option::Option::Some(1),
+                    Self::RequireUserAction => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                    1 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
-                    2 => std::borrow::Cow::Borrowed("REQUIRE_USER_ACTION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                    Self::InternalError => std::option::Option::Some("INTERNAL_ERROR"),
+                    Self::RequireUserAction => std::option::Option::Some("REQUIRE_USER_ACTION"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                    "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
-                    "REQUIRE_USER_ACTION" => std::option::Option::Some(Self::REQUIRE_USER_ACTION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ErrorCode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ErrorCode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ErrorCode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ErrorCode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unknown,
+                    1 => Self::InternalError,
+                    2 => Self::RequireUserAction,
+                    _ => Self::UnknownValue(error_code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ErrorCode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNKNOWN" => Self::Unknown,
+                    "INTERNAL_ERROR" => Self::InternalError,
+                    "REQUIRE_USER_ACTION" => Self::RequireUserAction,
+                    _ => Self::UnknownValue(error_code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ErrorCode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unknown => serializer.serialize_i32(0),
+                    Self::InternalError => serializer.serialize_i32(1),
+                    Self::RequireUserAction => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                    ".google.cloud.dataplex.v1.EncryptionConfig.FailureDetails.ErrorCode",
+                ))
             }
         }
     }
 
     /// State of encryption of the databases when EncryptionConfig is created or
     /// updated.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionState(i32);
-
-    impl EncryptionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EncryptionState {
         /// State is not specified.
-        pub const ENCRYPTION_STATE_UNSPECIFIED: EncryptionState = EncryptionState::new(0);
-
+        Unspecified,
         /// The encryption state of the database when the EncryptionConfig is created
         /// or updated. If the encryption fails, it is retried indefinitely and the
         /// state is shown as ENCRYPTING.
-        pub const ENCRYPTING: EncryptionState = EncryptionState::new(1);
-
+        Encrypting,
         /// The encryption of data has completed successfully.
-        pub const COMPLETED: EncryptionState = EncryptionState::new(2);
-
+        Completed,
         /// The encryption of data has failed.
         /// The state is set to FAILED when the encryption fails due to reasons like
         /// permission issues, invalid key etc.
-        pub const FAILED: EncryptionState = EncryptionState::new(3);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EncryptionState::value] or
+        /// [EncryptionState::name].
+        UnknownValue(encryption_state::UnknownValue),
+    }
 
-        /// Creates a new EncryptionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod encryption_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EncryptionState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Encrypting => std::option::Option::Some(1),
+                Self::Completed => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENCRYPTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENCRYPTING"),
-                2 => std::borrow::Cow::Borrowed("COMPLETED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENCRYPTION_STATE_UNSPECIFIED"),
+                Self::Encrypting => std::option::Option::Some("ENCRYPTING"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENCRYPTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_STATE_UNSPECIFIED)
-                }
-                "ENCRYPTING" => std::option::Option::Some(Self::ENCRYPTING),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EncryptionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EncryptionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EncryptionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Encrypting,
+                2 => Self::Completed,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(encryption_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EncryptionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENCRYPTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENCRYPTING" => Self::Encrypting,
+                "COMPLETED" => Self::Completed,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(encryption_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EncryptionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Encrypting => serializer.serialize_i32(1),
+                Self::Completed => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EncryptionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionState>::new(
+                ".google.cloud.dataplex.v1.EncryptionConfig.EncryptionState",
+            ))
         }
     }
 }
@@ -7209,62 +7713,121 @@ pub mod get_content_request {
 
     /// Specifies whether the request should return the full or the partial
     /// representation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContentView(i32);
-
-    impl ContentView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ContentView {
         /// Content view not specified. Defaults to BASIC.
         /// The API will default to the BASIC view.
-        pub const CONTENT_VIEW_UNSPECIFIED: ContentView = ContentView::new(0);
-
+        Unspecified,
         /// Will not return the `data_text` field.
-        pub const BASIC: ContentView = ContentView::new(1);
-
+        Basic,
         /// Returns the complete proto.
-        pub const FULL: ContentView = ContentView::new(2);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ContentView::value] or
+        /// [ContentView::name].
+        UnknownValue(content_view::UnknownValue),
+    }
 
-        /// Creates a new ContentView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod content_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ContentView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONTENT_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONTENT_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONTENT_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONTENT_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ContentView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ContentView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ContentView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ContentView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Full,
+                _ => Self::UnknownValue(content_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ContentView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONTENT_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(content_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ContentView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ContentView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentView>::new(
+                ".google.cloud.dataplex.v1.GetContentRequest.ContentView",
+            ))
         }
     }
 }
@@ -7453,65 +8016,126 @@ pub mod data_discovery_spec {
         use super::*;
 
         /// Determines how discovered tables are published.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TableType(i32);
-
-        impl TableType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TableType {
             /// Table type unspecified.
-            pub const TABLE_TYPE_UNSPECIFIED: TableType = TableType::new(0);
-
+            Unspecified,
             /// Default. Discovered tables are published as BigQuery external tables
             /// whose data is accessed using the credentials of the user querying the
             /// table.
-            pub const EXTERNAL: TableType = TableType::new(1);
-
+            External,
             /// Discovered tables are published as BigLake external tables whose data
             /// is accessed using the credentials of the associated BigQuery
             /// connection.
-            pub const BIGLAKE: TableType = TableType::new(2);
+            Biglake,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TableType::value] or
+            /// [TableType::name].
+            UnknownValue(table_type::UnknownValue),
+        }
 
-            /// Creates a new TableType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod table_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl TableType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::External => std::option::Option::Some(1),
+                    Self::Biglake => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TABLE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EXTERNAL"),
-                    2 => std::borrow::Cow::Borrowed("BIGLAKE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TABLE_TYPE_UNSPECIFIED"),
+                    Self::External => std::option::Option::Some("EXTERNAL"),
+                    Self::Biglake => std::option::Option::Some("BIGLAKE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TABLE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::TABLE_TYPE_UNSPECIFIED)
-                    }
-                    "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-                    "BIGLAKE" => std::option::Option::Some(Self::BIGLAKE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for TableType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TableType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TableType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TableType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::External,
+                    2 => Self::Biglake,
+                    _ => Self::UnknownValue(table_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TableType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TABLE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "EXTERNAL" => Self::External,
+                    "BIGLAKE" => Self::Biglake,
+                    _ => Self::UnknownValue(table_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TableType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::External => serializer.serialize_i32(1),
+                    Self::Biglake => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TableType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableType>::new(
+                    ".google.cloud.dataplex.v1.DataDiscoverySpec.BigQueryPublishingConfig.TableType"))
             }
         }
     }
@@ -9020,65 +9644,130 @@ pub mod data_profile_result {
             use super::*;
 
             /// Execution state for the exporting.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct State(i32);
-
-            impl State {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum State {
                 /// The exporting state is unspecified.
-                pub const STATE_UNSPECIFIED: State = State::new(0);
-
+                Unspecified,
                 /// The exporting completed successfully.
-                pub const SUCCEEDED: State = State::new(1);
-
+                Succeeded,
                 /// The exporting is no longer running due to an error.
-                pub const FAILED: State = State::new(2);
-
+                Failed,
                 /// The exporting is skipped due to no valid scan result to export
                 /// (usually caused by scan failed).
-                pub const SKIPPED: State = State::new(3);
+                Skipped,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [State::value] or
+                /// [State::name].
+                UnknownValue(state::UnknownValue),
+            }
 
-                /// Creates a new State instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl State {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Succeeded => std::option::Option::Some(1),
+                        Self::Failed => std::option::Option::Some(2),
+                        Self::Skipped => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                        2 => std::borrow::Cow::Borrowed("FAILED"),
-                        3 => std::borrow::Cow::Borrowed("SKIPPED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                        Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                        Self::Failed => std::option::Option::Some("FAILED"),
+                        Self::Skipped => std::option::Option::Some("SKIPPED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                        "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                        "FAILED" => std::option::Option::Some(Self::FAILED),
-                        "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for State {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for State {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for State {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for State {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Succeeded,
+                        2 => Self::Failed,
+                        3 => Self::Skipped,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for State {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "STATE_UNSPECIFIED" => Self::Unspecified,
+                        "SUCCEEDED" => Self::Succeeded,
+                        "FAILED" => Self::Failed,
+                        "SKIPPED" => Self::Skipped,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for State {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Succeeded => serializer.serialize_i32(1),
+                        Self::Failed => serializer.serialize_i32(2),
+                        Self::Skipped => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for State {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                        ".google.cloud.dataplex.v1.DataProfileResult.PostScanActionsResult.BigQueryExportResult.State"))
                 }
             }
         }
@@ -9730,65 +10419,130 @@ pub mod data_quality_result {
             use super::*;
 
             /// Execution state for the exporting.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct State(i32);
-
-            impl State {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum State {
                 /// The exporting state is unspecified.
-                pub const STATE_UNSPECIFIED: State = State::new(0);
-
+                Unspecified,
                 /// The exporting completed successfully.
-                pub const SUCCEEDED: State = State::new(1);
-
+                Succeeded,
                 /// The exporting is no longer running due to an error.
-                pub const FAILED: State = State::new(2);
-
+                Failed,
                 /// The exporting is skipped due to no valid scan result to export
                 /// (usually caused by scan failed).
-                pub const SKIPPED: State = State::new(3);
+                Skipped,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [State::value] or
+                /// [State::name].
+                UnknownValue(state::UnknownValue),
+            }
 
-                /// Creates a new State instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl State {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Succeeded => std::option::Option::Some(1),
+                        Self::Failed => std::option::Option::Some(2),
+                        Self::Skipped => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                        2 => std::borrow::Cow::Borrowed("FAILED"),
-                        3 => std::borrow::Cow::Borrowed("SKIPPED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                        Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                        Self::Failed => std::option::Option::Some("FAILED"),
+                        Self::Skipped => std::option::Option::Some("SKIPPED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                        "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                        "FAILED" => std::option::Option::Some(Self::FAILED),
-                        "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for State {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for State {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for State {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for State {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Succeeded,
+                        2 => Self::Failed,
+                        3 => Self::Skipped,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for State {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "STATE_UNSPECIFIED" => Self::Unspecified,
+                        "SUCCEEDED" => Self::Succeeded,
+                        "FAILED" => Self::Failed,
+                        "SKIPPED" => Self::Skipped,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for State {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Succeeded => serializer.serialize_i32(1),
+                        Self::Failed => serializer.serialize_i32(2),
+                        Self::Skipped => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for State {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                        ".google.cloud.dataplex.v1.DataQualityResult.PostScanActionsResult.BigQueryExportResult.State"))
                 }
             }
         }
@@ -10754,64 +11508,129 @@ pub mod data_quality_rule {
         use super::*;
 
         /// The list of aggregate metrics a rule can be evaluated against.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ColumnStatistic(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ColumnStatistic {
+            /// Unspecified statistic type
+            StatisticUndefined,
+            /// Evaluate the column mean
+            Mean,
+            /// Evaluate the column min
+            Min,
+            /// Evaluate the column max
+            Max,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ColumnStatistic::value] or
+            /// [ColumnStatistic::name].
+            UnknownValue(column_statistic::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod column_statistic {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ColumnStatistic {
-            /// Unspecified statistic type
-            pub const STATISTIC_UNDEFINED: ColumnStatistic = ColumnStatistic::new(0);
-
-            /// Evaluate the column mean
-            pub const MEAN: ColumnStatistic = ColumnStatistic::new(1);
-
-            /// Evaluate the column min
-            pub const MIN: ColumnStatistic = ColumnStatistic::new(2);
-
-            /// Evaluate the column max
-            pub const MAX: ColumnStatistic = ColumnStatistic::new(3);
-
-            /// Creates a new ColumnStatistic instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::StatisticUndefined => std::option::Option::Some(0),
+                    Self::Mean => std::option::Option::Some(1),
+                    Self::Min => std::option::Option::Some(2),
+                    Self::Max => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATISTIC_UNDEFINED"),
-                    1 => std::borrow::Cow::Borrowed("MEAN"),
-                    2 => std::borrow::Cow::Borrowed("MIN"),
-                    3 => std::borrow::Cow::Borrowed("MAX"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::StatisticUndefined => std::option::Option::Some("STATISTIC_UNDEFINED"),
+                    Self::Mean => std::option::Option::Some("MEAN"),
+                    Self::Min => std::option::Option::Some("MIN"),
+                    Self::Max => std::option::Option::Some("MAX"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATISTIC_UNDEFINED" => std::option::Option::Some(Self::STATISTIC_UNDEFINED),
-                    "MEAN" => std::option::Option::Some(Self::MEAN),
-                    "MIN" => std::option::Option::Some(Self::MIN),
-                    "MAX" => std::option::Option::Some(Self::MAX),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ColumnStatistic {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ColumnStatistic {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ColumnStatistic {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ColumnStatistic {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::StatisticUndefined,
+                    1 => Self::Mean,
+                    2 => Self::Min,
+                    3 => Self::Max,
+                    _ => Self::UnknownValue(column_statistic::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ColumnStatistic {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATISTIC_UNDEFINED" => Self::StatisticUndefined,
+                    "MEAN" => Self::Mean,
+                    "MIN" => Self::Min,
+                    "MAX" => Self::Max,
+                    _ => Self::UnknownValue(column_statistic::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ColumnStatistic {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::StatisticUndefined => serializer.serialize_i32(0),
+                    Self::Mean => serializer.serialize_i32(1),
+                    Self::Min => serializer.serialize_i32(2),
+                    Self::Max => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ColumnStatistic {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ColumnStatistic>::new(
+                    ".google.cloud.dataplex.v1.DataQualityRule.StatisticRangeExpectation.ColumnStatistic"))
             }
         }
     }
@@ -12989,61 +13808,120 @@ pub mod get_data_scan_request {
     use super::*;
 
     /// DataScan view options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataScanView(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataScanView {
+        /// The API will default to the `BASIC` view.
+        Unspecified,
+        /// Basic view that does not include *spec* and *result*.
+        Basic,
+        /// Include everything.
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataScanView::value] or
+        /// [DataScanView::name].
+        UnknownValue(data_scan_view::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_scan_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataScanView {
-        /// The API will default to the `BASIC` view.
-        pub const DATA_SCAN_VIEW_UNSPECIFIED: DataScanView = DataScanView::new(0);
-
-        /// Basic view that does not include *spec* and *result*.
-        pub const BASIC: DataScanView = DataScanView::new(1);
-
-        /// Include everything.
-        pub const FULL: DataScanView = DataScanView::new(10);
-
-        /// Creates a new DataScanView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_SCAN_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                10 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_SCAN_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_SCAN_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_SCAN_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataScanView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataScanView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataScanView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataScanView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                10 => Self::Full,
+                _ => Self::UnknownValue(data_scan_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataScanView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_SCAN_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(data_scan_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataScanView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataScanView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataScanView>::new(
+                ".google.cloud.dataplex.v1.GetDataScanRequest.DataScanView",
+            ))
         }
     }
 }
@@ -13333,61 +14211,120 @@ pub mod get_data_scan_job_request {
     use super::*;
 
     /// DataScanJob view options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataScanJobView(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataScanJobView {
+        /// The API will default to the `BASIC` view.
+        Unspecified,
+        /// Basic view that does not include *spec* and *result*.
+        Basic,
+        /// Include everything.
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataScanJobView::value] or
+        /// [DataScanJobView::name].
+        UnknownValue(data_scan_job_view::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_scan_job_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataScanJobView {
-        /// The API will default to the `BASIC` view.
-        pub const DATA_SCAN_JOB_VIEW_UNSPECIFIED: DataScanJobView = DataScanJobView::new(0);
-
-        /// Basic view that does not include *spec* and *result*.
-        pub const BASIC: DataScanJobView = DataScanJobView::new(1);
-
-        /// Include everything.
-        pub const FULL: DataScanJobView = DataScanJobView::new(10);
-
-        /// Creates a new DataScanJobView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_SCAN_JOB_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                10 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_SCAN_JOB_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_SCAN_JOB_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_SCAN_JOB_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataScanJobView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataScanJobView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataScanJobView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataScanJobView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                10 => Self::Full,
+                _ => Self::UnknownValue(data_scan_job_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataScanJobView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_SCAN_JOB_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(data_scan_job_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataScanJobView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataScanJobView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataScanJobView>::new(
+                ".google.cloud.dataplex.v1.GetDataScanJobRequest.DataScanJobView",
+            ))
         }
     }
 }
@@ -14573,79 +15510,148 @@ pub mod data_scan_job {
     use super::*;
 
     /// Execution state for the DataScanJob.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The DataScanJob state is unspecified.
+        Unspecified,
+        /// The DataScanJob is running.
+        Running,
+        /// The DataScanJob is canceling.
+        Canceling,
+        /// The DataScanJob cancellation was successful.
+        Cancelled,
+        /// The DataScanJob completed successfully.
+        Succeeded,
+        /// The DataScanJob is no longer running due to an error.
+        Failed,
+        /// The DataScanJob has been created but not started to run yet.
+        Pending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The DataScanJob state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The DataScanJob is running.
-        pub const RUNNING: State = State::new(1);
-
-        /// The DataScanJob is canceling.
-        pub const CANCELING: State = State::new(2);
-
-        /// The DataScanJob cancellation was successful.
-        pub const CANCELLED: State = State::new(3);
-
-        /// The DataScanJob completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
-        /// The DataScanJob is no longer running due to an error.
-        pub const FAILED: State = State::new(5);
-
-        /// The DataScanJob has been created but not started to run yet.
-        pub const PENDING: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Canceling => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Pending => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("CANCELING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("PENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Canceling => std::option::Option::Some("CANCELING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "CANCELING" => std::option::Option::Some(Self::CANCELING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Canceling,
+                3 => Self::Cancelled,
+                4 => Self::Succeeded,
+                5 => Self::Failed,
+                7 => Self::Pending,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "CANCELING" => Self::Canceling,
+                "CANCELLED" => Self::Cancelled,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "PENDING" => Self::Pending,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Canceling => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Pending => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataplex.v1.DataScanJob.State",
+            ))
         }
     }
 
@@ -15190,225 +16196,426 @@ pub mod discovery_event {
     }
 
     /// The type of the event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// An unspecified event type.
+        Unspecified,
+        /// An event representing discovery configuration in effect.
+        Config,
+        /// An event representing a metadata entity being created.
+        EntityCreated,
+        /// An event representing a metadata entity being updated.
+        EntityUpdated,
+        /// An event representing a metadata entity being deleted.
+        EntityDeleted,
+        /// An event representing a partition being created.
+        PartitionCreated,
+        /// An event representing a partition being updated.
+        PartitionUpdated,
+        /// An event representing a partition being deleted.
+        PartitionDeleted,
+        /// An event representing a table being published.
+        TablePublished,
+        /// An event representing a table being updated.
+        TableUpdated,
+        /// An event representing a table being skipped in publishing.
+        TableIgnored,
+        /// An event representing a table being deleted.
+        TableDeleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// An unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// An event representing discovery configuration in effect.
-        pub const CONFIG: EventType = EventType::new(1);
-
-        /// An event representing a metadata entity being created.
-        pub const ENTITY_CREATED: EventType = EventType::new(2);
-
-        /// An event representing a metadata entity being updated.
-        pub const ENTITY_UPDATED: EventType = EventType::new(3);
-
-        /// An event representing a metadata entity being deleted.
-        pub const ENTITY_DELETED: EventType = EventType::new(4);
-
-        /// An event representing a partition being created.
-        pub const PARTITION_CREATED: EventType = EventType::new(5);
-
-        /// An event representing a partition being updated.
-        pub const PARTITION_UPDATED: EventType = EventType::new(6);
-
-        /// An event representing a partition being deleted.
-        pub const PARTITION_DELETED: EventType = EventType::new(7);
-
-        /// An event representing a table being published.
-        pub const TABLE_PUBLISHED: EventType = EventType::new(10);
-
-        /// An event representing a table being updated.
-        pub const TABLE_UPDATED: EventType = EventType::new(11);
-
-        /// An event representing a table being skipped in publishing.
-        pub const TABLE_IGNORED: EventType = EventType::new(12);
-
-        /// An event representing a table being deleted.
-        pub const TABLE_DELETED: EventType = EventType::new(13);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Config => std::option::Option::Some(1),
+                Self::EntityCreated => std::option::Option::Some(2),
+                Self::EntityUpdated => std::option::Option::Some(3),
+                Self::EntityDeleted => std::option::Option::Some(4),
+                Self::PartitionCreated => std::option::Option::Some(5),
+                Self::PartitionUpdated => std::option::Option::Some(6),
+                Self::PartitionDeleted => std::option::Option::Some(7),
+                Self::TablePublished => std::option::Option::Some(10),
+                Self::TableUpdated => std::option::Option::Some(11),
+                Self::TableIgnored => std::option::Option::Some(12),
+                Self::TableDeleted => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFIG"),
-                2 => std::borrow::Cow::Borrowed("ENTITY_CREATED"),
-                3 => std::borrow::Cow::Borrowed("ENTITY_UPDATED"),
-                4 => std::borrow::Cow::Borrowed("ENTITY_DELETED"),
-                5 => std::borrow::Cow::Borrowed("PARTITION_CREATED"),
-                6 => std::borrow::Cow::Borrowed("PARTITION_UPDATED"),
-                7 => std::borrow::Cow::Borrowed("PARTITION_DELETED"),
-                10 => std::borrow::Cow::Borrowed("TABLE_PUBLISHED"),
-                11 => std::borrow::Cow::Borrowed("TABLE_UPDATED"),
-                12 => std::borrow::Cow::Borrowed("TABLE_IGNORED"),
-                13 => std::borrow::Cow::Borrowed("TABLE_DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::Config => std::option::Option::Some("CONFIG"),
+                Self::EntityCreated => std::option::Option::Some("ENTITY_CREATED"),
+                Self::EntityUpdated => std::option::Option::Some("ENTITY_UPDATED"),
+                Self::EntityDeleted => std::option::Option::Some("ENTITY_DELETED"),
+                Self::PartitionCreated => std::option::Option::Some("PARTITION_CREATED"),
+                Self::PartitionUpdated => std::option::Option::Some("PARTITION_UPDATED"),
+                Self::PartitionDeleted => std::option::Option::Some("PARTITION_DELETED"),
+                Self::TablePublished => std::option::Option::Some("TABLE_PUBLISHED"),
+                Self::TableUpdated => std::option::Option::Some("TABLE_UPDATED"),
+                Self::TableIgnored => std::option::Option::Some("TABLE_IGNORED"),
+                Self::TableDeleted => std::option::Option::Some("TABLE_DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "CONFIG" => std::option::Option::Some(Self::CONFIG),
-                "ENTITY_CREATED" => std::option::Option::Some(Self::ENTITY_CREATED),
-                "ENTITY_UPDATED" => std::option::Option::Some(Self::ENTITY_UPDATED),
-                "ENTITY_DELETED" => std::option::Option::Some(Self::ENTITY_DELETED),
-                "PARTITION_CREATED" => std::option::Option::Some(Self::PARTITION_CREATED),
-                "PARTITION_UPDATED" => std::option::Option::Some(Self::PARTITION_UPDATED),
-                "PARTITION_DELETED" => std::option::Option::Some(Self::PARTITION_DELETED),
-                "TABLE_PUBLISHED" => std::option::Option::Some(Self::TABLE_PUBLISHED),
-                "TABLE_UPDATED" => std::option::Option::Some(Self::TABLE_UPDATED),
-                "TABLE_IGNORED" => std::option::Option::Some(Self::TABLE_IGNORED),
-                "TABLE_DELETED" => std::option::Option::Some(Self::TABLE_DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Config,
+                2 => Self::EntityCreated,
+                3 => Self::EntityUpdated,
+                4 => Self::EntityDeleted,
+                5 => Self::PartitionCreated,
+                6 => Self::PartitionUpdated,
+                7 => Self::PartitionDeleted,
+                10 => Self::TablePublished,
+                11 => Self::TableUpdated,
+                12 => Self::TableIgnored,
+                13 => Self::TableDeleted,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CONFIG" => Self::Config,
+                "ENTITY_CREATED" => Self::EntityCreated,
+                "ENTITY_UPDATED" => Self::EntityUpdated,
+                "ENTITY_DELETED" => Self::EntityDeleted,
+                "PARTITION_CREATED" => Self::PartitionCreated,
+                "PARTITION_UPDATED" => Self::PartitionUpdated,
+                "PARTITION_DELETED" => Self::PartitionDeleted,
+                "TABLE_PUBLISHED" => Self::TablePublished,
+                "TABLE_UPDATED" => Self::TableUpdated,
+                "TABLE_IGNORED" => Self::TableIgnored,
+                "TABLE_DELETED" => Self::TableDeleted,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Config => serializer.serialize_i32(1),
+                Self::EntityCreated => serializer.serialize_i32(2),
+                Self::EntityUpdated => serializer.serialize_i32(3),
+                Self::EntityDeleted => serializer.serialize_i32(4),
+                Self::PartitionCreated => serializer.serialize_i32(5),
+                Self::PartitionUpdated => serializer.serialize_i32(6),
+                Self::PartitionDeleted => serializer.serialize_i32(7),
+                Self::TablePublished => serializer.serialize_i32(10),
+                Self::TableUpdated => serializer.serialize_i32(11),
+                Self::TableIgnored => serializer.serialize_i32(12),
+                Self::TableDeleted => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.dataplex.v1.DiscoveryEvent.EventType",
+            ))
         }
     }
 
     /// The type of the entity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EntityType {
+        /// An unspecified event type.
+        Unspecified,
+        /// Entities representing structured data.
+        Table,
+        /// Entities representing unstructured data.
+        Fileset,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EntityType::value] or
+        /// [EntityType::name].
+        UnknownValue(entity_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod entity_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EntityType {
-        /// An unspecified event type.
-        pub const ENTITY_TYPE_UNSPECIFIED: EntityType = EntityType::new(0);
-
-        /// Entities representing structured data.
-        pub const TABLE: EntityType = EntityType::new(1);
-
-        /// Entities representing unstructured data.
-        pub const FILESET: EntityType = EntityType::new(2);
-
-        /// Creates a new EntityType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Table => std::option::Option::Some(1),
+                Self::Fileset => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENTITY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TABLE"),
-                2 => std::borrow::Cow::Borrowed("FILESET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENTITY_TYPE_UNSPECIFIED"),
+                Self::Table => std::option::Option::Some("TABLE"),
+                Self::Fileset => std::option::Option::Some("FILESET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENTITY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENTITY_TYPE_UNSPECIFIED)
-                }
-                "TABLE" => std::option::Option::Some(Self::TABLE),
-                "FILESET" => std::option::Option::Some(Self::FILESET),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EntityType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EntityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EntityType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Table,
+                2 => Self::Fileset,
+                _ => Self::UnknownValue(entity_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EntityType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENTITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TABLE" => Self::Table,
+                "FILESET" => Self::Fileset,
+                _ => Self::UnknownValue(entity_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EntityType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Table => serializer.serialize_i32(1),
+                Self::Fileset => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EntityType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityType>::new(
+                ".google.cloud.dataplex.v1.DiscoveryEvent.EntityType",
+            ))
         }
     }
 
     /// The type of the published table.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TableType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TableType {
+        /// An unspecified table type.
+        Unspecified,
+        /// External table type.
+        ExternalTable,
+        /// BigLake table type.
+        BiglakeTable,
+        /// Object table type for unstructured data.
+        ObjectTable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TableType::value] or
+        /// [TableType::name].
+        UnknownValue(table_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod table_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TableType {
-        /// An unspecified table type.
-        pub const TABLE_TYPE_UNSPECIFIED: TableType = TableType::new(0);
-
-        /// External table type.
-        pub const EXTERNAL_TABLE: TableType = TableType::new(1);
-
-        /// BigLake table type.
-        pub const BIGLAKE_TABLE: TableType = TableType::new(2);
-
-        /// Object table type for unstructured data.
-        pub const OBJECT_TABLE: TableType = TableType::new(3);
-
-        /// Creates a new TableType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ExternalTable => std::option::Option::Some(1),
+                Self::BiglakeTable => std::option::Option::Some(2),
+                Self::ObjectTable => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TABLE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXTERNAL_TABLE"),
-                2 => std::borrow::Cow::Borrowed("BIGLAKE_TABLE"),
-                3 => std::borrow::Cow::Borrowed("OBJECT_TABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TABLE_TYPE_UNSPECIFIED"),
+                Self::ExternalTable => std::option::Option::Some("EXTERNAL_TABLE"),
+                Self::BiglakeTable => std::option::Option::Some("BIGLAKE_TABLE"),
+                Self::ObjectTable => std::option::Option::Some("OBJECT_TABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TABLE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TABLE_TYPE_UNSPECIFIED),
-                "EXTERNAL_TABLE" => std::option::Option::Some(Self::EXTERNAL_TABLE),
-                "BIGLAKE_TABLE" => std::option::Option::Some(Self::BIGLAKE_TABLE),
-                "OBJECT_TABLE" => std::option::Option::Some(Self::OBJECT_TABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TableType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TableType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TableType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TableType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ExternalTable,
+                2 => Self::BiglakeTable,
+                3 => Self::ObjectTable,
+                _ => Self::UnknownValue(table_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TableType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TABLE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "EXTERNAL_TABLE" => Self::ExternalTable,
+                "BIGLAKE_TABLE" => Self::BiglakeTable,
+                "OBJECT_TABLE" => Self::ObjectTable,
+                _ => Self::UnknownValue(table_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TableType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ExternalTable => serializer.serialize_i32(1),
+                Self::BiglakeTable => serializer.serialize_i32(2),
+                Self::ObjectTable => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TableType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableType>::new(
+                ".google.cloud.dataplex.v1.DiscoveryEvent.TableType",
+            ))
         }
     }
 
@@ -15573,238 +16780,482 @@ pub mod job_event {
     use super::*;
 
     /// The type of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified job type.
+        Unspecified,
+        /// Spark jobs.
+        Spark,
+        /// Notebook jobs.
+        Notebook,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified job type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Spark jobs.
-        pub const SPARK: Type = Type::new(1);
-
-        /// Notebook jobs.
-        pub const NOTEBOOK: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Spark => std::option::Option::Some(1),
+                Self::Notebook => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SPARK"),
-                2 => std::borrow::Cow::Borrowed("NOTEBOOK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Spark => std::option::Option::Some("SPARK"),
+                Self::Notebook => std::option::Option::Some("NOTEBOOK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "SPARK" => std::option::Option::Some(Self::SPARK),
-                "NOTEBOOK" => std::option::Option::Some(Self::NOTEBOOK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Spark,
+                2 => Self::Notebook,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SPARK" => Self::Spark,
+                "NOTEBOOK" => Self::Notebook,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Spark => serializer.serialize_i32(1),
+                Self::Notebook => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dataplex.v1.JobEvent.Type",
+            ))
         }
     }
 
     /// The completion status of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified job state.
+        Unspecified,
+        /// Job successfully completed.
+        Succeeded,
+        /// Job was unsuccessful.
+        Failed,
+        /// Job was cancelled by the user.
+        Cancelled,
+        /// Job was cancelled or aborted via the service executing the job.
+        Aborted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified job state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Job successfully completed.
-        pub const SUCCEEDED: State = State::new(1);
-
-        /// Job was unsuccessful.
-        pub const FAILED: State = State::new(2);
-
-        /// Job was cancelled by the user.
-        pub const CANCELLED: State = State::new(3);
-
-        /// Job was cancelled or aborted via the service executing the job.
-        pub const ABORTED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Aborted => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("ABORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                3 => Self::Cancelled,
+                4 => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                "ABORTED" => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Aborted => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataplex.v1.JobEvent.State",
+            ))
         }
     }
 
     /// The service used to execute the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Service(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Service {
+        /// Unspecified service.
+        Unspecified,
+        /// Cloud Dataproc.
+        Dataproc,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Service::value] or
+        /// [Service::name].
+        UnknownValue(service::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod service {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Service {
-        /// Unspecified service.
-        pub const SERVICE_UNSPECIFIED: Service = Service::new(0);
-
-        /// Cloud Dataproc.
-        pub const DATAPROC: Service = Service::new(1);
-
-        /// Creates a new Service instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dataproc => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SERVICE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATAPROC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SERVICE_UNSPECIFIED"),
+                Self::Dataproc => std::option::Option::Some("DATAPROC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SERVICE_UNSPECIFIED" => std::option::Option::Some(Self::SERVICE_UNSPECIFIED),
-                "DATAPROC" => std::option::Option::Some(Self::DATAPROC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Service {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Service {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Service {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Service {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dataproc,
+                _ => Self::UnknownValue(service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Service {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SERVICE_UNSPECIFIED" => Self::Unspecified,
+                "DATAPROC" => Self::Dataproc,
+                _ => Self::UnknownValue(service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Service {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dataproc => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Service {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Service>::new(
+                ".google.cloud.dataplex.v1.JobEvent.Service",
+            ))
         }
     }
 
     /// Job Execution trigger.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionTrigger(i32);
-
-    impl ExecutionTrigger {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExecutionTrigger {
         /// The job execution trigger is unspecified.
-        pub const EXECUTION_TRIGGER_UNSPECIFIED: ExecutionTrigger = ExecutionTrigger::new(0);
-
+        Unspecified,
         /// The job was triggered by Dataplex based on trigger spec from task
         /// definition.
-        pub const TASK_CONFIG: ExecutionTrigger = ExecutionTrigger::new(1);
-
+        TaskConfig,
         /// The job was triggered by the explicit call of Task API.
-        pub const RUN_REQUEST: ExecutionTrigger = ExecutionTrigger::new(2);
+        RunRequest,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExecutionTrigger::value] or
+        /// [ExecutionTrigger::name].
+        UnknownValue(execution_trigger::UnknownValue),
+    }
 
-        /// Creates a new ExecutionTrigger instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod execution_trigger {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExecutionTrigger {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TaskConfig => std::option::Option::Some(1),
+                Self::RunRequest => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXECUTION_TRIGGER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TASK_CONFIG"),
-                2 => std::borrow::Cow::Borrowed("RUN_REQUEST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXECUTION_TRIGGER_UNSPECIFIED"),
+                Self::TaskConfig => std::option::Option::Some("TASK_CONFIG"),
+                Self::RunRequest => std::option::Option::Some("RUN_REQUEST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXECUTION_TRIGGER_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXECUTION_TRIGGER_UNSPECIFIED)
-                }
-                "TASK_CONFIG" => std::option::Option::Some(Self::TASK_CONFIG),
-                "RUN_REQUEST" => std::option::Option::Some(Self::RUN_REQUEST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExecutionTrigger {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionTrigger {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExecutionTrigger {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExecutionTrigger {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TaskConfig,
+                2 => Self::RunRequest,
+                _ => Self::UnknownValue(execution_trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExecutionTrigger {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXECUTION_TRIGGER_UNSPECIFIED" => Self::Unspecified,
+                "TASK_CONFIG" => Self::TaskConfig,
+                "RUN_REQUEST" => Self::RunRequest,
+                _ => Self::UnknownValue(execution_trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExecutionTrigger {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TaskConfig => serializer.serialize_i32(1),
+                Self::RunRequest => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExecutionTrigger {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionTrigger>::new(
+                ".google.cloud.dataplex.v1.JobEvent.ExecutionTrigger",
+            ))
         }
     }
 }
@@ -16059,128 +17510,257 @@ pub mod session_event {
         use super::*;
 
         /// Query Execution engine.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Engine(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Engine {
+            /// An unspecified Engine type.
+            Unspecified,
+            /// Spark-sql engine is specified in Query.
+            SparkSql,
+            /// BigQuery engine is specified in Query.
+            Bigquery,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Engine::value] or
+            /// [Engine::name].
+            UnknownValue(engine::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod engine {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Engine {
-            /// An unspecified Engine type.
-            pub const ENGINE_UNSPECIFIED: Engine = Engine::new(0);
-
-            /// Spark-sql engine is specified in Query.
-            pub const SPARK_SQL: Engine = Engine::new(1);
-
-            /// BigQuery engine is specified in Query.
-            pub const BIGQUERY: Engine = Engine::new(2);
-
-            /// Creates a new Engine instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SparkSql => std::option::Option::Some(1),
+                    Self::Bigquery => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENGINE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SPARK_SQL"),
-                    2 => std::borrow::Cow::Borrowed("BIGQUERY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENGINE_UNSPECIFIED"),
+                    Self::SparkSql => std::option::Option::Some("SPARK_SQL"),
+                    Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENGINE_UNSPECIFIED" => std::option::Option::Some(Self::ENGINE_UNSPECIFIED),
-                    "SPARK_SQL" => std::option::Option::Some(Self::SPARK_SQL),
-                    "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Engine {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Engine {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Engine {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Engine {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SparkSql,
+                    2 => Self::Bigquery,
+                    _ => Self::UnknownValue(engine::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Engine {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENGINE_UNSPECIFIED" => Self::Unspecified,
+                    "SPARK_SQL" => Self::SparkSql,
+                    "BIGQUERY" => Self::Bigquery,
+                    _ => Self::UnknownValue(engine::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Engine {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SparkSql => serializer.serialize_i32(1),
+                    Self::Bigquery => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Engine {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Engine>::new(
+                    ".google.cloud.dataplex.v1.SessionEvent.QueryDetail.Engine",
+                ))
             }
         }
     }
 
     /// The type of the event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
-
-    impl EventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
         /// An unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
+        Unspecified,
         /// Event when the session is assigned to a user.
-        pub const START: EventType = EventType::new(1);
-
+        Start,
         /// Event for stop of a session.
-        pub const STOP: EventType = EventType::new(2);
-
+        Stop,
         /// Query events in the session.
-        pub const QUERY: EventType = EventType::new(3);
-
+        Query,
         /// Event for creation of a cluster. It is not yet assigned to a user.
         /// This comes before START in the sequence
-        pub const CREATE: EventType = EventType::new(4);
+        Create,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
 
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Start => std::option::Option::Some(1),
+                Self::Stop => std::option::Option::Some(2),
+                Self::Query => std::option::Option::Some(3),
+                Self::Create => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("START"),
-                2 => std::borrow::Cow::Borrowed("STOP"),
-                3 => std::borrow::Cow::Borrowed("QUERY"),
-                4 => std::borrow::Cow::Borrowed("CREATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::Start => std::option::Option::Some("START"),
+                Self::Stop => std::option::Option::Some("STOP"),
+                Self::Query => std::option::Option::Some("QUERY"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "START" => std::option::Option::Some(Self::START),
-                "STOP" => std::option::Option::Some(Self::STOP),
-                "QUERY" => std::option::Option::Some(Self::QUERY),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Start,
+                2 => Self::Stop,
+                3 => Self::Query,
+                4 => Self::Create,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "START" => Self::Start,
+                "STOP" => Self::Stop,
+                "QUERY" => Self::Query,
+                "CREATE" => Self::Create,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Start => serializer.serialize_i32(1),
+                Self::Stop => serializer.serialize_i32(2),
+                Self::Query => serializer.serialize_i32(3),
+                Self::Create => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.dataplex.v1.SessionEvent.EventType",
+            ))
         }
     }
 
@@ -16313,211 +17893,362 @@ pub mod governance_event {
         use super::*;
 
         /// Type of entity.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EntityType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EntityType {
+            /// An unspecified Entity type.
+            Unspecified,
+            /// Table entity type.
+            Table,
+            /// Fileset entity type.
+            Fileset,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EntityType::value] or
+            /// [EntityType::name].
+            UnknownValue(entity_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod entity_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl EntityType {
-            /// An unspecified Entity type.
-            pub const ENTITY_TYPE_UNSPECIFIED: EntityType = EntityType::new(0);
-
-            /// Table entity type.
-            pub const TABLE: EntityType = EntityType::new(1);
-
-            /// Fileset entity type.
-            pub const FILESET: EntityType = EntityType::new(2);
-
-            /// Creates a new EntityType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Table => std::option::Option::Some(1),
+                    Self::Fileset => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENTITY_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TABLE"),
-                    2 => std::borrow::Cow::Borrowed("FILESET"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENTITY_TYPE_UNSPECIFIED"),
+                    Self::Table => std::option::Option::Some("TABLE"),
+                    Self::Fileset => std::option::Option::Some("FILESET"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENTITY_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ENTITY_TYPE_UNSPECIFIED)
-                    }
-                    "TABLE" => std::option::Option::Some(Self::TABLE),
-                    "FILESET" => std::option::Option::Some(Self::FILESET),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EntityType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EntityType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EntityType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EntityType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Table,
+                    2 => Self::Fileset,
+                    _ => Self::UnknownValue(entity_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EntityType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENTITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "TABLE" => Self::Table,
+                    "FILESET" => Self::Fileset,
+                    _ => Self::UnknownValue(entity_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EntityType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Table => serializer.serialize_i32(1),
+                    Self::Fileset => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EntityType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityType>::new(
+                    ".google.cloud.dataplex.v1.GovernanceEvent.Entity.EntityType",
+                ))
             }
         }
     }
 
     /// Type of governance log event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// An unspecified event type.
+        Unspecified,
+        /// Resource IAM policy update event.
+        ResourceIamPolicyUpdate,
+        /// BigQuery table create event.
+        BigqueryTableCreate,
+        /// BigQuery table update event.
+        BigqueryTableUpdate,
+        /// BigQuery table delete event.
+        BigqueryTableDelete,
+        /// BigQuery connection create event.
+        BigqueryConnectionCreate,
+        /// BigQuery connection update event.
+        BigqueryConnectionUpdate,
+        /// BigQuery connection delete event.
+        BigqueryConnectionDelete,
+        /// BigQuery taxonomy created.
+        BigqueryTaxonomyCreate,
+        /// BigQuery policy tag created.
+        BigqueryPolicyTagCreate,
+        /// BigQuery policy tag deleted.
+        BigqueryPolicyTagDelete,
+        /// BigQuery set iam policy for policy tag.
+        BigqueryPolicyTagSetIamPolicy,
+        /// Access policy update event.
+        AccessPolicyUpdate,
+        /// Number of resources matched with particular Query.
+        GovernanceRuleMatchedResources,
+        /// Rule processing exceeds the allowed limit.
+        GovernanceRuleSearchLimitExceeds,
+        /// Rule processing errors.
+        GovernanceRuleErrors,
+        /// Governance rule processing Event.
+        GovernanceRuleProcessing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// An unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// Resource IAM policy update event.
-        pub const RESOURCE_IAM_POLICY_UPDATE: EventType = EventType::new(1);
-
-        /// BigQuery table create event.
-        pub const BIGQUERY_TABLE_CREATE: EventType = EventType::new(2);
-
-        /// BigQuery table update event.
-        pub const BIGQUERY_TABLE_UPDATE: EventType = EventType::new(3);
-
-        /// BigQuery table delete event.
-        pub const BIGQUERY_TABLE_DELETE: EventType = EventType::new(4);
-
-        /// BigQuery connection create event.
-        pub const BIGQUERY_CONNECTION_CREATE: EventType = EventType::new(5);
-
-        /// BigQuery connection update event.
-        pub const BIGQUERY_CONNECTION_UPDATE: EventType = EventType::new(6);
-
-        /// BigQuery connection delete event.
-        pub const BIGQUERY_CONNECTION_DELETE: EventType = EventType::new(7);
-
-        /// BigQuery taxonomy created.
-        pub const BIGQUERY_TAXONOMY_CREATE: EventType = EventType::new(10);
-
-        /// BigQuery policy tag created.
-        pub const BIGQUERY_POLICY_TAG_CREATE: EventType = EventType::new(11);
-
-        /// BigQuery policy tag deleted.
-        pub const BIGQUERY_POLICY_TAG_DELETE: EventType = EventType::new(12);
-
-        /// BigQuery set iam policy for policy tag.
-        pub const BIGQUERY_POLICY_TAG_SET_IAM_POLICY: EventType = EventType::new(13);
-
-        /// Access policy update event.
-        pub const ACCESS_POLICY_UPDATE: EventType = EventType::new(14);
-
-        /// Number of resources matched with particular Query.
-        pub const GOVERNANCE_RULE_MATCHED_RESOURCES: EventType = EventType::new(15);
-
-        /// Rule processing exceeds the allowed limit.
-        pub const GOVERNANCE_RULE_SEARCH_LIMIT_EXCEEDS: EventType = EventType::new(16);
-
-        /// Rule processing errors.
-        pub const GOVERNANCE_RULE_ERRORS: EventType = EventType::new(17);
-
-        /// Governance rule processing Event.
-        pub const GOVERNANCE_RULE_PROCESSING: EventType = EventType::new(18);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ResourceIamPolicyUpdate => std::option::Option::Some(1),
+                Self::BigqueryTableCreate => std::option::Option::Some(2),
+                Self::BigqueryTableUpdate => std::option::Option::Some(3),
+                Self::BigqueryTableDelete => std::option::Option::Some(4),
+                Self::BigqueryConnectionCreate => std::option::Option::Some(5),
+                Self::BigqueryConnectionUpdate => std::option::Option::Some(6),
+                Self::BigqueryConnectionDelete => std::option::Option::Some(7),
+                Self::BigqueryTaxonomyCreate => std::option::Option::Some(10),
+                Self::BigqueryPolicyTagCreate => std::option::Option::Some(11),
+                Self::BigqueryPolicyTagDelete => std::option::Option::Some(12),
+                Self::BigqueryPolicyTagSetIamPolicy => std::option::Option::Some(13),
+                Self::AccessPolicyUpdate => std::option::Option::Some(14),
+                Self::GovernanceRuleMatchedResources => std::option::Option::Some(15),
+                Self::GovernanceRuleSearchLimitExceeds => std::option::Option::Some(16),
+                Self::GovernanceRuleErrors => std::option::Option::Some(17),
+                Self::GovernanceRuleProcessing => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESOURCE_IAM_POLICY_UPDATE"),
-                2 => std::borrow::Cow::Borrowed("BIGQUERY_TABLE_CREATE"),
-                3 => std::borrow::Cow::Borrowed("BIGQUERY_TABLE_UPDATE"),
-                4 => std::borrow::Cow::Borrowed("BIGQUERY_TABLE_DELETE"),
-                5 => std::borrow::Cow::Borrowed("BIGQUERY_CONNECTION_CREATE"),
-                6 => std::borrow::Cow::Borrowed("BIGQUERY_CONNECTION_UPDATE"),
-                7 => std::borrow::Cow::Borrowed("BIGQUERY_CONNECTION_DELETE"),
-                10 => std::borrow::Cow::Borrowed("BIGQUERY_TAXONOMY_CREATE"),
-                11 => std::borrow::Cow::Borrowed("BIGQUERY_POLICY_TAG_CREATE"),
-                12 => std::borrow::Cow::Borrowed("BIGQUERY_POLICY_TAG_DELETE"),
-                13 => std::borrow::Cow::Borrowed("BIGQUERY_POLICY_TAG_SET_IAM_POLICY"),
-                14 => std::borrow::Cow::Borrowed("ACCESS_POLICY_UPDATE"),
-                15 => std::borrow::Cow::Borrowed("GOVERNANCE_RULE_MATCHED_RESOURCES"),
-                16 => std::borrow::Cow::Borrowed("GOVERNANCE_RULE_SEARCH_LIMIT_EXCEEDS"),
-                17 => std::borrow::Cow::Borrowed("GOVERNANCE_RULE_ERRORS"),
-                18 => std::borrow::Cow::Borrowed("GOVERNANCE_RULE_PROCESSING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::ResourceIamPolicyUpdate => {
+                    std::option::Option::Some("RESOURCE_IAM_POLICY_UPDATE")
+                }
+                Self::BigqueryTableCreate => std::option::Option::Some("BIGQUERY_TABLE_CREATE"),
+                Self::BigqueryTableUpdate => std::option::Option::Some("BIGQUERY_TABLE_UPDATE"),
+                Self::BigqueryTableDelete => std::option::Option::Some("BIGQUERY_TABLE_DELETE"),
+                Self::BigqueryConnectionCreate => {
+                    std::option::Option::Some("BIGQUERY_CONNECTION_CREATE")
+                }
+                Self::BigqueryConnectionUpdate => {
+                    std::option::Option::Some("BIGQUERY_CONNECTION_UPDATE")
+                }
+                Self::BigqueryConnectionDelete => {
+                    std::option::Option::Some("BIGQUERY_CONNECTION_DELETE")
+                }
+                Self::BigqueryTaxonomyCreate => {
+                    std::option::Option::Some("BIGQUERY_TAXONOMY_CREATE")
+                }
+                Self::BigqueryPolicyTagCreate => {
+                    std::option::Option::Some("BIGQUERY_POLICY_TAG_CREATE")
+                }
+                Self::BigqueryPolicyTagDelete => {
+                    std::option::Option::Some("BIGQUERY_POLICY_TAG_DELETE")
+                }
+                Self::BigqueryPolicyTagSetIamPolicy => {
+                    std::option::Option::Some("BIGQUERY_POLICY_TAG_SET_IAM_POLICY")
+                }
+                Self::AccessPolicyUpdate => std::option::Option::Some("ACCESS_POLICY_UPDATE"),
+                Self::GovernanceRuleMatchedResources => {
+                    std::option::Option::Some("GOVERNANCE_RULE_MATCHED_RESOURCES")
+                }
+                Self::GovernanceRuleSearchLimitExceeds => {
+                    std::option::Option::Some("GOVERNANCE_RULE_SEARCH_LIMIT_EXCEEDS")
+                }
+                Self::GovernanceRuleErrors => std::option::Option::Some("GOVERNANCE_RULE_ERRORS"),
+                Self::GovernanceRuleProcessing => {
+                    std::option::Option::Some("GOVERNANCE_RULE_PROCESSING")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "RESOURCE_IAM_POLICY_UPDATE" => {
-                    std::option::Option::Some(Self::RESOURCE_IAM_POLICY_UPDATE)
-                }
-                "BIGQUERY_TABLE_CREATE" => std::option::Option::Some(Self::BIGQUERY_TABLE_CREATE),
-                "BIGQUERY_TABLE_UPDATE" => std::option::Option::Some(Self::BIGQUERY_TABLE_UPDATE),
-                "BIGQUERY_TABLE_DELETE" => std::option::Option::Some(Self::BIGQUERY_TABLE_DELETE),
-                "BIGQUERY_CONNECTION_CREATE" => {
-                    std::option::Option::Some(Self::BIGQUERY_CONNECTION_CREATE)
-                }
-                "BIGQUERY_CONNECTION_UPDATE" => {
-                    std::option::Option::Some(Self::BIGQUERY_CONNECTION_UPDATE)
-                }
-                "BIGQUERY_CONNECTION_DELETE" => {
-                    std::option::Option::Some(Self::BIGQUERY_CONNECTION_DELETE)
-                }
-                "BIGQUERY_TAXONOMY_CREATE" => {
-                    std::option::Option::Some(Self::BIGQUERY_TAXONOMY_CREATE)
-                }
-                "BIGQUERY_POLICY_TAG_CREATE" => {
-                    std::option::Option::Some(Self::BIGQUERY_POLICY_TAG_CREATE)
-                }
-                "BIGQUERY_POLICY_TAG_DELETE" => {
-                    std::option::Option::Some(Self::BIGQUERY_POLICY_TAG_DELETE)
-                }
-                "BIGQUERY_POLICY_TAG_SET_IAM_POLICY" => {
-                    std::option::Option::Some(Self::BIGQUERY_POLICY_TAG_SET_IAM_POLICY)
-                }
-                "ACCESS_POLICY_UPDATE" => std::option::Option::Some(Self::ACCESS_POLICY_UPDATE),
-                "GOVERNANCE_RULE_MATCHED_RESOURCES" => {
-                    std::option::Option::Some(Self::GOVERNANCE_RULE_MATCHED_RESOURCES)
-                }
-                "GOVERNANCE_RULE_SEARCH_LIMIT_EXCEEDS" => {
-                    std::option::Option::Some(Self::GOVERNANCE_RULE_SEARCH_LIMIT_EXCEEDS)
-                }
-                "GOVERNANCE_RULE_ERRORS" => std::option::Option::Some(Self::GOVERNANCE_RULE_ERRORS),
-                "GOVERNANCE_RULE_PROCESSING" => {
-                    std::option::Option::Some(Self::GOVERNANCE_RULE_PROCESSING)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ResourceIamPolicyUpdate,
+                2 => Self::BigqueryTableCreate,
+                3 => Self::BigqueryTableUpdate,
+                4 => Self::BigqueryTableDelete,
+                5 => Self::BigqueryConnectionCreate,
+                6 => Self::BigqueryConnectionUpdate,
+                7 => Self::BigqueryConnectionDelete,
+                10 => Self::BigqueryTaxonomyCreate,
+                11 => Self::BigqueryPolicyTagCreate,
+                12 => Self::BigqueryPolicyTagDelete,
+                13 => Self::BigqueryPolicyTagSetIamPolicy,
+                14 => Self::AccessPolicyUpdate,
+                15 => Self::GovernanceRuleMatchedResources,
+                16 => Self::GovernanceRuleSearchLimitExceeds,
+                17 => Self::GovernanceRuleErrors,
+                18 => Self::GovernanceRuleProcessing,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "RESOURCE_IAM_POLICY_UPDATE" => Self::ResourceIamPolicyUpdate,
+                "BIGQUERY_TABLE_CREATE" => Self::BigqueryTableCreate,
+                "BIGQUERY_TABLE_UPDATE" => Self::BigqueryTableUpdate,
+                "BIGQUERY_TABLE_DELETE" => Self::BigqueryTableDelete,
+                "BIGQUERY_CONNECTION_CREATE" => Self::BigqueryConnectionCreate,
+                "BIGQUERY_CONNECTION_UPDATE" => Self::BigqueryConnectionUpdate,
+                "BIGQUERY_CONNECTION_DELETE" => Self::BigqueryConnectionDelete,
+                "BIGQUERY_TAXONOMY_CREATE" => Self::BigqueryTaxonomyCreate,
+                "BIGQUERY_POLICY_TAG_CREATE" => Self::BigqueryPolicyTagCreate,
+                "BIGQUERY_POLICY_TAG_DELETE" => Self::BigqueryPolicyTagDelete,
+                "BIGQUERY_POLICY_TAG_SET_IAM_POLICY" => Self::BigqueryPolicyTagSetIamPolicy,
+                "ACCESS_POLICY_UPDATE" => Self::AccessPolicyUpdate,
+                "GOVERNANCE_RULE_MATCHED_RESOURCES" => Self::GovernanceRuleMatchedResources,
+                "GOVERNANCE_RULE_SEARCH_LIMIT_EXCEEDS" => Self::GovernanceRuleSearchLimitExceeds,
+                "GOVERNANCE_RULE_ERRORS" => Self::GovernanceRuleErrors,
+                "GOVERNANCE_RULE_PROCESSING" => Self::GovernanceRuleProcessing,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ResourceIamPolicyUpdate => serializer.serialize_i32(1),
+                Self::BigqueryTableCreate => serializer.serialize_i32(2),
+                Self::BigqueryTableUpdate => serializer.serialize_i32(3),
+                Self::BigqueryTableDelete => serializer.serialize_i32(4),
+                Self::BigqueryConnectionCreate => serializer.serialize_i32(5),
+                Self::BigqueryConnectionUpdate => serializer.serialize_i32(6),
+                Self::BigqueryConnectionDelete => serializer.serialize_i32(7),
+                Self::BigqueryTaxonomyCreate => serializer.serialize_i32(10),
+                Self::BigqueryPolicyTagCreate => serializer.serialize_i32(11),
+                Self::BigqueryPolicyTagDelete => serializer.serialize_i32(12),
+                Self::BigqueryPolicyTagSetIamPolicy => serializer.serialize_i32(13),
+                Self::AccessPolicyUpdate => serializer.serialize_i32(14),
+                Self::GovernanceRuleMatchedResources => serializer.serialize_i32(15),
+                Self::GovernanceRuleSearchLimitExceeds => serializer.serialize_i32(16),
+                Self::GovernanceRuleErrors => serializer.serialize_i32(17),
+                Self::GovernanceRuleProcessing => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.dataplex.v1.GovernanceEvent.EventType",
+            ))
         }
     }
 }
@@ -17202,315 +18933,632 @@ pub mod data_scan_event {
             use super::*;
 
             /// Execution state for the exporting.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct State(i32);
-
-            impl State {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum State {
                 /// The exporting state is unspecified.
-                pub const STATE_UNSPECIFIED: State = State::new(0);
-
+                Unspecified,
                 /// The exporting completed successfully.
-                pub const SUCCEEDED: State = State::new(1);
-
+                Succeeded,
                 /// The exporting is no longer running due to an error.
-                pub const FAILED: State = State::new(2);
-
+                Failed,
                 /// The exporting is skipped due to no valid scan result to export
                 /// (usually caused by scan failed).
-                pub const SKIPPED: State = State::new(3);
+                Skipped,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [State::value] or
+                /// [State::name].
+                UnknownValue(state::UnknownValue),
+            }
 
-                /// Creates a new State instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl State {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Succeeded => std::option::Option::Some(1),
+                        Self::Failed => std::option::Option::Some(2),
+                        Self::Skipped => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                        2 => std::borrow::Cow::Borrowed("FAILED"),
-                        3 => std::borrow::Cow::Borrowed("SKIPPED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                        Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                        Self::Failed => std::option::Option::Some("FAILED"),
+                        Self::Skipped => std::option::Option::Some("SKIPPED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                        "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                        "FAILED" => std::option::Option::Some(Self::FAILED),
-                        "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for State {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for State {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for State {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for State {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Succeeded,
+                        2 => Self::Failed,
+                        3 => Self::Skipped,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for State {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "STATE_UNSPECIFIED" => Self::Unspecified,
+                        "SUCCEEDED" => Self::Succeeded,
+                        "FAILED" => Self::Failed,
+                        "SKIPPED" => Self::Skipped,
+                        _ => Self::UnknownValue(state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for State {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Succeeded => serializer.serialize_i32(1),
+                        Self::Failed => serializer.serialize_i32(2),
+                        Self::Skipped => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for State {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                        ".google.cloud.dataplex.v1.DataScanEvent.PostScanActionsResult.BigQueryExportResult.State"))
                 }
             }
         }
     }
 
     /// The type of the data scan.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ScanType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ScanType {
+        /// An unspecified data scan type.
+        Unspecified,
+        /// Data scan for data profile.
+        DataProfile,
+        /// Data scan for data quality.
+        DataQuality,
+        /// Data scan for data discovery.
+        DataDiscovery,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ScanType::value] or
+        /// [ScanType::name].
+        UnknownValue(scan_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scan_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ScanType {
-        /// An unspecified data scan type.
-        pub const SCAN_TYPE_UNSPECIFIED: ScanType = ScanType::new(0);
-
-        /// Data scan for data profile.
-        pub const DATA_PROFILE: ScanType = ScanType::new(1);
-
-        /// Data scan for data quality.
-        pub const DATA_QUALITY: ScanType = ScanType::new(2);
-
-        /// Data scan for data discovery.
-        pub const DATA_DISCOVERY: ScanType = ScanType::new(4);
-
-        /// Creates a new ScanType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DataProfile => std::option::Option::Some(1),
+                Self::DataQuality => std::option::Option::Some(2),
+                Self::DataDiscovery => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCAN_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATA_PROFILE"),
-                2 => std::borrow::Cow::Borrowed("DATA_QUALITY"),
-                4 => std::borrow::Cow::Borrowed("DATA_DISCOVERY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCAN_TYPE_UNSPECIFIED"),
+                Self::DataProfile => std::option::Option::Some("DATA_PROFILE"),
+                Self::DataQuality => std::option::Option::Some("DATA_QUALITY"),
+                Self::DataDiscovery => std::option::Option::Some("DATA_DISCOVERY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCAN_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SCAN_TYPE_UNSPECIFIED),
-                "DATA_PROFILE" => std::option::Option::Some(Self::DATA_PROFILE),
-                "DATA_QUALITY" => std::option::Option::Some(Self::DATA_QUALITY),
-                "DATA_DISCOVERY" => std::option::Option::Some(Self::DATA_DISCOVERY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ScanType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ScanType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ScanType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ScanType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DataProfile,
+                2 => Self::DataQuality,
+                4 => Self::DataDiscovery,
+                _ => Self::UnknownValue(scan_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ScanType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCAN_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DATA_PROFILE" => Self::DataProfile,
+                "DATA_QUALITY" => Self::DataQuality,
+                "DATA_DISCOVERY" => Self::DataDiscovery,
+                _ => Self::UnknownValue(scan_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ScanType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DataProfile => serializer.serialize_i32(1),
+                Self::DataQuality => serializer.serialize_i32(2),
+                Self::DataDiscovery => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ScanType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ScanType>::new(
+                ".google.cloud.dataplex.v1.DataScanEvent.ScanType",
+            ))
         }
     }
 
     /// The job state of the data scan.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified job state.
+        Unspecified,
+        /// Data scan job started.
+        Started,
+        /// Data scan job successfully completed.
+        Succeeded,
+        /// Data scan job was unsuccessful.
+        Failed,
+        /// Data scan job was cancelled.
+        Cancelled,
+        /// Data scan job was createed.
+        Created,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified job state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Data scan job started.
-        pub const STARTED: State = State::new(1);
-
-        /// Data scan job successfully completed.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// Data scan job was unsuccessful.
-        pub const FAILED: State = State::new(3);
-
-        /// Data scan job was cancelled.
-        pub const CANCELLED: State = State::new(4);
-
-        /// Data scan job was createed.
-        pub const CREATED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Started => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::Created => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STARTED"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                5 => std::borrow::Cow::Borrowed("CREATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Started => std::option::Option::Some("STARTED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STARTED" => std::option::Option::Some(Self::STARTED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Started,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelled,
+                5 => Self::Created,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STARTED" => Self::Started,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                "CREATED" => Self::Created,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Started => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::Created => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataplex.v1.DataScanEvent.State",
+            ))
         }
     }
 
     /// The trigger type for the data scan.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Trigger(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Trigger {
+        /// An unspecified trigger type.
+        Unspecified,
+        /// Data scan triggers on demand.
+        OnDemand,
+        /// Data scan triggers as per schedule.
+        Schedule,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Trigger::value] or
+        /// [Trigger::name].
+        UnknownValue(trigger::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod trigger {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Trigger {
-        /// An unspecified trigger type.
-        pub const TRIGGER_UNSPECIFIED: Trigger = Trigger::new(0);
-
-        /// Data scan triggers on demand.
-        pub const ON_DEMAND: Trigger = Trigger::new(1);
-
-        /// Data scan triggers as per schedule.
-        pub const SCHEDULE: Trigger = Trigger::new(2);
-
-        /// Creates a new Trigger instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OnDemand => std::option::Option::Some(1),
+                Self::Schedule => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRIGGER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                2 => std::borrow::Cow::Borrowed("SCHEDULE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRIGGER_UNSPECIFIED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::Schedule => std::option::Option::Some("SCHEDULE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRIGGER_UNSPECIFIED" => std::option::Option::Some(Self::TRIGGER_UNSPECIFIED),
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                "SCHEDULE" => std::option::Option::Some(Self::SCHEDULE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Trigger {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Trigger {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Trigger {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Trigger {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OnDemand,
+                2 => Self::Schedule,
+                _ => Self::UnknownValue(trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Trigger {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRIGGER_UNSPECIFIED" => Self::Unspecified,
+                "ON_DEMAND" => Self::OnDemand,
+                "SCHEDULE" => Self::Schedule,
+                _ => Self::UnknownValue(trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Trigger {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OnDemand => serializer.serialize_i32(1),
+                Self::Schedule => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Trigger {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Trigger>::new(
+                ".google.cloud.dataplex.v1.DataScanEvent.Trigger",
+            ))
         }
     }
 
     /// The scope of job for the data scan.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
+        /// An unspecified scope type.
+        Unspecified,
+        /// Data scan runs on all of the data.
+        Full,
+        /// Data scan runs on incremental data.
+        Incremental,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Scope {
-        /// An unspecified scope type.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
-
-        /// Data scan runs on all of the data.
-        pub const FULL: Scope = Scope::new(1);
-
-        /// Data scan runs on incremental data.
-        pub const INCREMENTAL: Scope = Scope::new(2);
-
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Full => std::option::Option::Some(1),
+                Self::Incremental => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FULL"),
-                2 => std::borrow::Cow::Borrowed("INCREMENTAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCOPE_UNSPECIFIED"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::Incremental => std::option::Option::Some("INCREMENTAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Full,
+                2 => Self::Incremental,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "FULL" => Self::Full,
+                "INCREMENTAL" => Self::Incremental,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Full => serializer.serialize_i32(1),
+                Self::Incremental => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".google.cloud.dataplex.v1.DataScanEvent.Scope",
+            ))
         }
     }
 
@@ -17719,243 +19767,438 @@ pub mod data_quality_scan_rule_result {
     use super::*;
 
     /// The type of the data quality rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RuleType(i32);
-
-    impl RuleType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RuleType {
         /// An unspecified rule type.
-        pub const RULE_TYPE_UNSPECIFIED: RuleType = RuleType::new(0);
-
+        Unspecified,
         /// See
         /// [DataQualityRule.NonNullExpectation][google.cloud.dataplex.v1.DataQualityRule.NonNullExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.NonNullExpectation]: crate::model::data_quality_rule::NonNullExpectation
-        pub const NON_NULL_EXPECTATION: RuleType = RuleType::new(1);
-
+        NonNullExpectation,
         /// See
         /// [DataQualityRule.RangeExpectation][google.cloud.dataplex.v1.DataQualityRule.RangeExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.RangeExpectation]: crate::model::data_quality_rule::RangeExpectation
-        pub const RANGE_EXPECTATION: RuleType = RuleType::new(2);
-
+        RangeExpectation,
         /// See
         /// [DataQualityRule.RegexExpectation][google.cloud.dataplex.v1.DataQualityRule.RegexExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.RegexExpectation]: crate::model::data_quality_rule::RegexExpectation
-        pub const REGEX_EXPECTATION: RuleType = RuleType::new(3);
-
+        RegexExpectation,
         /// See
         /// [DataQualityRule.RowConditionExpectation][google.cloud.dataplex.v1.DataQualityRule.RowConditionExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.RowConditionExpectation]: crate::model::data_quality_rule::RowConditionExpectation
-        pub const ROW_CONDITION_EXPECTATION: RuleType = RuleType::new(4);
-
+        RowConditionExpectation,
         /// See
         /// [DataQualityRule.SetExpectation][google.cloud.dataplex.v1.DataQualityRule.SetExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.SetExpectation]: crate::model::data_quality_rule::SetExpectation
-        pub const SET_EXPECTATION: RuleType = RuleType::new(5);
-
+        SetExpectation,
         /// See
         /// [DataQualityRule.StatisticRangeExpectation][google.cloud.dataplex.v1.DataQualityRule.StatisticRangeExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.StatisticRangeExpectation]: crate::model::data_quality_rule::StatisticRangeExpectation
-        pub const STATISTIC_RANGE_EXPECTATION: RuleType = RuleType::new(6);
-
+        StatisticRangeExpectation,
         /// See
         /// [DataQualityRule.TableConditionExpectation][google.cloud.dataplex.v1.DataQualityRule.TableConditionExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.TableConditionExpectation]: crate::model::data_quality_rule::TableConditionExpectation
-        pub const TABLE_CONDITION_EXPECTATION: RuleType = RuleType::new(7);
-
+        TableConditionExpectation,
         /// See
         /// [DataQualityRule.UniquenessExpectation][google.cloud.dataplex.v1.DataQualityRule.UniquenessExpectation].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.UniquenessExpectation]: crate::model::data_quality_rule::UniquenessExpectation
-        pub const UNIQUENESS_EXPECTATION: RuleType = RuleType::new(8);
-
+        UniquenessExpectation,
         /// See
         /// [DataQualityRule.SqlAssertion][google.cloud.dataplex.v1.DataQualityRule.SqlAssertion].
         ///
         /// [google.cloud.dataplex.v1.DataQualityRule.SqlAssertion]: crate::model::data_quality_rule::SqlAssertion
-        pub const SQL_ASSERTION: RuleType = RuleType::new(9);
+        SqlAssertion,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RuleType::value] or
+        /// [RuleType::name].
+        UnknownValue(rule_type::UnknownValue),
+    }
 
-        /// Creates a new RuleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod rule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RuleType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NonNullExpectation => std::option::Option::Some(1),
+                Self::RangeExpectation => std::option::Option::Some(2),
+                Self::RegexExpectation => std::option::Option::Some(3),
+                Self::RowConditionExpectation => std::option::Option::Some(4),
+                Self::SetExpectation => std::option::Option::Some(5),
+                Self::StatisticRangeExpectation => std::option::Option::Some(6),
+                Self::TableConditionExpectation => std::option::Option::Some(7),
+                Self::UniquenessExpectation => std::option::Option::Some(8),
+                Self::SqlAssertion => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NON_NULL_EXPECTATION"),
-                2 => std::borrow::Cow::Borrowed("RANGE_EXPECTATION"),
-                3 => std::borrow::Cow::Borrowed("REGEX_EXPECTATION"),
-                4 => std::borrow::Cow::Borrowed("ROW_CONDITION_EXPECTATION"),
-                5 => std::borrow::Cow::Borrowed("SET_EXPECTATION"),
-                6 => std::borrow::Cow::Borrowed("STATISTIC_RANGE_EXPECTATION"),
-                7 => std::borrow::Cow::Borrowed("TABLE_CONDITION_EXPECTATION"),
-                8 => std::borrow::Cow::Borrowed("UNIQUENESS_EXPECTATION"),
-                9 => std::borrow::Cow::Borrowed("SQL_ASSERTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RULE_TYPE_UNSPECIFIED"),
+                Self::NonNullExpectation => std::option::Option::Some("NON_NULL_EXPECTATION"),
+                Self::RangeExpectation => std::option::Option::Some("RANGE_EXPECTATION"),
+                Self::RegexExpectation => std::option::Option::Some("REGEX_EXPECTATION"),
+                Self::RowConditionExpectation => {
+                    std::option::Option::Some("ROW_CONDITION_EXPECTATION")
+                }
+                Self::SetExpectation => std::option::Option::Some("SET_EXPECTATION"),
+                Self::StatisticRangeExpectation => {
+                    std::option::Option::Some("STATISTIC_RANGE_EXPECTATION")
+                }
+                Self::TableConditionExpectation => {
+                    std::option::Option::Some("TABLE_CONDITION_EXPECTATION")
+                }
+                Self::UniquenessExpectation => std::option::Option::Some("UNIQUENESS_EXPECTATION"),
+                Self::SqlAssertion => std::option::Option::Some("SQL_ASSERTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RULE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RULE_TYPE_UNSPECIFIED),
-                "NON_NULL_EXPECTATION" => std::option::Option::Some(Self::NON_NULL_EXPECTATION),
-                "RANGE_EXPECTATION" => std::option::Option::Some(Self::RANGE_EXPECTATION),
-                "REGEX_EXPECTATION" => std::option::Option::Some(Self::REGEX_EXPECTATION),
-                "ROW_CONDITION_EXPECTATION" => {
-                    std::option::Option::Some(Self::ROW_CONDITION_EXPECTATION)
-                }
-                "SET_EXPECTATION" => std::option::Option::Some(Self::SET_EXPECTATION),
-                "STATISTIC_RANGE_EXPECTATION" => {
-                    std::option::Option::Some(Self::STATISTIC_RANGE_EXPECTATION)
-                }
-                "TABLE_CONDITION_EXPECTATION" => {
-                    std::option::Option::Some(Self::TABLE_CONDITION_EXPECTATION)
-                }
-                "UNIQUENESS_EXPECTATION" => std::option::Option::Some(Self::UNIQUENESS_EXPECTATION),
-                "SQL_ASSERTION" => std::option::Option::Some(Self::SQL_ASSERTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RuleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RuleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RuleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RuleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NonNullExpectation,
+                2 => Self::RangeExpectation,
+                3 => Self::RegexExpectation,
+                4 => Self::RowConditionExpectation,
+                5 => Self::SetExpectation,
+                6 => Self::StatisticRangeExpectation,
+                7 => Self::TableConditionExpectation,
+                8 => Self::UniquenessExpectation,
+                9 => Self::SqlAssertion,
+                _ => Self::UnknownValue(rule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RuleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NON_NULL_EXPECTATION" => Self::NonNullExpectation,
+                "RANGE_EXPECTATION" => Self::RangeExpectation,
+                "REGEX_EXPECTATION" => Self::RegexExpectation,
+                "ROW_CONDITION_EXPECTATION" => Self::RowConditionExpectation,
+                "SET_EXPECTATION" => Self::SetExpectation,
+                "STATISTIC_RANGE_EXPECTATION" => Self::StatisticRangeExpectation,
+                "TABLE_CONDITION_EXPECTATION" => Self::TableConditionExpectation,
+                "UNIQUENESS_EXPECTATION" => Self::UniquenessExpectation,
+                "SQL_ASSERTION" => Self::SqlAssertion,
+                _ => Self::UnknownValue(rule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RuleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NonNullExpectation => serializer.serialize_i32(1),
+                Self::RangeExpectation => serializer.serialize_i32(2),
+                Self::RegexExpectation => serializer.serialize_i32(3),
+                Self::RowConditionExpectation => serializer.serialize_i32(4),
+                Self::SetExpectation => serializer.serialize_i32(5),
+                Self::StatisticRangeExpectation => serializer.serialize_i32(6),
+                Self::TableConditionExpectation => serializer.serialize_i32(7),
+                Self::UniquenessExpectation => serializer.serialize_i32(8),
+                Self::SqlAssertion => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RuleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RuleType>::new(
+                ".google.cloud.dataplex.v1.DataQualityScanRuleResult.RuleType",
+            ))
         }
     }
 
     /// The evaluation type of the data quality rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EvaluationType {
+        /// An unspecified evaluation type.
+        Unspecified,
+        /// The rule evaluation is done at per row level.
+        PerRow,
+        /// The rule evaluation is done for an aggregate of rows.
+        Aggregate,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EvaluationType::value] or
+        /// [EvaluationType::name].
+        UnknownValue(evaluation_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod evaluation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EvaluationType {
-        /// An unspecified evaluation type.
-        pub const EVALUATION_TYPE_UNSPECIFIED: EvaluationType = EvaluationType::new(0);
-
-        /// The rule evaluation is done at per row level.
-        pub const PER_ROW: EvaluationType = EvaluationType::new(1);
-
-        /// The rule evaluation is done for an aggregate of rows.
-        pub const AGGREGATE: EvaluationType = EvaluationType::new(2);
-
-        /// Creates a new EvaluationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PerRow => std::option::Option::Some(1),
+                Self::Aggregate => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVALUATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PER_ROW"),
-                2 => std::borrow::Cow::Borrowed("AGGREGATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVALUATION_TYPE_UNSPECIFIED"),
+                Self::PerRow => std::option::Option::Some("PER_ROW"),
+                Self::Aggregate => std::option::Option::Some("AGGREGATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVALUATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVALUATION_TYPE_UNSPECIFIED)
-                }
-                "PER_ROW" => std::option::Option::Some(Self::PER_ROW),
-                "AGGREGATE" => std::option::Option::Some(Self::AGGREGATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EvaluationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EvaluationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EvaluationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PerRow,
+                2 => Self::Aggregate,
+                _ => Self::UnknownValue(evaluation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EvaluationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVALUATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PER_ROW" => Self::PerRow,
+                "AGGREGATE" => Self::Aggregate,
+                _ => Self::UnknownValue(evaluation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EvaluationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PerRow => serializer.serialize_i32(1),
+                Self::Aggregate => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EvaluationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EvaluationType>::new(
+                ".google.cloud.dataplex.v1.DataQualityScanRuleResult.EvaluationType",
+            ))
         }
     }
 
     /// Whether the data quality rule passed or failed.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Result {
+        /// An unspecified result.
+        Unspecified,
+        /// The data quality rule passed.
+        Passed,
+        /// The data quality rule failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Result::value] or
+        /// [Result::name].
+        UnknownValue(result::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Result {
-        /// An unspecified result.
-        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
-
-        /// The data quality rule passed.
-        pub const PASSED: Result = Result::new(1);
-
-        /// The data quality rule failed.
-        pub const FAILED: Result = Result::new(2);
-
-        /// Creates a new Result instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Passed => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PASSED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESULT_UNSPECIFIED"),
+                Self::Passed => std::option::Option::Some("PASSED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
-                "PASSED" => std::option::Option::Some(Self::PASSED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Result {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Passed,
+                2 => Self::Failed,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Result {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESULT_UNSPECIFIED" => Self::Unspecified,
+                "PASSED" => Self::Passed,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Result {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Passed => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Result {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Result>::new(
+                ".google.cloud.dataplex.v1.DataQualityScanRuleResult.Result",
+            ))
         }
     }
 }
@@ -18022,100 +20265,175 @@ pub mod business_glossary_event {
     use super::*;
 
     /// Type of glossary log event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// An unspecified event type.
+        Unspecified,
+        /// Glossary create event.
+        GlossaryCreate,
+        /// Glossary update event.
+        GlossaryUpdate,
+        /// Glossary delete event.
+        GlossaryDelete,
+        /// Glossary category create event.
+        GlossaryCategoryCreate,
+        /// Glossary category update event.
+        GlossaryCategoryUpdate,
+        /// Glossary category delete event.
+        GlossaryCategoryDelete,
+        /// Glossary term create event.
+        GlossaryTermCreate,
+        /// Glossary term update event.
+        GlossaryTermUpdate,
+        /// Glossary term delete event.
+        GlossaryTermDelete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// An unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// Glossary create event.
-        pub const GLOSSARY_CREATE: EventType = EventType::new(1);
-
-        /// Glossary update event.
-        pub const GLOSSARY_UPDATE: EventType = EventType::new(2);
-
-        /// Glossary delete event.
-        pub const GLOSSARY_DELETE: EventType = EventType::new(3);
-
-        /// Glossary category create event.
-        pub const GLOSSARY_CATEGORY_CREATE: EventType = EventType::new(4);
-
-        /// Glossary category update event.
-        pub const GLOSSARY_CATEGORY_UPDATE: EventType = EventType::new(5);
-
-        /// Glossary category delete event.
-        pub const GLOSSARY_CATEGORY_DELETE: EventType = EventType::new(6);
-
-        /// Glossary term create event.
-        pub const GLOSSARY_TERM_CREATE: EventType = EventType::new(7);
-
-        /// Glossary term update event.
-        pub const GLOSSARY_TERM_UPDATE: EventType = EventType::new(8);
-
-        /// Glossary term delete event.
-        pub const GLOSSARY_TERM_DELETE: EventType = EventType::new(9);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GlossaryCreate => std::option::Option::Some(1),
+                Self::GlossaryUpdate => std::option::Option::Some(2),
+                Self::GlossaryDelete => std::option::Option::Some(3),
+                Self::GlossaryCategoryCreate => std::option::Option::Some(4),
+                Self::GlossaryCategoryUpdate => std::option::Option::Some(5),
+                Self::GlossaryCategoryDelete => std::option::Option::Some(6),
+                Self::GlossaryTermCreate => std::option::Option::Some(7),
+                Self::GlossaryTermUpdate => std::option::Option::Some(8),
+                Self::GlossaryTermDelete => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GLOSSARY_CREATE"),
-                2 => std::borrow::Cow::Borrowed("GLOSSARY_UPDATE"),
-                3 => std::borrow::Cow::Borrowed("GLOSSARY_DELETE"),
-                4 => std::borrow::Cow::Borrowed("GLOSSARY_CATEGORY_CREATE"),
-                5 => std::borrow::Cow::Borrowed("GLOSSARY_CATEGORY_UPDATE"),
-                6 => std::borrow::Cow::Borrowed("GLOSSARY_CATEGORY_DELETE"),
-                7 => std::borrow::Cow::Borrowed("GLOSSARY_TERM_CREATE"),
-                8 => std::borrow::Cow::Borrowed("GLOSSARY_TERM_UPDATE"),
-                9 => std::borrow::Cow::Borrowed("GLOSSARY_TERM_DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::GlossaryCreate => std::option::Option::Some("GLOSSARY_CREATE"),
+                Self::GlossaryUpdate => std::option::Option::Some("GLOSSARY_UPDATE"),
+                Self::GlossaryDelete => std::option::Option::Some("GLOSSARY_DELETE"),
+                Self::GlossaryCategoryCreate => {
+                    std::option::Option::Some("GLOSSARY_CATEGORY_CREATE")
+                }
+                Self::GlossaryCategoryUpdate => {
+                    std::option::Option::Some("GLOSSARY_CATEGORY_UPDATE")
+                }
+                Self::GlossaryCategoryDelete => {
+                    std::option::Option::Some("GLOSSARY_CATEGORY_DELETE")
+                }
+                Self::GlossaryTermCreate => std::option::Option::Some("GLOSSARY_TERM_CREATE"),
+                Self::GlossaryTermUpdate => std::option::Option::Some("GLOSSARY_TERM_UPDATE"),
+                Self::GlossaryTermDelete => std::option::Option::Some("GLOSSARY_TERM_DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "GLOSSARY_CREATE" => std::option::Option::Some(Self::GLOSSARY_CREATE),
-                "GLOSSARY_UPDATE" => std::option::Option::Some(Self::GLOSSARY_UPDATE),
-                "GLOSSARY_DELETE" => std::option::Option::Some(Self::GLOSSARY_DELETE),
-                "GLOSSARY_CATEGORY_CREATE" => {
-                    std::option::Option::Some(Self::GLOSSARY_CATEGORY_CREATE)
-                }
-                "GLOSSARY_CATEGORY_UPDATE" => {
-                    std::option::Option::Some(Self::GLOSSARY_CATEGORY_UPDATE)
-                }
-                "GLOSSARY_CATEGORY_DELETE" => {
-                    std::option::Option::Some(Self::GLOSSARY_CATEGORY_DELETE)
-                }
-                "GLOSSARY_TERM_CREATE" => std::option::Option::Some(Self::GLOSSARY_TERM_CREATE),
-                "GLOSSARY_TERM_UPDATE" => std::option::Option::Some(Self::GLOSSARY_TERM_UPDATE),
-                "GLOSSARY_TERM_DELETE" => std::option::Option::Some(Self::GLOSSARY_TERM_DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GlossaryCreate,
+                2 => Self::GlossaryUpdate,
+                3 => Self::GlossaryDelete,
+                4 => Self::GlossaryCategoryCreate,
+                5 => Self::GlossaryCategoryUpdate,
+                6 => Self::GlossaryCategoryDelete,
+                7 => Self::GlossaryTermCreate,
+                8 => Self::GlossaryTermUpdate,
+                9 => Self::GlossaryTermDelete,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GLOSSARY_CREATE" => Self::GlossaryCreate,
+                "GLOSSARY_UPDATE" => Self::GlossaryUpdate,
+                "GLOSSARY_DELETE" => Self::GlossaryDelete,
+                "GLOSSARY_CATEGORY_CREATE" => Self::GlossaryCategoryCreate,
+                "GLOSSARY_CATEGORY_UPDATE" => Self::GlossaryCategoryUpdate,
+                "GLOSSARY_CATEGORY_DELETE" => Self::GlossaryCategoryDelete,
+                "GLOSSARY_TERM_CREATE" => Self::GlossaryTermCreate,
+                "GLOSSARY_TERM_UPDATE" => Self::GlossaryTermUpdate,
+                "GLOSSARY_TERM_DELETE" => Self::GlossaryTermDelete,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GlossaryCreate => serializer.serialize_i32(1),
+                Self::GlossaryUpdate => serializer.serialize_i32(2),
+                Self::GlossaryDelete => serializer.serialize_i32(3),
+                Self::GlossaryCategoryCreate => serializer.serialize_i32(4),
+                Self::GlossaryCategoryUpdate => serializer.serialize_i32(5),
+                Self::GlossaryCategoryDelete => serializer.serialize_i32(6),
+                Self::GlossaryTermCreate => serializer.serialize_i32(7),
+                Self::GlossaryTermUpdate => serializer.serialize_i32(8),
+                Self::GlossaryTermDelete => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.dataplex.v1.BusinessGlossaryEvent.EventType",
+            ))
         }
     }
 }
@@ -18180,59 +20498,120 @@ pub mod entry_link_event {
     use super::*;
 
     /// Type of entry link log event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// An unspecified event type.
+        Unspecified,
+        /// EntryLink create event.
+        EntryLinkCreate,
+        /// EntryLink delete event.
+        EntryLinkDelete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// An unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// EntryLink create event.
-        pub const ENTRY_LINK_CREATE: EventType = EventType::new(1);
-
-        /// EntryLink delete event.
-        pub const ENTRY_LINK_DELETE: EventType = EventType::new(2);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::EntryLinkCreate => std::option::Option::Some(1),
+                Self::EntryLinkDelete => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENTRY_LINK_CREATE"),
-                2 => std::borrow::Cow::Borrowed("ENTRY_LINK_DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::EntryLinkCreate => std::option::Option::Some("ENTRY_LINK_CREATE"),
+                Self::EntryLinkDelete => std::option::Option::Some("ENTRY_LINK_DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "ENTRY_LINK_CREATE" => std::option::Option::Some(Self::ENTRY_LINK_CREATE),
-                "ENTRY_LINK_DELETE" => std::option::Option::Some(Self::ENTRY_LINK_DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::EntryLinkCreate,
+                2 => Self::EntryLinkDelete,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ENTRY_LINK_CREATE" => Self::EntryLinkCreate,
+                "ENTRY_LINK_DELETE" => Self::EntryLinkDelete,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::EntryLinkCreate => serializer.serialize_i32(1),
+                Self::EntryLinkDelete => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.dataplex.v1.EntryLinkEvent.EventType",
+            ))
         }
     }
 }
@@ -18481,62 +20860,121 @@ pub mod list_entities_request {
     use super::*;
 
     /// Entity views.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityView(i32);
-
-    impl EntityView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EntityView {
         /// The default unset value. Return both table and fileset entities
         /// if unspecified.
-        pub const ENTITY_VIEW_UNSPECIFIED: EntityView = EntityView::new(0);
-
+        Unspecified,
         /// Only list table entities.
-        pub const TABLES: EntityView = EntityView::new(1);
-
+        Tables,
         /// Only list fileset entities.
-        pub const FILESETS: EntityView = EntityView::new(2);
+        Filesets,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EntityView::value] or
+        /// [EntityView::name].
+        UnknownValue(entity_view::UnknownValue),
+    }
 
-        /// Creates a new EntityView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod entity_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EntityView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tables => std::option::Option::Some(1),
+                Self::Filesets => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENTITY_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TABLES"),
-                2 => std::borrow::Cow::Borrowed("FILESETS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENTITY_VIEW_UNSPECIFIED"),
+                Self::Tables => std::option::Option::Some("TABLES"),
+                Self::Filesets => std::option::Option::Some("FILESETS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENTITY_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENTITY_VIEW_UNSPECIFIED)
-                }
-                "TABLES" => std::option::Option::Some(Self::TABLES),
-                "FILESETS" => std::option::Option::Some(Self::FILESETS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EntityView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EntityView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EntityView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tables,
+                2 => Self::Filesets,
+                _ => Self::UnknownValue(entity_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EntityView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENTITY_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "TABLES" => Self::Tables,
+                "FILESETS" => Self::Filesets,
+                _ => Self::UnknownValue(entity_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EntityView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tables => serializer.serialize_i32(1),
+                Self::Filesets => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EntityView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityView>::new(
+                ".google.cloud.dataplex.v1.ListEntitiesRequest.EntityView",
+            ))
         }
     }
 }
@@ -18655,66 +21093,127 @@ pub mod get_entity_request {
     use super::*;
 
     /// Entity views for get entity partial result.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityView(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EntityView {
+        /// The API will default to the `BASIC` view.
+        Unspecified,
+        /// Minimal view that does not include the schema.
+        Basic,
+        /// Include basic information and schema.
+        Schema,
+        /// Include everything. Currently, this is the same as the SCHEMA view.
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EntityView::value] or
+        /// [EntityView::name].
+        UnknownValue(entity_view::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod entity_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EntityView {
-        /// The API will default to the `BASIC` view.
-        pub const ENTITY_VIEW_UNSPECIFIED: EntityView = EntityView::new(0);
-
-        /// Minimal view that does not include the schema.
-        pub const BASIC: EntityView = EntityView::new(1);
-
-        /// Include basic information and schema.
-        pub const SCHEMA: EntityView = EntityView::new(2);
-
-        /// Include everything. Currently, this is the same as the SCHEMA view.
-        pub const FULL: EntityView = EntityView::new(4);
-
-        /// Creates a new EntityView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Schema => std::option::Option::Some(2),
+                Self::Full => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENTITY_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("SCHEMA"),
-                4 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENTITY_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Schema => std::option::Option::Some("SCHEMA"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENTITY_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENTITY_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "SCHEMA" => std::option::Option::Some(Self::SCHEMA),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EntityView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EntityView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EntityView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Schema,
+                4 => Self::Full,
+                _ => Self::UnknownValue(entity_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EntityView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENTITY_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "SCHEMA" => Self::Schema,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(entity_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EntityView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Schema => serializer.serialize_i32(2),
+                Self::Full => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EntityView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityView>::new(
+                ".google.cloud.dataplex.v1.GetEntityRequest.EntityView",
+            ))
         }
     }
 }
@@ -19364,59 +21863,120 @@ pub mod entity {
     }
 
     /// The type of entity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Type unspecified.
+        Unspecified,
+        /// Structured and semi-structured data.
+        Table,
+        /// Unstructured data.
+        Fileset,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Type unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Structured and semi-structured data.
-        pub const TABLE: Type = Type::new(1);
-
-        /// Unstructured data.
-        pub const FILESET: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Table => std::option::Option::Some(1),
+                Self::Fileset => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TABLE"),
-                2 => std::borrow::Cow::Borrowed("FILESET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Table => std::option::Option::Some("TABLE"),
+                Self::Fileset => std::option::Option::Some("FILESET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TABLE" => std::option::Option::Some(Self::TABLE),
-                "FILESET" => std::option::Option::Some(Self::FILESET),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Table,
+                2 => Self::Fileset,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TABLE" => Self::Table,
+                "FILESET" => Self::Fileset,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Table => serializer.serialize_i32(1),
+                Self::Fileset => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dataplex.v1.Entity.Type",
+            ))
         }
     }
 }
@@ -19717,243 +22277,450 @@ pub mod schema {
     }
 
     /// Type information for fields in schemas and partition schemas.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// SchemaType unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Boolean field.
-        pub const BOOLEAN: Type = Type::new(1);
-
+        Boolean,
         /// Single byte numeric field.
-        pub const BYTE: Type = Type::new(2);
-
+        Byte,
         /// 16-bit numeric field.
-        pub const INT16: Type = Type::new(3);
-
+        Int16,
         /// 32-bit numeric field.
-        pub const INT32: Type = Type::new(4);
-
+        Int32,
         /// 64-bit numeric field.
-        pub const INT64: Type = Type::new(5);
-
+        Int64,
         /// Floating point numeric field.
-        pub const FLOAT: Type = Type::new(6);
-
+        Float,
         /// Double precision numeric field.
-        pub const DOUBLE: Type = Type::new(7);
-
+        Double,
         /// Real value numeric field.
-        pub const DECIMAL: Type = Type::new(8);
-
+        Decimal,
         /// Sequence of characters field.
-        pub const STRING: Type = Type::new(9);
-
+        String,
         /// Sequence of bytes field.
-        pub const BINARY: Type = Type::new(10);
-
+        Binary,
         /// Date and time field.
-        pub const TIMESTAMP: Type = Type::new(11);
-
+        Timestamp,
         /// Date field.
-        pub const DATE: Type = Type::new(12);
-
+        Date,
         /// Time field.
-        pub const TIME: Type = Type::new(13);
-
+        Time,
         /// Structured field. Nested fields that define the structure of the map.
         /// If all nested fields are nullable, this field represents a union.
-        pub const RECORD: Type = Type::new(14);
-
+        Record,
         /// Null field that does not have values.
-        pub const NULL: Type = Type::new(100);
+        Null,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Boolean => std::option::Option::Some(1),
+                Self::Byte => std::option::Option::Some(2),
+                Self::Int16 => std::option::Option::Some(3),
+                Self::Int32 => std::option::Option::Some(4),
+                Self::Int64 => std::option::Option::Some(5),
+                Self::Float => std::option::Option::Some(6),
+                Self::Double => std::option::Option::Some(7),
+                Self::Decimal => std::option::Option::Some(8),
+                Self::String => std::option::Option::Some(9),
+                Self::Binary => std::option::Option::Some(10),
+                Self::Timestamp => std::option::Option::Some(11),
+                Self::Date => std::option::Option::Some(12),
+                Self::Time => std::option::Option::Some(13),
+                Self::Record => std::option::Option::Some(14),
+                Self::Null => std::option::Option::Some(100),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BOOLEAN"),
-                2 => std::borrow::Cow::Borrowed("BYTE"),
-                3 => std::borrow::Cow::Borrowed("INT16"),
-                4 => std::borrow::Cow::Borrowed("INT32"),
-                5 => std::borrow::Cow::Borrowed("INT64"),
-                6 => std::borrow::Cow::Borrowed("FLOAT"),
-                7 => std::borrow::Cow::Borrowed("DOUBLE"),
-                8 => std::borrow::Cow::Borrowed("DECIMAL"),
-                9 => std::borrow::Cow::Borrowed("STRING"),
-                10 => std::borrow::Cow::Borrowed("BINARY"),
-                11 => std::borrow::Cow::Borrowed("TIMESTAMP"),
-                12 => std::borrow::Cow::Borrowed("DATE"),
-                13 => std::borrow::Cow::Borrowed("TIME"),
-                14 => std::borrow::Cow::Borrowed("RECORD"),
-                100 => std::borrow::Cow::Borrowed("NULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Boolean => std::option::Option::Some("BOOLEAN"),
+                Self::Byte => std::option::Option::Some("BYTE"),
+                Self::Int16 => std::option::Option::Some("INT16"),
+                Self::Int32 => std::option::Option::Some("INT32"),
+                Self::Int64 => std::option::Option::Some("INT64"),
+                Self::Float => std::option::Option::Some("FLOAT"),
+                Self::Double => std::option::Option::Some("DOUBLE"),
+                Self::Decimal => std::option::Option::Some("DECIMAL"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Binary => std::option::Option::Some("BINARY"),
+                Self::Timestamp => std::option::Option::Some("TIMESTAMP"),
+                Self::Date => std::option::Option::Some("DATE"),
+                Self::Time => std::option::Option::Some("TIME"),
+                Self::Record => std::option::Option::Some("RECORD"),
+                Self::Null => std::option::Option::Some("NULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
-                "BYTE" => std::option::Option::Some(Self::BYTE),
-                "INT16" => std::option::Option::Some(Self::INT16),
-                "INT32" => std::option::Option::Some(Self::INT32),
-                "INT64" => std::option::Option::Some(Self::INT64),
-                "FLOAT" => std::option::Option::Some(Self::FLOAT),
-                "DOUBLE" => std::option::Option::Some(Self::DOUBLE),
-                "DECIMAL" => std::option::Option::Some(Self::DECIMAL),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "BINARY" => std::option::Option::Some(Self::BINARY),
-                "TIMESTAMP" => std::option::Option::Some(Self::TIMESTAMP),
-                "DATE" => std::option::Option::Some(Self::DATE),
-                "TIME" => std::option::Option::Some(Self::TIME),
-                "RECORD" => std::option::Option::Some(Self::RECORD),
-                "NULL" => std::option::Option::Some(Self::NULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Boolean,
+                2 => Self::Byte,
+                3 => Self::Int16,
+                4 => Self::Int32,
+                5 => Self::Int64,
+                6 => Self::Float,
+                7 => Self::Double,
+                8 => Self::Decimal,
+                9 => Self::String,
+                10 => Self::Binary,
+                11 => Self::Timestamp,
+                12 => Self::Date,
+                13 => Self::Time,
+                14 => Self::Record,
+                100 => Self::Null,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BOOLEAN" => Self::Boolean,
+                "BYTE" => Self::Byte,
+                "INT16" => Self::Int16,
+                "INT32" => Self::Int32,
+                "INT64" => Self::Int64,
+                "FLOAT" => Self::Float,
+                "DOUBLE" => Self::Double,
+                "DECIMAL" => Self::Decimal,
+                "STRING" => Self::String,
+                "BINARY" => Self::Binary,
+                "TIMESTAMP" => Self::Timestamp,
+                "DATE" => Self::Date,
+                "TIME" => Self::Time,
+                "RECORD" => Self::Record,
+                "NULL" => Self::Null,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Boolean => serializer.serialize_i32(1),
+                Self::Byte => serializer.serialize_i32(2),
+                Self::Int16 => serializer.serialize_i32(3),
+                Self::Int32 => serializer.serialize_i32(4),
+                Self::Int64 => serializer.serialize_i32(5),
+                Self::Float => serializer.serialize_i32(6),
+                Self::Double => serializer.serialize_i32(7),
+                Self::Decimal => serializer.serialize_i32(8),
+                Self::String => serializer.serialize_i32(9),
+                Self::Binary => serializer.serialize_i32(10),
+                Self::Timestamp => serializer.serialize_i32(11),
+                Self::Date => serializer.serialize_i32(12),
+                Self::Time => serializer.serialize_i32(13),
+                Self::Record => serializer.serialize_i32(14),
+                Self::Null => serializer.serialize_i32(100),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dataplex.v1.Schema.Type",
+            ))
         }
     }
 
     /// Additional qualifiers to define field semantics.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Mode unspecified.
+        Unspecified,
+        /// The field has required semantics.
+        Required,
+        /// The field has optional semantics, and may be null.
+        Nullable,
+        /// The field has repeated (0 or more) semantics, and is a list of values.
+        Repeated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Mode unspecified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// The field has required semantics.
-        pub const REQUIRED: Mode = Mode::new(1);
-
-        /// The field has optional semantics, and may be null.
-        pub const NULLABLE: Mode = Mode::new(2);
-
-        /// The field has repeated (0 or more) semantics, and is a list of values.
-        pub const REPEATED: Mode = Mode::new(3);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Required => std::option::Option::Some(1),
+                Self::Nullable => std::option::Option::Some(2),
+                Self::Repeated => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REQUIRED"),
-                2 => std::borrow::Cow::Borrowed("NULLABLE"),
-                3 => std::borrow::Cow::Borrowed("REPEATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Required => std::option::Option::Some("REQUIRED"),
+                Self::Nullable => std::option::Option::Some("NULLABLE"),
+                Self::Repeated => std::option::Option::Some("REPEATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "REQUIRED" => std::option::Option::Some(Self::REQUIRED),
-                "NULLABLE" => std::option::Option::Some(Self::NULLABLE),
-                "REPEATED" => std::option::Option::Some(Self::REPEATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Required,
+                2 => Self::Nullable,
+                3 => Self::Repeated,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "REQUIRED" => Self::Required,
+                "NULLABLE" => Self::Nullable,
+                "REPEATED" => Self::Repeated,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Required => serializer.serialize_i32(1),
+                Self::Nullable => serializer.serialize_i32(2),
+                Self::Repeated => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.dataplex.v1.Schema.Mode",
+            ))
         }
     }
 
     /// The structure of paths within the entity, which represent partitions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PartitionStyle(i32);
-
-    impl PartitionStyle {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PartitionStyle {
         /// PartitionStyle unspecified
-        pub const PARTITION_STYLE_UNSPECIFIED: PartitionStyle = PartitionStyle::new(0);
-
+        Unspecified,
         /// Partitions are hive-compatible.
         /// Examples: `gs://bucket/path/to/table/dt=2019-10-31/lang=en`,
         /// `gs://bucket/path/to/table/dt=2019-10-31/lang=en/late`.
-        pub const HIVE_COMPATIBLE: PartitionStyle = PartitionStyle::new(1);
+        HiveCompatible,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PartitionStyle::value] or
+        /// [PartitionStyle::name].
+        UnknownValue(partition_style::UnknownValue),
+    }
 
-        /// Creates a new PartitionStyle instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod partition_style {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PartitionStyle {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HiveCompatible => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PARTITION_STYLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIVE_COMPATIBLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PARTITION_STYLE_UNSPECIFIED"),
+                Self::HiveCompatible => std::option::Option::Some("HIVE_COMPATIBLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PARTITION_STYLE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PARTITION_STYLE_UNSPECIFIED)
-                }
-                "HIVE_COMPATIBLE" => std::option::Option::Some(Self::HIVE_COMPATIBLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PartitionStyle {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PartitionStyle {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PartitionStyle {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PartitionStyle {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HiveCompatible,
+                _ => Self::UnknownValue(partition_style::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PartitionStyle {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PARTITION_STYLE_UNSPECIFIED" => Self::Unspecified,
+                "HIVE_COMPATIBLE" => Self::HiveCompatible,
+                _ => Self::UnknownValue(partition_style::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PartitionStyle {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HiveCompatible => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PartitionStyle {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PartitionStyle>::new(
+                ".google.cloud.dataplex.v1.Schema.PartitionStyle",
+            ))
         }
     }
 }
@@ -20280,168 +23047,308 @@ pub mod storage_format {
     }
 
     /// The specific file format of the data.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Format {
+        /// Format unspecified.
+        Unspecified,
+        /// Parquet-formatted structured data.
+        Parquet,
+        /// Avro-formatted structured data.
+        Avro,
+        /// Orc-formatted structured data.
+        Orc,
+        /// Csv-formatted semi-structured data.
+        Csv,
+        /// Json-formatted semi-structured data.
+        Json,
+        /// Image data formats (such as jpg and png).
+        Image,
+        /// Audio data formats (such as mp3, and wav).
+        Audio,
+        /// Video data formats (such as mp4 and mpg).
+        Video,
+        /// Textual data formats (such as txt and xml).
+        Text,
+        /// TensorFlow record format.
+        Tfrecord,
+        /// Data that doesn't match a specific format.
+        Other,
+        /// Data of an unknown format.
+        Unknown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Format::value] or
+        /// [Format::name].
+        UnknownValue(format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Format {
-        /// Format unspecified.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
-
-        /// Parquet-formatted structured data.
-        pub const PARQUET: Format = Format::new(1);
-
-        /// Avro-formatted structured data.
-        pub const AVRO: Format = Format::new(2);
-
-        /// Orc-formatted structured data.
-        pub const ORC: Format = Format::new(3);
-
-        /// Csv-formatted semi-structured data.
-        pub const CSV: Format = Format::new(100);
-
-        /// Json-formatted semi-structured data.
-        pub const JSON: Format = Format::new(101);
-
-        /// Image data formats (such as jpg and png).
-        pub const IMAGE: Format = Format::new(200);
-
-        /// Audio data formats (such as mp3, and wav).
-        pub const AUDIO: Format = Format::new(201);
-
-        /// Video data formats (such as mp4 and mpg).
-        pub const VIDEO: Format = Format::new(202);
-
-        /// Textual data formats (such as txt and xml).
-        pub const TEXT: Format = Format::new(203);
-
-        /// TensorFlow record format.
-        pub const TFRECORD: Format = Format::new(204);
-
-        /// Data that doesn't match a specific format.
-        pub const OTHER: Format = Format::new(1000);
-
-        /// Data of an unknown format.
-        pub const UNKNOWN: Format = Format::new(1001);
-
-        /// Creates a new Format instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Parquet => std::option::Option::Some(1),
+                Self::Avro => std::option::Option::Some(2),
+                Self::Orc => std::option::Option::Some(3),
+                Self::Csv => std::option::Option::Some(100),
+                Self::Json => std::option::Option::Some(101),
+                Self::Image => std::option::Option::Some(200),
+                Self::Audio => std::option::Option::Some(201),
+                Self::Video => std::option::Option::Some(202),
+                Self::Text => std::option::Option::Some(203),
+                Self::Tfrecord => std::option::Option::Some(204),
+                Self::Other => std::option::Option::Some(1000),
+                Self::Unknown => std::option::Option::Some(1001),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PARQUET"),
-                2 => std::borrow::Cow::Borrowed("AVRO"),
-                3 => std::borrow::Cow::Borrowed("ORC"),
-                100 => std::borrow::Cow::Borrowed("CSV"),
-                101 => std::borrow::Cow::Borrowed("JSON"),
-                200 => std::borrow::Cow::Borrowed("IMAGE"),
-                201 => std::borrow::Cow::Borrowed("AUDIO"),
-                202 => std::borrow::Cow::Borrowed("VIDEO"),
-                203 => std::borrow::Cow::Borrowed("TEXT"),
-                204 => std::borrow::Cow::Borrowed("TFRECORD"),
-                1000 => std::borrow::Cow::Borrowed("OTHER"),
-                1001 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FORMAT_UNSPECIFIED"),
+                Self::Parquet => std::option::Option::Some("PARQUET"),
+                Self::Avro => std::option::Option::Some("AVRO"),
+                Self::Orc => std::option::Option::Some("ORC"),
+                Self::Csv => std::option::Option::Some("CSV"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::Image => std::option::Option::Some("IMAGE"),
+                Self::Audio => std::option::Option::Some("AUDIO"),
+                Self::Video => std::option::Option::Some("VIDEO"),
+                Self::Text => std::option::Option::Some("TEXT"),
+                Self::Tfrecord => std::option::Option::Some("TFRECORD"),
+                Self::Other => std::option::Option::Some("OTHER"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
-                "PARQUET" => std::option::Option::Some(Self::PARQUET),
-                "AVRO" => std::option::Option::Some(Self::AVRO),
-                "ORC" => std::option::Option::Some(Self::ORC),
-                "CSV" => std::option::Option::Some(Self::CSV),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                "IMAGE" => std::option::Option::Some(Self::IMAGE),
-                "AUDIO" => std::option::Option::Some(Self::AUDIO),
-                "VIDEO" => std::option::Option::Some(Self::VIDEO),
-                "TEXT" => std::option::Option::Some(Self::TEXT),
-                "TFRECORD" => std::option::Option::Some(Self::TFRECORD),
-                "OTHER" => std::option::Option::Some(Self::OTHER),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Format {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Format {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Parquet,
+                2 => Self::Avro,
+                3 => Self::Orc,
+                100 => Self::Csv,
+                101 => Self::Json,
+                200 => Self::Image,
+                201 => Self::Audio,
+                202 => Self::Video,
+                203 => Self::Text,
+                204 => Self::Tfrecord,
+                1000 => Self::Other,
+                1001 => Self::Unknown,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Format {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "PARQUET" => Self::Parquet,
+                "AVRO" => Self::Avro,
+                "ORC" => Self::Orc,
+                "CSV" => Self::Csv,
+                "JSON" => Self::Json,
+                "IMAGE" => Self::Image,
+                "AUDIO" => Self::Audio,
+                "VIDEO" => Self::Video,
+                "TEXT" => Self::Text,
+                "TFRECORD" => Self::Tfrecord,
+                "OTHER" => Self::Other,
+                "UNKNOWN" => Self::Unknown,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Format {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Parquet => serializer.serialize_i32(1),
+                Self::Avro => serializer.serialize_i32(2),
+                Self::Orc => serializer.serialize_i32(3),
+                Self::Csv => serializer.serialize_i32(100),
+                Self::Json => serializer.serialize_i32(101),
+                Self::Image => serializer.serialize_i32(200),
+                Self::Audio => serializer.serialize_i32(201),
+                Self::Video => serializer.serialize_i32(202),
+                Self::Text => serializer.serialize_i32(203),
+                Self::Tfrecord => serializer.serialize_i32(204),
+                Self::Other => serializer.serialize_i32(1000),
+                Self::Unknown => serializer.serialize_i32(1001),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Format {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Format>::new(
+                ".google.cloud.dataplex.v1.StorageFormat.Format",
+            ))
         }
     }
 
     /// The specific compressed file format of the data.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompressionFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompressionFormat {
+        /// CompressionFormat unspecified. Implies uncompressed data.
+        Unspecified,
+        /// GZip compressed set of files.
+        Gzip,
+        /// BZip2 compressed set of files.
+        Bzip2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompressionFormat::value] or
+        /// [CompressionFormat::name].
+        UnknownValue(compression_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod compression_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CompressionFormat {
-        /// CompressionFormat unspecified. Implies uncompressed data.
-        pub const COMPRESSION_FORMAT_UNSPECIFIED: CompressionFormat = CompressionFormat::new(0);
-
-        /// GZip compressed set of files.
-        pub const GZIP: CompressionFormat = CompressionFormat::new(2);
-
-        /// BZip2 compressed set of files.
-        pub const BZIP2: CompressionFormat = CompressionFormat::new(3);
-
-        /// Creates a new CompressionFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gzip => std::option::Option::Some(2),
+                Self::Bzip2 => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPRESSION_FORMAT_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("GZIP"),
-                3 => std::borrow::Cow::Borrowed("BZIP2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPRESSION_FORMAT_UNSPECIFIED"),
+                Self::Gzip => std::option::Option::Some("GZIP"),
+                Self::Bzip2 => std::option::Option::Some("BZIP2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPRESSION_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPRESSION_FORMAT_UNSPECIFIED)
-                }
-                "GZIP" => std::option::Option::Some(Self::GZIP),
-                "BZIP2" => std::option::Option::Some(Self::BZIP2),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompressionFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompressionFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompressionFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompressionFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Gzip,
+                3 => Self::Bzip2,
+                _ => Self::UnknownValue(compression_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompressionFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPRESSION_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "GZIP" => Self::Gzip,
+                "BZIP2" => Self::Bzip2,
+                _ => Self::UnknownValue(compression_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompressionFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gzip => serializer.serialize_i32(2),
+                Self::Bzip2 => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompressionFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompressionFormat>::new(
+                ".google.cloud.dataplex.v1.StorageFormat.CompressionFormat",
+            ))
         }
     }
 
@@ -20500,61 +23407,120 @@ pub mod storage_access {
     use super::*;
 
     /// Access Mode determines how data stored within the Entity is read.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AccessMode {
+        /// Access mode unspecified.
+        Unspecified,
+        /// Default. Data is accessed directly using storage APIs.
+        Direct,
+        /// Data is accessed through a managed interface using BigQuery APIs.
+        Managed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AccessMode::value] or
+        /// [AccessMode::name].
+        UnknownValue(access_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod access_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AccessMode {
-        /// Access mode unspecified.
-        pub const ACCESS_MODE_UNSPECIFIED: AccessMode = AccessMode::new(0);
-
-        /// Default. Data is accessed directly using storage APIs.
-        pub const DIRECT: AccessMode = AccessMode::new(1);
-
-        /// Data is accessed through a managed interface using BigQuery APIs.
-        pub const MANAGED: AccessMode = AccessMode::new(2);
-
-        /// Creates a new AccessMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Direct => std::option::Option::Some(1),
+                Self::Managed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCESS_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIRECT"),
-                2 => std::borrow::Cow::Borrowed("MANAGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCESS_MODE_UNSPECIFIED"),
+                Self::Direct => std::option::Option::Some("DIRECT"),
+                Self::Managed => std::option::Option::Some("MANAGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCESS_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCESS_MODE_UNSPECIFIED)
-                }
-                "DIRECT" => std::option::Option::Some(Self::DIRECT),
-                "MANAGED" => std::option::Option::Some(Self::MANAGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AccessMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AccessMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AccessMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Direct,
+                2 => Self::Managed,
+                _ => Self::UnknownValue(access_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AccessMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCESS_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DIRECT" => Self::Direct,
+                "MANAGED" => Self::Managed,
+                _ => Self::UnknownValue(access_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AccessMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Direct => serializer.serialize_i32(1),
+                Self::Managed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AccessMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessMode>::new(
+                ".google.cloud.dataplex.v1.StorageAccess.AccessMode",
+            ))
         }
     }
 }
@@ -21278,69 +24244,137 @@ pub mod lake {
         use super::*;
 
         /// Current state of association.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// Unspecified.
+            Unspecified,
+            /// A Metastore service instance is not associated with the lake.
+            None,
+            /// A Metastore service instance is attached to the lake.
+            Ready,
+            /// Attach/detach is in progress.
+            Updating,
+            /// Attach/detach could not be done due to errors.
+            Error,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// Unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// A Metastore service instance is not associated with the lake.
-            pub const NONE: State = State::new(1);
-
-            /// A Metastore service instance is attached to the lake.
-            pub const READY: State = State::new(2);
-
-            /// Attach/detach is in progress.
-            pub const UPDATING: State = State::new(3);
-
-            /// Attach/detach could not be done due to errors.
-            pub const ERROR: State = State::new(4);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::None => std::option::Option::Some(1),
+                    Self::Ready => std::option::Option::Some(2),
+                    Self::Updating => std::option::Option::Some(3),
+                    Self::Error => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NONE"),
-                    2 => std::borrow::Cow::Borrowed("READY"),
-                    3 => std::borrow::Cow::Borrowed("UPDATING"),
-                    4 => std::borrow::Cow::Borrowed("ERROR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::None => std::option::Option::Some("NONE"),
+                    Self::Ready => std::option::Option::Some("READY"),
+                    Self::Updating => std::option::Option::Some("UPDATING"),
+                    Self::Error => std::option::Option::Some("ERROR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "NONE" => std::option::Option::Some(Self::NONE),
-                    "READY" => std::option::Option::Some(Self::READY),
-                    "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                    "ERROR" => std::option::Option::Some(Self::ERROR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::None,
+                    2 => Self::Ready,
+                    3 => Self::Updating,
+                    4 => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "NONE" => Self::None,
+                    "READY" => Self::Ready,
+                    "UPDATING" => Self::Updating,
+                    "ERROR" => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::None => serializer.serialize_i32(1),
+                    Self::Ready => serializer.serialize_i32(2),
+                    Self::Updating => serializer.serialize_i32(3),
+                    Self::Error => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.dataplex.v1.Lake.MetastoreStatus.State",
+                ))
             }
         }
     }
@@ -21625,61 +24659,123 @@ pub mod zone {
         use super::*;
 
         /// Location type of the resources attached to a zone.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LocationType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum LocationType {
+            /// Unspecified location type.
+            Unspecified,
+            /// Resources that are associated with a single region.
+            SingleRegion,
+            /// Resources that are associated with a multi-region location.
+            MultiRegion,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [LocationType::value] or
+            /// [LocationType::name].
+            UnknownValue(location_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod location_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl LocationType {
-            /// Unspecified location type.
-            pub const LOCATION_TYPE_UNSPECIFIED: LocationType = LocationType::new(0);
-
-            /// Resources that are associated with a single region.
-            pub const SINGLE_REGION: LocationType = LocationType::new(1);
-
-            /// Resources that are associated with a multi-region location.
-            pub const MULTI_REGION: LocationType = LocationType::new(2);
-
-            /// Creates a new LocationType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SingleRegion => std::option::Option::Some(1),
+                    Self::MultiRegion => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("LOCATION_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SINGLE_REGION"),
-                    2 => std::borrow::Cow::Borrowed("MULTI_REGION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("LOCATION_TYPE_UNSPECIFIED"),
+                    Self::SingleRegion => std::option::Option::Some("SINGLE_REGION"),
+                    Self::MultiRegion => std::option::Option::Some("MULTI_REGION"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "LOCATION_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::LOCATION_TYPE_UNSPECIFIED)
-                    }
-                    "SINGLE_REGION" => std::option::Option::Some(Self::SINGLE_REGION),
-                    "MULTI_REGION" => std::option::Option::Some(Self::MULTI_REGION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for LocationType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for LocationType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for LocationType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for LocationType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SingleRegion,
+                    2 => Self::MultiRegion,
+                    _ => Self::UnknownValue(location_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for LocationType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "LOCATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SINGLE_REGION" => Self::SingleRegion,
+                    "MULTI_REGION" => Self::MultiRegion,
+                    _ => Self::UnknownValue(location_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for LocationType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SingleRegion => serializer.serialize_i32(1),
+                    Self::MultiRegion => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for LocationType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocationType>::new(
+                    ".google.cloud.dataplex.v1.Zone.ResourceSpec.LocationType",
+                ))
             }
         }
     }
@@ -21971,63 +25067,124 @@ pub mod zone {
     }
 
     /// Type of zone.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Zone type not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// A zone that contains data that needs further processing before it is
         /// considered generally ready for consumption and analytics workloads.
-        pub const RAW: Type = Type::new(1);
-
+        Raw,
         /// A zone that contains data that is considered to be ready for broader
         /// consumption and analytics workloads. Curated structured data stored in
         /// Cloud Storage must conform to certain file formats (parquet, avro and
         /// orc) and organized in a hive-compatible directory layout.
-        pub const CURATED: Type = Type::new(2);
+        Curated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Raw => std::option::Option::Some(1),
+                Self::Curated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RAW"),
-                2 => std::borrow::Cow::Borrowed("CURATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Raw => std::option::Option::Some("RAW"),
+                Self::Curated => std::option::Option::Some("CURATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "RAW" => std::option::Option::Some(Self::RAW),
-                "CURATED" => std::option::Option::Some(Self::CURATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Raw,
+                2 => Self::Curated,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "RAW" => Self::Raw,
+                "CURATED" => Self::Curated,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Raw => serializer.serialize_i32(1),
+                Self::Curated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dataplex.v1.Zone.Type",
+            ))
         }
     }
 }
@@ -22657,62 +25814,124 @@ pub mod action {
         use super::*;
 
         /// Whether the action relates to a schema that is incompatible or modified.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SchemaChange(i32);
-
-        impl SchemaChange {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SchemaChange {
             /// Schema change unspecified.
-            pub const SCHEMA_CHANGE_UNSPECIFIED: SchemaChange = SchemaChange::new(0);
-
+            Unspecified,
             /// Newly discovered schema is incompatible with existing schema.
-            pub const INCOMPATIBLE: SchemaChange = SchemaChange::new(1);
-
+            Incompatible,
             /// Newly discovered schema has changed from existing schema for data in a
             /// curated zone.
-            pub const MODIFIED: SchemaChange = SchemaChange::new(2);
+            Modified,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SchemaChange::value] or
+            /// [SchemaChange::name].
+            UnknownValue(schema_change::UnknownValue),
+        }
 
-            /// Creates a new SchemaChange instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod schema_change {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SchemaChange {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Incompatible => std::option::Option::Some(1),
+                    Self::Modified => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SCHEMA_CHANGE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("INCOMPATIBLE"),
-                    2 => std::borrow::Cow::Borrowed("MODIFIED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SCHEMA_CHANGE_UNSPECIFIED"),
+                    Self::Incompatible => std::option::Option::Some("INCOMPATIBLE"),
+                    Self::Modified => std::option::Option::Some("MODIFIED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SCHEMA_CHANGE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SCHEMA_CHANGE_UNSPECIFIED)
-                    }
-                    "INCOMPATIBLE" => std::option::Option::Some(Self::INCOMPATIBLE),
-                    "MODIFIED" => std::option::Option::Some(Self::MODIFIED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SchemaChange {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SchemaChange {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SchemaChange {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SchemaChange {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Incompatible,
+                    2 => Self::Modified,
+                    _ => Self::UnknownValue(schema_change::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SchemaChange {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SCHEMA_CHANGE_UNSPECIFIED" => Self::Unspecified,
+                    "INCOMPATIBLE" => Self::Incompatible,
+                    "MODIFIED" => Self::Modified,
+                    _ => Self::UnknownValue(schema_change::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SchemaChange {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Incompatible => serializer.serialize_i32(1),
+                    Self::Modified => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SchemaChange {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SchemaChange>::new(
+                    ".google.cloud.dataplex.v1.Action.IncompatibleDataSchema.SchemaChange",
+                ))
             }
         }
     }
@@ -22759,62 +25978,125 @@ pub mod action {
         use super::*;
 
         /// The expected partition structure.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PartitionStructure(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PartitionStructure {
+            /// PartitionStructure unspecified.
+            Unspecified,
+            /// Consistent hive-style partition definition (both raw and curated zone).
+            ConsistentKeys,
+            /// Hive style partition definition (curated zone only).
+            HiveStyleKeys,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PartitionStructure::value] or
+            /// [PartitionStructure::name].
+            UnknownValue(partition_structure::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod partition_structure {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PartitionStructure {
-            /// PartitionStructure unspecified.
-            pub const PARTITION_STRUCTURE_UNSPECIFIED: PartitionStructure =
-                PartitionStructure::new(0);
-
-            /// Consistent hive-style partition definition (both raw and curated zone).
-            pub const CONSISTENT_KEYS: PartitionStructure = PartitionStructure::new(1);
-
-            /// Hive style partition definition (curated zone only).
-            pub const HIVE_STYLE_KEYS: PartitionStructure = PartitionStructure::new(2);
-
-            /// Creates a new PartitionStructure instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ConsistentKeys => std::option::Option::Some(1),
+                    Self::HiveStyleKeys => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PARTITION_STRUCTURE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CONSISTENT_KEYS"),
-                    2 => std::borrow::Cow::Borrowed("HIVE_STYLE_KEYS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PARTITION_STRUCTURE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PARTITION_STRUCTURE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("PARTITION_STRUCTURE_UNSPECIFIED")
                     }
-                    "CONSISTENT_KEYS" => std::option::Option::Some(Self::CONSISTENT_KEYS),
-                    "HIVE_STYLE_KEYS" => std::option::Option::Some(Self::HIVE_STYLE_KEYS),
-                    _ => std::option::Option::None,
+                    Self::ConsistentKeys => std::option::Option::Some("CONSISTENT_KEYS"),
+                    Self::HiveStyleKeys => std::option::Option::Some("HIVE_STYLE_KEYS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for PartitionStructure {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PartitionStructure {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PartitionStructure {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PartitionStructure {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ConsistentKeys,
+                    2 => Self::HiveStyleKeys,
+                    _ => Self::UnknownValue(partition_structure::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PartitionStructure {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PARTITION_STRUCTURE_UNSPECIFIED" => Self::Unspecified,
+                    "CONSISTENT_KEYS" => Self::ConsistentKeys,
+                    "HIVE_STYLE_KEYS" => Self::HiveStyleKeys,
+                    _ => Self::UnknownValue(partition_structure::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PartitionStructure {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ConsistentKeys => serializer.serialize_i32(1),
+                    Self::HiveStyleKeys => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PartitionStructure {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PartitionStructure>::new(
+                    ".google.cloud.dataplex.v1.Action.InvalidDataPartition.PartitionStructure",
+                ))
             }
         }
     }
@@ -22864,64 +26146,127 @@ pub mod action {
     }
 
     /// The category of issues.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Category {
+        /// Unspecified category.
+        Unspecified,
+        /// Resource management related issues.
+        ResourceManagement,
+        /// Security policy related issues.
+        SecurityPolicy,
+        /// Data and discovery related issues.
+        DataDiscovery,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Category::value] or
+        /// [Category::name].
+        UnknownValue(category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Category {
-        /// Unspecified category.
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
-
-        /// Resource management related issues.
-        pub const RESOURCE_MANAGEMENT: Category = Category::new(1);
-
-        /// Security policy related issues.
-        pub const SECURITY_POLICY: Category = Category::new(2);
-
-        /// Data and discovery related issues.
-        pub const DATA_DISCOVERY: Category = Category::new(3);
-
-        /// Creates a new Category instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ResourceManagement => std::option::Option::Some(1),
+                Self::SecurityPolicy => std::option::Option::Some(2),
+                Self::DataDiscovery => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESOURCE_MANAGEMENT"),
-                2 => std::borrow::Cow::Borrowed("SECURITY_POLICY"),
-                3 => std::borrow::Cow::Borrowed("DATA_DISCOVERY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CATEGORY_UNSPECIFIED"),
+                Self::ResourceManagement => std::option::Option::Some("RESOURCE_MANAGEMENT"),
+                Self::SecurityPolicy => std::option::Option::Some("SECURITY_POLICY"),
+                Self::DataDiscovery => std::option::Option::Some("DATA_DISCOVERY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
-                "RESOURCE_MANAGEMENT" => std::option::Option::Some(Self::RESOURCE_MANAGEMENT),
-                "SECURITY_POLICY" => std::option::Option::Some(Self::SECURITY_POLICY),
-                "DATA_DISCOVERY" => std::option::Option::Some(Self::DATA_DISCOVERY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Category {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Category {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ResourceManagement,
+                2 => Self::SecurityPolicy,
+                3 => Self::DataDiscovery,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Category {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "RESOURCE_MANAGEMENT" => Self::ResourceManagement,
+                "SECURITY_POLICY" => Self::SecurityPolicy,
+                "DATA_DISCOVERY" => Self::DataDiscovery,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Category {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ResourceManagement => serializer.serialize_i32(1),
+                Self::SecurityPolicy => serializer.serialize_i32(2),
+                Self::DataDiscovery => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Category {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Category>::new(
+                ".google.cloud.dataplex.v1.Action.Category",
+            ))
         }
     }
 
@@ -23217,66 +26562,132 @@ pub mod asset {
         use super::*;
 
         /// The state of the security policy.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// State unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// Security policy has been successfully applied to the attached resource.
-            pub const READY: State = State::new(1);
-
+            Ready,
             /// Security policy is in the process of being applied to the attached
             /// resource.
-            pub const APPLYING: State = State::new(2);
-
+            Applying,
             /// Security policy could not be applied to the attached resource due to
             /// errors.
-            pub const ERROR: State = State::new(3);
+            Error,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Ready => std::option::Option::Some(1),
+                    Self::Applying => std::option::Option::Some(2),
+                    Self::Error => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("READY"),
-                    2 => std::borrow::Cow::Borrowed("APPLYING"),
-                    3 => std::borrow::Cow::Borrowed("ERROR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Ready => std::option::Option::Some("READY"),
+                    Self::Applying => std::option::Option::Some("APPLYING"),
+                    Self::Error => std::option::Option::Some("ERROR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "READY" => std::option::Option::Some(Self::READY),
-                    "APPLYING" => std::option::Option::Some(Self::APPLYING),
-                    "ERROR" => std::option::Option::Some(Self::ERROR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Ready,
+                    2 => Self::Applying,
+                    3 => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "READY" => Self::Ready,
+                    "APPLYING" => Self::Applying,
+                    "ERROR" => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Ready => serializer.serialize_i32(1),
+                    Self::Applying => serializer.serialize_i32(2),
+                    Self::Error => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.dataplex.v1.Asset.SecurityStatus.State",
+                ))
             }
         }
     }
@@ -23638,119 +27049,245 @@ pub mod asset {
         use super::*;
 
         /// Type of resource.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Type not specified.
+            Unspecified,
+            /// Cloud Storage bucket.
+            StorageBucket,
+            /// BigQuery dataset.
+            BigqueryDataset,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Type not specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// Cloud Storage bucket.
-            pub const STORAGE_BUCKET: Type = Type::new(1);
-
-            /// BigQuery dataset.
-            pub const BIGQUERY_DATASET: Type = Type::new(2);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::StorageBucket => std::option::Option::Some(1),
+                    Self::BigqueryDataset => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("STORAGE_BUCKET"),
-                    2 => std::borrow::Cow::Borrowed("BIGQUERY_DATASET"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::StorageBucket => std::option::Option::Some("STORAGE_BUCKET"),
+                    Self::BigqueryDataset => std::option::Option::Some("BIGQUERY_DATASET"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "STORAGE_BUCKET" => std::option::Option::Some(Self::STORAGE_BUCKET),
-                    "BIGQUERY_DATASET" => std::option::Option::Some(Self::BIGQUERY_DATASET),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::StorageBucket,
+                    2 => Self::BigqueryDataset,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "STORAGE_BUCKET" => Self::StorageBucket,
+                    "BIGQUERY_DATASET" => Self::BigqueryDataset,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::StorageBucket => serializer.serialize_i32(1),
+                    Self::BigqueryDataset => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.dataplex.v1.Asset.ResourceSpec.Type",
+                ))
             }
         }
 
         /// Access Mode determines how data stored within the resource is read. This
         /// is only applicable to storage bucket assets.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AccessMode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum AccessMode {
+            /// Access mode unspecified.
+            Unspecified,
+            /// Default. Data is accessed directly using storage APIs.
+            Direct,
+            /// Data is accessed through a managed interface using BigQuery APIs.
+            Managed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [AccessMode::value] or
+            /// [AccessMode::name].
+            UnknownValue(access_mode::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod access_mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl AccessMode {
-            /// Access mode unspecified.
-            pub const ACCESS_MODE_UNSPECIFIED: AccessMode = AccessMode::new(0);
-
-            /// Default. Data is accessed directly using storage APIs.
-            pub const DIRECT: AccessMode = AccessMode::new(1);
-
-            /// Data is accessed through a managed interface using BigQuery APIs.
-            pub const MANAGED: AccessMode = AccessMode::new(2);
-
-            /// Creates a new AccessMode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Direct => std::option::Option::Some(1),
+                    Self::Managed => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ACCESS_MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DIRECT"),
-                    2 => std::borrow::Cow::Borrowed("MANAGED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ACCESS_MODE_UNSPECIFIED"),
+                    Self::Direct => std::option::Option::Some("DIRECT"),
+                    Self::Managed => std::option::Option::Some("MANAGED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ACCESS_MODE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ACCESS_MODE_UNSPECIFIED)
-                    }
-                    "DIRECT" => std::option::Option::Some(Self::DIRECT),
-                    "MANAGED" => std::option::Option::Some(Self::MANAGED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for AccessMode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for AccessMode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for AccessMode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for AccessMode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Direct,
+                    2 => Self::Managed,
+                    _ => Self::UnknownValue(access_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for AccessMode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ACCESS_MODE_UNSPECIFIED" => Self::Unspecified,
+                    "DIRECT" => Self::Direct,
+                    "MANAGED" => Self::Managed,
+                    _ => Self::UnknownValue(access_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for AccessMode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Direct => serializer.serialize_i32(1),
+                    Self::Managed => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for AccessMode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessMode>::new(
+                    ".google.cloud.dataplex.v1.Asset.ResourceSpec.AccessMode",
+                ))
             }
         }
     }
@@ -23831,59 +27368,123 @@ pub mod asset {
         use super::*;
 
         /// The state of a resource.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// State unspecified.
+            Unspecified,
+            /// Resource does not have any errors.
+            Ready,
+            /// Resource has errors.
+            Error,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// State unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// Resource does not have any errors.
-            pub const READY: State = State::new(1);
-
-            /// Resource has errors.
-            pub const ERROR: State = State::new(2);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Ready => std::option::Option::Some(1),
+                    Self::Error => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("READY"),
-                    2 => std::borrow::Cow::Borrowed("ERROR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Ready => std::option::Option::Some("READY"),
+                    Self::Error => std::option::Option::Some("ERROR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "READY" => std::option::Option::Some(Self::READY),
-                    "ERROR" => std::option::Option::Some(Self::ERROR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Ready,
+                    2 => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "READY" => Self::Ready,
+                    "ERROR" => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Ready => serializer.serialize_i32(1),
+                    Self::Error => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.dataplex.v1.Asset.ResourceStatus.State",
+                ))
             }
         }
     }
@@ -24058,70 +27659,138 @@ pub mod asset {
         }
 
         /// Current state of discovery.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// State is unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// Discovery for the asset is scheduled.
-            pub const SCHEDULED: State = State::new(1);
-
+            Scheduled,
             /// Discovery for the asset is running.
-            pub const IN_PROGRESS: State = State::new(2);
-
+            InProgress,
             /// Discovery for the asset is currently paused (e.g. due to a lack
             /// of available resources). It will be automatically resumed.
-            pub const PAUSED: State = State::new(3);
-
+            Paused,
             /// Discovery for the asset is disabled.
-            pub const DISABLED: State = State::new(5);
+            Disabled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Scheduled => std::option::Option::Some(1),
+                    Self::InProgress => std::option::Option::Some(2),
+                    Self::Paused => std::option::Option::Some(3),
+                    Self::Disabled => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SCHEDULED"),
-                    2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                    3 => std::borrow::Cow::Borrowed("PAUSED"),
-                    5 => std::borrow::Cow::Borrowed("DISABLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Scheduled => std::option::Option::Some("SCHEDULED"),
+                    Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                    Self::Paused => std::option::Option::Some("PAUSED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
-                    "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                    "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Scheduled,
+                    2 => Self::InProgress,
+                    3 => Self::Paused,
+                    5 => Self::Disabled,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "SCHEDULED" => Self::Scheduled,
+                    "IN_PROGRESS" => Self::InProgress,
+                    "PAUSED" => Self::Paused,
+                    "DISABLED" => Self::Disabled,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Scheduled => serializer.serialize_i32(1),
+                    Self::InProgress => serializer.serialize_i32(2),
+                    Self::Paused => serializer.serialize_i32(3),
+                    Self::Disabled => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.dataplex.v1.Asset.DiscoveryStatus.State",
+                ))
             }
         }
     }
@@ -27596,59 +31265,123 @@ pub mod task {
         use super::*;
 
         /// Determines how often and when the job will run.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Unspecified trigger type.
+            Unspecified,
+            /// The task runs one-time shortly after Task Creation.
+            OnDemand,
+            /// The task is scheduled to run periodically.
+            Recurring,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Unspecified trigger type.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// The task runs one-time shortly after Task Creation.
-            pub const ON_DEMAND: Type = Type::new(1);
-
-            /// The task is scheduled to run periodically.
-            pub const RECURRING: Type = Type::new(2);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::OnDemand => std::option::Option::Some(1),
+                    Self::Recurring => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                    2 => std::borrow::Cow::Borrowed("RECURRING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                    Self::Recurring => std::option::Option::Some("RECURRING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                    "RECURRING" => std::option::Option::Some(Self::RECURRING),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::OnDemand,
+                    2 => Self::Recurring,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "ON_DEMAND" => Self::OnDemand,
+                    "RECURRING" => Self::Recurring,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::OnDemand => serializer.serialize_i32(1),
+                    Self::Recurring => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.dataplex.v1.Task.TriggerSpec.Type",
+                ))
             }
         }
 
@@ -28342,514 +32075,1010 @@ pub mod job {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Service(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Service {
+        /// Service used to run the job is unspecified.
+        Unspecified,
+        /// Dataproc service is used to run this job.
+        Dataproc,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Service::value] or
+        /// [Service::name].
+        UnknownValue(service::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod service {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Service {
-        /// Service used to run the job is unspecified.
-        pub const SERVICE_UNSPECIFIED: Service = Service::new(0);
-
-        /// Dataproc service is used to run this job.
-        pub const DATAPROC: Service = Service::new(1);
-
-        /// Creates a new Service instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dataproc => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SERVICE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATAPROC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SERVICE_UNSPECIFIED"),
+                Self::Dataproc => std::option::Option::Some("DATAPROC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SERVICE_UNSPECIFIED" => std::option::Option::Some(Self::SERVICE_UNSPECIFIED),
-                "DATAPROC" => std::option::Option::Some(Self::DATAPROC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Service {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Service {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    impl std::fmt::Display for Service {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Service {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dataproc,
+                _ => Self::UnknownValue(service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Service {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SERVICE_UNSPECIFIED" => Self::Unspecified,
+                "DATAPROC" => Self::Dataproc,
+                _ => Self::UnknownValue(service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Service {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dataproc => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Service {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Service>::new(
+                ".google.cloud.dataplex.v1.Job.Service",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The job state is unknown.
+        Unspecified,
+        /// The job is running.
+        Running,
+        /// The job is cancelling.
+        Cancelling,
+        /// The job cancellation was successful.
+        Cancelled,
+        /// The job completed successfully.
+        Succeeded,
+        /// The job is no longer running due to an error.
+        Failed,
+        /// The job was cancelled outside of Dataplex.
+        Aborted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The job state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The job is running.
-        pub const RUNNING: State = State::new(1);
-
-        /// The job is cancelling.
-        pub const CANCELLING: State = State::new(2);
-
-        /// The job cancellation was successful.
-        pub const CANCELLED: State = State::new(3);
-
-        /// The job completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
-        /// The job is no longer running due to an error.
-        pub const FAILED: State = State::new(5);
-
-        /// The job was cancelled outside of Dataplex.
-        pub const ABORTED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Cancelling => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Aborted => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("CANCELLING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("ABORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Cancelling,
+                3 => Self::Cancelled,
+                4 => Self::Succeeded,
+                5 => Self::Failed,
+                6 => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "ABORTED" => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Cancelling => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Aborted => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataplex.v1.Job.State",
+            ))
         }
     }
 
     /// Job execution trigger.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Trigger(i32);
-
-    impl Trigger {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Trigger {
         /// The trigger is unspecified.
-        pub const TRIGGER_UNSPECIFIED: Trigger = Trigger::new(0);
-
+        Unspecified,
         /// The job was triggered by Dataplex based on trigger spec from task
         /// definition.
-        pub const TASK_CONFIG: Trigger = Trigger::new(1);
-
+        TaskConfig,
         /// The job was triggered by the explicit call of Task API.
-        pub const RUN_REQUEST: Trigger = Trigger::new(2);
+        RunRequest,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Trigger::value] or
+        /// [Trigger::name].
+        UnknownValue(trigger::UnknownValue),
+    }
 
-        /// Creates a new Trigger instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod trigger {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Trigger {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TaskConfig => std::option::Option::Some(1),
+                Self::RunRequest => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRIGGER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TASK_CONFIG"),
-                2 => std::borrow::Cow::Borrowed("RUN_REQUEST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRIGGER_UNSPECIFIED"),
+                Self::TaskConfig => std::option::Option::Some("TASK_CONFIG"),
+                Self::RunRequest => std::option::Option::Some("RUN_REQUEST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRIGGER_UNSPECIFIED" => std::option::Option::Some(Self::TRIGGER_UNSPECIFIED),
-                "TASK_CONFIG" => std::option::Option::Some(Self::TASK_CONFIG),
-                "RUN_REQUEST" => std::option::Option::Some(Self::RUN_REQUEST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Trigger {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Trigger {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Trigger {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Trigger {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TaskConfig,
+                2 => Self::RunRequest,
+                _ => Self::UnknownValue(trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Trigger {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRIGGER_UNSPECIFIED" => Self::Unspecified,
+                "TASK_CONFIG" => Self::TaskConfig,
+                "RUN_REQUEST" => Self::RunRequest,
+                _ => Self::UnknownValue(trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Trigger {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TaskConfig => serializer.serialize_i32(1),
+                Self::RunRequest => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Trigger {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Trigger>::new(
+                ".google.cloud.dataplex.v1.Job.Trigger",
+            ))
         }
     }
 }
 
 /// View for controlling which parts of an entry are to be returned.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EntryView(i32);
-
-impl EntryView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EntryView {
     /// Unspecified EntryView. Defaults to FULL.
-    pub const ENTRY_VIEW_UNSPECIFIED: EntryView = EntryView::new(0);
-
+    Unspecified,
     /// Returns entry only, without aspects.
-    pub const BASIC: EntryView = EntryView::new(1);
-
+    Basic,
     /// Returns all required aspects as well as the keys of all non-required
     /// aspects.
-    pub const FULL: EntryView = EntryView::new(2);
-
+    Full,
     /// Returns aspects matching custom fields in GetEntryRequest. If the number of
     /// aspects exceeds 100, the first 100 will be returned.
-    pub const CUSTOM: EntryView = EntryView::new(3);
-
+    Custom,
     /// Returns all aspects. If the number of aspects exceeds 100, the first
     /// 100 will be returned.
-    pub const ALL: EntryView = EntryView::new(4);
+    All,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EntryView::value] or
+    /// [EntryView::name].
+    UnknownValue(entry_view::UnknownValue),
+}
 
-    /// Creates a new EntryView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod entry_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl EntryView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::Custom => std::option::Option::Some(3),
+            Self::All => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENTRY_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            3 => std::borrow::Cow::Borrowed("CUSTOM"),
-            4 => std::borrow::Cow::Borrowed("ALL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENTRY_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::Custom => std::option::Option::Some("CUSTOM"),
+            Self::All => std::option::Option::Some("ALL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENTRY_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::ENTRY_VIEW_UNSPECIFIED),
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-            "ALL" => std::option::Option::Some(Self::ALL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EntryView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EntryView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EntryView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EntryView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            3 => Self::Custom,
+            4 => Self::All,
+            _ => Self::UnknownValue(entry_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EntryView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENTRY_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            "CUSTOM" => Self::Custom,
+            "ALL" => Self::All,
+            _ => Self::UnknownValue(entry_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EntryView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::Custom => serializer.serialize_i32(3),
+            Self::All => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EntryView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntryView>::new(
+            ".google.cloud.dataplex.v1.EntryView",
+        ))
     }
 }
 
 /// Denotes the transfer status of a resource. It is unspecified for resources
 /// created from Dataplex API.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferStatus(i32);
-
-impl TransferStatus {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransferStatus {
     /// The default value. It is set for resources that were not subject for
     /// migration from Data Catalog service.
-    pub const TRANSFER_STATUS_UNSPECIFIED: TransferStatus = TransferStatus::new(0);
-
+    Unspecified,
     /// Indicates that a resource was migrated from Data Catalog service but it
     /// hasn't been transferred yet. In particular the resource cannot be updated
     /// from Dataplex API.
-    pub const TRANSFER_STATUS_MIGRATED: TransferStatus = TransferStatus::new(1);
-
+    Migrated,
     /// Indicates that a resource was transferred from Data Catalog service. The
     /// resource can only be updated from Dataplex API.
-    pub const TRANSFER_STATUS_TRANSFERRED: TransferStatus = TransferStatus::new(2);
+    Transferred,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransferStatus::value] or
+    /// [TransferStatus::name].
+    UnknownValue(transfer_status::UnknownValue),
+}
 
-    /// Creates a new TransferStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod transfer_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl TransferStatus {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Migrated => std::option::Option::Some(1),
+            Self::Transferred => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFER_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TRANSFER_STATUS_MIGRATED"),
-            2 => std::borrow::Cow::Borrowed("TRANSFER_STATUS_TRANSFERRED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFER_STATUS_UNSPECIFIED"),
+            Self::Migrated => std::option::Option::Some("TRANSFER_STATUS_MIGRATED"),
+            Self::Transferred => std::option::Option::Some("TRANSFER_STATUS_TRANSFERRED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFER_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFER_STATUS_UNSPECIFIED)
-            }
-            "TRANSFER_STATUS_MIGRATED" => std::option::Option::Some(Self::TRANSFER_STATUS_MIGRATED),
-            "TRANSFER_STATUS_TRANSFERRED" => {
-                std::option::Option::Some(Self::TRANSFER_STATUS_TRANSFERRED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransferStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransferStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransferStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Migrated,
+            2 => Self::Transferred,
+            _ => Self::UnknownValue(transfer_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransferStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFER_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "TRANSFER_STATUS_MIGRATED" => Self::Migrated,
+            "TRANSFER_STATUS_TRANSFERRED" => Self::Transferred,
+            _ => Self::UnknownValue(transfer_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransferStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Migrated => serializer.serialize_i32(1),
+            Self::Transferred => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransferStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransferStatus>::new(
+            ".google.cloud.dataplex.v1.TransferStatus",
+        ))
     }
 }
 
 /// The type of data scan.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataScanType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DataScanType {
+    /// The data scan type is unspecified.
+    Unspecified,
+    /// Data quality scan.
+    DataQuality,
+    /// Data profile scan.
+    DataProfile,
+    /// Data discovery scan.
+    DataDiscovery,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DataScanType::value] or
+    /// [DataScanType::name].
+    UnknownValue(data_scan_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod data_scan_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DataScanType {
-    /// The data scan type is unspecified.
-    pub const DATA_SCAN_TYPE_UNSPECIFIED: DataScanType = DataScanType::new(0);
-
-    /// Data quality scan.
-    pub const DATA_QUALITY: DataScanType = DataScanType::new(1);
-
-    /// Data profile scan.
-    pub const DATA_PROFILE: DataScanType = DataScanType::new(2);
-
-    /// Data discovery scan.
-    pub const DATA_DISCOVERY: DataScanType = DataScanType::new(3);
-
-    /// Creates a new DataScanType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::DataQuality => std::option::Option::Some(1),
+            Self::DataProfile => std::option::Option::Some(2),
+            Self::DataDiscovery => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATA_SCAN_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DATA_QUALITY"),
-            2 => std::borrow::Cow::Borrowed("DATA_PROFILE"),
-            3 => std::borrow::Cow::Borrowed("DATA_DISCOVERY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATA_SCAN_TYPE_UNSPECIFIED"),
+            Self::DataQuality => std::option::Option::Some("DATA_QUALITY"),
+            Self::DataProfile => std::option::Option::Some("DATA_PROFILE"),
+            Self::DataDiscovery => std::option::Option::Some("DATA_DISCOVERY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATA_SCAN_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATA_SCAN_TYPE_UNSPECIFIED)
-            }
-            "DATA_QUALITY" => std::option::Option::Some(Self::DATA_QUALITY),
-            "DATA_PROFILE" => std::option::Option::Some(Self::DATA_PROFILE),
-            "DATA_DISCOVERY" => std::option::Option::Some(Self::DATA_DISCOVERY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DataScanType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DataScanType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DataScanType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DataScanType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::DataQuality,
+            2 => Self::DataProfile,
+            3 => Self::DataDiscovery,
+            _ => Self::UnknownValue(data_scan_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DataScanType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATA_SCAN_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "DATA_QUALITY" => Self::DataQuality,
+            "DATA_PROFILE" => Self::DataProfile,
+            "DATA_DISCOVERY" => Self::DataDiscovery,
+            _ => Self::UnknownValue(data_scan_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DataScanType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::DataQuality => serializer.serialize_i32(1),
+            Self::DataProfile => serializer.serialize_i32(2),
+            Self::DataDiscovery => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DataScanType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataScanType>::new(
+            ".google.cloud.dataplex.v1.DataScanType",
+        ))
     }
 }
 
 /// Identifies the cloud system that manages the data storage.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StorageSystem(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum StorageSystem {
+    /// Storage system unspecified.
+    Unspecified,
+    /// The entity data is contained within a Cloud Storage bucket.
+    CloudStorage,
+    /// The entity data is contained within a BigQuery dataset.
+    Bigquery,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [StorageSystem::value] or
+    /// [StorageSystem::name].
+    UnknownValue(storage_system::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod storage_system {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl StorageSystem {
-    /// Storage system unspecified.
-    pub const STORAGE_SYSTEM_UNSPECIFIED: StorageSystem = StorageSystem::new(0);
-
-    /// The entity data is contained within a Cloud Storage bucket.
-    pub const CLOUD_STORAGE: StorageSystem = StorageSystem::new(1);
-
-    /// The entity data is contained within a BigQuery dataset.
-    pub const BIGQUERY: StorageSystem = StorageSystem::new(2);
-
-    /// Creates a new StorageSystem instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::CloudStorage => std::option::Option::Some(1),
+            Self::Bigquery => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STORAGE_SYSTEM_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CLOUD_STORAGE"),
-            2 => std::borrow::Cow::Borrowed("BIGQUERY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STORAGE_SYSTEM_UNSPECIFIED"),
+            Self::CloudStorage => std::option::Option::Some("CLOUD_STORAGE"),
+            Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STORAGE_SYSTEM_UNSPECIFIED" => {
-                std::option::Option::Some(Self::STORAGE_SYSTEM_UNSPECIFIED)
-            }
-            "CLOUD_STORAGE" => std::option::Option::Some(Self::CLOUD_STORAGE),
-            "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for StorageSystem {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for StorageSystem {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for StorageSystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for StorageSystem {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::CloudStorage,
+            2 => Self::Bigquery,
+            _ => Self::UnknownValue(storage_system::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for StorageSystem {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STORAGE_SYSTEM_UNSPECIFIED" => Self::Unspecified,
+            "CLOUD_STORAGE" => Self::CloudStorage,
+            "BIGQUERY" => Self::Bigquery,
+            _ => Self::UnknownValue(storage_system::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for StorageSystem {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::CloudStorage => serializer.serialize_i32(1),
+            Self::Bigquery => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for StorageSystem {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageSystem>::new(
+            ".google.cloud.dataplex.v1.StorageSystem",
+        ))
     }
 }
 
 /// State of a resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum State {
+    /// State is not specified.
+    Unspecified,
+    /// Resource is active, i.e., ready to use.
+    Active,
+    /// Resource is under creation.
+    Creating,
+    /// Resource is under deletion.
+    Deleting,
+    /// Resource is active but has unresolved actions.
+    ActionRequired,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [State::value] or
+    /// [State::name].
+    UnknownValue(state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl State {
-    /// State is not specified.
-    pub const STATE_UNSPECIFIED: State = State::new(0);
-
-    /// Resource is active, i.e., ready to use.
-    pub const ACTIVE: State = State::new(1);
-
-    /// Resource is under creation.
-    pub const CREATING: State = State::new(2);
-
-    /// Resource is under deletion.
-    pub const DELETING: State = State::new(3);
-
-    /// Resource is active but has unresolved actions.
-    pub const ACTION_REQUIRED: State = State::new(4);
-
-    /// Creates a new State instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Active => std::option::Option::Some(1),
+            Self::Creating => std::option::Option::Some(2),
+            Self::Deleting => std::option::Option::Some(3),
+            Self::ActionRequired => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVE"),
-            2 => std::borrow::Cow::Borrowed("CREATING"),
-            3 => std::borrow::Cow::Borrowed("DELETING"),
-            4 => std::borrow::Cow::Borrowed("ACTION_REQUIRED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::Creating => std::option::Option::Some("CREATING"),
+            Self::Deleting => std::option::Option::Some("DELETING"),
+            Self::ActionRequired => std::option::Option::Some("ACTION_REQUIRED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "CREATING" => std::option::Option::Some(Self::CREATING),
-            "DELETING" => std::option::Option::Some(Self::DELETING),
-            "ACTION_REQUIRED" => std::option::Option::Some(Self::ACTION_REQUIRED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for State {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Active,
+            2 => Self::Creating,
+            3 => Self::Deleting,
+            4 => Self::ActionRequired,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for State {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVE" => Self::Active,
+            "CREATING" => Self::Creating,
+            "DELETING" => Self::Deleting,
+            "ACTION_REQUIRED" => Self::ActionRequired,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Active => serializer.serialize_i32(1),
+            Self::Creating => serializer.serialize_i32(2),
+            Self::Deleting => serializer.serialize_i32(3),
+            Self::ActionRequired => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+            ".google.cloud.dataplex.v1.State",
+        ))
     }
 }

--- a/src/generated/cloud/dataplex/v1/src/transport.rs
+++ b/src/generated/cloud/dataplex/v1/src/transport.rs
@@ -523,7 +523,7 @@ impl super::stub::CatalogService for CatalogService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = req
             .aspect_types
             .iter()
@@ -554,7 +554,7 @@ impl super::stub::CatalogService for CatalogService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = req
             .aspect_types
             .iter()
@@ -1376,7 +1376,7 @@ impl super::stub::ContentService for ContentService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2330,7 +2330,7 @@ impl super::stub::DataScanService for DataScanService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2393,7 +2393,7 @@ impl super::stub::DataScanService for DataScanService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2763,7 +2763,7 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -2783,7 +2783,7 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -1504,79 +1504,148 @@ pub mod batch {
     }
 
     /// The batch state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The batch state is unknown.
+        Unspecified,
+        /// The batch is created before running.
+        Pending,
+        /// The batch is running.
+        Running,
+        /// The batch is cancelling.
+        Cancelling,
+        /// The batch cancellation was successful.
+        Cancelled,
+        /// The batch completed successfully.
+        Succeeded,
+        /// The batch is no longer running due to an error.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The batch state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The batch is created before running.
-        pub const PENDING: State = State::new(1);
-
-        /// The batch is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The batch is cancelling.
-        pub const CANCELLING: State = State::new(3);
-
-        /// The batch cancellation was successful.
-        pub const CANCELLED: State = State::new(4);
-
-        /// The batch completed successfully.
-        pub const SUCCEEDED: State = State::new(5);
-
-        /// The batch is no longer running due to an error.
-        pub const FAILED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Cancelling => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::Succeeded => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLING"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Cancelling,
+                4 => Self::Cancelled,
+                5 => Self::Succeeded,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Cancelling => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::Succeeded => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.Batch.State",
+            ))
         }
     }
 
@@ -3126,78 +3195,139 @@ pub mod gce_cluster_config {
     /// These values are directly mapped to corresponding values in the
     /// [Compute Engine Instance
     /// fields](https://cloud.google.com/compute/docs/reference/rest/v1/instances).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivateIpv6GoogleAccess(i32);
-
-    impl PrivateIpv6GoogleAccess {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PrivateIpv6GoogleAccess {
         /// If unspecified, Compute Engine default behavior will apply, which
         /// is the same as
         /// [INHERIT_FROM_SUBNETWORK][google.cloud.dataproc.v1.GceClusterConfig.PrivateIpv6GoogleAccess.INHERIT_FROM_SUBNETWORK].
         ///
-        /// [google.cloud.dataproc.v1.GceClusterConfig.PrivateIpv6GoogleAccess.INHERIT_FROM_SUBNETWORK]: crate::model::gce_cluster_config::private_ipv_6_google_access::INHERIT_FROM_SUBNETWORK
-        pub const PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED: PrivateIpv6GoogleAccess =
-            PrivateIpv6GoogleAccess::new(0);
-
+        /// [google.cloud.dataproc.v1.GceClusterConfig.PrivateIpv6GoogleAccess.INHERIT_FROM_SUBNETWORK]: crate::model::gce_cluster_config::PrivateIpv6GoogleAccess::InheritFromSubnetwork
+        Unspecified,
         /// Private access to and from Google Services configuration
         /// inherited from the subnetwork configuration. This is the
         /// default Compute Engine behavior.
-        pub const INHERIT_FROM_SUBNETWORK: PrivateIpv6GoogleAccess =
-            PrivateIpv6GoogleAccess::new(1);
-
+        InheritFromSubnetwork,
         /// Enables outbound private IPv6 access to Google Services from the Dataproc
         /// cluster.
-        pub const OUTBOUND: PrivateIpv6GoogleAccess = PrivateIpv6GoogleAccess::new(2);
-
+        Outbound,
         /// Enables bidirectional private IPv6 access between Google Services and the
         /// Dataproc cluster.
-        pub const BIDIRECTIONAL: PrivateIpv6GoogleAccess = PrivateIpv6GoogleAccess::new(3);
+        Bidirectional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PrivateIpv6GoogleAccess::value] or
+        /// [PrivateIpv6GoogleAccess::name].
+        UnknownValue(private_ipv_6_google_access::UnknownValue),
+    }
 
-        /// Creates a new PrivateIpv6GoogleAccess instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod private_ipv_6_google_access {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PrivateIpv6GoogleAccess {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InheritFromSubnetwork => std::option::Option::Some(1),
+                Self::Outbound => std::option::Option::Some(2),
+                Self::Bidirectional => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INHERIT_FROM_SUBNETWORK"),
-                2 => std::borrow::Cow::Borrowed("OUTBOUND"),
-                3 => std::borrow::Cow::Borrowed("BIDIRECTIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED")
                 }
-                "INHERIT_FROM_SUBNETWORK" => {
-                    std::option::Option::Some(Self::INHERIT_FROM_SUBNETWORK)
-                }
-                "OUTBOUND" => std::option::Option::Some(Self::OUTBOUND),
-                "BIDIRECTIONAL" => std::option::Option::Some(Self::BIDIRECTIONAL),
-                _ => std::option::Option::None,
+                Self::InheritFromSubnetwork => std::option::Option::Some("INHERIT_FROM_SUBNETWORK"),
+                Self::Outbound => std::option::Option::Some("OUTBOUND"),
+                Self::Bidirectional => std::option::Option::Some("BIDIRECTIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PrivateIpv6GoogleAccess {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivateIpv6GoogleAccess {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PrivateIpv6GoogleAccess {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PrivateIpv6GoogleAccess {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InheritFromSubnetwork,
+                2 => Self::Outbound,
+                3 => Self::Bidirectional,
+                _ => Self::UnknownValue(private_ipv_6_google_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PrivateIpv6GoogleAccess {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => Self::Unspecified,
+                "INHERIT_FROM_SUBNETWORK" => Self::InheritFromSubnetwork,
+                "OUTBOUND" => Self::Outbound,
+                "BIDIRECTIONAL" => Self::Bidirectional,
+                _ => Self::UnknownValue(private_ipv_6_google_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PrivateIpv6GoogleAccess {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InheritFromSubnetwork => serializer.serialize_i32(1),
+                Self::Outbound => serializer.serialize_i32(2),
+                Self::Bidirectional => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PrivateIpv6GoogleAccess {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<PrivateIpv6GoogleAccess>::new(
+                    ".google.cloud.dataproc.v1.GceClusterConfig.PrivateIpv6GoogleAccess",
+                ),
+            )
         }
     }
 }
@@ -3617,28 +3747,24 @@ pub mod instance_group_config {
     use super::*;
 
     /// Controls the use of preemptible instances within the group.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Preemptibility(i32);
-
-    impl Preemptibility {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Preemptibility {
         /// Preemptibility is unspecified, the system will choose the
         /// appropriate setting for each instance group.
-        pub const PREEMPTIBILITY_UNSPECIFIED: Preemptibility = Preemptibility::new(0);
-
+        Unspecified,
         /// Instances are non-preemptible.
         ///
         /// This option is allowed for all instance groups and is the only valid
         /// value for Master and Worker instance groups.
-        pub const NON_PREEMPTIBLE: Preemptibility = Preemptibility::new(1);
-
+        NonPreemptible,
         /// Instances are [preemptible]
         /// (<https://cloud.google.com/compute/docs/instances/preemptible>).
         ///
         /// This option is allowed only for [secondary worker]
         /// (<https://cloud.google.com/dataproc/docs/concepts/compute/secondary-vms>)
         /// groups.
-        pub const PREEMPTIBLE: Preemptibility = Preemptibility::new(2);
-
+        Preemptible,
         /// Instances are [Spot VMs]
         /// (<https://cloud.google.com/compute/docs/instances/spot>).
         ///
@@ -3647,52 +3773,117 @@ pub mod instance_group_config {
         /// groups. Spot VMs are the latest version of [preemptible VMs]
         /// (<https://cloud.google.com/compute/docs/instances/preemptible>), and
         /// provide additional features.
-        pub const SPOT: Preemptibility = Preemptibility::new(3);
+        Spot,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Preemptibility::value] or
+        /// [Preemptibility::name].
+        UnknownValue(preemptibility::UnknownValue),
+    }
 
-        /// Creates a new Preemptibility instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod preemptibility {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Preemptibility {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NonPreemptible => std::option::Option::Some(1),
+                Self::Preemptible => std::option::Option::Some(2),
+                Self::Spot => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PREEMPTIBILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NON_PREEMPTIBLE"),
-                2 => std::borrow::Cow::Borrowed("PREEMPTIBLE"),
-                3 => std::borrow::Cow::Borrowed("SPOT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PREEMPTIBILITY_UNSPECIFIED"),
+                Self::NonPreemptible => std::option::Option::Some("NON_PREEMPTIBLE"),
+                Self::Preemptible => std::option::Option::Some("PREEMPTIBLE"),
+                Self::Spot => std::option::Option::Some("SPOT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PREEMPTIBILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PREEMPTIBILITY_UNSPECIFIED)
-                }
-                "NON_PREEMPTIBLE" => std::option::Option::Some(Self::NON_PREEMPTIBLE),
-                "PREEMPTIBLE" => std::option::Option::Some(Self::PREEMPTIBLE),
-                "SPOT" => std::option::Option::Some(Self::SPOT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Preemptibility {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Preemptibility {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Preemptibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Preemptibility {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NonPreemptible,
+                2 => Self::Preemptible,
+                3 => Self::Spot,
+                _ => Self::UnknownValue(preemptibility::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Preemptibility {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PREEMPTIBILITY_UNSPECIFIED" => Self::Unspecified,
+                "NON_PREEMPTIBLE" => Self::NonPreemptible,
+                "PREEMPTIBLE" => Self::Preemptible,
+                "SPOT" => Self::Spot,
+                _ => Self::UnknownValue(preemptibility::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Preemptibility {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NonPreemptible => serializer.serialize_i32(1),
+                Self::Preemptible => serializer.serialize_i32(2),
+                Self::Spot => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Preemptibility {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Preemptibility>::new(
+                ".google.cloud.dataproc.v1.InstanceGroupConfig.Preemptibility",
+            ))
         }
     }
 }
@@ -4433,54 +4624,113 @@ pub mod node_group {
     use super::*;
 
     /// Node pool roles.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
+        /// Required unspecified role.
+        Unspecified,
+        /// Job drivers run on the node pool.
+        Driver,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Role {
-        /// Required unspecified role.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
-        /// Job drivers run on the node pool.
-        pub const DRIVER: Role = Role::new(1);
-
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Driver => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRIVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::Driver => std::option::Option::Some("DRIVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "DRIVER" => std::option::Option::Some(Self::DRIVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Driver,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "DRIVER" => Self::Driver,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Driver => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.dataproc.v1.NodeGroup.Role",
+            ))
         }
     }
 }
@@ -4614,168 +4864,306 @@ pub mod cluster_status {
     use super::*;
 
     /// The cluster state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The cluster state is unknown.
-        pub const UNKNOWN: State = State::new(0);
-
+        Unknown,
         /// The cluster is being created and set up. It is not ready for use.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The cluster is currently running and healthy. It is ready for use.
         ///
         /// **Note:** The cluster state changes from "creating" to "running" status
         /// after the master node(s), first two primary worker nodes (and the last
         /// primary worker node if primary workers > 2) are running.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The cluster encountered an error. It is not ready for use.
-        pub const ERROR: State = State::new(3);
-
+        Error,
         /// The cluster has encountered an error while being updated. Jobs can
         /// be submitted to the cluster, but the cluster cannot be updated.
-        pub const ERROR_DUE_TO_UPDATE: State = State::new(9);
-
+        ErrorDueToUpdate,
         /// The cluster is being deleted. It cannot be used.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The cluster is being updated. It continues to accept and process jobs.
-        pub const UPDATING: State = State::new(5);
-
+        Updating,
         /// The cluster is being stopped. It cannot be used.
-        pub const STOPPING: State = State::new(6);
-
+        Stopping,
         /// The cluster is currently stopped. It is not ready for use.
-        pub const STOPPED: State = State::new(7);
-
+        Stopped,
         /// The cluster is being started. It is not ready for use.
-        pub const STARTING: State = State::new(8);
-
+        Starting,
         /// The cluster is being repaired. It is not ready for use.
-        pub const REPAIRING: State = State::new(10);
+        Repairing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::ErrorDueToUpdate => std::option::Option::Some(9),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::Stopping => std::option::Option::Some(6),
+                Self::Stopped => std::option::Option::Some(7),
+                Self::Starting => std::option::Option::Some(8),
+                Self::Repairing => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                6 => std::borrow::Cow::Borrowed("STOPPING"),
-                7 => std::borrow::Cow::Borrowed("STOPPED"),
-                8 => std::borrow::Cow::Borrowed("STARTING"),
-                9 => std::borrow::Cow::Borrowed("ERROR_DUE_TO_UPDATE"),
-                10 => std::borrow::Cow::Borrowed("REPAIRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::ErrorDueToUpdate => std::option::Option::Some("ERROR_DUE_TO_UPDATE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "ERROR_DUE_TO_UPDATE" => std::option::Option::Some(Self::ERROR_DUE_TO_UPDATE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Creating,
+                2 => Self::Running,
+                3 => Self::Error,
+                4 => Self::Deleting,
+                5 => Self::Updating,
+                6 => Self::Stopping,
+                7 => Self::Stopped,
+                8 => Self::Starting,
+                9 => Self::ErrorDueToUpdate,
+                10 => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "CREATING" => Self::Creating,
+                "RUNNING" => Self::Running,
+                "ERROR" => Self::Error,
+                "ERROR_DUE_TO_UPDATE" => Self::ErrorDueToUpdate,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "STOPPING" => Self::Stopping,
+                "STOPPED" => Self::Stopped,
+                "STARTING" => Self::Starting,
+                "REPAIRING" => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::ErrorDueToUpdate => serializer.serialize_i32(9),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::Stopping => serializer.serialize_i32(6),
+                Self::Stopped => serializer.serialize_i32(7),
+                Self::Starting => serializer.serialize_i32(8),
+                Self::Repairing => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.ClusterStatus.State",
+            ))
         }
     }
 
     /// The cluster substate.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Substate(i32);
-
-    impl Substate {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Substate {
         /// The cluster substate is unknown.
-        pub const UNSPECIFIED: Substate = Substate::new(0);
-
+        Unspecified,
         /// The cluster is known to be in an unhealthy state
         /// (for example, critical daemons are not running or HDFS capacity is
         /// exhausted).
         ///
         /// Applies to RUNNING state.
-        pub const UNHEALTHY: Substate = Substate::new(1);
-
+        Unhealthy,
         /// The agent-reported status is out of date (may occur if
         /// Dataproc loses communication with Agent).
         ///
         /// Applies to RUNNING state.
-        pub const STALE_STATUS: Substate = Substate::new(2);
+        StaleStatus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Substate::value] or
+        /// [Substate::name].
+        UnknownValue(substate::UnknownValue),
+    }
 
-        /// Creates a new Substate instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod substate {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Substate {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unhealthy => std::option::Option::Some(1),
+                Self::StaleStatus => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNHEALTHY"),
-                2 => std::borrow::Cow::Borrowed("STALE_STATUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Unhealthy => std::option::Option::Some("UNHEALTHY"),
+                Self::StaleStatus => std::option::Option::Some("STALE_STATUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
-                "STALE_STATUS" => std::option::Option::Some(Self::STALE_STATUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Substate {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Substate {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Substate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Substate {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unhealthy,
+                2 => Self::StaleStatus,
+                _ => Self::UnknownValue(substate::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Substate {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "UNHEALTHY" => Self::Unhealthy,
+                "STALE_STATUS" => Self::StaleStatus,
+                _ => Self::UnknownValue(substate::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Substate {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unhealthy => serializer.serialize_i32(1),
+                Self::StaleStatus => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Substate {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Substate>::new(
+                ".google.cloud.dataproc.v1.ClusterStatus.Substate",
+            ))
         }
     }
 }
@@ -5551,96 +5939,167 @@ pub mod dataproc_metric_config {
     /// A source for the collection of Dataproc custom metrics (see [Custom
     /// metrics]
     /// (<https://cloud.google.com//dataproc/docs/guides/dataproc-metrics#custom_metrics>)).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetricSource(i32);
-
-    impl MetricSource {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MetricSource {
         /// Required unspecified metric source.
-        pub const METRIC_SOURCE_UNSPECIFIED: MetricSource = MetricSource::new(0);
-
+        Unspecified,
         /// Monitoring agent metrics. If this source is enabled,
         /// Dataproc enables the monitoring agent in Compute Engine,
         /// and collects monitoring agent metrics, which are published
         /// with an `agent.googleapis.com` prefix.
-        pub const MONITORING_AGENT_DEFAULTS: MetricSource = MetricSource::new(1);
-
+        MonitoringAgentDefaults,
         /// HDFS metric source.
-        pub const HDFS: MetricSource = MetricSource::new(2);
-
+        Hdfs,
         /// Spark metric source.
-        pub const SPARK: MetricSource = MetricSource::new(3);
-
+        Spark,
         /// YARN metric source.
-        pub const YARN: MetricSource = MetricSource::new(4);
-
+        Yarn,
         /// Spark History Server metric source.
-        pub const SPARK_HISTORY_SERVER: MetricSource = MetricSource::new(5);
-
+        SparkHistoryServer,
         /// Hiveserver2 metric source.
-        pub const HIVESERVER2: MetricSource = MetricSource::new(6);
-
+        Hiveserver2,
         /// hivemetastore metric source
-        pub const HIVEMETASTORE: MetricSource = MetricSource::new(7);
-
+        Hivemetastore,
         /// flink metric source
-        pub const FLINK: MetricSource = MetricSource::new(8);
+        Flink,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MetricSource::value] or
+        /// [MetricSource::name].
+        UnknownValue(metric_source::UnknownValue),
+    }
 
-        /// Creates a new MetricSource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod metric_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MetricSource {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MonitoringAgentDefaults => std::option::Option::Some(1),
+                Self::Hdfs => std::option::Option::Some(2),
+                Self::Spark => std::option::Option::Some(3),
+                Self::Yarn => std::option::Option::Some(4),
+                Self::SparkHistoryServer => std::option::Option::Some(5),
+                Self::Hiveserver2 => std::option::Option::Some(6),
+                Self::Hivemetastore => std::option::Option::Some(7),
+                Self::Flink => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METRIC_SOURCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MONITORING_AGENT_DEFAULTS"),
-                2 => std::borrow::Cow::Borrowed("HDFS"),
-                3 => std::borrow::Cow::Borrowed("SPARK"),
-                4 => std::borrow::Cow::Borrowed("YARN"),
-                5 => std::borrow::Cow::Borrowed("SPARK_HISTORY_SERVER"),
-                6 => std::borrow::Cow::Borrowed("HIVESERVER2"),
-                7 => std::borrow::Cow::Borrowed("HIVEMETASTORE"),
-                8 => std::borrow::Cow::Borrowed("FLINK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METRIC_SOURCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METRIC_SOURCE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METRIC_SOURCE_UNSPECIFIED"),
+                Self::MonitoringAgentDefaults => {
+                    std::option::Option::Some("MONITORING_AGENT_DEFAULTS")
                 }
-                "MONITORING_AGENT_DEFAULTS" => {
-                    std::option::Option::Some(Self::MONITORING_AGENT_DEFAULTS)
-                }
-                "HDFS" => std::option::Option::Some(Self::HDFS),
-                "SPARK" => std::option::Option::Some(Self::SPARK),
-                "YARN" => std::option::Option::Some(Self::YARN),
-                "SPARK_HISTORY_SERVER" => std::option::Option::Some(Self::SPARK_HISTORY_SERVER),
-                "HIVESERVER2" => std::option::Option::Some(Self::HIVESERVER2),
-                "HIVEMETASTORE" => std::option::Option::Some(Self::HIVEMETASTORE),
-                "FLINK" => std::option::Option::Some(Self::FLINK),
-                _ => std::option::Option::None,
+                Self::Hdfs => std::option::Option::Some("HDFS"),
+                Self::Spark => std::option::Option::Some("SPARK"),
+                Self::Yarn => std::option::Option::Some("YARN"),
+                Self::SparkHistoryServer => std::option::Option::Some("SPARK_HISTORY_SERVER"),
+                Self::Hiveserver2 => std::option::Option::Some("HIVESERVER2"),
+                Self::Hivemetastore => std::option::Option::Some("HIVEMETASTORE"),
+                Self::Flink => std::option::Option::Some("FLINK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for MetricSource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MetricSource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MetricSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MetricSource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MonitoringAgentDefaults,
+                2 => Self::Hdfs,
+                3 => Self::Spark,
+                4 => Self::Yarn,
+                5 => Self::SparkHistoryServer,
+                6 => Self::Hiveserver2,
+                7 => Self::Hivemetastore,
+                8 => Self::Flink,
+                _ => Self::UnknownValue(metric_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MetricSource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METRIC_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "MONITORING_AGENT_DEFAULTS" => Self::MonitoringAgentDefaults,
+                "HDFS" => Self::Hdfs,
+                "SPARK" => Self::Spark,
+                "YARN" => Self::Yarn,
+                "SPARK_HISTORY_SERVER" => Self::SparkHistoryServer,
+                "HIVESERVER2" => Self::Hiveserver2,
+                "HIVEMETASTORE" => Self::Hivemetastore,
+                "FLINK" => Self::Flink,
+                _ => Self::UnknownValue(metric_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MetricSource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MonitoringAgentDefaults => serializer.serialize_i32(1),
+                Self::Hdfs => serializer.serialize_i32(2),
+                Self::Spark => serializer.serialize_i32(3),
+                Self::Yarn => serializer.serialize_i32(4),
+                Self::SparkHistoryServer => serializer.serialize_i32(5),
+                Self::Hiveserver2 => serializer.serialize_i32(6),
+                Self::Hivemetastore => serializer.serialize_i32(7),
+                Self::Flink => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MetricSource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetricSource>::new(
+                ".google.cloud.dataproc.v1.DataprocMetricConfig.MetricSource",
+            ))
         }
     }
 }
@@ -6496,65 +6955,124 @@ pub mod diagnose_cluster_request {
     use super::*;
 
     /// Defines who has access to the diagnostic tarball
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TarballAccess(i32);
-
-    impl TarballAccess {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TarballAccess {
         /// Tarball Access unspecified. Falls back to default access of the bucket
-        pub const TARBALL_ACCESS_UNSPECIFIED: TarballAccess = TarballAccess::new(0);
-
+        Unspecified,
         /// Google Cloud Support group has read access to the
         /// diagnostic tarball
-        pub const GOOGLE_CLOUD_SUPPORT: TarballAccess = TarballAccess::new(1);
-
+        GoogleCloudSupport,
         /// Google Cloud Dataproc Diagnose service account has read access to the
         /// diagnostic tarball
-        pub const GOOGLE_DATAPROC_DIAGNOSE: TarballAccess = TarballAccess::new(2);
+        GoogleDataprocDiagnose,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TarballAccess::value] or
+        /// [TarballAccess::name].
+        UnknownValue(tarball_access::UnknownValue),
+    }
 
-        /// Creates a new TarballAccess instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod tarball_access {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TarballAccess {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleCloudSupport => std::option::Option::Some(1),
+                Self::GoogleDataprocDiagnose => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TARBALL_ACCESS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD_SUPPORT"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_DATAPROC_DIAGNOSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TARBALL_ACCESS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TARBALL_ACCESS_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TARBALL_ACCESS_UNSPECIFIED"),
+                Self::GoogleCloudSupport => std::option::Option::Some("GOOGLE_CLOUD_SUPPORT"),
+                Self::GoogleDataprocDiagnose => {
+                    std::option::Option::Some("GOOGLE_DATAPROC_DIAGNOSE")
                 }
-                "GOOGLE_CLOUD_SUPPORT" => std::option::Option::Some(Self::GOOGLE_CLOUD_SUPPORT),
-                "GOOGLE_DATAPROC_DIAGNOSE" => {
-                    std::option::Option::Some(Self::GOOGLE_DATAPROC_DIAGNOSE)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TarballAccess {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TarballAccess {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TarballAccess {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TarballAccess {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleCloudSupport,
+                2 => Self::GoogleDataprocDiagnose,
+                _ => Self::UnknownValue(tarball_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TarballAccess {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TARBALL_ACCESS_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_CLOUD_SUPPORT" => Self::GoogleCloudSupport,
+                "GOOGLE_DATAPROC_DIAGNOSE" => Self::GoogleDataprocDiagnose,
+                _ => Self::UnknownValue(tarball_access::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TarballAccess {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleCloudSupport => serializer.serialize_i32(1),
+                Self::GoogleDataprocDiagnose => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TarballAccess {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TarballAccess>::new(
+                ".google.cloud.dataproc.v1.DiagnoseClusterRequest.TarballAccess",
+            ))
         }
     }
 }
@@ -6660,64 +7178,127 @@ pub mod reservation_affinity {
     use super::*;
 
     /// Indicates whether to consume capacity from an reservation or not.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        Unspecified,
         /// Do not consume from any allocated capacity.
-        pub const NO_RESERVATION: Type = Type::new(1);
-
+        NoReservation,
         /// Consume any reservation available.
-        pub const ANY_RESERVATION: Type = Type::new(2);
-
+        AnyReservation,
         /// Must consume from a specific reservation. Must specify key value fields
         /// for specifying the reservations.
-        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+        SpecificReservation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoReservation => std::option::Option::Some(1),
+                Self::AnyReservation => std::option::Option::Some(2),
+                Self::SpecificReservation => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
-                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::NoReservation => std::option::Option::Some("NO_RESERVATION"),
+                Self::AnyReservation => std::option::Option::Some("ANY_RESERVATION"),
+                Self::SpecificReservation => std::option::Option::Some("SPECIFIC_RESERVATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
-                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
-                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoReservation,
+                2 => Self::AnyReservation,
+                3 => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NO_RESERVATION" => Self::NoReservation,
+                "ANY_RESERVATION" => Self::AnyReservation,
+                "SPECIFIC_RESERVATION" => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoReservation => serializer.serialize_i32(1),
+                Self::AnyReservation => serializer.serialize_i32(2),
+                Self::SpecificReservation => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dataproc.v1.ReservationAffinity.Type",
+            ))
         }
     }
 }
@@ -6775,89 +7356,162 @@ pub mod logging_config {
     /// The Log4j level for job execution. When running an
     /// [Apache Hive](https://hive.apache.org/) job, Cloud
     /// Dataproc configures the Hive client to an equivalent verbosity level.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Level(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Level {
+        /// Level is unspecified. Use default level for log4j.
+        Unspecified,
+        /// Use ALL level for log4j.
+        All,
+        /// Use TRACE level for log4j.
+        Trace,
+        /// Use DEBUG level for log4j.
+        Debug,
+        /// Use INFO level for log4j.
+        Info,
+        /// Use WARN level for log4j.
+        Warn,
+        /// Use ERROR level for log4j.
+        Error,
+        /// Use FATAL level for log4j.
+        Fatal,
+        /// Turn off log4j.
+        Off,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Level::value] or
+        /// [Level::name].
+        UnknownValue(level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Level {
-        /// Level is unspecified. Use default level for log4j.
-        pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
-
-        /// Use ALL level for log4j.
-        pub const ALL: Level = Level::new(1);
-
-        /// Use TRACE level for log4j.
-        pub const TRACE: Level = Level::new(2);
-
-        /// Use DEBUG level for log4j.
-        pub const DEBUG: Level = Level::new(3);
-
-        /// Use INFO level for log4j.
-        pub const INFO: Level = Level::new(4);
-
-        /// Use WARN level for log4j.
-        pub const WARN: Level = Level::new(5);
-
-        /// Use ERROR level for log4j.
-        pub const ERROR: Level = Level::new(6);
-
-        /// Use FATAL level for log4j.
-        pub const FATAL: Level = Level::new(7);
-
-        /// Turn off log4j.
-        pub const OFF: Level = Level::new(8);
-
-        /// Creates a new Level instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::All => std::option::Option::Some(1),
+                Self::Trace => std::option::Option::Some(2),
+                Self::Debug => std::option::Option::Some(3),
+                Self::Info => std::option::Option::Some(4),
+                Self::Warn => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::Fatal => std::option::Option::Some(7),
+                Self::Off => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL"),
-                2 => std::borrow::Cow::Borrowed("TRACE"),
-                3 => std::borrow::Cow::Borrowed("DEBUG"),
-                4 => std::borrow::Cow::Borrowed("INFO"),
-                5 => std::borrow::Cow::Borrowed("WARN"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("FATAL"),
-                8 => std::borrow::Cow::Borrowed("OFF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LEVEL_UNSPECIFIED"),
+                Self::All => std::option::Option::Some("ALL"),
+                Self::Trace => std::option::Option::Some("TRACE"),
+                Self::Debug => std::option::Option::Some("DEBUG"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warn => std::option::Option::Some("WARN"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Fatal => std::option::Option::Some("FATAL"),
+                Self::Off => std::option::Option::Some("OFF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
-                "ALL" => std::option::Option::Some(Self::ALL),
-                "TRACE" => std::option::Option::Some(Self::TRACE),
-                "DEBUG" => std::option::Option::Some(Self::DEBUG),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARN" => std::option::Option::Some(Self::WARN),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "FATAL" => std::option::Option::Some(Self::FATAL),
-                "OFF" => std::option::Option::Some(Self::OFF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Level {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Level {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Level {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Level {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::All,
+                2 => Self::Trace,
+                3 => Self::Debug,
+                4 => Self::Info,
+                5 => Self::Warn,
+                6 => Self::Error,
+                7 => Self::Fatal,
+                8 => Self::Off,
+                _ => Self::UnknownValue(level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Level {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "ALL" => Self::All,
+                "TRACE" => Self::Trace,
+                "DEBUG" => Self::Debug,
+                "INFO" => Self::Info,
+                "WARN" => Self::Warn,
+                "ERROR" => Self::Error,
+                "FATAL" => Self::Fatal,
+                "OFF" => Self::Off,
+                _ => Self::UnknownValue(level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Level {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::All => serializer.serialize_i32(1),
+                Self::Trace => serializer.serialize_i32(2),
+                Self::Debug => serializer.serialize_i32(3),
+                Self::Info => serializer.serialize_i32(4),
+                Self::Warn => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::Fatal => serializer.serialize_i32(7),
+                Self::Off => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Level {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Level>::new(
+                ".google.cloud.dataproc.v1.LoggingConfig.Level",
+            ))
         }
     }
 }
@@ -8863,171 +9517,309 @@ pub mod job_status {
     use super::*;
 
     /// The job state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The job state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The job is pending; it has been submitted, but is not yet running.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// Job has been received by the service and completed initial setup;
         /// it will soon be submitted to the cluster.
-        pub const SETUP_DONE: State = State::new(8);
-
+        SetupDone,
         /// The job is running on the cluster.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// A CancelJob request has been received, but is pending.
-        pub const CANCEL_PENDING: State = State::new(3);
-
+        CancelPending,
         /// Transient in-flight resources have been canceled, and the request to
         /// cancel the running job has been issued to the cluster.
-        pub const CANCEL_STARTED: State = State::new(7);
-
+        CancelStarted,
         /// The job cancellation was successful.
-        pub const CANCELLED: State = State::new(4);
-
+        Cancelled,
         /// The job has completed successfully.
-        pub const DONE: State = State::new(5);
-
+        Done,
         /// The job has completed, but encountered an error.
-        pub const ERROR: State = State::new(6);
-
+        Error,
         /// Job attempt has failed. The detail field contains failure details for
         /// this attempt.
         ///
         /// Applies to restartable jobs only.
-        pub const ATTEMPT_FAILURE: State = State::new(9);
+        AttemptFailure,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::SetupDone => std::option::Option::Some(8),
+                Self::Running => std::option::Option::Some(2),
+                Self::CancelPending => std::option::Option::Some(3),
+                Self::CancelStarted => std::option::Option::Some(7),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::Done => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::AttemptFailure => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("CANCEL_PENDING"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                5 => std::borrow::Cow::Borrowed("DONE"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("CANCEL_STARTED"),
-                8 => std::borrow::Cow::Borrowed("SETUP_DONE"),
-                9 => std::borrow::Cow::Borrowed("ATTEMPT_FAILURE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::SetupDone => std::option::Option::Some("SETUP_DONE"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::CancelPending => std::option::Option::Some("CANCEL_PENDING"),
+                Self::CancelStarted => std::option::Option::Some("CANCEL_STARTED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::AttemptFailure => std::option::Option::Some("ATTEMPT_FAILURE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "SETUP_DONE" => std::option::Option::Some(Self::SETUP_DONE),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "CANCEL_PENDING" => std::option::Option::Some(Self::CANCEL_PENDING),
-                "CANCEL_STARTED" => std::option::Option::Some(Self::CANCEL_STARTED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "ATTEMPT_FAILURE" => std::option::Option::Some(Self::ATTEMPT_FAILURE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::CancelPending,
+                4 => Self::Cancelled,
+                5 => Self::Done,
+                6 => Self::Error,
+                7 => Self::CancelStarted,
+                8 => Self::SetupDone,
+                9 => Self::AttemptFailure,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "SETUP_DONE" => Self::SetupDone,
+                "RUNNING" => Self::Running,
+                "CANCEL_PENDING" => Self::CancelPending,
+                "CANCEL_STARTED" => Self::CancelStarted,
+                "CANCELLED" => Self::Cancelled,
+                "DONE" => Self::Done,
+                "ERROR" => Self::Error,
+                "ATTEMPT_FAILURE" => Self::AttemptFailure,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::SetupDone => serializer.serialize_i32(8),
+                Self::Running => serializer.serialize_i32(2),
+                Self::CancelPending => serializer.serialize_i32(3),
+                Self::CancelStarted => serializer.serialize_i32(7),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::Done => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::AttemptFailure => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.JobStatus.State",
+            ))
         }
     }
 
     /// The job substate.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Substate(i32);
-
-    impl Substate {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Substate {
         /// The job substate is unknown.
-        pub const UNSPECIFIED: Substate = Substate::new(0);
-
+        Unspecified,
         /// The Job is submitted to the agent.
         ///
         /// Applies to RUNNING state.
-        pub const SUBMITTED: Substate = Substate::new(1);
-
+        Submitted,
         /// The Job has been received and is awaiting execution (it might be waiting
         /// for a condition to be met). See the "details" field for the reason for
         /// the delay.
         ///
         /// Applies to RUNNING state.
-        pub const QUEUED: Substate = Substate::new(2);
-
+        Queued,
         /// The agent-reported status is out of date, which can be caused by a
         /// loss of communication between the agent and Dataproc. If the
         /// agent does not send a timely update, the job will fail.
         ///
         /// Applies to RUNNING state.
-        pub const STALE_STATUS: Substate = Substate::new(3);
+        StaleStatus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Substate::value] or
+        /// [Substate::name].
+        UnknownValue(substate::UnknownValue),
+    }
 
-        /// Creates a new Substate instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod substate {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Substate {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Submitted => std::option::Option::Some(1),
+                Self::Queued => std::option::Option::Some(2),
+                Self::StaleStatus => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUBMITTED"),
-                2 => std::borrow::Cow::Borrowed("QUEUED"),
-                3 => std::borrow::Cow::Borrowed("STALE_STATUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Submitted => std::option::Option::Some("SUBMITTED"),
+                Self::Queued => std::option::Option::Some("QUEUED"),
+                Self::StaleStatus => std::option::Option::Some("STALE_STATUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "SUBMITTED" => std::option::Option::Some(Self::SUBMITTED),
-                "QUEUED" => std::option::Option::Some(Self::QUEUED),
-                "STALE_STATUS" => std::option::Option::Some(Self::STALE_STATUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Substate {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Substate {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Substate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Substate {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Submitted,
+                2 => Self::Queued,
+                3 => Self::StaleStatus,
+                _ => Self::UnknownValue(substate::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Substate {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "SUBMITTED" => Self::Submitted,
+                "QUEUED" => Self::Queued,
+                "STALE_STATUS" => Self::StaleStatus,
+                _ => Self::UnknownValue(substate::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Substate {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Submitted => serializer.serialize_i32(1),
+                Self::Queued => serializer.serialize_i32(2),
+                Self::StaleStatus => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Substate {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Substate>::new(
+                ".google.cloud.dataproc.v1.JobStatus.Substate",
+            ))
         }
     }
 }
@@ -9158,89 +9950,162 @@ pub mod yarn_application {
 
     /// The application state, corresponding to
     /// \<code\>YarnProtos.YarnApplicationStateProto\</code\>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Status is unspecified.
+        Unspecified,
+        /// Status is NEW.
+        New,
+        /// Status is NEW_SAVING.
+        NewSaving,
+        /// Status is SUBMITTED.
+        Submitted,
+        /// Status is ACCEPTED.
+        Accepted,
+        /// Status is RUNNING.
+        Running,
+        /// Status is FINISHED.
+        Finished,
+        /// Status is FAILED.
+        Failed,
+        /// Status is KILLED.
+        Killed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Status is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Status is NEW.
-        pub const NEW: State = State::new(1);
-
-        /// Status is NEW_SAVING.
-        pub const NEW_SAVING: State = State::new(2);
-
-        /// Status is SUBMITTED.
-        pub const SUBMITTED: State = State::new(3);
-
-        /// Status is ACCEPTED.
-        pub const ACCEPTED: State = State::new(4);
-
-        /// Status is RUNNING.
-        pub const RUNNING: State = State::new(5);
-
-        /// Status is FINISHED.
-        pub const FINISHED: State = State::new(6);
-
-        /// Status is FAILED.
-        pub const FAILED: State = State::new(7);
-
-        /// Status is KILLED.
-        pub const KILLED: State = State::new(8);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::New => std::option::Option::Some(1),
+                Self::NewSaving => std::option::Option::Some(2),
+                Self::Submitted => std::option::Option::Some(3),
+                Self::Accepted => std::option::Option::Some(4),
+                Self::Running => std::option::Option::Some(5),
+                Self::Finished => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::Killed => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEW"),
-                2 => std::borrow::Cow::Borrowed("NEW_SAVING"),
-                3 => std::borrow::Cow::Borrowed("SUBMITTED"),
-                4 => std::borrow::Cow::Borrowed("ACCEPTED"),
-                5 => std::borrow::Cow::Borrowed("RUNNING"),
-                6 => std::borrow::Cow::Borrowed("FINISHED"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                8 => std::borrow::Cow::Borrowed("KILLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::New => std::option::Option::Some("NEW"),
+                Self::NewSaving => std::option::Option::Some("NEW_SAVING"),
+                Self::Submitted => std::option::Option::Some("SUBMITTED"),
+                Self::Accepted => std::option::Option::Some("ACCEPTED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Finished => std::option::Option::Some("FINISHED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Killed => std::option::Option::Some("KILLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NEW" => std::option::Option::Some(Self::NEW),
-                "NEW_SAVING" => std::option::Option::Some(Self::NEW_SAVING),
-                "SUBMITTED" => std::option::Option::Some(Self::SUBMITTED),
-                "ACCEPTED" => std::option::Option::Some(Self::ACCEPTED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "FINISHED" => std::option::Option::Some(Self::FINISHED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "KILLED" => std::option::Option::Some(Self::KILLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::New,
+                2 => Self::NewSaving,
+                3 => Self::Submitted,
+                4 => Self::Accepted,
+                5 => Self::Running,
+                6 => Self::Finished,
+                7 => Self::Failed,
+                8 => Self::Killed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NEW" => Self::New,
+                "NEW_SAVING" => Self::NewSaving,
+                "SUBMITTED" => Self::Submitted,
+                "ACCEPTED" => Self::Accepted,
+                "RUNNING" => Self::Running,
+                "FINISHED" => Self::Finished,
+                "FAILED" => Self::Failed,
+                "KILLED" => Self::Killed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::New => serializer.serialize_i32(1),
+                Self::NewSaving => serializer.serialize_i32(2),
+                Self::Submitted => serializer.serialize_i32(3),
+                Self::Accepted => serializer.serialize_i32(4),
+                Self::Running => serializer.serialize_i32(5),
+                Self::Finished => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::Killed => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.YarnApplication.State",
+            ))
         }
     }
 }
@@ -10168,60 +11033,121 @@ pub mod list_jobs_request {
     use super::*;
 
     /// A matcher that specifies categories of job states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobStateMatcher(i32);
-
-    impl JobStateMatcher {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JobStateMatcher {
         /// Match all jobs, regardless of state.
-        pub const ALL: JobStateMatcher = JobStateMatcher::new(0);
-
+        All,
         /// Only match jobs in non-terminal states: PENDING, RUNNING, or
         /// CANCEL_PENDING.
-        pub const ACTIVE: JobStateMatcher = JobStateMatcher::new(1);
-
+        Active,
         /// Only match jobs in terminal states: CANCELLED, DONE, or ERROR.
-        pub const NON_ACTIVE: JobStateMatcher = JobStateMatcher::new(2);
+        NonActive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JobStateMatcher::value] or
+        /// [JobStateMatcher::name].
+        UnknownValue(job_state_matcher::UnknownValue),
+    }
 
-        /// Creates a new JobStateMatcher instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod job_state_matcher {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl JobStateMatcher {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::All => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::NonActive => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ALL"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("NON_ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::All => std::option::Option::Some("ALL"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::NonActive => std::option::Option::Some("NON_ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ALL" => std::option::Option::Some(Self::ALL),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "NON_ACTIVE" => std::option::Option::Some(Self::NON_ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JobStateMatcher {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JobStateMatcher {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JobStateMatcher {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JobStateMatcher {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::All,
+                1 => Self::Active,
+                2 => Self::NonActive,
+                _ => Self::UnknownValue(job_state_matcher::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JobStateMatcher {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ALL" => Self::All,
+                "ACTIVE" => Self::Active,
+                "NON_ACTIVE" => Self::NonActive,
+                _ => Self::UnknownValue(job_state_matcher::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JobStateMatcher {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::All => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::NonActive => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JobStateMatcher {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobStateMatcher>::new(
+                ".google.cloud.dataproc.v1.ListJobsRequest.JobStateMatcher",
+            ))
         }
     }
 }
@@ -10840,56 +11766,113 @@ pub mod batch_operation_metadata {
     use super::*;
 
     /// Operation type for Batch resources
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BatchOperationType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BatchOperationType {
+        /// Batch operation type is unknown.
+        Unspecified,
+        /// Batch operation type.
+        Batch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BatchOperationType::value] or
+        /// [BatchOperationType::name].
+        UnknownValue(batch_operation_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod batch_operation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BatchOperationType {
-        /// Batch operation type is unknown.
-        pub const BATCH_OPERATION_TYPE_UNSPECIFIED: BatchOperationType = BatchOperationType::new(0);
-
-        /// Batch operation type.
-        pub const BATCH: BatchOperationType = BatchOperationType::new(1);
-
-        /// Creates a new BatchOperationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Batch => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BATCH_OPERATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BATCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BATCH_OPERATION_TYPE_UNSPECIFIED"),
+                Self::Batch => std::option::Option::Some("BATCH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BATCH_OPERATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BATCH_OPERATION_TYPE_UNSPECIFIED)
-                }
-                "BATCH" => std::option::Option::Some(Self::BATCH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BatchOperationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BatchOperationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BatchOperationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BatchOperationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Batch,
+                _ => Self::UnknownValue(batch_operation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BatchOperationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BATCH_OPERATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BATCH" => Self::Batch,
+                _ => Self::UnknownValue(batch_operation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BatchOperationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Batch => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BatchOperationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BatchOperationType>::new(
+                ".google.cloud.dataproc.v1.BatchOperationMetadata.BatchOperationType",
+            ))
         }
     }
 }
@@ -11023,67 +12006,129 @@ pub mod session_operation_metadata {
     use super::*;
 
     /// Operation type for Session resources
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SessionOperationType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SessionOperationType {
+        /// Session operation type is unknown.
+        Unspecified,
+        /// Create Session operation type.
+        Create,
+        /// Terminate Session operation type.
+        Terminate,
+        /// Delete Session operation type.
+        Delete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SessionOperationType::value] or
+        /// [SessionOperationType::name].
+        UnknownValue(session_operation_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod session_operation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SessionOperationType {
-        /// Session operation type is unknown.
-        pub const SESSION_OPERATION_TYPE_UNSPECIFIED: SessionOperationType =
-            SessionOperationType::new(0);
-
-        /// Create Session operation type.
-        pub const CREATE: SessionOperationType = SessionOperationType::new(1);
-
-        /// Terminate Session operation type.
-        pub const TERMINATE: SessionOperationType = SessionOperationType::new(2);
-
-        /// Delete Session operation type.
-        pub const DELETE: SessionOperationType = SessionOperationType::new(3);
-
-        /// Creates a new SessionOperationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Terminate => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SESSION_OPERATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("TERMINATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SESSION_OPERATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SESSION_OPERATION_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("SESSION_OPERATION_TYPE_UNSPECIFIED")
                 }
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "TERMINATE" => std::option::Option::Some(Self::TERMINATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                _ => std::option::Option::None,
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Terminate => std::option::Option::Some("TERMINATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SessionOperationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SessionOperationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SessionOperationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SessionOperationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Terminate,
+                3 => Self::Delete,
+                _ => Self::UnknownValue(session_operation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SessionOperationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SESSION_OPERATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "TERMINATE" => Self::Terminate,
+                "DELETE" => Self::Delete,
+                _ => Self::UnknownValue(session_operation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SessionOperationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Terminate => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SessionOperationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SessionOperationType>::new(
+                ".google.cloud.dataproc.v1.SessionOperationMetadata.SessionOperationType",
+            ))
         }
     }
 }
@@ -11161,64 +12206,127 @@ pub mod cluster_operation_status {
     use super::*;
 
     /// The operation state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unused.
+        Unknown,
+        /// The operation has been created.
+        Pending,
+        /// The operation is running.
+        Running,
+        /// The operation is done; either cancelled or completed.
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unused.
-        pub const UNKNOWN: State = State::new(0);
-
-        /// The operation has been created.
-        pub const PENDING: State = State::new(1);
-
-        /// The operation is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The operation is done; either cancelled or completed.
-        pub const DONE: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.ClusterOperationStatus.State",
+            ))
         }
     }
 }
@@ -11494,72 +12602,136 @@ pub mod node_group_operation_metadata {
     use super::*;
 
     /// Operation type for node group resources.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeGroupOperationType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NodeGroupOperationType {
+        /// Node group operation type is unknown.
+        Unspecified,
+        /// Create node group operation type.
+        Create,
+        /// Update node group operation type.
+        Update,
+        /// Delete node group operation type.
+        Delete,
+        /// Resize node group operation type.
+        Resize,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NodeGroupOperationType::value] or
+        /// [NodeGroupOperationType::name].
+        UnknownValue(node_group_operation_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod node_group_operation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl NodeGroupOperationType {
-        /// Node group operation type is unknown.
-        pub const NODE_GROUP_OPERATION_TYPE_UNSPECIFIED: NodeGroupOperationType =
-            NodeGroupOperationType::new(0);
-
-        /// Create node group operation type.
-        pub const CREATE: NodeGroupOperationType = NodeGroupOperationType::new(1);
-
-        /// Update node group operation type.
-        pub const UPDATE: NodeGroupOperationType = NodeGroupOperationType::new(2);
-
-        /// Delete node group operation type.
-        pub const DELETE: NodeGroupOperationType = NodeGroupOperationType::new(3);
-
-        /// Resize node group operation type.
-        pub const RESIZE: NodeGroupOperationType = NodeGroupOperationType::new(4);
-
-        /// Creates a new NodeGroupOperationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::Resize => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NODE_GROUP_OPERATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                4 => std::borrow::Cow::Borrowed("RESIZE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NODE_GROUP_OPERATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NODE_GROUP_OPERATION_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("NODE_GROUP_OPERATION_TYPE_UNSPECIFIED")
                 }
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "RESIZE" => std::option::Option::Some(Self::RESIZE),
-                _ => std::option::Option::None,
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Resize => std::option::Option::Some("RESIZE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for NodeGroupOperationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeGroupOperationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NodeGroupOperationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NodeGroupOperationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                4 => Self::Resize,
+                _ => Self::UnknownValue(node_group_operation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NodeGroupOperationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NODE_GROUP_OPERATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                "RESIZE" => Self::Resize,
+                _ => Self::UnknownValue(node_group_operation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NodeGroupOperationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::Resize => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NodeGroupOperationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodeGroupOperationType>::new(
+                ".google.cloud.dataproc.v1.NodeGroupOperationMetadata.NodeGroupOperationType",
+            ))
         }
     }
 }
@@ -12799,74 +13971,141 @@ pub mod session {
     }
 
     /// The session state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The session state is unknown.
+        Unspecified,
+        /// The session is created prior to running.
+        Creating,
+        /// The session is running.
+        Active,
+        /// The session is terminating.
+        Terminating,
+        /// The session is terminated successfully.
+        Terminated,
+        /// The session is no longer running due to an error.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The session state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The session is created prior to running.
-        pub const CREATING: State = State::new(1);
-
-        /// The session is running.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The session is terminating.
-        pub const TERMINATING: State = State::new(3);
-
-        /// The session is terminated successfully.
-        pub const TERMINATED: State = State::new(4);
-
-        /// The session is no longer running due to an error.
-        pub const FAILED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Terminating => std::option::Option::Some(3),
+                Self::Terminated => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("TERMINATING"),
-                4 => std::borrow::Cow::Borrowed("TERMINATED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Terminating => std::option::Option::Some("TERMINATING"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Terminating,
+                4 => Self::Terminated,
+                5 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "TERMINATING" => Self::Terminating,
+                "TERMINATED" => Self::Terminated,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Terminating => serializer.serialize_i32(3),
+                Self::Terminated => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.Session.State",
+            ))
         }
     }
 
@@ -12932,59 +14171,120 @@ pub mod jupyter_config {
     use super::*;
 
     /// Jupyter kernel types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kernel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kernel {
+        /// The kernel is unknown.
+        Unspecified,
+        /// Python kernel.
+        Python,
+        /// Scala kernel.
+        Scala,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kernel::value] or
+        /// [Kernel::name].
+        UnknownValue(kernel::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod kernel {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Kernel {
-        /// The kernel is unknown.
-        pub const KERNEL_UNSPECIFIED: Kernel = Kernel::new(0);
-
-        /// Python kernel.
-        pub const PYTHON: Kernel = Kernel::new(1);
-
-        /// Scala kernel.
-        pub const SCALA: Kernel = Kernel::new(2);
-
-        /// Creates a new Kernel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Python => std::option::Option::Some(1),
+                Self::Scala => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KERNEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PYTHON"),
-                2 => std::borrow::Cow::Borrowed("SCALA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KERNEL_UNSPECIFIED"),
+                Self::Python => std::option::Option::Some("PYTHON"),
+                Self::Scala => std::option::Option::Some("SCALA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KERNEL_UNSPECIFIED" => std::option::Option::Some(Self::KERNEL_UNSPECIFIED),
-                "PYTHON" => std::option::Option::Some(Self::PYTHON),
-                "SCALA" => std::option::Option::Some(Self::SCALA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kernel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kernel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kernel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kernel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Python,
+                2 => Self::Scala,
+                _ => Self::UnknownValue(kernel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kernel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KERNEL_UNSPECIFIED" => Self::Unspecified,
+                "PYTHON" => Self::Python,
+                "SCALA" => Self::Scala,
+                _ => Self::UnknownValue(kernel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kernel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Python => serializer.serialize_i32(1),
+                Self::Scala => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kernel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kernel>::new(
+                ".google.cloud.dataproc.v1.JupyterConfig.Kernel",
+            ))
         }
     }
 }
@@ -14100,74 +15400,139 @@ pub mod gke_node_pool_target {
     /// workloads that are not associated with a node pool.
     ///
     /// [google.cloud.dataproc.v1.GkeNodePoolTarget]: crate::model::GkeNodePoolTarget
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
-
-    impl Role {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
         /// Role is unspecified.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
+        Unspecified,
         /// At least one node pool must have the `DEFAULT` role.
         /// Work assigned to a role that is not associated with a node pool
         /// is assigned to the node pool with the `DEFAULT` role. For example,
         /// work assigned to the `CONTROLLER` role will be assigned to the node pool
         /// with the `DEFAULT` role if no node pool has the `CONTROLLER` role.
-        pub const DEFAULT: Role = Role::new(1);
-
+        Default,
         /// Run work associated with the Dataproc control plane (for example,
         /// controllers and webhooks). Very low resource requirements.
-        pub const CONTROLLER: Role = Role::new(2);
-
+        Controller,
         /// Run work associated with a Spark driver of a job.
-        pub const SPARK_DRIVER: Role = Role::new(3);
-
+        SparkDriver,
         /// Run work associated with a Spark executor of a job.
-        pub const SPARK_EXECUTOR: Role = Role::new(4);
+        SparkExecutor,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
 
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Role {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::Controller => std::option::Option::Some(2),
+                Self::SparkDriver => std::option::Option::Some(3),
+                Self::SparkExecutor => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("CONTROLLER"),
-                3 => std::borrow::Cow::Borrowed("SPARK_DRIVER"),
-                4 => std::borrow::Cow::Borrowed("SPARK_EXECUTOR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Controller => std::option::Option::Some("CONTROLLER"),
+                Self::SparkDriver => std::option::Option::Some("SPARK_DRIVER"),
+                Self::SparkExecutor => std::option::Option::Some("SPARK_EXECUTOR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "CONTROLLER" => std::option::Option::Some(Self::CONTROLLER),
-                "SPARK_DRIVER" => std::option::Option::Some(Self::SPARK_DRIVER),
-                "SPARK_EXECUTOR" => std::option::Option::Some(Self::SPARK_EXECUTOR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::Controller,
+                3 => Self::SparkDriver,
+                4 => Self::SparkExecutor,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "CONTROLLER" => Self::Controller,
+                "SPARK_DRIVER" => Self::SparkDriver,
+                "SPARK_EXECUTOR" => Self::SparkExecutor,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::Controller => serializer.serialize_i32(2),
+                Self::SparkDriver => serializer.serialize_i32(3),
+                Self::SparkExecutor => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.dataproc.v1.GkeNodePoolTarget.Role",
+            ))
         }
     }
 }
@@ -14557,64 +15922,123 @@ pub mod authentication_config {
     use super::*;
 
     /// Authentication types for workload execution.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthenticationType(i32);
-
-    impl AuthenticationType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AuthenticationType {
         /// If AuthenticationType is unspecified then END_USER_CREDENTIALS is used
         /// for 3.0 and newer runtimes, and SERVICE_ACCOUNT is used for older
         /// runtimes.
-        pub const AUTHENTICATION_TYPE_UNSPECIFIED: AuthenticationType = AuthenticationType::new(0);
-
+        Unspecified,
         /// Use service account credentials for authenticating to other services.
-        pub const SERVICE_ACCOUNT: AuthenticationType = AuthenticationType::new(1);
-
+        ServiceAccount,
         /// Use OAuth credentials associated with the workload creator/user for
         /// authenticating to other services.
-        pub const END_USER_CREDENTIALS: AuthenticationType = AuthenticationType::new(2);
+        EndUserCredentials,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AuthenticationType::value] or
+        /// [AuthenticationType::name].
+        UnknownValue(authentication_type::UnknownValue),
+    }
 
-        /// Creates a new AuthenticationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod authentication_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AuthenticationType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ServiceAccount => std::option::Option::Some(1),
+                Self::EndUserCredentials => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTHENTICATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVICE_ACCOUNT"),
-                2 => std::borrow::Cow::Borrowed("END_USER_CREDENTIALS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTHENTICATION_TYPE_UNSPECIFIED"),
+                Self::ServiceAccount => std::option::Option::Some("SERVICE_ACCOUNT"),
+                Self::EndUserCredentials => std::option::Option::Some("END_USER_CREDENTIALS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTHENTICATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTHENTICATION_TYPE_UNSPECIFIED)
-                }
-                "SERVICE_ACCOUNT" => std::option::Option::Some(Self::SERVICE_ACCOUNT),
-                "END_USER_CREDENTIALS" => std::option::Option::Some(Self::END_USER_CREDENTIALS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AuthenticationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthenticationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AuthenticationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AuthenticationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ServiceAccount,
+                2 => Self::EndUserCredentials,
+                _ => Self::UnknownValue(authentication_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AuthenticationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTHENTICATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SERVICE_ACCOUNT" => Self::ServiceAccount,
+                "END_USER_CREDENTIALS" => Self::EndUserCredentials,
+                _ => Self::UnknownValue(authentication_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AuthenticationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ServiceAccount => serializer.serialize_i32(1),
+                Self::EndUserCredentials => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AuthenticationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthenticationType>::new(
+                ".google.cloud.dataproc.v1.AuthenticationConfig.AuthenticationType",
+            ))
         }
     }
 }
@@ -14663,64 +16087,127 @@ pub mod autotuning_config {
 
     /// Scenario represents a specific goal that autotuning will attempt to achieve
     /// by modifying workloads.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scenario(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scenario {
+        /// Default value.
+        Unspecified,
+        /// Scaling recommendations such as initialExecutors.
+        Scaling,
+        /// Adding hints for potential relation broadcasts.
+        BroadcastHashJoin,
+        /// Memory management for workloads.
+        Memory,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scenario::value] or
+        /// [Scenario::name].
+        UnknownValue(scenario::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scenario {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Scenario {
-        /// Default value.
-        pub const SCENARIO_UNSPECIFIED: Scenario = Scenario::new(0);
-
-        /// Scaling recommendations such as initialExecutors.
-        pub const SCALING: Scenario = Scenario::new(2);
-
-        /// Adding hints for potential relation broadcasts.
-        pub const BROADCAST_HASH_JOIN: Scenario = Scenario::new(3);
-
-        /// Memory management for workloads.
-        pub const MEMORY: Scenario = Scenario::new(4);
-
-        /// Creates a new Scenario instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Scaling => std::option::Option::Some(2),
+                Self::BroadcastHashJoin => std::option::Option::Some(3),
+                Self::Memory => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCENARIO_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("SCALING"),
-                3 => std::borrow::Cow::Borrowed("BROADCAST_HASH_JOIN"),
-                4 => std::borrow::Cow::Borrowed("MEMORY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCENARIO_UNSPECIFIED"),
+                Self::Scaling => std::option::Option::Some("SCALING"),
+                Self::BroadcastHashJoin => std::option::Option::Some("BROADCAST_HASH_JOIN"),
+                Self::Memory => std::option::Option::Some("MEMORY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCENARIO_UNSPECIFIED" => std::option::Option::Some(Self::SCENARIO_UNSPECIFIED),
-                "SCALING" => std::option::Option::Some(Self::SCALING),
-                "BROADCAST_HASH_JOIN" => std::option::Option::Some(Self::BROADCAST_HASH_JOIN),
-                "MEMORY" => std::option::Option::Some(Self::MEMORY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scenario {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scenario {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scenario {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scenario {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Scaling,
+                3 => Self::BroadcastHashJoin,
+                4 => Self::Memory,
+                _ => Self::UnknownValue(scenario::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scenario {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCENARIO_UNSPECIFIED" => Self::Unspecified,
+                "SCALING" => Self::Scaling,
+                "BROADCAST_HASH_JOIN" => Self::BroadcastHashJoin,
+                "MEMORY" => Self::Memory,
+                _ => Self::UnknownValue(scenario::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scenario {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Scaling => serializer.serialize_i32(2),
+                Self::BroadcastHashJoin => serializer.serialize_i32(3),
+                Self::Memory => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scenario {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scenario>::new(
+                ".google.cloud.dataproc.v1.AutotuningConfig.Scenario",
+            ))
         }
     }
 }
@@ -16275,64 +17762,127 @@ pub mod workflow_metadata {
     use super::*;
 
     /// The operation state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unused.
+        Unknown,
+        /// The operation has been created.
+        Pending,
+        /// The operation is running.
+        Running,
+        /// The operation is done; either cancelled or completed.
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unused.
-        pub const UNKNOWN: State = State::new(0);
-
-        /// The operation has been created.
-        pub const PENDING: State = State::new(1);
-
-        /// The operation is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The operation is done; either cancelled or completed.
-        pub const DONE: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dataproc.v1.WorkflowMetadata.State",
+            ))
         }
     }
 }
@@ -16511,75 +18061,142 @@ pub mod workflow_node {
     use super::*;
 
     /// The workflow node state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeState(i32);
-
-    impl NodeState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NodeState {
         /// State is unspecified.
-        pub const NODE_STATE_UNSPECIFIED: NodeState = NodeState::new(0);
-
+        Unspecified,
         /// The node is awaiting prerequisite node to finish.
-        pub const BLOCKED: NodeState = NodeState::new(1);
-
+        Blocked,
         /// The node is runnable but not running.
-        pub const RUNNABLE: NodeState = NodeState::new(2);
-
+        Runnable,
         /// The node is running.
-        pub const RUNNING: NodeState = NodeState::new(3);
-
+        Running,
         /// The node completed successfully.
-        pub const COMPLETED: NodeState = NodeState::new(4);
-
+        Completed,
         /// The node failed. A node can be marked FAILED because
         /// its ancestor or peer failed.
-        pub const FAILED: NodeState = NodeState::new(5);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NodeState::value] or
+        /// [NodeState::name].
+        UnknownValue(node_state::UnknownValue),
+    }
 
-        /// Creates a new NodeState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod node_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NodeState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Blocked => std::option::Option::Some(1),
+                Self::Runnable => std::option::Option::Some(2),
+                Self::Running => std::option::Option::Some(3),
+                Self::Completed => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NODE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BLOCKED"),
-                2 => std::borrow::Cow::Borrowed("RUNNABLE"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                4 => std::borrow::Cow::Borrowed("COMPLETED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NODE_STATE_UNSPECIFIED"),
+                Self::Blocked => std::option::Option::Some("BLOCKED"),
+                Self::Runnable => std::option::Option::Some("RUNNABLE"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NODE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::NODE_STATE_UNSPECIFIED),
-                "BLOCKED" => std::option::Option::Some(Self::BLOCKED),
-                "RUNNABLE" => std::option::Option::Some(Self::RUNNABLE),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NodeState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NodeState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NodeState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Blocked,
+                2 => Self::Runnable,
+                3 => Self::Running,
+                4 => Self::Completed,
+                5 => Self::Failed,
+                _ => Self::UnknownValue(node_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NodeState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NODE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "BLOCKED" => Self::Blocked,
+                "RUNNABLE" => Self::Runnable,
+                "RUNNING" => Self::Running,
+                "COMPLETED" => Self::Completed,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(node_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NodeState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Blocked => serializer.serialize_i32(1),
+                Self::Runnable => serializer.serialize_i32(2),
+                Self::Running => serializer.serialize_i32(3),
+                Self::Completed => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NodeState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodeState>::new(
+                ".google.cloud.dataproc.v1.WorkflowNode.NodeState",
+            ))
         }
     }
 }
@@ -17102,182 +18719,326 @@ impl wkt::message::Message for DeleteWorkflowTemplateRequest {
 }
 
 /// Cluster components that can be activated.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Component(i32);
-
-impl Component {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Component {
     /// Unspecified component. Specifying this will cause Cluster creation to fail.
-    pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
-
+    Unspecified,
     /// The Anaconda component is no longer supported or applicable to
     /// [supported Dataproc on Compute Engine image versions]
     /// (<https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-version-clusters#supported-dataproc-image-versions>).
     /// It cannot be activated on clusters created with supported Dataproc on
     /// Compute Engine image versions.
-    pub const ANACONDA: Component = Component::new(5);
-
+    Anaconda,
     /// Docker
-    pub const DOCKER: Component = Component::new(13);
-
+    Docker,
     /// The Druid query engine. (alpha)
-    pub const DRUID: Component = Component::new(9);
-
+    Druid,
     /// Flink
-    pub const FLINK: Component = Component::new(14);
-
+    Flink,
     /// HBase. (beta)
-    pub const HBASE: Component = Component::new(11);
-
+    Hbase,
     /// The Hive Web HCatalog (the REST service for accessing HCatalog).
-    pub const HIVE_WEBHCAT: Component = Component::new(3);
-
+    HiveWebhcat,
     /// Hudi.
-    pub const HUDI: Component = Component::new(18);
-
+    Hudi,
     /// The Jupyter Notebook.
-    pub const JUPYTER: Component = Component::new(1);
-
+    Jupyter,
     /// The Presto query engine.
-    pub const PRESTO: Component = Component::new(6);
-
+    Presto,
     /// The Trino query engine.
-    pub const TRINO: Component = Component::new(17);
-
+    Trino,
     /// The Ranger service.
-    pub const RANGER: Component = Component::new(12);
-
+    Ranger,
     /// The Solr service.
-    pub const SOLR: Component = Component::new(10);
-
+    Solr,
     /// The Zeppelin notebook.
-    pub const ZEPPELIN: Component = Component::new(4);
-
+    Zeppelin,
     /// The Zookeeper service.
-    pub const ZOOKEEPER: Component = Component::new(8);
+    Zookeeper,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Component::value] or
+    /// [Component::name].
+    UnknownValue(component::UnknownValue),
+}
 
-    /// Creates a new Component instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod component {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl Component {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Anaconda => std::option::Option::Some(5),
+            Self::Docker => std::option::Option::Some(13),
+            Self::Druid => std::option::Option::Some(9),
+            Self::Flink => std::option::Option::Some(14),
+            Self::Hbase => std::option::Option::Some(11),
+            Self::HiveWebhcat => std::option::Option::Some(3),
+            Self::Hudi => std::option::Option::Some(18),
+            Self::Jupyter => std::option::Option::Some(1),
+            Self::Presto => std::option::Option::Some(6),
+            Self::Trino => std::option::Option::Some(17),
+            Self::Ranger => std::option::Option::Some(12),
+            Self::Solr => std::option::Option::Some(10),
+            Self::Zeppelin => std::option::Option::Some(4),
+            Self::Zookeeper => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("JUPYTER"),
-            3 => std::borrow::Cow::Borrowed("HIVE_WEBHCAT"),
-            4 => std::borrow::Cow::Borrowed("ZEPPELIN"),
-            5 => std::borrow::Cow::Borrowed("ANACONDA"),
-            6 => std::borrow::Cow::Borrowed("PRESTO"),
-            8 => std::borrow::Cow::Borrowed("ZOOKEEPER"),
-            9 => std::borrow::Cow::Borrowed("DRUID"),
-            10 => std::borrow::Cow::Borrowed("SOLR"),
-            11 => std::borrow::Cow::Borrowed("HBASE"),
-            12 => std::borrow::Cow::Borrowed("RANGER"),
-            13 => std::borrow::Cow::Borrowed("DOCKER"),
-            14 => std::borrow::Cow::Borrowed("FLINK"),
-            17 => std::borrow::Cow::Borrowed("TRINO"),
-            18 => std::borrow::Cow::Borrowed("HUDI"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMPONENT_UNSPECIFIED"),
+            Self::Anaconda => std::option::Option::Some("ANACONDA"),
+            Self::Docker => std::option::Option::Some("DOCKER"),
+            Self::Druid => std::option::Option::Some("DRUID"),
+            Self::Flink => std::option::Option::Some("FLINK"),
+            Self::Hbase => std::option::Option::Some("HBASE"),
+            Self::HiveWebhcat => std::option::Option::Some("HIVE_WEBHCAT"),
+            Self::Hudi => std::option::Option::Some("HUDI"),
+            Self::Jupyter => std::option::Option::Some("JUPYTER"),
+            Self::Presto => std::option::Option::Some("PRESTO"),
+            Self::Trino => std::option::Option::Some("TRINO"),
+            Self::Ranger => std::option::Option::Some("RANGER"),
+            Self::Solr => std::option::Option::Some("SOLR"),
+            Self::Zeppelin => std::option::Option::Some("ZEPPELIN"),
+            Self::Zookeeper => std::option::Option::Some("ZOOKEEPER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
-            "ANACONDA" => std::option::Option::Some(Self::ANACONDA),
-            "DOCKER" => std::option::Option::Some(Self::DOCKER),
-            "DRUID" => std::option::Option::Some(Self::DRUID),
-            "FLINK" => std::option::Option::Some(Self::FLINK),
-            "HBASE" => std::option::Option::Some(Self::HBASE),
-            "HIVE_WEBHCAT" => std::option::Option::Some(Self::HIVE_WEBHCAT),
-            "HUDI" => std::option::Option::Some(Self::HUDI),
-            "JUPYTER" => std::option::Option::Some(Self::JUPYTER),
-            "PRESTO" => std::option::Option::Some(Self::PRESTO),
-            "TRINO" => std::option::Option::Some(Self::TRINO),
-            "RANGER" => std::option::Option::Some(Self::RANGER),
-            "SOLR" => std::option::Option::Some(Self::SOLR),
-            "ZEPPELIN" => std::option::Option::Some(Self::ZEPPELIN),
-            "ZOOKEEPER" => std::option::Option::Some(Self::ZOOKEEPER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Component {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Component {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Component {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Component {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Jupyter,
+            3 => Self::HiveWebhcat,
+            4 => Self::Zeppelin,
+            5 => Self::Anaconda,
+            6 => Self::Presto,
+            8 => Self::Zookeeper,
+            9 => Self::Druid,
+            10 => Self::Solr,
+            11 => Self::Hbase,
+            12 => Self::Ranger,
+            13 => Self::Docker,
+            14 => Self::Flink,
+            17 => Self::Trino,
+            18 => Self::Hudi,
+            _ => Self::UnknownValue(component::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Component {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPONENT_UNSPECIFIED" => Self::Unspecified,
+            "ANACONDA" => Self::Anaconda,
+            "DOCKER" => Self::Docker,
+            "DRUID" => Self::Druid,
+            "FLINK" => Self::Flink,
+            "HBASE" => Self::Hbase,
+            "HIVE_WEBHCAT" => Self::HiveWebhcat,
+            "HUDI" => Self::Hudi,
+            "JUPYTER" => Self::Jupyter,
+            "PRESTO" => Self::Presto,
+            "TRINO" => Self::Trino,
+            "RANGER" => Self::Ranger,
+            "SOLR" => Self::Solr,
+            "ZEPPELIN" => Self::Zeppelin,
+            "ZOOKEEPER" => Self::Zookeeper,
+            _ => Self::UnknownValue(component::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Component {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Anaconda => serializer.serialize_i32(5),
+            Self::Docker => serializer.serialize_i32(13),
+            Self::Druid => serializer.serialize_i32(9),
+            Self::Flink => serializer.serialize_i32(14),
+            Self::Hbase => serializer.serialize_i32(11),
+            Self::HiveWebhcat => serializer.serialize_i32(3),
+            Self::Hudi => serializer.serialize_i32(18),
+            Self::Jupyter => serializer.serialize_i32(1),
+            Self::Presto => serializer.serialize_i32(6),
+            Self::Trino => serializer.serialize_i32(17),
+            Self::Ranger => serializer.serialize_i32(12),
+            Self::Solr => serializer.serialize_i32(10),
+            Self::Zeppelin => serializer.serialize_i32(4),
+            Self::Zookeeper => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Component {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Component>::new(
+            ".google.cloud.dataproc.v1.Component",
+        ))
     }
 }
 
 /// Actions in response to failure of a resource associated with a cluster.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FailureAction(i32);
-
-impl FailureAction {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FailureAction {
     /// When FailureAction is unspecified, failure action defaults to NO_ACTION.
-    pub const FAILURE_ACTION_UNSPECIFIED: FailureAction = FailureAction::new(0);
-
+    Unspecified,
     /// Take no action on failure to create a cluster resource. NO_ACTION is the
     /// default.
-    pub const NO_ACTION: FailureAction = FailureAction::new(1);
-
+    NoAction,
     /// Delete the failed cluster resource.
-    pub const DELETE: FailureAction = FailureAction::new(2);
+    Delete,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FailureAction::value] or
+    /// [FailureAction::name].
+    UnknownValue(failure_action::UnknownValue),
+}
 
-    /// Creates a new FailureAction instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod failure_action {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl FailureAction {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NoAction => std::option::Option::Some(1),
+            Self::Delete => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FAILURE_ACTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NO_ACTION"),
-            2 => std::borrow::Cow::Borrowed("DELETE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FAILURE_ACTION_UNSPECIFIED"),
+            Self::NoAction => std::option::Option::Some("NO_ACTION"),
+            Self::Delete => std::option::Option::Some("DELETE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FAILURE_ACTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FAILURE_ACTION_UNSPECIFIED)
-            }
-            "NO_ACTION" => std::option::Option::Some(Self::NO_ACTION),
-            "DELETE" => std::option::Option::Some(Self::DELETE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FailureAction {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FailureAction {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FailureAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FailureAction {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NoAction,
+            2 => Self::Delete,
+            _ => Self::UnknownValue(failure_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FailureAction {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FAILURE_ACTION_UNSPECIFIED" => Self::Unspecified,
+            "NO_ACTION" => Self::NoAction,
+            "DELETE" => Self::Delete,
+            _ => Self::UnknownValue(failure_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FailureAction {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NoAction => serializer.serialize_i32(1),
+            Self::Delete => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FailureAction {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureAction>::new(
+            ".google.cloud.dataproc.v1.FailureAction",
+        ))
     }
 }

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -613,7 +613,7 @@ impl super::stub::ClusterController for ClusterController {
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[(
             "actionOnFailedPrimaryWorkers",
-            &req.action_on_failed_primary_workers.value(),
+            &req.action_on_failed_primary_workers,
         )]);
         self.inner
             .execute(builder, Some(req.cluster), options)
@@ -1089,7 +1089,7 @@ impl super::stub::JobController for JobController {
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("clusterName", &req.cluster_name)]);
-        let builder = builder.query(&[("jobStateMatcher", &req.job_state_matcher.value())]);
+        let builder = builder.query(&[("jobStateMatcher", &req.job_state_matcher)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -4016,74 +4016,141 @@ pub mod private_connection {
     use super::*;
 
     /// Private Connection state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// The private connection is in creation state - creating resources.
+        Creating,
+        /// The private connection has been created with all of its resources.
+        Created,
+        /// The private connection creation has failed.
+        Failed,
+        /// The private connection is being deleted.
+        Deleting,
+        /// Delete request has failed, resource is in invalid state.
+        FailedToDelete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The private connection is in creation state - creating resources.
-        pub const CREATING: State = State::new(1);
-
-        /// The private connection has been created with all of its resources.
-        pub const CREATED: State = State::new(2);
-
-        /// The private connection creation has failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The private connection is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Delete request has failed, resource is in invalid state.
-        pub const FAILED_TO_DELETE: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Created => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::FailedToDelete => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("CREATED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("FAILED_TO_DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::FailedToDelete => std::option::Option::Some("FAILED_TO_DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED_TO_DELETE" => std::option::Option::Some(Self::FAILED_TO_DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Created,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                5 => Self::FailedToDelete,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "CREATED" => Self::Created,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "FAILED_TO_DELETE" => Self::FailedToDelete,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Created => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::FailedToDelete => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datastream.v1.PrivateConnection.State",
+            ))
         }
     }
 }
@@ -7673,120 +7740,238 @@ pub mod json_file_format {
     use super::*;
 
     /// Schema file format.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SchemaFileFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SchemaFileFormat {
+        /// Unspecified schema file format.
+        Unspecified,
+        /// Do not attach schema file.
+        NoSchemaFile,
+        /// Avro schema format.
+        AvroSchemaFile,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SchemaFileFormat::value] or
+        /// [SchemaFileFormat::name].
+        UnknownValue(schema_file_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod schema_file_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SchemaFileFormat {
-        /// Unspecified schema file format.
-        pub const SCHEMA_FILE_FORMAT_UNSPECIFIED: SchemaFileFormat = SchemaFileFormat::new(0);
-
-        /// Do not attach schema file.
-        pub const NO_SCHEMA_FILE: SchemaFileFormat = SchemaFileFormat::new(1);
-
-        /// Avro schema format.
-        pub const AVRO_SCHEMA_FILE: SchemaFileFormat = SchemaFileFormat::new(2);
-
-        /// Creates a new SchemaFileFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoSchemaFile => std::option::Option::Some(1),
+                Self::AvroSchemaFile => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCHEMA_FILE_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_SCHEMA_FILE"),
-                2 => std::borrow::Cow::Borrowed("AVRO_SCHEMA_FILE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCHEMA_FILE_FORMAT_UNSPECIFIED"),
+                Self::NoSchemaFile => std::option::Option::Some("NO_SCHEMA_FILE"),
+                Self::AvroSchemaFile => std::option::Option::Some("AVRO_SCHEMA_FILE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCHEMA_FILE_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SCHEMA_FILE_FORMAT_UNSPECIFIED)
-                }
-                "NO_SCHEMA_FILE" => std::option::Option::Some(Self::NO_SCHEMA_FILE),
-                "AVRO_SCHEMA_FILE" => std::option::Option::Some(Self::AVRO_SCHEMA_FILE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SchemaFileFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SchemaFileFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SchemaFileFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SchemaFileFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoSchemaFile,
+                2 => Self::AvroSchemaFile,
+                _ => Self::UnknownValue(schema_file_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SchemaFileFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCHEMA_FILE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "NO_SCHEMA_FILE" => Self::NoSchemaFile,
+                "AVRO_SCHEMA_FILE" => Self::AvroSchemaFile,
+                _ => Self::UnknownValue(schema_file_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SchemaFileFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoSchemaFile => serializer.serialize_i32(1),
+                Self::AvroSchemaFile => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SchemaFileFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SchemaFileFormat>::new(
+                ".google.cloud.datastream.v1.JsonFileFormat.SchemaFileFormat",
+            ))
         }
     }
 
     /// Json file compression.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JsonCompression(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JsonCompression {
+        /// Unspecified json file compression.
+        Unspecified,
+        /// Do not compress JSON file.
+        NoCompression,
+        /// Gzip compression.
+        Gzip,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JsonCompression::value] or
+        /// [JsonCompression::name].
+        UnknownValue(json_compression::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod json_compression {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl JsonCompression {
-        /// Unspecified json file compression.
-        pub const JSON_COMPRESSION_UNSPECIFIED: JsonCompression = JsonCompression::new(0);
-
-        /// Do not compress JSON file.
-        pub const NO_COMPRESSION: JsonCompression = JsonCompression::new(1);
-
-        /// Gzip compression.
-        pub const GZIP: JsonCompression = JsonCompression::new(2);
-
-        /// Creates a new JsonCompression instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoCompression => std::option::Option::Some(1),
+                Self::Gzip => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JSON_COMPRESSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_COMPRESSION"),
-                2 => std::borrow::Cow::Borrowed("GZIP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("JSON_COMPRESSION_UNSPECIFIED"),
+                Self::NoCompression => std::option::Option::Some("NO_COMPRESSION"),
+                Self::Gzip => std::option::Option::Some("GZIP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JSON_COMPRESSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::JSON_COMPRESSION_UNSPECIFIED)
-                }
-                "NO_COMPRESSION" => std::option::Option::Some(Self::NO_COMPRESSION),
-                "GZIP" => std::option::Option::Some(Self::GZIP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JsonCompression {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JsonCompression {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JsonCompression {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JsonCompression {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoCompression,
+                2 => Self::Gzip,
+                _ => Self::UnknownValue(json_compression::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JsonCompression {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JSON_COMPRESSION_UNSPECIFIED" => Self::Unspecified,
+                "NO_COMPRESSION" => Self::NoCompression,
+                "GZIP" => Self::Gzip,
+                _ => Self::UnknownValue(json_compression::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JsonCompression {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoCompression => serializer.serialize_i32(1),
+                Self::Gzip => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JsonCompression {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JsonCompression>::new(
+                ".google.cloud.datastream.v1.JsonFileFormat.JsonCompression",
+            ))
         }
     }
 }
@@ -8429,110 +8614,230 @@ pub mod big_query_destination_config {
         use super::*;
 
         /// Supported file formats for BigLake managed tables.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FileFormat(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum FileFormat {
+            /// Default value.
+            Unspecified,
+            /// Parquet file format.
+            Parquet,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [FileFormat::value] or
+            /// [FileFormat::name].
+            UnknownValue(file_format::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod file_format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl FileFormat {
-            /// Default value.
-            pub const FILE_FORMAT_UNSPECIFIED: FileFormat = FileFormat::new(0);
-
-            /// Parquet file format.
-            pub const PARQUET: FileFormat = FileFormat::new(1);
-
-            /// Creates a new FileFormat instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Parquet => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("FILE_FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PARQUET"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("FILE_FORMAT_UNSPECIFIED"),
+                    Self::Parquet => std::option::Option::Some("PARQUET"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "FILE_FORMAT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::FILE_FORMAT_UNSPECIFIED)
-                    }
-                    "PARQUET" => std::option::Option::Some(Self::PARQUET),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for FileFormat {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for FileFormat {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for FileFormat {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for FileFormat {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Parquet,
+                    _ => Self::UnknownValue(file_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for FileFormat {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "FILE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "PARQUET" => Self::Parquet,
+                    _ => Self::UnknownValue(file_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for FileFormat {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Parquet => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for FileFormat {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileFormat>::new(
+                    ".google.cloud.datastream.v1.BigQueryDestinationConfig.BlmtConfig.FileFormat",
+                ))
             }
         }
 
         /// Supported table formats for BigLake managed tables.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TableFormat(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TableFormat {
+            /// Default value.
+            Unspecified,
+            /// Iceberg table format.
+            Iceberg,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TableFormat::value] or
+            /// [TableFormat::name].
+            UnknownValue(table_format::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod table_format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl TableFormat {
-            /// Default value.
-            pub const TABLE_FORMAT_UNSPECIFIED: TableFormat = TableFormat::new(0);
-
-            /// Iceberg table format.
-            pub const ICEBERG: TableFormat = TableFormat::new(1);
-
-            /// Creates a new TableFormat instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Iceberg => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TABLE_FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ICEBERG"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TABLE_FORMAT_UNSPECIFIED"),
+                    Self::Iceberg => std::option::Option::Some("ICEBERG"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TABLE_FORMAT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::TABLE_FORMAT_UNSPECIFIED)
-                    }
-                    "ICEBERG" => std::option::Option::Some(Self::ICEBERG),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for TableFormat {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TableFormat {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TableFormat {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TableFormat {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Iceberg,
+                    _ => Self::UnknownValue(table_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TableFormat {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TABLE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "ICEBERG" => Self::Iceberg,
+                    _ => Self::UnknownValue(table_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TableFormat {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Iceberg => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TableFormat {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TableFormat>::new(
+                    ".google.cloud.datastream.v1.BigQueryDestinationConfig.BlmtConfig.TableFormat",
+                ))
             }
         }
     }
@@ -9282,93 +9587,166 @@ pub mod stream {
     }
 
     /// Stream state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified stream state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The stream has been created but has not yet started streaming data.
-        pub const NOT_STARTED: State = State::new(1);
-
+        NotStarted,
         /// The stream is running.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The stream is paused.
-        pub const PAUSED: State = State::new(3);
-
+        Paused,
         /// The stream is in maintenance mode.
         ///
         /// Updates are rejected on the resource in this state.
-        pub const MAINTENANCE: State = State::new(4);
-
+        Maintenance,
         /// The stream is experiencing an error that is preventing data from being
         /// streamed.
-        pub const FAILED: State = State::new(5);
-
+        Failed,
         /// The stream has experienced a terminal failure.
-        pub const FAILED_PERMANENTLY: State = State::new(6);
-
+        FailedPermanently,
         /// The stream is starting, but not yet running.
-        pub const STARTING: State = State::new(7);
-
+        Starting,
         /// The Stream is no longer reading new events, but still writing events in
         /// the buffer.
-        pub const DRAINING: State = State::new(8);
+        Draining,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotStarted => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Paused => std::option::Option::Some(3),
+                Self::Maintenance => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::FailedPermanently => std::option::Option::Some(6),
+                Self::Starting => std::option::Option::Some(7),
+                Self::Draining => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("PAUSED"),
-                4 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("FAILED_PERMANENTLY"),
-                7 => std::borrow::Cow::Borrowed("STARTING"),
-                8 => std::borrow::Cow::Borrowed("DRAINING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::NotStarted => std::option::Option::Some("NOT_STARTED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::FailedPermanently => std::option::Option::Some("FAILED_PERMANENTLY"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Draining => std::option::Option::Some("DRAINING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "FAILED_PERMANENTLY" => std::option::Option::Some(Self::FAILED_PERMANENTLY),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "DRAINING" => std::option::Option::Some(Self::DRAINING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotStarted,
+                2 => Self::Running,
+                3 => Self::Paused,
+                4 => Self::Maintenance,
+                5 => Self::Failed,
+                6 => Self::FailedPermanently,
+                7 => Self::Starting,
+                8 => Self::Draining,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NOT_STARTED" => Self::NotStarted,
+                "RUNNING" => Self::Running,
+                "PAUSED" => Self::Paused,
+                "MAINTENANCE" => Self::Maintenance,
+                "FAILED" => Self::Failed,
+                "FAILED_PERMANENTLY" => Self::FailedPermanently,
+                "STARTING" => Self::Starting,
+                "DRAINING" => Self::Draining,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotStarted => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Paused => serializer.serialize_i32(3),
+                Self::Maintenance => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::FailedPermanently => serializer.serialize_i32(6),
+                Self::Starting => serializer.serialize_i32(7),
+                Self::Draining => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datastream.v1.Stream.State",
+            ))
         }
     }
 
@@ -10051,145 +10429,277 @@ pub mod backfill_job {
     use super::*;
 
     /// State of the stream object's backfill job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Backfill job was never started for the stream object (stream has backfill
         /// strategy defined as manual or object was explicitly excluded from
         /// automatic backfill).
-        pub const NOT_STARTED: State = State::new(1);
-
+        NotStarted,
         /// Backfill job will start pending available resources.
-        pub const PENDING: State = State::new(2);
-
+        Pending,
         /// Backfill job is running.
-        pub const ACTIVE: State = State::new(3);
-
+        Active,
         /// Backfill job stopped (next job run will start from beginning).
-        pub const STOPPED: State = State::new(4);
-
+        Stopped,
         /// Backfill job failed (due to an error).
-        pub const FAILED: State = State::new(5);
-
+        Failed,
         /// Backfill completed successfully.
-        pub const COMPLETED: State = State::new(6);
-
+        Completed,
         /// Backfill job failed since the table structure is currently unsupported
         /// for backfill.
-        pub const UNSUPPORTED: State = State::new(7);
+        Unsupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotStarted => std::option::Option::Some(1),
+                Self::Pending => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::Stopped => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Completed => std::option::Option::Some(6),
+                Self::Unsupported => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
-                2 => std::borrow::Cow::Borrowed("PENDING"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("STOPPED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("COMPLETED"),
-                7 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::NotStarted => std::option::Option::Some("NOT_STARTED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::Unsupported => std::option::Option::Some("UNSUPPORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotStarted,
+                2 => Self::Pending,
+                3 => Self::Active,
+                4 => Self::Stopped,
+                5 => Self::Failed,
+                6 => Self::Completed,
+                7 => Self::Unsupported,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NOT_STARTED" => Self::NotStarted,
+                "PENDING" => Self::Pending,
+                "ACTIVE" => Self::Active,
+                "STOPPED" => Self::Stopped,
+                "FAILED" => Self::Failed,
+                "COMPLETED" => Self::Completed,
+                "UNSUPPORTED" => Self::Unsupported,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotStarted => serializer.serialize_i32(1),
+                Self::Pending => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::Stopped => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Completed => serializer.serialize_i32(6),
+                Self::Unsupported => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datastream.v1.BackfillJob.State",
+            ))
         }
     }
 
     /// Triggering reason for a backfill job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Trigger(i32);
-
-    impl Trigger {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Trigger {
         /// Default value.
-        pub const TRIGGER_UNSPECIFIED: Trigger = Trigger::new(0);
-
+        Unspecified,
         /// Object backfill job was triggered automatically according to the stream's
         /// backfill strategy.
-        pub const AUTOMATIC: Trigger = Trigger::new(1);
-
+        Automatic,
         /// Object backfill job was triggered manually using the dedicated API.
-        pub const MANUAL: Trigger = Trigger::new(2);
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Trigger::value] or
+        /// [Trigger::name].
+        UnknownValue(trigger::UnknownValue),
+    }
 
-        /// Creates a new Trigger instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod trigger {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Trigger {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRIGGER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRIGGER_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRIGGER_UNSPECIFIED" => std::option::Option::Some(Self::TRIGGER_UNSPECIFIED),
-                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Trigger {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Trigger {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Trigger {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Trigger {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Trigger {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRIGGER_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC" => Self::Automatic,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(trigger::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Trigger {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Trigger {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Trigger>::new(
+                ".google.cloud.datastream.v1.BackfillJob.Trigger",
+            ))
         }
     }
 }
@@ -10389,69 +10899,134 @@ pub mod validation {
     use super::*;
 
     /// Validation execution state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// Validation did not execute.
+        NotExecuted,
+        /// Validation failed.
+        Failed,
+        /// Validation passed.
+        Passed,
+        /// Validation executed with warnings.
+        Warning,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Validation did not execute.
-        pub const NOT_EXECUTED: State = State::new(1);
-
-        /// Validation failed.
-        pub const FAILED: State = State::new(2);
-
-        /// Validation passed.
-        pub const PASSED: State = State::new(3);
-
-        /// Validation executed with warnings.
-        pub const WARNING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotExecuted => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Passed => std::option::Option::Some(3),
+                Self::Warning => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_EXECUTED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("PASSED"),
-                4 => std::borrow::Cow::Borrowed("WARNING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::NotExecuted => std::option::Option::Some("NOT_EXECUTED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Passed => std::option::Option::Some("PASSED"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NOT_EXECUTED" => std::option::Option::Some(Self::NOT_EXECUTED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PASSED" => std::option::Option::Some(Self::PASSED),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotExecuted,
+                2 => Self::Failed,
+                3 => Self::Passed,
+                4 => Self::Warning,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NOT_EXECUTED" => Self::NotExecuted,
+                "FAILED" => Self::Failed,
+                "PASSED" => Self::Passed,
+                "WARNING" => Self::Warning,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotExecuted => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Passed => serializer.serialize_i32(3),
+                Self::Warning => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.datastream.v1.Validation.State",
+            ))
         }
     }
 }
@@ -10532,59 +11107,120 @@ pub mod validation_message {
     use super::*;
 
     /// Validation message level.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Level(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Level {
+        /// Unspecified level.
+        Unspecified,
+        /// Potentially cause issues with the Stream.
+        Warning,
+        /// Definitely cause issues with the Stream.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Level::value] or
+        /// [Level::name].
+        UnknownValue(level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Level {
-        /// Unspecified level.
-        pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
-
-        /// Potentially cause issues with the Stream.
-        pub const WARNING: Level = Level::new(1);
-
-        /// Definitely cause issues with the Stream.
-        pub const ERROR: Level = Level::new(2);
-
-        /// Creates a new Level instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Warning => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WARNING"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LEVEL_UNSPECIFIED"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Level {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Level {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Level {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Level {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Warning,
+                2 => Self::Error,
+                _ => Self::UnknownValue(level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Level {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Level {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Warning => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Level {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Level>::new(
+                ".google.cloud.datastream.v1.ValidationMessage.Level",
+            ))
         }
     }
 }

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -3298,77 +3298,145 @@ pub mod execution_config {
     use super::*;
 
     /// Possible usages of this configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionEnvironmentUsage(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExecutionEnvironmentUsage {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// Use for rendering.
+        Render,
+        /// Use for deploying and deployment hooks.
+        Deploy,
+        /// Use for deployment verification.
+        Verify,
+        /// Use for predeploy job execution.
+        Predeploy,
+        /// Use for postdeploy job execution.
+        Postdeploy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExecutionEnvironmentUsage::value] or
+        /// [ExecutionEnvironmentUsage::name].
+        UnknownValue(execution_environment_usage::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod execution_environment_usage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ExecutionEnvironmentUsage {
-        /// Default value. This value is unused.
-        pub const EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED: ExecutionEnvironmentUsage =
-            ExecutionEnvironmentUsage::new(0);
-
-        /// Use for rendering.
-        pub const RENDER: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(1);
-
-        /// Use for deploying and deployment hooks.
-        pub const DEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(2);
-
-        /// Use for deployment verification.
-        pub const VERIFY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(3);
-
-        /// Use for predeploy job execution.
-        pub const PREDEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(4);
-
-        /// Use for postdeploy job execution.
-        pub const POSTDEPLOY: ExecutionEnvironmentUsage = ExecutionEnvironmentUsage::new(5);
-
-        /// Creates a new ExecutionEnvironmentUsage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Render => std::option::Option::Some(1),
+                Self::Deploy => std::option::Option::Some(2),
+                Self::Verify => std::option::Option::Some(3),
+                Self::Predeploy => std::option::Option::Some(4),
+                Self::Postdeploy => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RENDER"),
-                2 => std::borrow::Cow::Borrowed("DEPLOY"),
-                3 => std::borrow::Cow::Borrowed("VERIFY"),
-                4 => std::borrow::Cow::Borrowed("PREDEPLOY"),
-                5 => std::borrow::Cow::Borrowed("POSTDEPLOY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED")
                 }
-                "RENDER" => std::option::Option::Some(Self::RENDER),
-                "DEPLOY" => std::option::Option::Some(Self::DEPLOY),
-                "VERIFY" => std::option::Option::Some(Self::VERIFY),
-                "PREDEPLOY" => std::option::Option::Some(Self::PREDEPLOY),
-                "POSTDEPLOY" => std::option::Option::Some(Self::POSTDEPLOY),
-                _ => std::option::Option::None,
+                Self::Render => std::option::Option::Some("RENDER"),
+                Self::Deploy => std::option::Option::Some("DEPLOY"),
+                Self::Verify => std::option::Option::Some("VERIFY"),
+                Self::Predeploy => std::option::Option::Some("PREDEPLOY"),
+                Self::Postdeploy => std::option::Option::Some("POSTDEPLOY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ExecutionEnvironmentUsage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionEnvironmentUsage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExecutionEnvironmentUsage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExecutionEnvironmentUsage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Render,
+                2 => Self::Deploy,
+                3 => Self::Verify,
+                4 => Self::Predeploy,
+                5 => Self::Postdeploy,
+                _ => Self::UnknownValue(execution_environment_usage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExecutionEnvironmentUsage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXECUTION_ENVIRONMENT_USAGE_UNSPECIFIED" => Self::Unspecified,
+                "RENDER" => Self::Render,
+                "DEPLOY" => Self::Deploy,
+                "VERIFY" => Self::Verify,
+                "PREDEPLOY" => Self::Predeploy,
+                "POSTDEPLOY" => Self::Postdeploy,
+                _ => Self::UnknownValue(execution_environment_usage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExecutionEnvironmentUsage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Render => serializer.serialize_i32(1),
+                Self::Deploy => serializer.serialize_i32(2),
+                Self::Verify => serializer.serialize_i32(3),
+                Self::Predeploy => serializer.serialize_i32(4),
+                Self::Postdeploy => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExecutionEnvironmentUsage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<ExecutionEnvironmentUsage>::new(
+                    ".google.cloud.deploy.v1.ExecutionConfig.ExecutionEnvironmentUsage",
+                ),
+            )
         }
     }
 
@@ -5515,60 +5583,121 @@ pub mod deploy_policy {
 
     /// What invoked the action. Filters enforcing the policy depending on what
     /// invoked the action.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Invoker(i32);
-
-    impl Invoker {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Invoker {
         /// Unspecified.
-        pub const INVOKER_UNSPECIFIED: Invoker = Invoker::new(0);
-
+        Unspecified,
         /// The action is user-driven. For example, creating a rollout manually via a
         /// gcloud create command.
-        pub const USER: Invoker = Invoker::new(1);
-
+        User,
         /// Automated action by Cloud Deploy.
-        pub const DEPLOY_AUTOMATION: Invoker = Invoker::new(2);
+        DeployAutomation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Invoker::value] or
+        /// [Invoker::name].
+        UnknownValue(invoker::UnknownValue),
+    }
 
-        /// Creates a new Invoker instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod invoker {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Invoker {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::User => std::option::Option::Some(1),
+                Self::DeployAutomation => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INVOKER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER"),
-                2 => std::borrow::Cow::Borrowed("DEPLOY_AUTOMATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INVOKER_UNSPECIFIED"),
+                Self::User => std::option::Option::Some("USER"),
+                Self::DeployAutomation => std::option::Option::Some("DEPLOY_AUTOMATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INVOKER_UNSPECIFIED" => std::option::Option::Some(Self::INVOKER_UNSPECIFIED),
-                "USER" => std::option::Option::Some(Self::USER),
-                "DEPLOY_AUTOMATION" => std::option::Option::Some(Self::DEPLOY_AUTOMATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Invoker {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Invoker {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Invoker {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Invoker {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::User,
+                2 => Self::DeployAutomation,
+                _ => Self::UnknownValue(invoker::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Invoker {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INVOKER_UNSPECIFIED" => Self::Unspecified,
+                "USER" => Self::User,
+                "DEPLOY_AUTOMATION" => Self::DeployAutomation,
+                _ => Self::UnknownValue(invoker::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Invoker {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::User => serializer.serialize_i32(1),
+                Self::DeployAutomation => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Invoker {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Invoker>::new(
+                ".google.cloud.deploy.v1.DeployPolicy.Invoker",
+            ))
         }
     }
 }
@@ -5899,91 +6028,162 @@ pub mod rollout_restriction {
     use super::*;
 
     /// Rollout actions to be restricted as part of the policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutActions(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolloutActions {
+        /// Unspecified.
+        Unspecified,
+        /// Advance the rollout to the next phase.
+        Advance,
+        /// Approve the rollout.
+        Approve,
+        /// Cancel the rollout.
+        Cancel,
+        /// Create a rollout.
+        Create,
+        /// Ignore a job result on the rollout.
+        IgnoreJob,
+        /// Retry a job for a rollout.
+        RetryJob,
+        /// Rollback a rollout.
+        Rollback,
+        /// Terminate a jobrun.
+        TerminateJobrun,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolloutActions::value] or
+        /// [RolloutActions::name].
+        UnknownValue(rollout_actions::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod rollout_actions {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RolloutActions {
-        /// Unspecified.
-        pub const ROLLOUT_ACTIONS_UNSPECIFIED: RolloutActions = RolloutActions::new(0);
-
-        /// Advance the rollout to the next phase.
-        pub const ADVANCE: RolloutActions = RolloutActions::new(1);
-
-        /// Approve the rollout.
-        pub const APPROVE: RolloutActions = RolloutActions::new(2);
-
-        /// Cancel the rollout.
-        pub const CANCEL: RolloutActions = RolloutActions::new(3);
-
-        /// Create a rollout.
-        pub const CREATE: RolloutActions = RolloutActions::new(4);
-
-        /// Ignore a job result on the rollout.
-        pub const IGNORE_JOB: RolloutActions = RolloutActions::new(5);
-
-        /// Retry a job for a rollout.
-        pub const RETRY_JOB: RolloutActions = RolloutActions::new(6);
-
-        /// Rollback a rollout.
-        pub const ROLLBACK: RolloutActions = RolloutActions::new(7);
-
-        /// Terminate a jobrun.
-        pub const TERMINATE_JOBRUN: RolloutActions = RolloutActions::new(8);
-
-        /// Creates a new RolloutActions instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Advance => std::option::Option::Some(1),
+                Self::Approve => std::option::Option::Some(2),
+                Self::Cancel => std::option::Option::Some(3),
+                Self::Create => std::option::Option::Some(4),
+                Self::IgnoreJob => std::option::Option::Some(5),
+                Self::RetryJob => std::option::Option::Some(6),
+                Self::Rollback => std::option::Option::Some(7),
+                Self::TerminateJobrun => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLLOUT_ACTIONS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADVANCE"),
-                2 => std::borrow::Cow::Borrowed("APPROVE"),
-                3 => std::borrow::Cow::Borrowed("CANCEL"),
-                4 => std::borrow::Cow::Borrowed("CREATE"),
-                5 => std::borrow::Cow::Borrowed("IGNORE_JOB"),
-                6 => std::borrow::Cow::Borrowed("RETRY_JOB"),
-                7 => std::borrow::Cow::Borrowed("ROLLBACK"),
-                8 => std::borrow::Cow::Borrowed("TERMINATE_JOBRUN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLLOUT_ACTIONS_UNSPECIFIED"),
+                Self::Advance => std::option::Option::Some("ADVANCE"),
+                Self::Approve => std::option::Option::Some("APPROVE"),
+                Self::Cancel => std::option::Option::Some("CANCEL"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::IgnoreJob => std::option::Option::Some("IGNORE_JOB"),
+                Self::RetryJob => std::option::Option::Some("RETRY_JOB"),
+                Self::Rollback => std::option::Option::Some("ROLLBACK"),
+                Self::TerminateJobrun => std::option::Option::Some("TERMINATE_JOBRUN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLLOUT_ACTIONS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLLOUT_ACTIONS_UNSPECIFIED)
-                }
-                "ADVANCE" => std::option::Option::Some(Self::ADVANCE),
-                "APPROVE" => std::option::Option::Some(Self::APPROVE),
-                "CANCEL" => std::option::Option::Some(Self::CANCEL),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "IGNORE_JOB" => std::option::Option::Some(Self::IGNORE_JOB),
-                "RETRY_JOB" => std::option::Option::Some(Self::RETRY_JOB),
-                "ROLLBACK" => std::option::Option::Some(Self::ROLLBACK),
-                "TERMINATE_JOBRUN" => std::option::Option::Some(Self::TERMINATE_JOBRUN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolloutActions {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutActions {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolloutActions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolloutActions {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Advance,
+                2 => Self::Approve,
+                3 => Self::Cancel,
+                4 => Self::Create,
+                5 => Self::IgnoreJob,
+                6 => Self::RetryJob,
+                7 => Self::Rollback,
+                8 => Self::TerminateJobrun,
+                _ => Self::UnknownValue(rollout_actions::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolloutActions {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLLOUT_ACTIONS_UNSPECIFIED" => Self::Unspecified,
+                "ADVANCE" => Self::Advance,
+                "APPROVE" => Self::Approve,
+                "CANCEL" => Self::Cancel,
+                "CREATE" => Self::Create,
+                "IGNORE_JOB" => Self::IgnoreJob,
+                "RETRY_JOB" => Self::RetryJob,
+                "ROLLBACK" => Self::Rollback,
+                "TERMINATE_JOBRUN" => Self::TerminateJobrun,
+                _ => Self::UnknownValue(rollout_actions::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolloutActions {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Advance => serializer.serialize_i32(1),
+                Self::Approve => serializer.serialize_i32(2),
+                Self::Cancel => serializer.serialize_i32(3),
+                Self::Create => serializer.serialize_i32(4),
+                Self::IgnoreJob => serializer.serialize_i32(5),
+                Self::RetryJob => serializer.serialize_i32(6),
+                Self::Rollback => serializer.serialize_i32(7),
+                Self::TerminateJobrun => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolloutActions {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolloutActions>::new(
+                ".google.cloud.deploy.v1.RolloutRestriction.RolloutActions",
+            ))
         }
     }
 }
@@ -6745,172 +6945,309 @@ pub mod release {
         use super::*;
 
         /// Valid states of the render operation.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TargetRenderState(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TargetRenderState {
+            /// The render operation state is unspecified.
+            Unspecified,
+            /// The render operation has completed successfully.
+            Succeeded,
+            /// The render operation has failed.
+            Failed,
+            /// The render operation is in progress.
+            InProgress,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TargetRenderState::value] or
+            /// [TargetRenderState::name].
+            UnknownValue(target_render_state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod target_render_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl TargetRenderState {
-            /// The render operation state is unspecified.
-            pub const TARGET_RENDER_STATE_UNSPECIFIED: TargetRenderState =
-                TargetRenderState::new(0);
-
-            /// The render operation has completed successfully.
-            pub const SUCCEEDED: TargetRenderState = TargetRenderState::new(1);
-
-            /// The render operation has failed.
-            pub const FAILED: TargetRenderState = TargetRenderState::new(2);
-
-            /// The render operation is in progress.
-            pub const IN_PROGRESS: TargetRenderState = TargetRenderState::new(3);
-
-            /// Creates a new TargetRenderState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Succeeded => std::option::Option::Some(1),
+                    Self::Failed => std::option::Option::Some(2),
+                    Self::InProgress => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TARGET_RENDER_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                    2 => std::borrow::Cow::Borrowed("FAILED"),
-                    3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TARGET_RENDER_STATE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::TARGET_RENDER_STATE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("TARGET_RENDER_STATE_UNSPECIFIED")
                     }
-                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                    _ => std::option::Option::None,
+                    Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for TargetRenderState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TargetRenderState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TargetRenderState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TargetRenderState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Succeeded,
+                    2 => Self::Failed,
+                    3 => Self::InProgress,
+                    _ => Self::UnknownValue(target_render_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TargetRenderState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TARGET_RENDER_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "SUCCEEDED" => Self::Succeeded,
+                    "FAILED" => Self::Failed,
+                    "IN_PROGRESS" => Self::InProgress,
+                    _ => Self::UnknownValue(target_render_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TargetRenderState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Succeeded => serializer.serialize_i32(1),
+                    Self::Failed => serializer.serialize_i32(2),
+                    Self::InProgress => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TargetRenderState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TargetRenderState>::new(
+                    ".google.cloud.deploy.v1.Release.TargetRender.TargetRenderState",
+                ))
             }
         }
 
         /// Well-known rendering failures.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FailureCause(i32);
-
-        impl FailureCause {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum FailureCause {
             /// No reason for failure is specified.
-            pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
-
+            Unspecified,
             /// Cloud Build is not available, either because it is not enabled or
             /// because Cloud Deploy has insufficient permissions. See [required
             /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-            pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
-
+            CloudBuildUnavailable,
             /// The render operation did not complete successfully; check Cloud Build
             /// logs.
-            pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
-
+            ExecutionFailed,
             /// Cloud Build failed to fulfill Cloud Deploy's request. See
             /// failure_message for additional details.
-            pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(3);
-
+            CloudBuildRequestFailed,
             /// The render operation did not complete successfully because the
             /// verification stanza required for verify was not found on the Skaffold
             /// configuration.
-            pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause = FailureCause::new(4);
-
+            VerificationConfigNotFound,
             /// The render operation did not complete successfully because the custom
             /// action(s) required for Rollout jobs were not found in the Skaffold
             /// configuration. See failure_message for additional details.
-            pub const CUSTOM_ACTION_NOT_FOUND: FailureCause = FailureCause::new(5);
-
+            CustomActionNotFound,
             /// Release failed during rendering because the release configuration is
             /// not supported with the specified deployment strategy.
-            pub const DEPLOYMENT_STRATEGY_NOT_SUPPORTED: FailureCause = FailureCause::new(6);
-
+            DeploymentStrategyNotSupported,
             /// The render operation had a feature configured that is not supported.
-            pub const RENDER_FEATURE_NOT_SUPPORTED: FailureCause = FailureCause::new(7);
+            RenderFeatureNotSupported,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [FailureCause::value] or
+            /// [FailureCause::name].
+            UnknownValue(failure_cause::UnknownValue),
+        }
 
-            /// Creates a new FailureCause instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod failure_cause {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl FailureCause {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::CloudBuildUnavailable => std::option::Option::Some(1),
+                    Self::ExecutionFailed => std::option::Option::Some(2),
+                    Self::CloudBuildRequestFailed => std::option::Option::Some(3),
+                    Self::VerificationConfigNotFound => std::option::Option::Some(4),
+                    Self::CustomActionNotFound => std::option::Option::Some(5),
+                    Self::DeploymentStrategyNotSupported => std::option::Option::Some(6),
+                    Self::RenderFeatureNotSupported => std::option::Option::Some(7),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
-                    2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                    3 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
-                    4 => std::borrow::Cow::Borrowed("VERIFICATION_CONFIG_NOT_FOUND"),
-                    5 => std::borrow::Cow::Borrowed("CUSTOM_ACTION_NOT_FOUND"),
-                    6 => std::borrow::Cow::Borrowed("DEPLOYMENT_STRATEGY_NOT_SUPPORTED"),
-                    7 => std::borrow::Cow::Borrowed("RENDER_FEATURE_NOT_SUPPORTED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("FAILURE_CAUSE_UNSPECIFIED"),
+                    Self::CloudBuildUnavailable => {
+                        std::option::Option::Some("CLOUD_BUILD_UNAVAILABLE")
+                    }
+                    Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                    Self::CloudBuildRequestFailed => {
+                        std::option::Option::Some("CLOUD_BUILD_REQUEST_FAILED")
+                    }
+                    Self::VerificationConfigNotFound => {
+                        std::option::Option::Some("VERIFICATION_CONFIG_NOT_FOUND")
+                    }
+                    Self::CustomActionNotFound => {
+                        std::option::Option::Some("CUSTOM_ACTION_NOT_FOUND")
+                    }
+                    Self::DeploymentStrategyNotSupported => {
+                        std::option::Option::Some("DEPLOYMENT_STRATEGY_NOT_SUPPORTED")
+                    }
+                    Self::RenderFeatureNotSupported => {
+                        std::option::Option::Some("RENDER_FEATURE_NOT_SUPPORTED")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "FAILURE_CAUSE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
-                    }
-                    "CLOUD_BUILD_UNAVAILABLE" => {
-                        std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
-                    }
-                    "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                    "CLOUD_BUILD_REQUEST_FAILED" => {
-                        std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
-                    }
-                    "VERIFICATION_CONFIG_NOT_FOUND" => {
-                        std::option::Option::Some(Self::VERIFICATION_CONFIG_NOT_FOUND)
-                    }
-                    "CUSTOM_ACTION_NOT_FOUND" => {
-                        std::option::Option::Some(Self::CUSTOM_ACTION_NOT_FOUND)
-                    }
-                    "DEPLOYMENT_STRATEGY_NOT_SUPPORTED" => {
-                        std::option::Option::Some(Self::DEPLOYMENT_STRATEGY_NOT_SUPPORTED)
-                    }
-                    "RENDER_FEATURE_NOT_SUPPORTED" => {
-                        std::option::Option::Some(Self::RENDER_FEATURE_NOT_SUPPORTED)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for FailureCause {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for FailureCause {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for FailureCause {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for FailureCause {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::CloudBuildUnavailable,
+                    2 => Self::ExecutionFailed,
+                    3 => Self::CloudBuildRequestFailed,
+                    4 => Self::VerificationConfigNotFound,
+                    5 => Self::CustomActionNotFound,
+                    6 => Self::DeploymentStrategyNotSupported,
+                    7 => Self::RenderFeatureNotSupported,
+                    _ => Self::UnknownValue(failure_cause::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for FailureCause {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "FAILURE_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                    "CLOUD_BUILD_UNAVAILABLE" => Self::CloudBuildUnavailable,
+                    "EXECUTION_FAILED" => Self::ExecutionFailed,
+                    "CLOUD_BUILD_REQUEST_FAILED" => Self::CloudBuildRequestFailed,
+                    "VERIFICATION_CONFIG_NOT_FOUND" => Self::VerificationConfigNotFound,
+                    "CUSTOM_ACTION_NOT_FOUND" => Self::CustomActionNotFound,
+                    "DEPLOYMENT_STRATEGY_NOT_SUPPORTED" => Self::DeploymentStrategyNotSupported,
+                    "RENDER_FEATURE_NOT_SUPPORTED" => Self::RenderFeatureNotSupported,
+                    _ => Self::UnknownValue(failure_cause::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for FailureCause {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::CloudBuildUnavailable => serializer.serialize_i32(1),
+                    Self::ExecutionFailed => serializer.serialize_i32(2),
+                    Self::CloudBuildRequestFailed => serializer.serialize_i32(3),
+                    Self::VerificationConfigNotFound => serializer.serialize_i32(4),
+                    Self::CustomActionNotFound => serializer.serialize_i32(5),
+                    Self::DeploymentStrategyNotSupported => serializer.serialize_i32(6),
+                    Self::RenderFeatureNotSupported => serializer.serialize_i32(7),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for FailureCause {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureCause>::new(
+                    ".google.cloud.deploy.v1.Release.TargetRender.FailureCause",
+                ))
             }
         }
     }
@@ -7089,66 +7426,127 @@ pub mod release {
     }
 
     /// Valid states of the render operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RenderState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RenderState {
+        /// The render state is unspecified.
+        Unspecified,
+        /// All rendering operations have completed successfully.
+        Succeeded,
+        /// All rendering operations have completed, and one or more have failed.
+        Failed,
+        /// Rendering has started and is not complete.
+        InProgress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RenderState::value] or
+        /// [RenderState::name].
+        UnknownValue(render_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod render_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RenderState {
-        /// The render state is unspecified.
-        pub const RENDER_STATE_UNSPECIFIED: RenderState = RenderState::new(0);
-
-        /// All rendering operations have completed successfully.
-        pub const SUCCEEDED: RenderState = RenderState::new(1);
-
-        /// All rendering operations have completed, and one or more have failed.
-        pub const FAILED: RenderState = RenderState::new(2);
-
-        /// Rendering has started and is not complete.
-        pub const IN_PROGRESS: RenderState = RenderState::new(3);
-
-        /// Creates a new RenderState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::InProgress => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RENDER_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RENDER_STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RENDER_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RENDER_STATE_UNSPECIFIED)
-                }
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RenderState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RenderState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RenderState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RenderState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                3 => Self::InProgress,
+                _ => Self::UnknownValue(render_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RenderState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RENDER_STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "IN_PROGRESS" => Self::InProgress,
+                _ => Self::UnknownValue(render_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RenderState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::InProgress => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RenderState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RenderState>::new(
+                ".google.cloud.deploy.v1.Release.RenderState",
+            ))
         }
     }
 }
@@ -8620,270 +9018,479 @@ pub mod rollout {
     use super::*;
 
     /// Valid approval states of a `Rollout`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApprovalState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ApprovalState {
+        /// The `Rollout` has an unspecified approval state.
+        Unspecified,
+        /// The `Rollout` requires approval.
+        NeedsApproval,
+        /// The `Rollout` does not require approval.
+        DoesNotNeedApproval,
+        /// The `Rollout` has been approved.
+        Approved,
+        /// The `Rollout` has been rejected.
+        Rejected,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ApprovalState::value] or
+        /// [ApprovalState::name].
+        UnknownValue(approval_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod approval_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ApprovalState {
-        /// The `Rollout` has an unspecified approval state.
-        pub const APPROVAL_STATE_UNSPECIFIED: ApprovalState = ApprovalState::new(0);
-
-        /// The `Rollout` requires approval.
-        pub const NEEDS_APPROVAL: ApprovalState = ApprovalState::new(1);
-
-        /// The `Rollout` does not require approval.
-        pub const DOES_NOT_NEED_APPROVAL: ApprovalState = ApprovalState::new(2);
-
-        /// The `Rollout` has been approved.
-        pub const APPROVED: ApprovalState = ApprovalState::new(3);
-
-        /// The `Rollout` has been rejected.
-        pub const REJECTED: ApprovalState = ApprovalState::new(4);
-
-        /// Creates a new ApprovalState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NeedsApproval => std::option::Option::Some(1),
+                Self::DoesNotNeedApproval => std::option::Option::Some(2),
+                Self::Approved => std::option::Option::Some(3),
+                Self::Rejected => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("APPROVAL_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEEDS_APPROVAL"),
-                2 => std::borrow::Cow::Borrowed("DOES_NOT_NEED_APPROVAL"),
-                3 => std::borrow::Cow::Borrowed("APPROVED"),
-                4 => std::borrow::Cow::Borrowed("REJECTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("APPROVAL_STATE_UNSPECIFIED"),
+                Self::NeedsApproval => std::option::Option::Some("NEEDS_APPROVAL"),
+                Self::DoesNotNeedApproval => std::option::Option::Some("DOES_NOT_NEED_APPROVAL"),
+                Self::Approved => std::option::Option::Some("APPROVED"),
+                Self::Rejected => std::option::Option::Some("REJECTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "APPROVAL_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::APPROVAL_STATE_UNSPECIFIED)
-                }
-                "NEEDS_APPROVAL" => std::option::Option::Some(Self::NEEDS_APPROVAL),
-                "DOES_NOT_NEED_APPROVAL" => std::option::Option::Some(Self::DOES_NOT_NEED_APPROVAL),
-                "APPROVED" => std::option::Option::Some(Self::APPROVED),
-                "REJECTED" => std::option::Option::Some(Self::REJECTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ApprovalState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ApprovalState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ApprovalState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ApprovalState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NeedsApproval,
+                2 => Self::DoesNotNeedApproval,
+                3 => Self::Approved,
+                4 => Self::Rejected,
+                _ => Self::UnknownValue(approval_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ApprovalState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "APPROVAL_STATE_UNSPECIFIED" => Self::Unspecified,
+                "NEEDS_APPROVAL" => Self::NeedsApproval,
+                "DOES_NOT_NEED_APPROVAL" => Self::DoesNotNeedApproval,
+                "APPROVED" => Self::Approved,
+                "REJECTED" => Self::Rejected,
+                _ => Self::UnknownValue(approval_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ApprovalState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NeedsApproval => serializer.serialize_i32(1),
+                Self::DoesNotNeedApproval => serializer.serialize_i32(2),
+                Self::Approved => serializer.serialize_i32(3),
+                Self::Rejected => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ApprovalState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ApprovalState>::new(
+                ".google.cloud.deploy.v1.Rollout.ApprovalState",
+            ))
         }
     }
 
     /// Valid states of a `Rollout`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The `Rollout` has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The `Rollout` has completed successfully.
-        pub const SUCCEEDED: State = State::new(1);
-
+        Succeeded,
         /// The `Rollout` has failed.
-        pub const FAILED: State = State::new(2);
-
+        Failed,
         /// The `Rollout` is being deployed.
-        pub const IN_PROGRESS: State = State::new(3);
-
+        InProgress,
         /// The `Rollout` needs approval.
-        pub const PENDING_APPROVAL: State = State::new(4);
-
+        PendingApproval,
         /// An approver rejected the `Rollout`.
-        pub const APPROVAL_REJECTED: State = State::new(5);
-
+        ApprovalRejected,
         /// The `Rollout` is waiting for an earlier Rollout(s) to complete on this
         /// `Target`.
-        pub const PENDING: State = State::new(6);
-
+        Pending,
         /// The `Rollout` is waiting for the `Release` to be fully rendered.
-        pub const PENDING_RELEASE: State = State::new(7);
-
+        PendingRelease,
         /// The `Rollout` is in the process of being cancelled.
-        pub const CANCELLING: State = State::new(8);
-
+        Cancelling,
         /// The `Rollout` has been cancelled.
-        pub const CANCELLED: State = State::new(9);
-
+        Cancelled,
         /// The `Rollout` is halted.
-        pub const HALTED: State = State::new(10);
+        Halted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::InProgress => std::option::Option::Some(3),
+                Self::PendingApproval => std::option::Option::Some(4),
+                Self::ApprovalRejected => std::option::Option::Some(5),
+                Self::Pending => std::option::Option::Some(6),
+                Self::PendingRelease => std::option::Option::Some(7),
+                Self::Cancelling => std::option::Option::Some(8),
+                Self::Cancelled => std::option::Option::Some(9),
+                Self::Halted => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                4 => std::borrow::Cow::Borrowed("PENDING_APPROVAL"),
-                5 => std::borrow::Cow::Borrowed("APPROVAL_REJECTED"),
-                6 => std::borrow::Cow::Borrowed("PENDING"),
-                7 => std::borrow::Cow::Borrowed("PENDING_RELEASE"),
-                8 => std::borrow::Cow::Borrowed("CANCELLING"),
-                9 => std::borrow::Cow::Borrowed("CANCELLED"),
-                10 => std::borrow::Cow::Borrowed("HALTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::PendingApproval => std::option::Option::Some("PENDING_APPROVAL"),
+                Self::ApprovalRejected => std::option::Option::Some("APPROVAL_REJECTED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::PendingRelease => std::option::Option::Some("PENDING_RELEASE"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Halted => std::option::Option::Some("HALTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "PENDING_APPROVAL" => std::option::Option::Some(Self::PENDING_APPROVAL),
-                "APPROVAL_REJECTED" => std::option::Option::Some(Self::APPROVAL_REJECTED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "PENDING_RELEASE" => std::option::Option::Some(Self::PENDING_RELEASE),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "HALTED" => std::option::Option::Some(Self::HALTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                3 => Self::InProgress,
+                4 => Self::PendingApproval,
+                5 => Self::ApprovalRejected,
+                6 => Self::Pending,
+                7 => Self::PendingRelease,
+                8 => Self::Cancelling,
+                9 => Self::Cancelled,
+                10 => Self::Halted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "IN_PROGRESS" => Self::InProgress,
+                "PENDING_APPROVAL" => Self::PendingApproval,
+                "APPROVAL_REJECTED" => Self::ApprovalRejected,
+                "PENDING" => Self::Pending,
+                "PENDING_RELEASE" => Self::PendingRelease,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "HALTED" => Self::Halted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::InProgress => serializer.serialize_i32(3),
+                Self::PendingApproval => serializer.serialize_i32(4),
+                Self::ApprovalRejected => serializer.serialize_i32(5),
+                Self::Pending => serializer.serialize_i32(6),
+                Self::PendingRelease => serializer.serialize_i32(7),
+                Self::Cancelling => serializer.serialize_i32(8),
+                Self::Cancelled => serializer.serialize_i32(9),
+                Self::Halted => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.deploy.v1.Rollout.State",
+            ))
         }
     }
 
     /// Well-known rollout failures.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(i32);
-
-    impl FailureCause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FailureCause {
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
-
+        Unspecified,
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
-
+        CloudBuildUnavailable,
         /// The deploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
-
+        ExecutionFailed,
         /// Deployment did not complete within the allotted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
-
+        DeadlineExceeded,
         /// Release is in a failed state.
-        pub const RELEASE_FAILED: FailureCause = FailureCause::new(4);
-
+        ReleaseFailed,
         /// Release is abandoned.
-        pub const RELEASE_ABANDONED: FailureCause = FailureCause::new(5);
-
+        ReleaseAbandoned,
         /// No Skaffold verify configuration was found.
-        pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause = FailureCause::new(6);
-
+        VerificationConfigNotFound,
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(7);
-
+        CloudBuildRequestFailed,
         /// A Rollout operation had a feature configured that is not supported.
-        pub const OPERATION_FEATURE_NOT_SUPPORTED: FailureCause = FailureCause::new(8);
+        OperationFeatureNotSupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FailureCause::value] or
+        /// [FailureCause::name].
+        UnknownValue(failure_cause::UnknownValue),
+    }
 
-        /// Creates a new FailureCause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod failure_cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FailureCause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildUnavailable => std::option::Option::Some(1),
+                Self::ExecutionFailed => std::option::Option::Some(2),
+                Self::DeadlineExceeded => std::option::Option::Some(3),
+                Self::ReleaseFailed => std::option::Option::Some(4),
+                Self::ReleaseAbandoned => std::option::Option::Some(5),
+                Self::VerificationConfigNotFound => std::option::Option::Some(6),
+                Self::CloudBuildRequestFailed => std::option::Option::Some(7),
+                Self::OperationFeatureNotSupported => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
-                4 => std::borrow::Cow::Borrowed("RELEASE_FAILED"),
-                5 => std::borrow::Cow::Borrowed("RELEASE_ABANDONED"),
-                6 => std::borrow::Cow::Borrowed("VERIFICATION_CONFIG_NOT_FOUND"),
-                7 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
-                8 => std::borrow::Cow::Borrowed("OPERATION_FEATURE_NOT_SUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FAILURE_CAUSE_UNSPECIFIED"),
+                Self::CloudBuildUnavailable => std::option::Option::Some("CLOUD_BUILD_UNAVAILABLE"),
+                Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                Self::DeadlineExceeded => std::option::Option::Some("DEADLINE_EXCEEDED"),
+                Self::ReleaseFailed => std::option::Option::Some("RELEASE_FAILED"),
+                Self::ReleaseAbandoned => std::option::Option::Some("RELEASE_ABANDONED"),
+                Self::VerificationConfigNotFound => {
+                    std::option::Option::Some("VERIFICATION_CONFIG_NOT_FOUND")
+                }
+                Self::CloudBuildRequestFailed => {
+                    std::option::Option::Some("CLOUD_BUILD_REQUEST_FAILED")
+                }
+                Self::OperationFeatureNotSupported => {
+                    std::option::Option::Some("OPERATION_FEATURE_NOT_SUPPORTED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FAILURE_CAUSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
-                }
-                "CLOUD_BUILD_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
-                }
-                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
-                "RELEASE_FAILED" => std::option::Option::Some(Self::RELEASE_FAILED),
-                "RELEASE_ABANDONED" => std::option::Option::Some(Self::RELEASE_ABANDONED),
-                "VERIFICATION_CONFIG_NOT_FOUND" => {
-                    std::option::Option::Some(Self::VERIFICATION_CONFIG_NOT_FOUND)
-                }
-                "CLOUD_BUILD_REQUEST_FAILED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
-                }
-                "OPERATION_FEATURE_NOT_SUPPORTED" => {
-                    std::option::Option::Some(Self::OPERATION_FEATURE_NOT_SUPPORTED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FailureCause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FailureCause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildUnavailable,
+                2 => Self::ExecutionFailed,
+                3 => Self::DeadlineExceeded,
+                4 => Self::ReleaseFailed,
+                5 => Self::ReleaseAbandoned,
+                6 => Self::VerificationConfigNotFound,
+                7 => Self::CloudBuildRequestFailed,
+                8 => Self::OperationFeatureNotSupported,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FailureCause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FAILURE_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_UNAVAILABLE" => Self::CloudBuildUnavailable,
+                "EXECUTION_FAILED" => Self::ExecutionFailed,
+                "DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+                "RELEASE_FAILED" => Self::ReleaseFailed,
+                "RELEASE_ABANDONED" => Self::ReleaseAbandoned,
+                "VERIFICATION_CONFIG_NOT_FOUND" => Self::VerificationConfigNotFound,
+                "CLOUD_BUILD_REQUEST_FAILED" => Self::CloudBuildRequestFailed,
+                "OPERATION_FEATURE_NOT_SUPPORTED" => Self::OperationFeatureNotSupported,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FailureCause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildUnavailable => serializer.serialize_i32(1),
+                Self::ExecutionFailed => serializer.serialize_i32(2),
+                Self::DeadlineExceeded => serializer.serialize_i32(3),
+                Self::ReleaseFailed => serializer.serialize_i32(4),
+                Self::ReleaseAbandoned => serializer.serialize_i32(5),
+                Self::VerificationConfigNotFound => serializer.serialize_i32(6),
+                Self::CloudBuildRequestFailed => serializer.serialize_i32(7),
+                Self::OperationFeatureNotSupported => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FailureCause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureCause>::new(
+                ".google.cloud.deploy.v1.Rollout.FailureCause",
+            ))
         }
     }
 }
@@ -9367,79 +9974,148 @@ pub mod phase {
     use super::*;
 
     /// Valid states of a Phase.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The Phase has an unspecified state.
+        Unspecified,
+        /// The Phase is waiting for an earlier Phase(s) to complete.
+        Pending,
+        /// The Phase is in progress.
+        InProgress,
+        /// The Phase has succeeded.
+        Succeeded,
+        /// The Phase has failed.
+        Failed,
+        /// The Phase was aborted.
+        Aborted,
+        /// The Phase was skipped.
+        Skipped,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The Phase has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Phase is waiting for an earlier Phase(s) to complete.
-        pub const PENDING: State = State::new(1);
-
-        /// The Phase is in progress.
-        pub const IN_PROGRESS: State = State::new(2);
-
-        /// The Phase has succeeded.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// The Phase has failed.
-        pub const FAILED: State = State::new(4);
-
-        /// The Phase was aborted.
-        pub const ABORTED: State = State::new(5);
-
-        /// The Phase was skipped.
-        pub const SKIPPED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::InProgress => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Aborted => std::option::Option::Some(5),
+                Self::Skipped => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("ABORTED"),
-                6 => std::borrow::Cow::Borrowed("SKIPPED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::Skipped => std::option::Option::Some("SKIPPED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::InProgress,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Aborted,
+                6 => Self::Skipped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "IN_PROGRESS" => Self::InProgress,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "ABORTED" => Self::Aborted,
+                "SKIPPED" => Self::Skipped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::InProgress => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Aborted => serializer.serialize_i32(5),
+                Self::Skipped => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.deploy.v1.Phase.State",
+            ))
         }
     }
 
@@ -9828,89 +10504,162 @@ pub mod job {
     use super::*;
 
     /// Valid states of a Job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The Job has an unspecified state.
+        Unspecified,
+        /// The Job is waiting for an earlier Phase(s) or Job(s) to complete.
+        Pending,
+        /// The Job is disabled.
+        Disabled,
+        /// The Job is in progress.
+        InProgress,
+        /// The Job succeeded.
+        Succeeded,
+        /// The Job failed.
+        Failed,
+        /// The Job was aborted.
+        Aborted,
+        /// The Job was skipped.
+        Skipped,
+        /// The Job was ignored.
+        Ignored,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The Job has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Job is waiting for an earlier Phase(s) or Job(s) to complete.
-        pub const PENDING: State = State::new(1);
-
-        /// The Job is disabled.
-        pub const DISABLED: State = State::new(2);
-
-        /// The Job is in progress.
-        pub const IN_PROGRESS: State = State::new(3);
-
-        /// The Job succeeded.
-        pub const SUCCEEDED: State = State::new(4);
-
-        /// The Job failed.
-        pub const FAILED: State = State::new(5);
-
-        /// The Job was aborted.
-        pub const ABORTED: State = State::new(6);
-
-        /// The Job was skipped.
-        pub const SKIPPED: State = State::new(7);
-
-        /// The Job was ignored.
-        pub const IGNORED: State = State::new(8);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::InProgress => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Aborted => std::option::Option::Some(6),
+                Self::Skipped => std::option::Option::Some(7),
+                Self::Ignored => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("ABORTED"),
-                7 => std::borrow::Cow::Borrowed("SKIPPED"),
-                8 => std::borrow::Cow::Borrowed("IGNORED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::Skipped => std::option::Option::Some("SKIPPED"),
+                Self::Ignored => std::option::Option::Some("IGNORED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                "IGNORED" => std::option::Option::Some(Self::IGNORED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Disabled,
+                3 => Self::InProgress,
+                4 => Self::Succeeded,
+                5 => Self::Failed,
+                6 => Self::Aborted,
+                7 => Self::Skipped,
+                8 => Self::Ignored,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "DISABLED" => Self::Disabled,
+                "IN_PROGRESS" => Self::InProgress,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "ABORTED" => Self::Aborted,
+                "SKIPPED" => Self::Skipped,
+                "IGNORED" => Self::Ignored,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::InProgress => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Aborted => serializer.serialize_i32(6),
+                Self::Skipped => serializer.serialize_i32(7),
+                Self::Ignored => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.deploy.v1.Job.State",
+            ))
         }
     }
 
@@ -11312,74 +12061,141 @@ pub mod job_run {
     use super::*;
 
     /// Valid states of a `JobRun`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The `JobRun` has an unspecified state.
+        Unspecified,
+        /// The `JobRun` is in progress.
+        InProgress,
+        /// The `JobRun` has succeeded.
+        Succeeded,
+        /// The `JobRun` has failed.
+        Failed,
+        /// The `JobRun` is terminating.
+        Terminating,
+        /// The `JobRun` was terminated.
+        Terminated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The `JobRun` has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The `JobRun` is in progress.
-        pub const IN_PROGRESS: State = State::new(1);
-
-        /// The `JobRun` has succeeded.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The `JobRun` has failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The `JobRun` is terminating.
-        pub const TERMINATING: State = State::new(4);
-
-        /// The `JobRun` was terminated.
-        pub const TERMINATED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Terminating => std::option::Option::Some(4),
+                Self::Terminated => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("TERMINATING"),
-                5 => std::borrow::Cow::Borrowed("TERMINATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Terminating => std::option::Option::Some("TERMINATING"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Terminating,
+                5 => Self::Terminated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "TERMINATING" => Self::Terminating,
+                "TERMINATED" => Self::Terminated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Terminating => serializer.serialize_i32(4),
+                Self::Terminated => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.deploy.v1.JobRun.State",
+            ))
         }
     }
 
@@ -11496,94 +12312,159 @@ pub mod deploy_job_run {
     use super::*;
 
     /// Well-known deploy failures.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(i32);
-
-    impl FailureCause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FailureCause {
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
-
+        Unspecified,
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [Required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
-
+        CloudBuildUnavailable,
         /// The deploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
-
+        ExecutionFailed,
         /// The deploy job run did not complete within the allotted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
-
+        DeadlineExceeded,
         /// There were missing resources in the runtime environment required for a
         /// canary deployment. Check the Cloud Build logs for more information.
-        pub const MISSING_RESOURCES_FOR_CANARY: FailureCause = FailureCause::new(4);
-
+        MissingResourcesForCanary,
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(5);
-
+        CloudBuildRequestFailed,
         /// The deploy operation had a feature configured that is not supported.
-        pub const DEPLOY_FEATURE_NOT_SUPPORTED: FailureCause = FailureCause::new(6);
+        DeployFeatureNotSupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FailureCause::value] or
+        /// [FailureCause::name].
+        UnknownValue(failure_cause::UnknownValue),
+    }
 
-        /// Creates a new FailureCause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod failure_cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FailureCause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildUnavailable => std::option::Option::Some(1),
+                Self::ExecutionFailed => std::option::Option::Some(2),
+                Self::DeadlineExceeded => std::option::Option::Some(3),
+                Self::MissingResourcesForCanary => std::option::Option::Some(4),
+                Self::CloudBuildRequestFailed => std::option::Option::Some(5),
+                Self::DeployFeatureNotSupported => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
-                4 => std::borrow::Cow::Borrowed("MISSING_RESOURCES_FOR_CANARY"),
-                5 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
-                6 => std::borrow::Cow::Borrowed("DEPLOY_FEATURE_NOT_SUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FAILURE_CAUSE_UNSPECIFIED"),
+                Self::CloudBuildUnavailable => std::option::Option::Some("CLOUD_BUILD_UNAVAILABLE"),
+                Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                Self::DeadlineExceeded => std::option::Option::Some("DEADLINE_EXCEEDED"),
+                Self::MissingResourcesForCanary => {
+                    std::option::Option::Some("MISSING_RESOURCES_FOR_CANARY")
+                }
+                Self::CloudBuildRequestFailed => {
+                    std::option::Option::Some("CLOUD_BUILD_REQUEST_FAILED")
+                }
+                Self::DeployFeatureNotSupported => {
+                    std::option::Option::Some("DEPLOY_FEATURE_NOT_SUPPORTED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FAILURE_CAUSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
-                }
-                "CLOUD_BUILD_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
-                }
-                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
-                "MISSING_RESOURCES_FOR_CANARY" => {
-                    std::option::Option::Some(Self::MISSING_RESOURCES_FOR_CANARY)
-                }
-                "CLOUD_BUILD_REQUEST_FAILED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
-                }
-                "DEPLOY_FEATURE_NOT_SUPPORTED" => {
-                    std::option::Option::Some(Self::DEPLOY_FEATURE_NOT_SUPPORTED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FailureCause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FailureCause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildUnavailable,
+                2 => Self::ExecutionFailed,
+                3 => Self::DeadlineExceeded,
+                4 => Self::MissingResourcesForCanary,
+                5 => Self::CloudBuildRequestFailed,
+                6 => Self::DeployFeatureNotSupported,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FailureCause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FAILURE_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_UNAVAILABLE" => Self::CloudBuildUnavailable,
+                "EXECUTION_FAILED" => Self::ExecutionFailed,
+                "DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+                "MISSING_RESOURCES_FOR_CANARY" => Self::MissingResourcesForCanary,
+                "CLOUD_BUILD_REQUEST_FAILED" => Self::CloudBuildRequestFailed,
+                "DEPLOY_FEATURE_NOT_SUPPORTED" => Self::DeployFeatureNotSupported,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FailureCause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildUnavailable => serializer.serialize_i32(1),
+                Self::ExecutionFailed => serializer.serialize_i32(2),
+                Self::DeadlineExceeded => serializer.serialize_i32(3),
+                Self::MissingResourcesForCanary => serializer.serialize_i32(4),
+                Self::CloudBuildRequestFailed => serializer.serialize_i32(5),
+                Self::DeployFeatureNotSupported => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FailureCause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureCause>::new(
+                ".google.cloud.deploy.v1.DeployJobRun.FailureCause",
+            ))
         }
     }
 }
@@ -11673,86 +12554,149 @@ pub mod verify_job_run {
     use super::*;
 
     /// Well-known verify failures.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(i32);
-
-    impl FailureCause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FailureCause {
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
-
+        Unspecified,
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
-
+        CloudBuildUnavailable,
         /// The verify operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
-
+        ExecutionFailed,
         /// The verify job run did not complete within the allotted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
-
+        DeadlineExceeded,
         /// No Skaffold verify configuration was found.
-        pub const VERIFICATION_CONFIG_NOT_FOUND: FailureCause = FailureCause::new(4);
-
+        VerificationConfigNotFound,
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(5);
+        CloudBuildRequestFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FailureCause::value] or
+        /// [FailureCause::name].
+        UnknownValue(failure_cause::UnknownValue),
+    }
 
-        /// Creates a new FailureCause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod failure_cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FailureCause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildUnavailable => std::option::Option::Some(1),
+                Self::ExecutionFailed => std::option::Option::Some(2),
+                Self::DeadlineExceeded => std::option::Option::Some(3),
+                Self::VerificationConfigNotFound => std::option::Option::Some(4),
+                Self::CloudBuildRequestFailed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
-                4 => std::borrow::Cow::Borrowed("VERIFICATION_CONFIG_NOT_FOUND"),
-                5 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FAILURE_CAUSE_UNSPECIFIED"),
+                Self::CloudBuildUnavailable => std::option::Option::Some("CLOUD_BUILD_UNAVAILABLE"),
+                Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                Self::DeadlineExceeded => std::option::Option::Some("DEADLINE_EXCEEDED"),
+                Self::VerificationConfigNotFound => {
+                    std::option::Option::Some("VERIFICATION_CONFIG_NOT_FOUND")
+                }
+                Self::CloudBuildRequestFailed => {
+                    std::option::Option::Some("CLOUD_BUILD_REQUEST_FAILED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FAILURE_CAUSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
-                }
-                "CLOUD_BUILD_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
-                }
-                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
-                "VERIFICATION_CONFIG_NOT_FOUND" => {
-                    std::option::Option::Some(Self::VERIFICATION_CONFIG_NOT_FOUND)
-                }
-                "CLOUD_BUILD_REQUEST_FAILED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FailureCause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FailureCause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildUnavailable,
+                2 => Self::ExecutionFailed,
+                3 => Self::DeadlineExceeded,
+                4 => Self::VerificationConfigNotFound,
+                5 => Self::CloudBuildRequestFailed,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FailureCause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FAILURE_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_UNAVAILABLE" => Self::CloudBuildUnavailable,
+                "EXECUTION_FAILED" => Self::ExecutionFailed,
+                "DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+                "VERIFICATION_CONFIG_NOT_FOUND" => Self::VerificationConfigNotFound,
+                "CLOUD_BUILD_REQUEST_FAILED" => Self::CloudBuildRequestFailed,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FailureCause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildUnavailable => serializer.serialize_i32(1),
+                Self::ExecutionFailed => serializer.serialize_i32(2),
+                Self::DeadlineExceeded => serializer.serialize_i32(3),
+                Self::VerificationConfigNotFound => serializer.serialize_i32(4),
+                Self::CloudBuildRequestFailed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FailureCause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureCause>::new(
+                ".google.cloud.deploy.v1.VerifyJobRun.FailureCause",
+            ))
         }
     }
 }
@@ -11823,79 +12767,140 @@ pub mod predeploy_job_run {
     use super::*;
 
     /// Well-known predeploy failures.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(i32);
-
-    impl FailureCause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FailureCause {
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
-
+        Unspecified,
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
-
+        CloudBuildUnavailable,
         /// The predeploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
-
+        ExecutionFailed,
         /// The predeploy job run did not complete within the allotted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
-
+        DeadlineExceeded,
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(4);
+        CloudBuildRequestFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FailureCause::value] or
+        /// [FailureCause::name].
+        UnknownValue(failure_cause::UnknownValue),
+    }
 
-        /// Creates a new FailureCause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod failure_cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FailureCause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildUnavailable => std::option::Option::Some(1),
+                Self::ExecutionFailed => std::option::Option::Some(2),
+                Self::DeadlineExceeded => std::option::Option::Some(3),
+                Self::CloudBuildRequestFailed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
-                4 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FAILURE_CAUSE_UNSPECIFIED"),
+                Self::CloudBuildUnavailable => std::option::Option::Some("CLOUD_BUILD_UNAVAILABLE"),
+                Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                Self::DeadlineExceeded => std::option::Option::Some("DEADLINE_EXCEEDED"),
+                Self::CloudBuildRequestFailed => {
+                    std::option::Option::Some("CLOUD_BUILD_REQUEST_FAILED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FAILURE_CAUSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
-                }
-                "CLOUD_BUILD_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
-                }
-                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
-                "CLOUD_BUILD_REQUEST_FAILED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FailureCause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FailureCause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildUnavailable,
+                2 => Self::ExecutionFailed,
+                3 => Self::DeadlineExceeded,
+                4 => Self::CloudBuildRequestFailed,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FailureCause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FAILURE_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_UNAVAILABLE" => Self::CloudBuildUnavailable,
+                "EXECUTION_FAILED" => Self::ExecutionFailed,
+                "DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+                "CLOUD_BUILD_REQUEST_FAILED" => Self::CloudBuildRequestFailed,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FailureCause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildUnavailable => serializer.serialize_i32(1),
+                Self::ExecutionFailed => serializer.serialize_i32(2),
+                Self::DeadlineExceeded => serializer.serialize_i32(3),
+                Self::CloudBuildRequestFailed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FailureCause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureCause>::new(
+                ".google.cloud.deploy.v1.PredeployJobRun.FailureCause",
+            ))
         }
     }
 }
@@ -11966,79 +12971,140 @@ pub mod postdeploy_job_run {
     use super::*;
 
     /// Well-known postdeploy failures.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FailureCause(i32);
-
-    impl FailureCause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FailureCause {
         /// No reason for failure is specified.
-        pub const FAILURE_CAUSE_UNSPECIFIED: FailureCause = FailureCause::new(0);
-
+        Unspecified,
         /// Cloud Build is not available, either because it is not enabled or because
         /// Cloud Deploy has insufficient permissions. See [required
         /// permission](https://cloud.google.com/deploy/docs/cloud-deploy-service-account#required_permissions).
-        pub const CLOUD_BUILD_UNAVAILABLE: FailureCause = FailureCause::new(1);
-
+        CloudBuildUnavailable,
         /// The postdeploy operation did not complete successfully; check Cloud Build
         /// logs.
-        pub const EXECUTION_FAILED: FailureCause = FailureCause::new(2);
-
+        ExecutionFailed,
         /// The postdeploy job run did not complete within the allotted time.
-        pub const DEADLINE_EXCEEDED: FailureCause = FailureCause::new(3);
-
+        DeadlineExceeded,
         /// Cloud Build failed to fulfill Cloud Deploy's request. See failure_message
         /// for additional details.
-        pub const CLOUD_BUILD_REQUEST_FAILED: FailureCause = FailureCause::new(4);
+        CloudBuildRequestFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FailureCause::value] or
+        /// [FailureCause::name].
+        UnknownValue(failure_cause::UnknownValue),
+    }
 
-        /// Creates a new FailureCause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod failure_cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FailureCause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudBuildUnavailable => std::option::Option::Some(1),
+                Self::ExecutionFailed => std::option::Option::Some(2),
+                Self::DeadlineExceeded => std::option::Option::Some(3),
+                Self::CloudBuildRequestFailed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FAILURE_CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_BUILD_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
-                4 => std::borrow::Cow::Borrowed("CLOUD_BUILD_REQUEST_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FAILURE_CAUSE_UNSPECIFIED"),
+                Self::CloudBuildUnavailable => std::option::Option::Some("CLOUD_BUILD_UNAVAILABLE"),
+                Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                Self::DeadlineExceeded => std::option::Option::Some("DEADLINE_EXCEEDED"),
+                Self::CloudBuildRequestFailed => {
+                    std::option::Option::Some("CLOUD_BUILD_REQUEST_FAILED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FAILURE_CAUSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FAILURE_CAUSE_UNSPECIFIED)
-                }
-                "CLOUD_BUILD_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_UNAVAILABLE)
-                }
-                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
-                "CLOUD_BUILD_REQUEST_FAILED" => {
-                    std::option::Option::Some(Self::CLOUD_BUILD_REQUEST_FAILED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FailureCause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FailureCause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FailureCause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FailureCause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudBuildUnavailable,
+                2 => Self::ExecutionFailed,
+                3 => Self::DeadlineExceeded,
+                4 => Self::CloudBuildRequestFailed,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FailureCause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FAILURE_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_BUILD_UNAVAILABLE" => Self::CloudBuildUnavailable,
+                "EXECUTION_FAILED" => Self::ExecutionFailed,
+                "DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+                "CLOUD_BUILD_REQUEST_FAILED" => Self::CloudBuildRequestFailed,
+                _ => Self::UnknownValue(failure_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FailureCause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudBuildUnavailable => serializer.serialize_i32(1),
+                Self::ExecutionFailed => serializer.serialize_i32(2),
+                Self::DeadlineExceeded => serializer.serialize_i32(3),
+                Self::CloudBuildRequestFailed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FailureCause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureCause>::new(
+                ".google.cloud.deploy.v1.PostdeployJobRun.FailureCause",
+            ))
         }
     }
 }
@@ -14655,79 +15721,148 @@ pub mod automation_run {
     use super::*;
 
     /// Valid state of an `AutomationRun`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The `AutomationRun` has an unspecified state.
+        Unspecified,
+        /// The `AutomationRun` has succeeded.
+        Succeeded,
+        /// The `AutomationRun` was cancelled.
+        Cancelled,
+        /// The `AutomationRun` has failed.
+        Failed,
+        /// The `AutomationRun` is in progress.
+        InProgress,
+        /// The `AutomationRun` is pending.
+        Pending,
+        /// The `AutomationRun` was aborted.
+        Aborted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The `AutomationRun` has an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The `AutomationRun` has succeeded.
-        pub const SUCCEEDED: State = State::new(1);
-
-        /// The `AutomationRun` was cancelled.
-        pub const CANCELLED: State = State::new(2);
-
-        /// The `AutomationRun` has failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The `AutomationRun` is in progress.
-        pub const IN_PROGRESS: State = State::new(4);
-
-        /// The `AutomationRun` is pending.
-        pub const PENDING: State = State::new(5);
-
-        /// The `AutomationRun` was aborted.
-        pub const ABORTED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Cancelled => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::InProgress => std::option::Option::Some(4),
+                Self::Pending => std::option::Option::Some(5),
+                Self::Aborted => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("CANCELLED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                5 => std::borrow::Cow::Borrowed("PENDING"),
-                6 => std::borrow::Cow::Borrowed("ABORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Cancelled,
+                3 => Self::Failed,
+                4 => Self::InProgress,
+                5 => Self::Pending,
+                6 => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                "IN_PROGRESS" => Self::InProgress,
+                "PENDING" => Self::Pending,
+                "ABORTED" => Self::Aborted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Cancelled => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::InProgress => serializer.serialize_i32(4),
+                Self::Pending => serializer.serialize_i32(5),
+                Self::Aborted => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.deploy.v1.AutomationRun.State",
+            ))
         }
     }
 
@@ -15897,124 +17032,243 @@ pub mod deploy_policy_evaluation_event {
     use super::*;
 
     /// The policy verdict of the request.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyVerdict(i32);
-
-    impl PolicyVerdict {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PolicyVerdict {
         /// This should never happen.
-        pub const POLICY_VERDICT_UNSPECIFIED: PolicyVerdict = PolicyVerdict::new(0);
-
+        Unspecified,
         /// Allowed by policy. This enum value is not currently used but may be used
         /// in the future. Currently logs are only generated when a request is denied
         /// by policy.
-        pub const ALLOWED_BY_POLICY: PolicyVerdict = PolicyVerdict::new(1);
-
+        AllowedByPolicy,
         /// Denied by policy.
-        pub const DENIED_BY_POLICY: PolicyVerdict = PolicyVerdict::new(2);
+        DeniedByPolicy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PolicyVerdict::value] or
+        /// [PolicyVerdict::name].
+        UnknownValue(policy_verdict::UnknownValue),
+    }
 
-        /// Creates a new PolicyVerdict instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod policy_verdict {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PolicyVerdict {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllowedByPolicy => std::option::Option::Some(1),
+                Self::DeniedByPolicy => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POLICY_VERDICT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOWED_BY_POLICY"),
-                2 => std::borrow::Cow::Borrowed("DENIED_BY_POLICY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POLICY_VERDICT_UNSPECIFIED"),
+                Self::AllowedByPolicy => std::option::Option::Some("ALLOWED_BY_POLICY"),
+                Self::DeniedByPolicy => std::option::Option::Some("DENIED_BY_POLICY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POLICY_VERDICT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POLICY_VERDICT_UNSPECIFIED)
-                }
-                "ALLOWED_BY_POLICY" => std::option::Option::Some(Self::ALLOWED_BY_POLICY),
-                "DENIED_BY_POLICY" => std::option::Option::Some(Self::DENIED_BY_POLICY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PolicyVerdict {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyVerdict {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PolicyVerdict {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PolicyVerdict {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllowedByPolicy,
+                2 => Self::DeniedByPolicy,
+                _ => Self::UnknownValue(policy_verdict::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PolicyVerdict {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POLICY_VERDICT_UNSPECIFIED" => Self::Unspecified,
+                "ALLOWED_BY_POLICY" => Self::AllowedByPolicy,
+                "DENIED_BY_POLICY" => Self::DeniedByPolicy,
+                _ => Self::UnknownValue(policy_verdict::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PolicyVerdict {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllowedByPolicy => serializer.serialize_i32(1),
+                Self::DeniedByPolicy => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PolicyVerdict {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PolicyVerdict>::new(
+                ".google.cloud.deploy.v1.DeployPolicyEvaluationEvent.PolicyVerdict",
+            ))
         }
     }
 
     /// Things that could have overridden the policy verdict. When overrides are
     /// used, the request will be allowed even if it is DENIED_BY_POLICY.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyVerdictOverride(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PolicyVerdictOverride {
+        /// This should never happen.
+        Unspecified,
+        /// The policy was overridden.
+        PolicyOverridden,
+        /// The policy was suspended.
+        PolicySuspended,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PolicyVerdictOverride::value] or
+        /// [PolicyVerdictOverride::name].
+        UnknownValue(policy_verdict_override::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod policy_verdict_override {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PolicyVerdictOverride {
-        /// This should never happen.
-        pub const POLICY_VERDICT_OVERRIDE_UNSPECIFIED: PolicyVerdictOverride =
-            PolicyVerdictOverride::new(0);
-
-        /// The policy was overridden.
-        pub const POLICY_OVERRIDDEN: PolicyVerdictOverride = PolicyVerdictOverride::new(1);
-
-        /// The policy was suspended.
-        pub const POLICY_SUSPENDED: PolicyVerdictOverride = PolicyVerdictOverride::new(2);
-
-        /// Creates a new PolicyVerdictOverride instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PolicyOverridden => std::option::Option::Some(1),
+                Self::PolicySuspended => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POLICY_VERDICT_OVERRIDE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("POLICY_OVERRIDDEN"),
-                2 => std::borrow::Cow::Borrowed("POLICY_SUSPENDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POLICY_VERDICT_OVERRIDE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POLICY_VERDICT_OVERRIDE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("POLICY_VERDICT_OVERRIDE_UNSPECIFIED")
                 }
-                "POLICY_OVERRIDDEN" => std::option::Option::Some(Self::POLICY_OVERRIDDEN),
-                "POLICY_SUSPENDED" => std::option::Option::Some(Self::POLICY_SUSPENDED),
-                _ => std::option::Option::None,
+                Self::PolicyOverridden => std::option::Option::Some("POLICY_OVERRIDDEN"),
+                Self::PolicySuspended => std::option::Option::Some("POLICY_SUSPENDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PolicyVerdictOverride {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyVerdictOverride {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PolicyVerdictOverride {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PolicyVerdictOverride {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PolicyOverridden,
+                2 => Self::PolicySuspended,
+                _ => Self::UnknownValue(policy_verdict_override::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PolicyVerdictOverride {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POLICY_VERDICT_OVERRIDE_UNSPECIFIED" => Self::Unspecified,
+                "POLICY_OVERRIDDEN" => Self::PolicyOverridden,
+                "POLICY_SUSPENDED" => Self::PolicySuspended,
+                _ => Self::UnknownValue(policy_verdict_override::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PolicyVerdictOverride {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PolicyOverridden => serializer.serialize_i32(1),
+                Self::PolicySuspended => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PolicyVerdictOverride {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PolicyVerdictOverride>::new(
+                ".google.cloud.deploy.v1.DeployPolicyEvaluationEvent.PolicyVerdictOverride",
+            ))
         }
     }
 }
@@ -16572,116 +17826,197 @@ pub mod rollout_update_event {
     use super::*;
 
     /// RolloutUpdateType indicates the type of the rollout update.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutUpdateType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolloutUpdateType {
+        /// Rollout update type unspecified.
+        Unspecified,
+        /// rollout state updated to pending.
+        Pending,
+        /// Rollout state updated to pending release.
+        PendingRelease,
+        /// Rollout state updated to in progress.
+        InProgress,
+        /// Rollout state updated to cancelling.
+        Cancelling,
+        /// Rollout state updated to cancelled.
+        Cancelled,
+        /// Rollout state updated to halted.
+        Halted,
+        /// Rollout state updated to succeeded.
+        Succeeded,
+        /// Rollout state updated to failed.
+        Failed,
+        /// Rollout requires approval.
+        ApprovalRequired,
+        /// Rollout has been approved.
+        Approved,
+        /// Rollout has been rejected.
+        Rejected,
+        /// Rollout requires advance to the next phase.
+        AdvanceRequired,
+        /// Rollout has been advanced.
+        Advanced,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolloutUpdateType::value] or
+        /// [RolloutUpdateType::name].
+        UnknownValue(rollout_update_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod rollout_update_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RolloutUpdateType {
-        /// Rollout update type unspecified.
-        pub const ROLLOUT_UPDATE_TYPE_UNSPECIFIED: RolloutUpdateType = RolloutUpdateType::new(0);
-
-        /// rollout state updated to pending.
-        pub const PENDING: RolloutUpdateType = RolloutUpdateType::new(1);
-
-        /// Rollout state updated to pending release.
-        pub const PENDING_RELEASE: RolloutUpdateType = RolloutUpdateType::new(2);
-
-        /// Rollout state updated to in progress.
-        pub const IN_PROGRESS: RolloutUpdateType = RolloutUpdateType::new(3);
-
-        /// Rollout state updated to cancelling.
-        pub const CANCELLING: RolloutUpdateType = RolloutUpdateType::new(4);
-
-        /// Rollout state updated to cancelled.
-        pub const CANCELLED: RolloutUpdateType = RolloutUpdateType::new(5);
-
-        /// Rollout state updated to halted.
-        pub const HALTED: RolloutUpdateType = RolloutUpdateType::new(6);
-
-        /// Rollout state updated to succeeded.
-        pub const SUCCEEDED: RolloutUpdateType = RolloutUpdateType::new(7);
-
-        /// Rollout state updated to failed.
-        pub const FAILED: RolloutUpdateType = RolloutUpdateType::new(8);
-
-        /// Rollout requires approval.
-        pub const APPROVAL_REQUIRED: RolloutUpdateType = RolloutUpdateType::new(9);
-
-        /// Rollout has been approved.
-        pub const APPROVED: RolloutUpdateType = RolloutUpdateType::new(10);
-
-        /// Rollout has been rejected.
-        pub const REJECTED: RolloutUpdateType = RolloutUpdateType::new(11);
-
-        /// Rollout requires advance to the next phase.
-        pub const ADVANCE_REQUIRED: RolloutUpdateType = RolloutUpdateType::new(12);
-
-        /// Rollout has been advanced.
-        pub const ADVANCED: RolloutUpdateType = RolloutUpdateType::new(13);
-
-        /// Creates a new RolloutUpdateType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::PendingRelease => std::option::Option::Some(2),
+                Self::InProgress => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::Halted => std::option::Option::Some(6),
+                Self::Succeeded => std::option::Option::Some(7),
+                Self::Failed => std::option::Option::Some(8),
+                Self::ApprovalRequired => std::option::Option::Some(9),
+                Self::Approved => std::option::Option::Some(10),
+                Self::Rejected => std::option::Option::Some(11),
+                Self::AdvanceRequired => std::option::Option::Some(12),
+                Self::Advanced => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLLOUT_UPDATE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("PENDING_RELEASE"),
-                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                6 => std::borrow::Cow::Borrowed("HALTED"),
-                7 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                8 => std::borrow::Cow::Borrowed("FAILED"),
-                9 => std::borrow::Cow::Borrowed("APPROVAL_REQUIRED"),
-                10 => std::borrow::Cow::Borrowed("APPROVED"),
-                11 => std::borrow::Cow::Borrowed("REJECTED"),
-                12 => std::borrow::Cow::Borrowed("ADVANCE_REQUIRED"),
-                13 => std::borrow::Cow::Borrowed("ADVANCED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLLOUT_UPDATE_TYPE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::PendingRelease => std::option::Option::Some("PENDING_RELEASE"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Halted => std::option::Option::Some("HALTED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::ApprovalRequired => std::option::Option::Some("APPROVAL_REQUIRED"),
+                Self::Approved => std::option::Option::Some("APPROVED"),
+                Self::Rejected => std::option::Option::Some("REJECTED"),
+                Self::AdvanceRequired => std::option::Option::Some("ADVANCE_REQUIRED"),
+                Self::Advanced => std::option::Option::Some("ADVANCED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLLOUT_UPDATE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLLOUT_UPDATE_TYPE_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "PENDING_RELEASE" => std::option::Option::Some(Self::PENDING_RELEASE),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "HALTED" => std::option::Option::Some(Self::HALTED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "APPROVAL_REQUIRED" => std::option::Option::Some(Self::APPROVAL_REQUIRED),
-                "APPROVED" => std::option::Option::Some(Self::APPROVED),
-                "REJECTED" => std::option::Option::Some(Self::REJECTED),
-                "ADVANCE_REQUIRED" => std::option::Option::Some(Self::ADVANCE_REQUIRED),
-                "ADVANCED" => std::option::Option::Some(Self::ADVANCED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolloutUpdateType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutUpdateType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolloutUpdateType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolloutUpdateType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::PendingRelease,
+                3 => Self::InProgress,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                6 => Self::Halted,
+                7 => Self::Succeeded,
+                8 => Self::Failed,
+                9 => Self::ApprovalRequired,
+                10 => Self::Approved,
+                11 => Self::Rejected,
+                12 => Self::AdvanceRequired,
+                13 => Self::Advanced,
+                _ => Self::UnknownValue(rollout_update_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolloutUpdateType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLLOUT_UPDATE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "PENDING_RELEASE" => Self::PendingRelease,
+                "IN_PROGRESS" => Self::InProgress,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "HALTED" => Self::Halted,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "APPROVAL_REQUIRED" => Self::ApprovalRequired,
+                "APPROVED" => Self::Approved,
+                "REJECTED" => Self::Rejected,
+                "ADVANCE_REQUIRED" => Self::AdvanceRequired,
+                "ADVANCED" => Self::Advanced,
+                _ => Self::UnknownValue(rollout_update_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolloutUpdateType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::PendingRelease => serializer.serialize_i32(2),
+                Self::InProgress => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::Halted => serializer.serialize_i32(6),
+                Self::Succeeded => serializer.serialize_i32(7),
+                Self::Failed => serializer.serialize_i32(8),
+                Self::ApprovalRequired => serializer.serialize_i32(9),
+                Self::Approved => serializer.serialize_i32(10),
+                Self::Rejected => serializer.serialize_i32(11),
+                Self::AdvanceRequired => serializer.serialize_i32(12),
+                Self::Advanced => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolloutUpdateType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolloutUpdateType>::new(
+                ".google.cloud.deploy.v1.RolloutUpdateEvent.RolloutUpdateType",
+            ))
         }
     }
 }
@@ -16741,305 +18076,556 @@ impl wkt::message::Message for TargetNotificationEvent {
 }
 
 /// The support state of a specific Skaffold version.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SkaffoldSupportState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SkaffoldSupportState {
+    /// Default value. This value is unused.
+    Unspecified,
+    /// This Skaffold version is currently supported.
+    Supported,
+    /// This Skaffold version is in maintenance mode.
+    MaintenanceMode,
+    /// This Skaffold version is no longer supported.
+    Unsupported,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SkaffoldSupportState::value] or
+    /// [SkaffoldSupportState::name].
+    UnknownValue(skaffold_support_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod skaffold_support_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SkaffoldSupportState {
-    /// Default value. This value is unused.
-    pub const SKAFFOLD_SUPPORT_STATE_UNSPECIFIED: SkaffoldSupportState =
-        SkaffoldSupportState::new(0);
-
-    /// This Skaffold version is currently supported.
-    pub const SKAFFOLD_SUPPORT_STATE_SUPPORTED: SkaffoldSupportState = SkaffoldSupportState::new(1);
-
-    /// This Skaffold version is in maintenance mode.
-    pub const SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE: SkaffoldSupportState =
-        SkaffoldSupportState::new(2);
-
-    /// This Skaffold version is no longer supported.
-    pub const SKAFFOLD_SUPPORT_STATE_UNSUPPORTED: SkaffoldSupportState =
-        SkaffoldSupportState::new(3);
-
-    /// Creates a new SkaffoldSupportState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Supported => std::option::Option::Some(1),
+            Self::MaintenanceMode => std::option::Option::Some(2),
+            Self::Unsupported => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_SUPPORTED"),
-            2 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE"),
-            3 => std::borrow::Cow::Borrowed("SKAFFOLD_SUPPORT_STATE_UNSUPPORTED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SKAFFOLD_SUPPORT_STATE_UNSPECIFIED"),
+            Self::Supported => std::option::Option::Some("SKAFFOLD_SUPPORT_STATE_SUPPORTED"),
+            Self::MaintenanceMode => {
+                std::option::Option::Some("SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE")
+            }
+            Self::Unsupported => std::option::Option::Some("SKAFFOLD_SUPPORT_STATE_UNSUPPORTED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SKAFFOLD_SUPPORT_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_UNSPECIFIED)
-            }
-            "SKAFFOLD_SUPPORT_STATE_SUPPORTED" => {
-                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_SUPPORTED)
-            }
-            "SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE" => {
-                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE)
-            }
-            "SKAFFOLD_SUPPORT_STATE_UNSUPPORTED" => {
-                std::option::Option::Some(Self::SKAFFOLD_SUPPORT_STATE_UNSUPPORTED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SkaffoldSupportState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SkaffoldSupportState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SkaffoldSupportState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SkaffoldSupportState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Supported,
+            2 => Self::MaintenanceMode,
+            3 => Self::Unsupported,
+            _ => Self::UnknownValue(skaffold_support_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SkaffoldSupportState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SKAFFOLD_SUPPORT_STATE_UNSPECIFIED" => Self::Unspecified,
+            "SKAFFOLD_SUPPORT_STATE_SUPPORTED" => Self::Supported,
+            "SKAFFOLD_SUPPORT_STATE_MAINTENANCE_MODE" => Self::MaintenanceMode,
+            "SKAFFOLD_SUPPORT_STATE_UNSUPPORTED" => Self::Unsupported,
+            _ => Self::UnknownValue(skaffold_support_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SkaffoldSupportState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Supported => serializer.serialize_i32(1),
+            Self::MaintenanceMode => serializer.serialize_i32(2),
+            Self::Unsupported => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SkaffoldSupportState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SkaffoldSupportState>::new(
+            ".google.cloud.deploy.v1.SkaffoldSupportState",
+        ))
     }
 }
 
 /// The pattern of how wait time is increased.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BackoffMode(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BackoffMode {
+    /// No WaitMode is specified.
+    Unspecified,
+    /// Increases the wait time linearly.
+    Linear,
+    /// Increases the wait time exponentially.
+    Exponential,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BackoffMode::value] or
+    /// [BackoffMode::name].
+    UnknownValue(backoff_mode::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod backoff_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl BackoffMode {
-    /// No WaitMode is specified.
-    pub const BACKOFF_MODE_UNSPECIFIED: BackoffMode = BackoffMode::new(0);
-
-    /// Increases the wait time linearly.
-    pub const BACKOFF_MODE_LINEAR: BackoffMode = BackoffMode::new(1);
-
-    /// Increases the wait time exponentially.
-    pub const BACKOFF_MODE_EXPONENTIAL: BackoffMode = BackoffMode::new(2);
-
-    /// Creates a new BackoffMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linear => std::option::Option::Some(1),
+            Self::Exponential => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BACKOFF_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BACKOFF_MODE_LINEAR"),
-            2 => std::borrow::Cow::Borrowed("BACKOFF_MODE_EXPONENTIAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BACKOFF_MODE_UNSPECIFIED"),
+            Self::Linear => std::option::Option::Some("BACKOFF_MODE_LINEAR"),
+            Self::Exponential => std::option::Option::Some("BACKOFF_MODE_EXPONENTIAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BACKOFF_MODE_UNSPECIFIED" => std::option::Option::Some(Self::BACKOFF_MODE_UNSPECIFIED),
-            "BACKOFF_MODE_LINEAR" => std::option::Option::Some(Self::BACKOFF_MODE_LINEAR),
-            "BACKOFF_MODE_EXPONENTIAL" => std::option::Option::Some(Self::BACKOFF_MODE_EXPONENTIAL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BackoffMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BackoffMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BackoffMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BackoffMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linear,
+            2 => Self::Exponential,
+            _ => Self::UnknownValue(backoff_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BackoffMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BACKOFF_MODE_UNSPECIFIED" => Self::Unspecified,
+            "BACKOFF_MODE_LINEAR" => Self::Linear,
+            "BACKOFF_MODE_EXPONENTIAL" => Self::Exponential,
+            _ => Self::UnknownValue(backoff_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BackoffMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linear => serializer.serialize_i32(1),
+            Self::Exponential => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BackoffMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackoffMode>::new(
+            ".google.cloud.deploy.v1.BackoffMode",
+        ))
     }
 }
 
 /// Valid state of a repair attempt.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RepairState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RepairState {
+    /// The `repair` has an unspecified state.
+    Unspecified,
+    /// The `repair` action has succeeded.
+    Succeeded,
+    /// The `repair` action was cancelled.
+    Cancelled,
+    /// The `repair` action has failed.
+    Failed,
+    /// The `repair` action is in progress.
+    InProgress,
+    /// The `repair` action is pending.
+    Pending,
+    /// The `repair` action was aborted.
+    Aborted,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RepairState::value] or
+    /// [RepairState::name].
+    UnknownValue(repair_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod repair_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RepairState {
-    /// The `repair` has an unspecified state.
-    pub const REPAIR_STATE_UNSPECIFIED: RepairState = RepairState::new(0);
-
-    /// The `repair` action has succeeded.
-    pub const REPAIR_STATE_SUCCEEDED: RepairState = RepairState::new(1);
-
-    /// The `repair` action was cancelled.
-    pub const REPAIR_STATE_CANCELLED: RepairState = RepairState::new(2);
-
-    /// The `repair` action has failed.
-    pub const REPAIR_STATE_FAILED: RepairState = RepairState::new(3);
-
-    /// The `repair` action is in progress.
-    pub const REPAIR_STATE_IN_PROGRESS: RepairState = RepairState::new(4);
-
-    /// The `repair` action is pending.
-    pub const REPAIR_STATE_PENDING: RepairState = RepairState::new(5);
-
-    /// The `repair` action was aborted.
-    pub const REPAIR_STATE_ABORTED: RepairState = RepairState::new(7);
-
-    /// Creates a new RepairState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Succeeded => std::option::Option::Some(1),
+            Self::Cancelled => std::option::Option::Some(2),
+            Self::Failed => std::option::Option::Some(3),
+            Self::InProgress => std::option::Option::Some(4),
+            Self::Pending => std::option::Option::Some(5),
+            Self::Aborted => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REPAIR_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("REPAIR_STATE_SUCCEEDED"),
-            2 => std::borrow::Cow::Borrowed("REPAIR_STATE_CANCELLED"),
-            3 => std::borrow::Cow::Borrowed("REPAIR_STATE_FAILED"),
-            4 => std::borrow::Cow::Borrowed("REPAIR_STATE_IN_PROGRESS"),
-            5 => std::borrow::Cow::Borrowed("REPAIR_STATE_PENDING"),
-            7 => std::borrow::Cow::Borrowed("REPAIR_STATE_ABORTED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("REPAIR_STATE_UNSPECIFIED"),
+            Self::Succeeded => std::option::Option::Some("REPAIR_STATE_SUCCEEDED"),
+            Self::Cancelled => std::option::Option::Some("REPAIR_STATE_CANCELLED"),
+            Self::Failed => std::option::Option::Some("REPAIR_STATE_FAILED"),
+            Self::InProgress => std::option::Option::Some("REPAIR_STATE_IN_PROGRESS"),
+            Self::Pending => std::option::Option::Some("REPAIR_STATE_PENDING"),
+            Self::Aborted => std::option::Option::Some("REPAIR_STATE_ABORTED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REPAIR_STATE_UNSPECIFIED" => std::option::Option::Some(Self::REPAIR_STATE_UNSPECIFIED),
-            "REPAIR_STATE_SUCCEEDED" => std::option::Option::Some(Self::REPAIR_STATE_SUCCEEDED),
-            "REPAIR_STATE_CANCELLED" => std::option::Option::Some(Self::REPAIR_STATE_CANCELLED),
-            "REPAIR_STATE_FAILED" => std::option::Option::Some(Self::REPAIR_STATE_FAILED),
-            "REPAIR_STATE_IN_PROGRESS" => std::option::Option::Some(Self::REPAIR_STATE_IN_PROGRESS),
-            "REPAIR_STATE_PENDING" => std::option::Option::Some(Self::REPAIR_STATE_PENDING),
-            "REPAIR_STATE_ABORTED" => std::option::Option::Some(Self::REPAIR_STATE_ABORTED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RepairState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RepairState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RepairState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RepairState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Succeeded,
+            2 => Self::Cancelled,
+            3 => Self::Failed,
+            4 => Self::InProgress,
+            5 => Self::Pending,
+            7 => Self::Aborted,
+            _ => Self::UnknownValue(repair_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RepairState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REPAIR_STATE_UNSPECIFIED" => Self::Unspecified,
+            "REPAIR_STATE_SUCCEEDED" => Self::Succeeded,
+            "REPAIR_STATE_CANCELLED" => Self::Cancelled,
+            "REPAIR_STATE_FAILED" => Self::Failed,
+            "REPAIR_STATE_IN_PROGRESS" => Self::InProgress,
+            "REPAIR_STATE_PENDING" => Self::Pending,
+            "REPAIR_STATE_ABORTED" => Self::Aborted,
+            _ => Self::UnknownValue(repair_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RepairState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Succeeded => serializer.serialize_i32(1),
+            Self::Cancelled => serializer.serialize_i32(2),
+            Self::Failed => serializer.serialize_i32(3),
+            Self::InProgress => serializer.serialize_i32(4),
+            Self::Pending => serializer.serialize_i32(5),
+            Self::Aborted => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RepairState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RepairState>::new(
+            ".google.cloud.deploy.v1.RepairState",
+        ))
     }
 }
 
 /// Type indicates the type of the log entry and can be used as a filter.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Type(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Type {
+    /// Type is unspecified.
+    Unspecified,
+    /// A Pub/Sub notification failed to be sent.
+    PubsubNotificationFailure,
+    /// Resource state changed.
+    ResourceStateChange,
+    /// A process aborted.
+    ProcessAborted,
+    /// Restriction check failed.
+    RestrictionViolated,
+    /// Resource deleted.
+    ResourceDeleted,
+    /// Rollout updated.
+    RolloutUpdate,
+    /// Deploy Policy evaluation.
+    DeployPolicyEvaluation,
+    /// Deprecated: This field is never used. Use release_render log type instead.
+    RenderStatuesChange,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Type::value] or
+    /// [Type::name].
+    UnknownValue(r#type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod r#type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Type {
-    /// Type is unspecified.
-    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-    /// A Pub/Sub notification failed to be sent.
-    pub const TYPE_PUBSUB_NOTIFICATION_FAILURE: Type = Type::new(1);
-
-    /// Resource state changed.
-    pub const TYPE_RESOURCE_STATE_CHANGE: Type = Type::new(3);
-
-    /// A process aborted.
-    pub const TYPE_PROCESS_ABORTED: Type = Type::new(4);
-
-    /// Restriction check failed.
-    pub const TYPE_RESTRICTION_VIOLATED: Type = Type::new(5);
-
-    /// Resource deleted.
-    pub const TYPE_RESOURCE_DELETED: Type = Type::new(6);
-
-    /// Rollout updated.
-    pub const TYPE_ROLLOUT_UPDATE: Type = Type::new(7);
-
-    /// Deploy Policy evaluation.
-    pub const TYPE_DEPLOY_POLICY_EVALUATION: Type = Type::new(8);
-
-    /// Deprecated: This field is never used. Use release_render log type instead.
-    pub const TYPE_RENDER_STATUES_CHANGE: Type = Type::new(2);
-
-    /// Creates a new Type instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PubsubNotificationFailure => std::option::Option::Some(1),
+            Self::ResourceStateChange => std::option::Option::Some(3),
+            Self::ProcessAborted => std::option::Option::Some(4),
+            Self::RestrictionViolated => std::option::Option::Some(5),
+            Self::ResourceDeleted => std::option::Option::Some(6),
+            Self::RolloutUpdate => std::option::Option::Some(7),
+            Self::DeployPolicyEvaluation => std::option::Option::Some(8),
+            Self::RenderStatuesChange => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TYPE_PUBSUB_NOTIFICATION_FAILURE"),
-            2 => std::borrow::Cow::Borrowed("TYPE_RENDER_STATUES_CHANGE"),
-            3 => std::borrow::Cow::Borrowed("TYPE_RESOURCE_STATE_CHANGE"),
-            4 => std::borrow::Cow::Borrowed("TYPE_PROCESS_ABORTED"),
-            5 => std::borrow::Cow::Borrowed("TYPE_RESTRICTION_VIOLATED"),
-            6 => std::borrow::Cow::Borrowed("TYPE_RESOURCE_DELETED"),
-            7 => std::borrow::Cow::Borrowed("TYPE_ROLLOUT_UPDATE"),
-            8 => std::borrow::Cow::Borrowed("TYPE_DEPLOY_POLICY_EVALUATION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+            Self::PubsubNotificationFailure => {
+                std::option::Option::Some("TYPE_PUBSUB_NOTIFICATION_FAILURE")
+            }
+            Self::ResourceStateChange => std::option::Option::Some("TYPE_RESOURCE_STATE_CHANGE"),
+            Self::ProcessAborted => std::option::Option::Some("TYPE_PROCESS_ABORTED"),
+            Self::RestrictionViolated => std::option::Option::Some("TYPE_RESTRICTION_VIOLATED"),
+            Self::ResourceDeleted => std::option::Option::Some("TYPE_RESOURCE_DELETED"),
+            Self::RolloutUpdate => std::option::Option::Some("TYPE_ROLLOUT_UPDATE"),
+            Self::DeployPolicyEvaluation => {
+                std::option::Option::Some("TYPE_DEPLOY_POLICY_EVALUATION")
+            }
+            Self::RenderStatuesChange => std::option::Option::Some("TYPE_RENDER_STATUES_CHANGE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-            "TYPE_PUBSUB_NOTIFICATION_FAILURE" => {
-                std::option::Option::Some(Self::TYPE_PUBSUB_NOTIFICATION_FAILURE)
-            }
-            "TYPE_RESOURCE_STATE_CHANGE" => {
-                std::option::Option::Some(Self::TYPE_RESOURCE_STATE_CHANGE)
-            }
-            "TYPE_PROCESS_ABORTED" => std::option::Option::Some(Self::TYPE_PROCESS_ABORTED),
-            "TYPE_RESTRICTION_VIOLATED" => {
-                std::option::Option::Some(Self::TYPE_RESTRICTION_VIOLATED)
-            }
-            "TYPE_RESOURCE_DELETED" => std::option::Option::Some(Self::TYPE_RESOURCE_DELETED),
-            "TYPE_ROLLOUT_UPDATE" => std::option::Option::Some(Self::TYPE_ROLLOUT_UPDATE),
-            "TYPE_DEPLOY_POLICY_EVALUATION" => {
-                std::option::Option::Some(Self::TYPE_DEPLOY_POLICY_EVALUATION)
-            }
-            "TYPE_RENDER_STATUES_CHANGE" => {
-                std::option::Option::Some(Self::TYPE_RENDER_STATUES_CHANGE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Type {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Type {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Type {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PubsubNotificationFailure,
+            2 => Self::RenderStatuesChange,
+            3 => Self::ResourceStateChange,
+            4 => Self::ProcessAborted,
+            5 => Self::RestrictionViolated,
+            6 => Self::ResourceDeleted,
+            7 => Self::RolloutUpdate,
+            8 => Self::DeployPolicyEvaluation,
+            _ => Self::UnknownValue(r#type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Type {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TYPE_UNSPECIFIED" => Self::Unspecified,
+            "TYPE_PUBSUB_NOTIFICATION_FAILURE" => Self::PubsubNotificationFailure,
+            "TYPE_RESOURCE_STATE_CHANGE" => Self::ResourceStateChange,
+            "TYPE_PROCESS_ABORTED" => Self::ProcessAborted,
+            "TYPE_RESTRICTION_VIOLATED" => Self::RestrictionViolated,
+            "TYPE_RESOURCE_DELETED" => Self::ResourceDeleted,
+            "TYPE_ROLLOUT_UPDATE" => Self::RolloutUpdate,
+            "TYPE_DEPLOY_POLICY_EVALUATION" => Self::DeployPolicyEvaluation,
+            "TYPE_RENDER_STATUES_CHANGE" => Self::RenderStatuesChange,
+            _ => Self::UnknownValue(r#type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Type {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PubsubNotificationFailure => serializer.serialize_i32(1),
+            Self::ResourceStateChange => serializer.serialize_i32(3),
+            Self::ProcessAborted => serializer.serialize_i32(4),
+            Self::RestrictionViolated => serializer.serialize_i32(5),
+            Self::ResourceDeleted => serializer.serialize_i32(6),
+            Self::RolloutUpdate => serializer.serialize_i32(7),
+            Self::DeployPolicyEvaluation => serializer.serialize_i32(8),
+            Self::RenderStatuesChange => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Type {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+            ".google.cloud.deploy.v1.Type",
+        ))
     }
 }

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -476,70 +476,135 @@ pub mod installation_state {
     use super::*;
 
     /// Stage of the installation process.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Stage(i32);
-
-    impl Stage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Stage {
         /// No stage specified.
-        pub const STAGE_UNSPECIFIED: Stage = Stage::new(0);
-
+        Unspecified,
         /// Only for GitHub Enterprise. An App creation has been requested.
         /// The user needs to confirm the creation in their GitHub enterprise host.
-        pub const PENDING_CREATE_APP: Stage = Stage::new(1);
-
+        PendingCreateApp,
         /// User needs to authorize the GitHub (or Enterprise) App via OAuth.
-        pub const PENDING_USER_OAUTH: Stage = Stage::new(2);
-
+        PendingUserOauth,
         /// User needs to follow the link to install the GitHub (or Enterprise) App.
-        pub const PENDING_INSTALL_APP: Stage = Stage::new(3);
-
+        PendingInstallApp,
         /// Installation process has been completed.
-        pub const COMPLETE: Stage = Stage::new(10);
+        Complete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Stage::value] or
+        /// [Stage::name].
+        UnknownValue(stage::UnknownValue),
+    }
 
-        /// Creates a new Stage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Stage {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PendingCreateApp => std::option::Option::Some(1),
+                Self::PendingUserOauth => std::option::Option::Some(2),
+                Self::PendingInstallApp => std::option::Option::Some(3),
+                Self::Complete => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING_CREATE_APP"),
-                2 => std::borrow::Cow::Borrowed("PENDING_USER_OAUTH"),
-                3 => std::borrow::Cow::Borrowed("PENDING_INSTALL_APP"),
-                10 => std::borrow::Cow::Borrowed("COMPLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STAGE_UNSPECIFIED"),
+                Self::PendingCreateApp => std::option::Option::Some("PENDING_CREATE_APP"),
+                Self::PendingUserOauth => std::option::Option::Some("PENDING_USER_OAUTH"),
+                Self::PendingInstallApp => std::option::Option::Some("PENDING_INSTALL_APP"),
+                Self::Complete => std::option::Option::Some("COMPLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STAGE_UNSPECIFIED" => std::option::Option::Some(Self::STAGE_UNSPECIFIED),
-                "PENDING_CREATE_APP" => std::option::Option::Some(Self::PENDING_CREATE_APP),
-                "PENDING_USER_OAUTH" => std::option::Option::Some(Self::PENDING_USER_OAUTH),
-                "PENDING_INSTALL_APP" => std::option::Option::Some(Self::PENDING_INSTALL_APP),
-                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Stage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Stage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Stage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Stage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PendingCreateApp,
+                2 => Self::PendingUserOauth,
+                3 => Self::PendingInstallApp,
+                10 => Self::Complete,
+                _ => Self::UnknownValue(stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Stage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STAGE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING_CREATE_APP" => Self::PendingCreateApp,
+                "PENDING_USER_OAUTH" => Self::PendingUserOauth,
+                "PENDING_INSTALL_APP" => Self::PendingInstallApp,
+                "COMPLETE" => Self::Complete,
+                _ => Self::UnknownValue(stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Stage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PendingCreateApp => serializer.serialize_i32(1),
+                Self::PendingUserOauth => serializer.serialize_i32(2),
+                Self::PendingInstallApp => serializer.serialize_i32(3),
+                Self::Complete => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Stage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Stage>::new(
+                ".google.cloud.developerconnect.v1.InstallationState.Stage",
+            ))
         }
     }
 }
@@ -628,61 +693,120 @@ pub mod git_hub_config {
 
     /// Represents the various GitHub Applications that can be installed to a
     /// GitHub user or organization and used with Developer Connect.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GitHubApp(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum GitHubApp {
+        /// GitHub App not specified.
+        Unspecified,
+        /// The Developer Connect GitHub Application.
+        DeveloperConnect,
+        /// The Firebase GitHub Application.
+        Firebase,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [GitHubApp::value] or
+        /// [GitHubApp::name].
+        UnknownValue(git_hub_app::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod git_hub_app {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl GitHubApp {
-        /// GitHub App not specified.
-        pub const GIT_HUB_APP_UNSPECIFIED: GitHubApp = GitHubApp::new(0);
-
-        /// The Developer Connect GitHub Application.
-        pub const DEVELOPER_CONNECT: GitHubApp = GitHubApp::new(1);
-
-        /// The Firebase GitHub Application.
-        pub const FIREBASE: GitHubApp = GitHubApp::new(2);
-
-        /// Creates a new GitHubApp instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DeveloperConnect => std::option::Option::Some(1),
+                Self::Firebase => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GIT_HUB_APP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEVELOPER_CONNECT"),
-                2 => std::borrow::Cow::Borrowed("FIREBASE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("GIT_HUB_APP_UNSPECIFIED"),
+                Self::DeveloperConnect => std::option::Option::Some("DEVELOPER_CONNECT"),
+                Self::Firebase => std::option::Option::Some("FIREBASE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GIT_HUB_APP_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::GIT_HUB_APP_UNSPECIFIED)
-                }
-                "DEVELOPER_CONNECT" => std::option::Option::Some(Self::DEVELOPER_CONNECT),
-                "FIREBASE" => std::option::Option::Some(Self::FIREBASE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for GitHubApp {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for GitHubApp {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for GitHubApp {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for GitHubApp {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DeveloperConnect,
+                2 => Self::Firebase,
+                _ => Self::UnknownValue(git_hub_app::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for GitHubApp {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GIT_HUB_APP_UNSPECIFIED" => Self::Unspecified,
+                "DEVELOPER_CONNECT" => Self::DeveloperConnect,
+                "FIREBASE" => Self::Firebase,
+                _ => Self::UnknownValue(git_hub_app::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for GitHubApp {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DeveloperConnect => serializer.serialize_i32(1),
+                Self::Firebase => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for GitHubApp {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<GitHubApp>::new(
+                ".google.cloud.developerconnect.v1.GitHubConfig.GitHubApp",
+            ))
         }
     }
 }
@@ -2764,59 +2888,120 @@ pub mod fetch_git_refs_request {
     use super::*;
 
     /// Type of refs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RefType {
+        /// No type specified.
+        Unspecified,
+        /// To fetch tags.
+        Tag,
+        /// To fetch branches.
+        Branch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RefType::value] or
+        /// [RefType::name].
+        UnknownValue(ref_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ref_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RefType {
-        /// No type specified.
-        pub const REF_TYPE_UNSPECIFIED: RefType = RefType::new(0);
-
-        /// To fetch tags.
-        pub const TAG: RefType = RefType::new(1);
-
-        /// To fetch branches.
-        pub const BRANCH: RefType = RefType::new(2);
-
-        /// Creates a new RefType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tag => std::option::Option::Some(1),
+                Self::Branch => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REF_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TAG"),
-                2 => std::borrow::Cow::Borrowed("BRANCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REF_TYPE_UNSPECIFIED"),
+                Self::Tag => std::option::Option::Some("TAG"),
+                Self::Branch => std::option::Option::Some("BRANCH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REF_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REF_TYPE_UNSPECIFIED),
-                "TAG" => std::option::Option::Some(Self::TAG),
-                "BRANCH" => std::option::Option::Some(Self::BRANCH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RefType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RefType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RefType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RefType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tag,
+                2 => Self::Branch,
+                _ => Self::UnknownValue(ref_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RefType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REF_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TAG" => Self::Tag,
+                "BRANCH" => Self::Branch,
+                _ => Self::UnknownValue(ref_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RefType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tag => serializer.serialize_i32(1),
+                Self::Branch => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RefType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RefType>::new(
+                ".google.cloud.developerconnect.v1.FetchGitRefsRequest.RefType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -364,7 +364,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("refType", &req.ref_type.value())]);
+        let builder = builder.query(&[("refType", &req.ref_type)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -1620,61 +1620,120 @@ pub mod export_agent_request {
     }
 
     /// Data format of the exported agent.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataFormat {
+        /// Unspecified format.
+        Unspecified,
+        /// Agent content will be exported as raw bytes.
+        Blob,
+        /// Agent content will be exported in JSON Package format.
+        JsonPackage,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataFormat::value] or
+        /// [DataFormat::name].
+        UnknownValue(data_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataFormat {
-        /// Unspecified format.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
-        /// Agent content will be exported as raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new(1);
-
-        /// Agent content will be exported in JSON Package format.
-        pub const JSON_PACKAGE: DataFormat = DataFormat::new(4);
-
-        /// Creates a new DataFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Blob => std::option::Option::Some(1),
+                Self::JsonPackage => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BLOB"),
-                4 => std::borrow::Cow::Borrowed("JSON_PACKAGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+                Self::Blob => std::option::Option::Some("BLOB"),
+                Self::JsonPackage => std::option::Option::Some("JSON_PACKAGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
-                }
-                "BLOB" => std::option::Option::Some(Self::BLOB),
-                "JSON_PACKAGE" => std::option::Option::Some(Self::JSON_PACKAGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Blob,
+                4 => Self::JsonPackage,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "BLOB" => Self::Blob,
+                "JSON_PACKAGE" => Self::JsonPackage,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Blob => serializer.serialize_i32(1),
+                Self::JsonPackage => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+                ".google.cloud.dialogflow.cx.v3.ExportAgentRequest.DataFormat",
+            ))
         }
     }
 }
@@ -2015,64 +2074,123 @@ pub mod restore_agent_request {
     }
 
     /// Restore option.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestoreOption(i32);
-
-    impl RestoreOption {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RestoreOption {
         /// Unspecified. Treated as KEEP.
-        pub const RESTORE_OPTION_UNSPECIFIED: RestoreOption = RestoreOption::new(0);
-
+        Unspecified,
         /// Always respect the settings from the exported agent file. It may cause
         /// a restoration failure if some settings (e.g. model type) are not
         /// supported in the target agent.
-        pub const KEEP: RestoreOption = RestoreOption::new(1);
-
+        Keep,
         /// Fallback to default settings if some settings are not supported in the
         /// target agent.
-        pub const FALLBACK: RestoreOption = RestoreOption::new(2);
+        Fallback,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RestoreOption::value] or
+        /// [RestoreOption::name].
+        UnknownValue(restore_option::UnknownValue),
+    }
 
-        /// Creates a new RestoreOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod restore_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RestoreOption {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Keep => std::option::Option::Some(1),
+                Self::Fallback => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESTORE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KEEP"),
-                2 => std::borrow::Cow::Borrowed("FALLBACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESTORE_OPTION_UNSPECIFIED"),
+                Self::Keep => std::option::Option::Some("KEEP"),
+                Self::Fallback => std::option::Option::Some("FALLBACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESTORE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESTORE_OPTION_UNSPECIFIED)
-                }
-                "KEEP" => std::option::Option::Some(Self::KEEP),
-                "FALLBACK" => std::option::Option::Some(Self::FALLBACK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RestoreOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RestoreOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RestoreOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RestoreOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Keep,
+                2 => Self::Fallback,
+                _ => Self::UnknownValue(restore_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RestoreOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESTORE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "KEEP" => Self::Keep,
+                "FALLBACK" => Self::Fallback,
+                _ => Self::UnknownValue(restore_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RestoreOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Keep => serializer.serialize_i32(1),
+                Self::Fallback => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RestoreOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestoreOption>::new(
+                ".google.cloud.dialogflow.cx.v3.RestoreAgentRequest.RestoreOption",
+            ))
         }
     }
 
@@ -3799,140 +3917,267 @@ pub mod data_store_connection_signals {
         use super::*;
 
         /// Represents the decision of the grounding check.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct GroundingDecision(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum GroundingDecision {
+            /// Decision not specified.
+            Unspecified,
+            /// Grounding have accepted the answer.
+            AcceptedByGrounding,
+            /// Grounding have rejected the answer.
+            RejectedByGrounding,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [GroundingDecision::value] or
+            /// [GroundingDecision::name].
+            UnknownValue(grounding_decision::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod grounding_decision {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl GroundingDecision {
-            /// Decision not specified.
-            pub const GROUNDING_DECISION_UNSPECIFIED: GroundingDecision = GroundingDecision::new(0);
-
-            /// Grounding have accepted the answer.
-            pub const ACCEPTED_BY_GROUNDING: GroundingDecision = GroundingDecision::new(1);
-
-            /// Grounding have rejected the answer.
-            pub const REJECTED_BY_GROUNDING: GroundingDecision = GroundingDecision::new(2);
-
-            /// Creates a new GroundingDecision instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::AcceptedByGrounding => std::option::Option::Some(1),
+                    Self::RejectedByGrounding => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("GROUNDING_DECISION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ACCEPTED_BY_GROUNDING"),
-                    2 => std::borrow::Cow::Borrowed("REJECTED_BY_GROUNDING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("GROUNDING_DECISION_UNSPECIFIED")
+                    }
+                    Self::AcceptedByGrounding => std::option::Option::Some("ACCEPTED_BY_GROUNDING"),
+                    Self::RejectedByGrounding => std::option::Option::Some("REJECTED_BY_GROUNDING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "GROUNDING_DECISION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::GROUNDING_DECISION_UNSPECIFIED)
-                    }
-                    "ACCEPTED_BY_GROUNDING" => {
-                        std::option::Option::Some(Self::ACCEPTED_BY_GROUNDING)
-                    }
-                    "REJECTED_BY_GROUNDING" => {
-                        std::option::Option::Some(Self::REJECTED_BY_GROUNDING)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for GroundingDecision {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for GroundingDecision {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for GroundingDecision {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for GroundingDecision {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::AcceptedByGrounding,
+                    2 => Self::RejectedByGrounding,
+                    _ => Self::UnknownValue(grounding_decision::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for GroundingDecision {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "GROUNDING_DECISION_UNSPECIFIED" => Self::Unspecified,
+                    "ACCEPTED_BY_GROUNDING" => Self::AcceptedByGrounding,
+                    "REJECTED_BY_GROUNDING" => Self::RejectedByGrounding,
+                    _ => Self::UnknownValue(grounding_decision::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for GroundingDecision {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::AcceptedByGrounding => serializer.serialize_i32(1),
+                    Self::RejectedByGrounding => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for GroundingDecision {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<GroundingDecision>::new(
+                    ".google.cloud.dialogflow.cx.v3.DataStoreConnectionSignals.GroundingSignals.GroundingDecision"))
             }
         }
 
         /// Grounding score buckets.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct GroundingScoreBucket(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum GroundingScoreBucket {
+            /// Score not specified.
+            Unspecified,
+            /// We have very low confidence that the answer is grounded.
+            VeryLow,
+            /// We have low confidence that the answer is grounded.
+            Low,
+            /// We have medium confidence that the answer is grounded.
+            Medium,
+            /// We have high confidence that the answer is grounded.
+            High,
+            /// We have very high confidence that the answer is grounded.
+            VeryHigh,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [GroundingScoreBucket::value] or
+            /// [GroundingScoreBucket::name].
+            UnknownValue(grounding_score_bucket::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod grounding_score_bucket {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl GroundingScoreBucket {
-            /// Score not specified.
-            pub const GROUNDING_SCORE_BUCKET_UNSPECIFIED: GroundingScoreBucket =
-                GroundingScoreBucket::new(0);
-
-            /// We have very low confidence that the answer is grounded.
-            pub const VERY_LOW: GroundingScoreBucket = GroundingScoreBucket::new(1);
-
-            /// We have low confidence that the answer is grounded.
-            pub const LOW: GroundingScoreBucket = GroundingScoreBucket::new(3);
-
-            /// We have medium confidence that the answer is grounded.
-            pub const MEDIUM: GroundingScoreBucket = GroundingScoreBucket::new(4);
-
-            /// We have high confidence that the answer is grounded.
-            pub const HIGH: GroundingScoreBucket = GroundingScoreBucket::new(5);
-
-            /// We have very high confidence that the answer is grounded.
-            pub const VERY_HIGH: GroundingScoreBucket = GroundingScoreBucket::new(6);
-
-            /// Creates a new GroundingScoreBucket instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::VeryLow => std::option::Option::Some(1),
+                    Self::Low => std::option::Option::Some(3),
+                    Self::Medium => std::option::Option::Some(4),
+                    Self::High => std::option::Option::Some(5),
+                    Self::VeryHigh => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("GROUNDING_SCORE_BUCKET_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("VERY_LOW"),
-                    3 => std::borrow::Cow::Borrowed("LOW"),
-                    4 => std::borrow::Cow::Borrowed("MEDIUM"),
-                    5 => std::borrow::Cow::Borrowed("HIGH"),
-                    6 => std::borrow::Cow::Borrowed("VERY_HIGH"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "GROUNDING_SCORE_BUCKET_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::GROUNDING_SCORE_BUCKET_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("GROUNDING_SCORE_BUCKET_UNSPECIFIED")
                     }
-                    "VERY_LOW" => std::option::Option::Some(Self::VERY_LOW),
-                    "LOW" => std::option::Option::Some(Self::LOW),
-                    "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                    "HIGH" => std::option::Option::Some(Self::HIGH),
-                    "VERY_HIGH" => std::option::Option::Some(Self::VERY_HIGH),
-                    _ => std::option::Option::None,
+                    Self::VeryLow => std::option::Option::Some("VERY_LOW"),
+                    Self::Low => std::option::Option::Some("LOW"),
+                    Self::Medium => std::option::Option::Some("MEDIUM"),
+                    Self::High => std::option::Option::Some("HIGH"),
+                    Self::VeryHigh => std::option::Option::Some("VERY_HIGH"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for GroundingScoreBucket {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for GroundingScoreBucket {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for GroundingScoreBucket {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for GroundingScoreBucket {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::VeryLow,
+                    3 => Self::Low,
+                    4 => Self::Medium,
+                    5 => Self::High,
+                    6 => Self::VeryHigh,
+                    _ => Self::UnknownValue(grounding_score_bucket::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for GroundingScoreBucket {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "GROUNDING_SCORE_BUCKET_UNSPECIFIED" => Self::Unspecified,
+                    "VERY_LOW" => Self::VeryLow,
+                    "LOW" => Self::Low,
+                    "MEDIUM" => Self::Medium,
+                    "HIGH" => Self::High,
+                    "VERY_HIGH" => Self::VeryHigh,
+                    _ => Self::UnknownValue(grounding_score_bucket::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for GroundingScoreBucket {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::VeryLow => serializer.serialize_i32(1),
+                    Self::Low => serializer.serialize_i32(3),
+                    Self::Medium => serializer.serialize_i32(4),
+                    Self::High => serializer.serialize_i32(5),
+                    Self::VeryHigh => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for GroundingScoreBucket {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<GroundingScoreBucket>::new(
+                    ".google.cloud.dialogflow.cx.v3.DataStoreConnectionSignals.GroundingSignals.GroundingScoreBucket"))
             }
         }
     }
@@ -4013,136 +4258,255 @@ pub mod data_store_connection_signals {
         /// Safety decision.
         /// All kinds of check are incorporated into this final decision, including
         /// banned phrases check.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SafetyDecision(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SafetyDecision {
+            /// Decision not specified.
+            Unspecified,
+            /// No manual or automatic safety check fired.
+            AcceptedBySafetyCheck,
+            /// One ore more safety checks fired.
+            RejectedBySafetyCheck,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SafetyDecision::value] or
+            /// [SafetyDecision::name].
+            UnknownValue(safety_decision::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod safety_decision {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SafetyDecision {
-            /// Decision not specified.
-            pub const SAFETY_DECISION_UNSPECIFIED: SafetyDecision = SafetyDecision::new(0);
-
-            /// No manual or automatic safety check fired.
-            pub const ACCEPTED_BY_SAFETY_CHECK: SafetyDecision = SafetyDecision::new(1);
-
-            /// One ore more safety checks fired.
-            pub const REJECTED_BY_SAFETY_CHECK: SafetyDecision = SafetyDecision::new(2);
-
-            /// Creates a new SafetyDecision instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::AcceptedBySafetyCheck => std::option::Option::Some(1),
+                    Self::RejectedBySafetyCheck => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SAFETY_DECISION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ACCEPTED_BY_SAFETY_CHECK"),
-                    2 => std::borrow::Cow::Borrowed("REJECTED_BY_SAFETY_CHECK"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SAFETY_DECISION_UNSPECIFIED"),
+                    Self::AcceptedBySafetyCheck => {
+                        std::option::Option::Some("ACCEPTED_BY_SAFETY_CHECK")
+                    }
+                    Self::RejectedBySafetyCheck => {
+                        std::option::Option::Some("REJECTED_BY_SAFETY_CHECK")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SAFETY_DECISION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SAFETY_DECISION_UNSPECIFIED)
-                    }
-                    "ACCEPTED_BY_SAFETY_CHECK" => {
-                        std::option::Option::Some(Self::ACCEPTED_BY_SAFETY_CHECK)
-                    }
-                    "REJECTED_BY_SAFETY_CHECK" => {
-                        std::option::Option::Some(Self::REJECTED_BY_SAFETY_CHECK)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SafetyDecision {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SafetyDecision {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SafetyDecision {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SafetyDecision {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::AcceptedBySafetyCheck,
+                    2 => Self::RejectedBySafetyCheck,
+                    _ => Self::UnknownValue(safety_decision::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SafetyDecision {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SAFETY_DECISION_UNSPECIFIED" => Self::Unspecified,
+                    "ACCEPTED_BY_SAFETY_CHECK" => Self::AcceptedBySafetyCheck,
+                    "REJECTED_BY_SAFETY_CHECK" => Self::RejectedBySafetyCheck,
+                    _ => Self::UnknownValue(safety_decision::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SafetyDecision {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::AcceptedBySafetyCheck => serializer.serialize_i32(1),
+                    Self::RejectedBySafetyCheck => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SafetyDecision {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SafetyDecision>::new(
+                    ".google.cloud.dialogflow.cx.v3.DataStoreConnectionSignals.SafetySignals.SafetyDecision"))
             }
         }
 
         /// Specifies banned phrase match subject.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BannedPhraseMatch(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum BannedPhraseMatch {
+            /// No banned phrase check was executed.
+            Unspecified,
+            /// All banned phrase checks led to no match.
+            None,
+            /// A banned phrase matched the query.
+            Query,
+            /// A banned phrase matched the response.
+            Response,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [BannedPhraseMatch::value] or
+            /// [BannedPhraseMatch::name].
+            UnknownValue(banned_phrase_match::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod banned_phrase_match {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl BannedPhraseMatch {
-            /// No banned phrase check was executed.
-            pub const BANNED_PHRASE_MATCH_UNSPECIFIED: BannedPhraseMatch =
-                BannedPhraseMatch::new(0);
-
-            /// All banned phrase checks led to no match.
-            pub const BANNED_PHRASE_MATCH_NONE: BannedPhraseMatch = BannedPhraseMatch::new(1);
-
-            /// A banned phrase matched the query.
-            pub const BANNED_PHRASE_MATCH_QUERY: BannedPhraseMatch = BannedPhraseMatch::new(2);
-
-            /// A banned phrase matched the response.
-            pub const BANNED_PHRASE_MATCH_RESPONSE: BannedPhraseMatch = BannedPhraseMatch::new(3);
-
-            /// Creates a new BannedPhraseMatch instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::None => std::option::Option::Some(1),
+                    Self::Query => std::option::Option::Some(2),
+                    Self::Response => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_NONE"),
-                    2 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_QUERY"),
-                    3 => std::borrow::Cow::Borrowed("BANNED_PHRASE_MATCH_RESPONSE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("BANNED_PHRASE_MATCH_UNSPECIFIED")
+                    }
+                    Self::None => std::option::Option::Some("BANNED_PHRASE_MATCH_NONE"),
+                    Self::Query => std::option::Option::Some("BANNED_PHRASE_MATCH_QUERY"),
+                    Self::Response => std::option::Option::Some("BANNED_PHRASE_MATCH_RESPONSE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "BANNED_PHRASE_MATCH_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_UNSPECIFIED)
-                    }
-                    "BANNED_PHRASE_MATCH_NONE" => {
-                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_NONE)
-                    }
-                    "BANNED_PHRASE_MATCH_QUERY" => {
-                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_QUERY)
-                    }
-                    "BANNED_PHRASE_MATCH_RESPONSE" => {
-                        std::option::Option::Some(Self::BANNED_PHRASE_MATCH_RESPONSE)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for BannedPhraseMatch {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for BannedPhraseMatch {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for BannedPhraseMatch {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for BannedPhraseMatch {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::None,
+                    2 => Self::Query,
+                    3 => Self::Response,
+                    _ => Self::UnknownValue(banned_phrase_match::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for BannedPhraseMatch {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "BANNED_PHRASE_MATCH_UNSPECIFIED" => Self::Unspecified,
+                    "BANNED_PHRASE_MATCH_NONE" => Self::None,
+                    "BANNED_PHRASE_MATCH_QUERY" => Self::Query,
+                    "BANNED_PHRASE_MATCH_RESPONSE" => Self::Response,
+                    _ => Self::UnknownValue(banned_phrase_match::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for BannedPhraseMatch {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::None => serializer.serialize_i32(1),
+                    Self::Query => serializer.serialize_i32(2),
+                    Self::Response => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for BannedPhraseMatch {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<BannedPhraseMatch>::new(
+                    ".google.cloud.dialogflow.cx.v3.DataStoreConnectionSignals.SafetySignals.BannedPhraseMatch"))
             }
         }
     }
@@ -4307,64 +4671,127 @@ pub mod deployment {
     }
 
     /// The state of the deployment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State unspecified.
+        Unspecified,
+        /// The deployment is running.
+        Running,
+        /// The deployment succeeded.
+        Succeeded,
+        /// The deployment failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The deployment is running.
-        pub const RUNNING: State = State::new(1);
-
-        /// The deployment succeeded.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The deployment failed.
-        pub const FAILED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.cx.v3.Deployment.State",
+            ))
         }
     }
 }
@@ -4800,127 +5227,245 @@ pub mod entity_type {
     }
 
     /// Represents kinds of entities.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(i32);
-
-    impl Kind {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kind {
         /// Not specified. This value should be never used.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
-
+        Unspecified,
         /// Map entity types allow mapping of a group of synonyms to a canonical
         /// value.
-        pub const KIND_MAP: Kind = Kind::new(1);
-
+        Map,
         /// List entity types contain a set of entries that do not map to canonical
         /// values. However, list entity types can contain references to other entity
         /// types (with or without aliases).
-        pub const KIND_LIST: Kind = Kind::new(2);
-
+        List,
         /// Regexp entity types allow to specify regular expressions in entries
         /// values.
-        pub const KIND_REGEXP: Kind = Kind::new(3);
+        Regexp,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kind::value] or
+        /// [Kind::name].
+        UnknownValue(kind::UnknownValue),
+    }
 
-        /// Creates a new Kind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Kind {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Map => std::option::Option::Some(1),
+                Self::List => std::option::Option::Some(2),
+                Self::Regexp => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KIND_MAP"),
-                2 => std::borrow::Cow::Borrowed("KIND_LIST"),
-                3 => std::borrow::Cow::Borrowed("KIND_REGEXP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KIND_UNSPECIFIED"),
+                Self::Map => std::option::Option::Some("KIND_MAP"),
+                Self::List => std::option::Option::Some("KIND_LIST"),
+                Self::Regexp => std::option::Option::Some("KIND_REGEXP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
-                "KIND_MAP" => std::option::Option::Some(Self::KIND_MAP),
-                "KIND_LIST" => std::option::Option::Some(Self::KIND_LIST),
-                "KIND_REGEXP" => std::option::Option::Some(Self::KIND_REGEXP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Map,
+                2 => Self::List,
+                3 => Self::Regexp,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KIND_UNSPECIFIED" => Self::Unspecified,
+                "KIND_MAP" => Self::Map,
+                "KIND_LIST" => Self::List,
+                "KIND_REGEXP" => Self::Regexp,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Map => serializer.serialize_i32(1),
+                Self::List => serializer.serialize_i32(2),
+                Self::Regexp => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                ".google.cloud.dialogflow.cx.v3.EntityType.Kind",
+            ))
         }
     }
 
     /// Represents different entity type expansion modes. Automated expansion
     /// allows an agent to recognize values that have not been explicitly listed in
     /// the entity (for example, new kinds of shopping list items).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutoExpansionMode(i32);
-
-    impl AutoExpansionMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AutoExpansionMode {
         /// Auto expansion disabled for the entity.
-        pub const AUTO_EXPANSION_MODE_UNSPECIFIED: AutoExpansionMode = AutoExpansionMode::new(0);
-
+        Unspecified,
         /// Allows an agent to recognize values that have not been explicitly
         /// listed in the entity.
-        pub const AUTO_EXPANSION_MODE_DEFAULT: AutoExpansionMode = AutoExpansionMode::new(1);
+        Default,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AutoExpansionMode::value] or
+        /// [AutoExpansionMode::name].
+        UnknownValue(auto_expansion_mode::UnknownValue),
+    }
 
-        /// Creates a new AutoExpansionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod auto_expansion_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AutoExpansionMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_DEFAULT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTO_EXPANSION_MODE_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("AUTO_EXPANSION_MODE_DEFAULT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTO_EXPANSION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_UNSPECIFIED)
-                }
-                "AUTO_EXPANSION_MODE_DEFAULT" => {
-                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_DEFAULT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AutoExpansionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AutoExpansionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AutoExpansionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AutoExpansionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                _ => Self::UnknownValue(auto_expansion_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AutoExpansionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTO_EXPANSION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTO_EXPANSION_MODE_DEFAULT" => Self::Default,
+                _ => Self::UnknownValue(auto_expansion_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AutoExpansionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AutoExpansionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AutoExpansionMode>::new(
+                ".google.cloud.dialogflow.cx.v3.EntityType.AutoExpansionMode",
+            ))
         }
     }
 }
@@ -5095,61 +5640,120 @@ pub mod export_entity_types_request {
     use super::*;
 
     /// Data format of the exported entity types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataFormat {
+        /// Unspecified format. Treated as `BLOB`.
+        Unspecified,
+        /// EntityTypes will be exported as raw bytes.
+        Blob,
+        /// EntityTypes will be exported in JSON Package format.
+        JsonPackage,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataFormat::value] or
+        /// [DataFormat::name].
+        UnknownValue(data_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataFormat {
-        /// Unspecified format. Treated as `BLOB`.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
-        /// EntityTypes will be exported as raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new(1);
-
-        /// EntityTypes will be exported in JSON Package format.
-        pub const JSON_PACKAGE: DataFormat = DataFormat::new(5);
-
-        /// Creates a new DataFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Blob => std::option::Option::Some(1),
+                Self::JsonPackage => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BLOB"),
-                5 => std::borrow::Cow::Borrowed("JSON_PACKAGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+                Self::Blob => std::option::Option::Some("BLOB"),
+                Self::JsonPackage => std::option::Option::Some("JSON_PACKAGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
-                }
-                "BLOB" => std::option::Option::Some(Self::BLOB),
-                "JSON_PACKAGE" => std::option::Option::Some(Self::JSON_PACKAGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Blob,
+                5 => Self::JsonPackage,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "BLOB" => Self::Blob,
+                "JSON_PACKAGE" => Self::JsonPackage,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Blob => serializer.serialize_i32(1),
+                Self::JsonPackage => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+                ".google.cloud.dialogflow.cx.v3.ExportEntityTypesRequest.DataFormat",
+            ))
         }
     }
 
@@ -5496,81 +6100,146 @@ pub mod import_entity_types_request {
     use super::*;
 
     /// Merge option when display name conflicts exist during import.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MergeOption(i32);
-
-    impl MergeOption {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MergeOption {
         /// Unspecified. If used, system uses REPORT_CONFLICT as default.
-        pub const MERGE_OPTION_UNSPECIFIED: MergeOption = MergeOption::new(0);
-
+        Unspecified,
         /// Replace the original entity type in the agent with the new entity type
         /// when display name conflicts exist.
-        pub const REPLACE: MergeOption = MergeOption::new(1);
-
+        Replace,
         /// Merge the original entity type with the new entity type when display name
         /// conflicts exist.
-        pub const MERGE: MergeOption = MergeOption::new(2);
-
+        Merge,
         /// Create new entity types with new display names to differentiate them from
         /// the existing entity types when display name conflicts exist.
-        pub const RENAME: MergeOption = MergeOption::new(3);
-
+        Rename,
         /// Report conflict information if display names conflict is detected.
         /// Otherwise, import entity types.
-        pub const REPORT_CONFLICT: MergeOption = MergeOption::new(4);
-
+        ReportConflict,
         /// Keep the original entity type and discard the conflicting new entity type
         /// when display name conflicts exist.
-        pub const KEEP: MergeOption = MergeOption::new(5);
+        Keep,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MergeOption::value] or
+        /// [MergeOption::name].
+        UnknownValue(merge_option::UnknownValue),
+    }
 
-        /// Creates a new MergeOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod merge_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MergeOption {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Replace => std::option::Option::Some(1),
+                Self::Merge => std::option::Option::Some(2),
+                Self::Rename => std::option::Option::Some(3),
+                Self::ReportConflict => std::option::Option::Some(4),
+                Self::Keep => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MERGE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REPLACE"),
-                2 => std::borrow::Cow::Borrowed("MERGE"),
-                3 => std::borrow::Cow::Borrowed("RENAME"),
-                4 => std::borrow::Cow::Borrowed("REPORT_CONFLICT"),
-                5 => std::borrow::Cow::Borrowed("KEEP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MERGE_OPTION_UNSPECIFIED"),
+                Self::Replace => std::option::Option::Some("REPLACE"),
+                Self::Merge => std::option::Option::Some("MERGE"),
+                Self::Rename => std::option::Option::Some("RENAME"),
+                Self::ReportConflict => std::option::Option::Some("REPORT_CONFLICT"),
+                Self::Keep => std::option::Option::Some("KEEP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MERGE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MERGE_OPTION_UNSPECIFIED)
-                }
-                "REPLACE" => std::option::Option::Some(Self::REPLACE),
-                "MERGE" => std::option::Option::Some(Self::MERGE),
-                "RENAME" => std::option::Option::Some(Self::RENAME),
-                "REPORT_CONFLICT" => std::option::Option::Some(Self::REPORT_CONFLICT),
-                "KEEP" => std::option::Option::Some(Self::KEEP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MergeOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MergeOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MergeOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MergeOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Replace,
+                2 => Self::Merge,
+                3 => Self::Rename,
+                4 => Self::ReportConflict,
+                5 => Self::Keep,
+                _ => Self::UnknownValue(merge_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MergeOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MERGE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "REPLACE" => Self::Replace,
+                "MERGE" => Self::Merge,
+                "RENAME" => Self::Rename,
+                "REPORT_CONFLICT" => Self::ReportConflict,
+                "KEEP" => Self::Keep,
+                _ => Self::UnknownValue(merge_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MergeOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Replace => serializer.serialize_i32(1),
+                Self::Merge => serializer.serialize_i32(2),
+                Self::Rename => serializer.serialize_i32(3),
+                Self::ReportConflict => serializer.serialize_i32(4),
+                Self::Keep => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MergeOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MergeOption>::new(
+                ".google.cloud.dialogflow.cx.v3.ImportEntityTypesRequest.MergeOption",
+            ))
         }
     }
 
@@ -6949,62 +7618,122 @@ pub mod continuous_test_result {
     use super::*;
 
     /// The overall result for a continuous test run in an agent environment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregatedTestResult(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AggregatedTestResult {
+        /// Not specified. Should never be used.
+        Unspecified,
+        /// All the tests passed.
+        Passed,
+        /// At least one test did not pass.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AggregatedTestResult::value] or
+        /// [AggregatedTestResult::name].
+        UnknownValue(aggregated_test_result::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod aggregated_test_result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AggregatedTestResult {
-        /// Not specified. Should never be used.
-        pub const AGGREGATED_TEST_RESULT_UNSPECIFIED: AggregatedTestResult =
-            AggregatedTestResult::new(0);
-
-        /// All the tests passed.
-        pub const PASSED: AggregatedTestResult = AggregatedTestResult::new(1);
-
-        /// At least one test did not pass.
-        pub const FAILED: AggregatedTestResult = AggregatedTestResult::new(2);
-
-        /// Creates a new AggregatedTestResult instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Passed => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AGGREGATED_TEST_RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PASSED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AGGREGATED_TEST_RESULT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AGGREGATED_TEST_RESULT_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("AGGREGATED_TEST_RESULT_UNSPECIFIED")
                 }
-                "PASSED" => std::option::Option::Some(Self::PASSED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
+                Self::Passed => std::option::Option::Some("PASSED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for AggregatedTestResult {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregatedTestResult {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AggregatedTestResult {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AggregatedTestResult {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Passed,
+                2 => Self::Failed,
+                _ => Self::UnknownValue(aggregated_test_result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AggregatedTestResult {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AGGREGATED_TEST_RESULT_UNSPECIFIED" => Self::Unspecified,
+                "PASSED" => Self::Passed,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(aggregated_test_result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AggregatedTestResult {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Passed => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AggregatedTestResult {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AggregatedTestResult>::new(
+                ".google.cloud.dialogflow.cx.v3.ContinuousTestResult.AggregatedTestResult",
+            ))
         }
     }
 }
@@ -8069,215 +8798,412 @@ pub mod experiment {
         }
 
         /// Types of ratio-based metric for Dialogflow experiment.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MetricType(i32);
-
-        impl MetricType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MetricType {
             /// Metric unspecified.
-            pub const METRIC_UNSPECIFIED: MetricType = MetricType::new(0);
-
+            MetricUnspecified,
             /// Percentage of contained sessions without user calling back in 24 hours.
-            pub const CONTAINED_SESSION_NO_CALLBACK_RATE: MetricType = MetricType::new(1);
-
+            ContainedSessionNoCallbackRate,
             /// Percentage of sessions that were handed to a human agent.
-            pub const LIVE_AGENT_HANDOFF_RATE: MetricType = MetricType::new(2);
-
+            LiveAgentHandoffRate,
             /// Percentage of sessions with the same user calling back.
-            pub const CALLBACK_SESSION_RATE: MetricType = MetricType::new(3);
-
+            CallbackSessionRate,
             /// Percentage of sessions where user hung up.
-            pub const ABANDONED_SESSION_RATE: MetricType = MetricType::new(4);
-
+            AbandonedSessionRate,
             /// Percentage of sessions reached Dialogflow 'END_PAGE' or
             /// 'END_SESSION'.
-            pub const SESSION_END_RATE: MetricType = MetricType::new(5);
+            SessionEndRate,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MetricType::value] or
+            /// [MetricType::name].
+            UnknownValue(metric_type::UnknownValue),
+        }
 
-            /// Creates a new MetricType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod metric_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl MetricType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::MetricUnspecified => std::option::Option::Some(0),
+                    Self::ContainedSessionNoCallbackRate => std::option::Option::Some(1),
+                    Self::LiveAgentHandoffRate => std::option::Option::Some(2),
+                    Self::CallbackSessionRate => std::option::Option::Some(3),
+                    Self::AbandonedSessionRate => std::option::Option::Some(4),
+                    Self::SessionEndRate => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("METRIC_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CONTAINED_SESSION_NO_CALLBACK_RATE"),
-                    2 => std::borrow::Cow::Borrowed("LIVE_AGENT_HANDOFF_RATE"),
-                    3 => std::borrow::Cow::Borrowed("CALLBACK_SESSION_RATE"),
-                    4 => std::borrow::Cow::Borrowed("ABANDONED_SESSION_RATE"),
-                    5 => std::borrow::Cow::Borrowed("SESSION_END_RATE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::MetricUnspecified => std::option::Option::Some("METRIC_UNSPECIFIED"),
+                    Self::ContainedSessionNoCallbackRate => {
+                        std::option::Option::Some("CONTAINED_SESSION_NO_CALLBACK_RATE")
+                    }
+                    Self::LiveAgentHandoffRate => {
+                        std::option::Option::Some("LIVE_AGENT_HANDOFF_RATE")
+                    }
+                    Self::CallbackSessionRate => std::option::Option::Some("CALLBACK_SESSION_RATE"),
+                    Self::AbandonedSessionRate => {
+                        std::option::Option::Some("ABANDONED_SESSION_RATE")
+                    }
+                    Self::SessionEndRate => std::option::Option::Some("SESSION_END_RATE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "METRIC_UNSPECIFIED" => std::option::Option::Some(Self::METRIC_UNSPECIFIED),
-                    "CONTAINED_SESSION_NO_CALLBACK_RATE" => {
-                        std::option::Option::Some(Self::CONTAINED_SESSION_NO_CALLBACK_RATE)
-                    }
-                    "LIVE_AGENT_HANDOFF_RATE" => {
-                        std::option::Option::Some(Self::LIVE_AGENT_HANDOFF_RATE)
-                    }
-                    "CALLBACK_SESSION_RATE" => {
-                        std::option::Option::Some(Self::CALLBACK_SESSION_RATE)
-                    }
-                    "ABANDONED_SESSION_RATE" => {
-                        std::option::Option::Some(Self::ABANDONED_SESSION_RATE)
-                    }
-                    "SESSION_END_RATE" => std::option::Option::Some(Self::SESSION_END_RATE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MetricType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MetricType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MetricType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MetricType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::MetricUnspecified,
+                    1 => Self::ContainedSessionNoCallbackRate,
+                    2 => Self::LiveAgentHandoffRate,
+                    3 => Self::CallbackSessionRate,
+                    4 => Self::AbandonedSessionRate,
+                    5 => Self::SessionEndRate,
+                    _ => Self::UnknownValue(metric_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MetricType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "METRIC_UNSPECIFIED" => Self::MetricUnspecified,
+                    "CONTAINED_SESSION_NO_CALLBACK_RATE" => Self::ContainedSessionNoCallbackRate,
+                    "LIVE_AGENT_HANDOFF_RATE" => Self::LiveAgentHandoffRate,
+                    "CALLBACK_SESSION_RATE" => Self::CallbackSessionRate,
+                    "ABANDONED_SESSION_RATE" => Self::AbandonedSessionRate,
+                    "SESSION_END_RATE" => Self::SessionEndRate,
+                    _ => Self::UnknownValue(metric_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MetricType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::MetricUnspecified => serializer.serialize_i32(0),
+                    Self::ContainedSessionNoCallbackRate => serializer.serialize_i32(1),
+                    Self::LiveAgentHandoffRate => serializer.serialize_i32(2),
+                    Self::CallbackSessionRate => serializer.serialize_i32(3),
+                    Self::AbandonedSessionRate => serializer.serialize_i32(4),
+                    Self::SessionEndRate => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MetricType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetricType>::new(
+                    ".google.cloud.dialogflow.cx.v3.Experiment.Result.MetricType",
+                ))
             }
         }
 
         /// Types of count-based metric for Dialogflow experiment.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct CountType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum CountType {
+            /// Count type unspecified.
+            Unspecified,
+            /// Total number of occurrences of a 'NO_MATCH'.
+            TotalNoMatchCount,
+            /// Total number of turn counts.
+            TotalTurnCount,
+            /// Average turn count in a session.
+            AverageTurnCount,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [CountType::value] or
+            /// [CountType::name].
+            UnknownValue(count_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod count_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl CountType {
-            /// Count type unspecified.
-            pub const COUNT_TYPE_UNSPECIFIED: CountType = CountType::new(0);
-
-            /// Total number of occurrences of a 'NO_MATCH'.
-            pub const TOTAL_NO_MATCH_COUNT: CountType = CountType::new(1);
-
-            /// Total number of turn counts.
-            pub const TOTAL_TURN_COUNT: CountType = CountType::new(2);
-
-            /// Average turn count in a session.
-            pub const AVERAGE_TURN_COUNT: CountType = CountType::new(3);
-
-            /// Creates a new CountType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::TotalNoMatchCount => std::option::Option::Some(1),
+                    Self::TotalTurnCount => std::option::Option::Some(2),
+                    Self::AverageTurnCount => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("COUNT_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TOTAL_NO_MATCH_COUNT"),
-                    2 => std::borrow::Cow::Borrowed("TOTAL_TURN_COUNT"),
-                    3 => std::borrow::Cow::Borrowed("AVERAGE_TURN_COUNT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("COUNT_TYPE_UNSPECIFIED"),
+                    Self::TotalNoMatchCount => std::option::Option::Some("TOTAL_NO_MATCH_COUNT"),
+                    Self::TotalTurnCount => std::option::Option::Some("TOTAL_TURN_COUNT"),
+                    Self::AverageTurnCount => std::option::Option::Some("AVERAGE_TURN_COUNT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "COUNT_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::COUNT_TYPE_UNSPECIFIED)
-                    }
-                    "TOTAL_NO_MATCH_COUNT" => std::option::Option::Some(Self::TOTAL_NO_MATCH_COUNT),
-                    "TOTAL_TURN_COUNT" => std::option::Option::Some(Self::TOTAL_TURN_COUNT),
-                    "AVERAGE_TURN_COUNT" => std::option::Option::Some(Self::AVERAGE_TURN_COUNT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for CountType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for CountType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for CountType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for CountType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::TotalNoMatchCount,
+                    2 => Self::TotalTurnCount,
+                    3 => Self::AverageTurnCount,
+                    _ => Self::UnknownValue(count_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for CountType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "COUNT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "TOTAL_NO_MATCH_COUNT" => Self::TotalNoMatchCount,
+                    "TOTAL_TURN_COUNT" => Self::TotalTurnCount,
+                    "AVERAGE_TURN_COUNT" => Self::AverageTurnCount,
+                    _ => Self::UnknownValue(count_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for CountType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::TotalNoMatchCount => serializer.serialize_i32(1),
+                    Self::TotalTurnCount => serializer.serialize_i32(2),
+                    Self::AverageTurnCount => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for CountType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<CountType>::new(
+                    ".google.cloud.dialogflow.cx.v3.Experiment.Result.CountType",
+                ))
             }
         }
     }
 
     /// The state of the experiment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State unspecified.
+        Unspecified,
+        /// The experiment is created but not started yet.
+        Draft,
+        /// The experiment is running.
+        Running,
+        /// The experiment is done.
+        Done,
+        /// The experiment with auto-rollout enabled has failed.
+        RolloutFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The experiment is created but not started yet.
-        pub const DRAFT: State = State::new(1);
-
-        /// The experiment is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The experiment is done.
-        pub const DONE: State = State::new(3);
-
-        /// The experiment with auto-rollout enabled has failed.
-        pub const ROLLOUT_FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::RolloutFailed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                4 => std::borrow::Cow::Borrowed("ROLLOUT_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::RolloutFailed => std::option::Option::Some("ROLLOUT_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "ROLLOUT_FAILED" => std::option::Option::Some(Self::ROLLOUT_FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Running,
+                3 => Self::Done,
+                4 => Self::RolloutFailed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                "ROLLOUT_FAILED" => Self::RolloutFailed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::RolloutFailed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.cx.v3.Experiment.State",
+            ))
         }
     }
 }
@@ -9129,124 +10055,240 @@ pub mod nlu_settings {
     use super::*;
 
     /// NLU model type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelType {
+        /// Not specified. `MODEL_TYPE_STANDARD` will be used.
+        Unspecified,
+        /// Use standard NLU model.
+        Standard,
+        /// Use advanced NLU model.
+        Advanced,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelType::value] or
+        /// [ModelType::name].
+        UnknownValue(model_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod model_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ModelType {
-        /// Not specified. `MODEL_TYPE_STANDARD` will be used.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
-
-        /// Use standard NLU model.
-        pub const MODEL_TYPE_STANDARD: ModelType = ModelType::new(1);
-
-        /// Use advanced NLU model.
-        pub const MODEL_TYPE_ADVANCED: ModelType = ModelType::new(3);
-
-        /// Creates a new ModelType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Advanced => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODEL_TYPE_STANDARD"),
-                3 => std::borrow::Cow::Borrowed("MODEL_TYPE_ADVANCED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_TYPE_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("MODEL_TYPE_STANDARD"),
+                Self::Advanced => std::option::Option::Some("MODEL_TYPE_ADVANCED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
-                "MODEL_TYPE_STANDARD" => std::option::Option::Some(Self::MODEL_TYPE_STANDARD),
-                "MODEL_TYPE_ADVANCED" => std::option::Option::Some(Self::MODEL_TYPE_ADVANCED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                3 => Self::Advanced,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MODEL_TYPE_STANDARD" => Self::Standard,
+                "MODEL_TYPE_ADVANCED" => Self::Advanced,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Advanced => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelType>::new(
+                ".google.cloud.dialogflow.cx.v3.NluSettings.ModelType",
+            ))
         }
     }
 
     /// NLU model training mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelTrainingMode(i32);
-
-    impl ModelTrainingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelTrainingMode {
         /// Not specified. `MODEL_TRAINING_MODE_AUTOMATIC` will be used.
-        pub const MODEL_TRAINING_MODE_UNSPECIFIED: ModelTrainingMode = ModelTrainingMode::new(0);
-
+        Unspecified,
         /// NLU model training is automatically triggered when a flow gets modified.
         /// User can also manually trigger model training in this mode.
-        pub const MODEL_TRAINING_MODE_AUTOMATIC: ModelTrainingMode = ModelTrainingMode::new(1);
-
+        Automatic,
         /// User needs to manually trigger NLU model training. Best for large flows
         /// whose models take long time to train.
-        pub const MODEL_TRAINING_MODE_MANUAL: ModelTrainingMode = ModelTrainingMode::new(2);
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelTrainingMode::value] or
+        /// [ModelTrainingMode::name].
+        UnknownValue(model_training_mode::UnknownValue),
+    }
 
-        /// Creates a new ModelTrainingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod model_training_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ModelTrainingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_TRAINING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODEL_TRAINING_MODE_AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MODEL_TRAINING_MODE_MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_TRAINING_MODE_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("MODEL_TRAINING_MODE_AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MODEL_TRAINING_MODE_MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_TRAINING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MODEL_TRAINING_MODE_UNSPECIFIED)
-                }
-                "MODEL_TRAINING_MODE_AUTOMATIC" => {
-                    std::option::Option::Some(Self::MODEL_TRAINING_MODE_AUTOMATIC)
-                }
-                "MODEL_TRAINING_MODE_MANUAL" => {
-                    std::option::Option::Some(Self::MODEL_TRAINING_MODE_MANUAL)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelTrainingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelTrainingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelTrainingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelTrainingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(model_training_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelTrainingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_TRAINING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MODEL_TRAINING_MODE_AUTOMATIC" => Self::Automatic,
+                "MODEL_TRAINING_MODE_MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(model_training_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelTrainingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelTrainingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelTrainingMode>::new(
+                ".google.cloud.dialogflow.cx.v3.NluSettings.ModelTrainingMode",
+            ))
         }
     }
 }
@@ -10289,65 +11331,124 @@ pub mod import_flow_request {
     use super::*;
 
     /// Import option.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportOption(i32);
-
-    impl ImportOption {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ImportOption {
         /// Unspecified. Treated as `KEEP`.
-        pub const IMPORT_OPTION_UNSPECIFIED: ImportOption = ImportOption::new(0);
-
+        Unspecified,
         /// Always respect settings in exported flow content. It may cause a
         /// import failure if some settings (e.g. custom NLU) are not supported in
         /// the agent to import into.
-        pub const KEEP: ImportOption = ImportOption::new(1);
-
+        Keep,
         /// Fallback to default settings if some settings are not supported in the
         /// agent to import into. E.g. Standard NLU will be used if custom NLU is
         /// not available.
-        pub const FALLBACK: ImportOption = ImportOption::new(2);
+        Fallback,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ImportOption::value] or
+        /// [ImportOption::name].
+        UnknownValue(import_option::UnknownValue),
+    }
 
-        /// Creates a new ImportOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod import_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ImportOption {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Keep => std::option::Option::Some(1),
+                Self::Fallback => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPORT_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KEEP"),
-                2 => std::borrow::Cow::Borrowed("FALLBACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPORT_OPTION_UNSPECIFIED"),
+                Self::Keep => std::option::Option::Some("KEEP"),
+                Self::Fallback => std::option::Option::Some("FALLBACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPORT_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IMPORT_OPTION_UNSPECIFIED)
-                }
-                "KEEP" => std::option::Option::Some(Self::KEEP),
-                "FALLBACK" => std::option::Option::Some(Self::FALLBACK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ImportOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ImportOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ImportOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Keep,
+                2 => Self::Fallback,
+                _ => Self::UnknownValue(import_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ImportOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPORT_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "KEEP" => Self::Keep,
+                "FALLBACK" => Self::Fallback,
+                _ => Self::UnknownValue(import_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ImportOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Keep => serializer.serialize_i32(1),
+                Self::Fallback => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ImportOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportOption>::new(
+                ".google.cloud.dialogflow.cx.v3.ImportFlowRequest.ImportOption",
+            ))
         }
     }
 
@@ -13016,89 +14117,156 @@ pub mod import_intents_request {
     use super::*;
 
     /// Merge option when display name conflicts exist during import.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MergeOption(i32);
-
-    impl MergeOption {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MergeOption {
         /// Unspecified. Should not be used.
-        pub const MERGE_OPTION_UNSPECIFIED: MergeOption = MergeOption::new(0);
-
+        Unspecified,
         /// DEPRECATED: Please use
         /// [REPORT_CONFLICT][ImportIntentsRequest.REPORT_CONFLICT] instead.
         /// Fail the request if there are intents whose display names conflict with
         /// the display names of intents in the agent.
-        pub const REJECT: MergeOption = MergeOption::new(1);
-
+        Reject,
         /// Replace the original intent in the agent with the new intent when display
         /// name conflicts exist.
-        pub const REPLACE: MergeOption = MergeOption::new(2);
-
+        Replace,
         /// Merge the original intent with the new intent when display name conflicts
         /// exist.
-        pub const MERGE: MergeOption = MergeOption::new(3);
-
+        Merge,
         /// Create new intents with new display names to differentiate them from the
         /// existing intents when display name conflicts exist.
-        pub const RENAME: MergeOption = MergeOption::new(4);
-
+        Rename,
         /// Report conflict information if display names conflict is detected.
         /// Otherwise, import intents.
-        pub const REPORT_CONFLICT: MergeOption = MergeOption::new(5);
-
+        ReportConflict,
         /// Keep the original intent and discard the conflicting new intent when
         /// display name conflicts exist.
-        pub const KEEP: MergeOption = MergeOption::new(6);
+        Keep,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MergeOption::value] or
+        /// [MergeOption::name].
+        UnknownValue(merge_option::UnknownValue),
+    }
 
-        /// Creates a new MergeOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod merge_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MergeOption {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Reject => std::option::Option::Some(1),
+                Self::Replace => std::option::Option::Some(2),
+                Self::Merge => std::option::Option::Some(3),
+                Self::Rename => std::option::Option::Some(4),
+                Self::ReportConflict => std::option::Option::Some(5),
+                Self::Keep => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MERGE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REJECT"),
-                2 => std::borrow::Cow::Borrowed("REPLACE"),
-                3 => std::borrow::Cow::Borrowed("MERGE"),
-                4 => std::borrow::Cow::Borrowed("RENAME"),
-                5 => std::borrow::Cow::Borrowed("REPORT_CONFLICT"),
-                6 => std::borrow::Cow::Borrowed("KEEP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MERGE_OPTION_UNSPECIFIED"),
+                Self::Reject => std::option::Option::Some("REJECT"),
+                Self::Replace => std::option::Option::Some("REPLACE"),
+                Self::Merge => std::option::Option::Some("MERGE"),
+                Self::Rename => std::option::Option::Some("RENAME"),
+                Self::ReportConflict => std::option::Option::Some("REPORT_CONFLICT"),
+                Self::Keep => std::option::Option::Some("KEEP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MERGE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MERGE_OPTION_UNSPECIFIED)
-                }
-                "REJECT" => std::option::Option::Some(Self::REJECT),
-                "REPLACE" => std::option::Option::Some(Self::REPLACE),
-                "MERGE" => std::option::Option::Some(Self::MERGE),
-                "RENAME" => std::option::Option::Some(Self::RENAME),
-                "REPORT_CONFLICT" => std::option::Option::Some(Self::REPORT_CONFLICT),
-                "KEEP" => std::option::Option::Some(Self::KEEP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MergeOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MergeOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MergeOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MergeOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Reject,
+                2 => Self::Replace,
+                3 => Self::Merge,
+                4 => Self::Rename,
+                5 => Self::ReportConflict,
+                6 => Self::Keep,
+                _ => Self::UnknownValue(merge_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MergeOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MERGE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "REJECT" => Self::Reject,
+                "REPLACE" => Self::Replace,
+                "MERGE" => Self::Merge,
+                "RENAME" => Self::Rename,
+                "REPORT_CONFLICT" => Self::ReportConflict,
+                "KEEP" => Self::Keep,
+                _ => Self::UnknownValue(merge_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MergeOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Reject => serializer.serialize_i32(1),
+                Self::Replace => serializer.serialize_i32(2),
+                Self::Merge => serializer.serialize_i32(3),
+                Self::Rename => serializer.serialize_i32(4),
+                Self::ReportConflict => serializer.serialize_i32(5),
+                Self::Keep => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MergeOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MergeOption>::new(
+                ".google.cloud.dialogflow.cx.v3.ImportIntentsRequest.MergeOption",
+            ))
         }
     }
 
@@ -13412,66 +14580,127 @@ pub mod export_intents_request {
     use super::*;
 
     /// Data format of the exported intents.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataFormat {
+        /// Unspecified format. Treated as `BLOB`.
+        Unspecified,
+        /// Intents will be exported as raw bytes.
+        Blob,
+        /// Intents will be exported in JSON format.
+        Json,
+        /// Intents will be exported in CSV format.
+        Csv,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataFormat::value] or
+        /// [DataFormat::name].
+        UnknownValue(data_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataFormat {
-        /// Unspecified format. Treated as `BLOB`.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
-        /// Intents will be exported as raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new(1);
-
-        /// Intents will be exported in JSON format.
-        pub const JSON: DataFormat = DataFormat::new(2);
-
-        /// Intents will be exported in CSV format.
-        pub const CSV: DataFormat = DataFormat::new(3);
-
-        /// Creates a new DataFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Blob => std::option::Option::Some(1),
+                Self::Json => std::option::Option::Some(2),
+                Self::Csv => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BLOB"),
-                2 => std::borrow::Cow::Borrowed("JSON"),
-                3 => std::borrow::Cow::Borrowed("CSV"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+                Self::Blob => std::option::Option::Some("BLOB"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::Csv => std::option::Option::Some("CSV"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
-                }
-                "BLOB" => std::option::Option::Some(Self::BLOB),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                "CSV" => std::option::Option::Some(Self::CSV),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Blob,
+                2 => Self::Json,
+                3 => Self::Csv,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "BLOB" => Self::Blob,
+                "JSON" => Self::Json,
+                "CSV" => Self::Csv,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Blob => serializer.serialize_i32(1),
+                Self::Json => serializer.serialize_i32(2),
+                Self::Csv => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+                ".google.cloud.dialogflow.cx.v3.ExportIntentsRequest.DataFormat",
+            ))
         }
     }
 
@@ -16212,79 +17441,140 @@ pub mod response_message {
     }
 
     /// Represents different response types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseType(i32);
-
-    impl ResponseType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResponseType {
         /// Not specified.
-        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType = ResponseType::new(0);
-
+        Unspecified,
         /// The response is from an [entry
         /// prompt][google.cloud.dialogflow.cx.v3.Page.entry_fulfillment] in the
         /// page.
         ///
         /// [google.cloud.dialogflow.cx.v3.Page.entry_fulfillment]: crate::model::Page::entry_fulfillment
-        pub const ENTRY_PROMPT: ResponseType = ResponseType::new(1);
-
+        EntryPrompt,
         /// The response is from [form-filling
         /// prompt][google.cloud.dialogflow.cx.v3.Form.Parameter.fill_behavior] in
         /// the page.
         ///
         /// [google.cloud.dialogflow.cx.v3.Form.Parameter.fill_behavior]: crate::model::form::Parameter::fill_behavior
-        pub const PARAMETER_PROMPT: ResponseType = ResponseType::new(2);
-
+        ParameterPrompt,
         /// The response is from a [transition
         /// route][google.cloud.dialogflow.cx.v3.TransitionRoute] or an [event
         /// handler][EventHandler] in the page or flow or transition route group.
         ///
         /// [EventHandler]: crate::model::EventHandler
         /// [google.cloud.dialogflow.cx.v3.TransitionRoute]: crate::model::TransitionRoute
-        pub const HANDLER_PROMPT: ResponseType = ResponseType::new(3);
+        HandlerPrompt,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResponseType::value] or
+        /// [ResponseType::name].
+        UnknownValue(response_type::UnknownValue),
+    }
 
-        /// Creates a new ResponseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod response_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ResponseType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::EntryPrompt => std::option::Option::Some(1),
+                Self::ParameterPrompt => std::option::Option::Some(2),
+                Self::HandlerPrompt => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESPONSE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENTRY_PROMPT"),
-                2 => std::borrow::Cow::Borrowed("PARAMETER_PROMPT"),
-                3 => std::borrow::Cow::Borrowed("HANDLER_PROMPT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESPONSE_TYPE_UNSPECIFIED"),
+                Self::EntryPrompt => std::option::Option::Some("ENTRY_PROMPT"),
+                Self::ParameterPrompt => std::option::Option::Some("PARAMETER_PROMPT"),
+                Self::HandlerPrompt => std::option::Option::Some("HANDLER_PROMPT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESPONSE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESPONSE_TYPE_UNSPECIFIED)
-                }
-                "ENTRY_PROMPT" => std::option::Option::Some(Self::ENTRY_PROMPT),
-                "PARAMETER_PROMPT" => std::option::Option::Some(Self::PARAMETER_PROMPT),
-                "HANDLER_PROMPT" => std::option::Option::Some(Self::HANDLER_PROMPT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResponseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResponseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResponseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::EntryPrompt,
+                2 => Self::ParameterPrompt,
+                3 => Self::HandlerPrompt,
+                _ => Self::UnknownValue(response_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResponseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESPONSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ENTRY_PROMPT" => Self::EntryPrompt,
+                "PARAMETER_PROMPT" => Self::ParameterPrompt,
+                "HANDLER_PROMPT" => Self::HandlerPrompt,
+                _ => Self::UnknownValue(response_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResponseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::EntryPrompt => serializer.serialize_i32(1),
+                Self::ParameterPrompt => serializer.serialize_i32(2),
+                Self::HandlerPrompt => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResponseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseType>::new(
+                ".google.cloud.dialogflow.cx.v3.ResponseMessage.ResponseType",
+            ))
         }
     }
 
@@ -17118,66 +18408,129 @@ pub mod security_settings {
 
         /// File format for exported audio file. Currently only in telephony
         /// recordings.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AudioFormat(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum AudioFormat {
+            /// Unspecified. Do not use.
+            Unspecified,
+            /// G.711 mu-law PCM with 8kHz sample rate.
+            Mulaw,
+            /// MP3 file format.
+            Mp3,
+            /// OGG Vorbis.
+            Ogg,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [AudioFormat::value] or
+            /// [AudioFormat::name].
+            UnknownValue(audio_format::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod audio_format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl AudioFormat {
-            /// Unspecified. Do not use.
-            pub const AUDIO_FORMAT_UNSPECIFIED: AudioFormat = AudioFormat::new(0);
-
-            /// G.711 mu-law PCM with 8kHz sample rate.
-            pub const MULAW: AudioFormat = AudioFormat::new(1);
-
-            /// MP3 file format.
-            pub const MP3: AudioFormat = AudioFormat::new(2);
-
-            /// OGG Vorbis.
-            pub const OGG: AudioFormat = AudioFormat::new(3);
-
-            /// Creates a new AudioFormat instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Mulaw => std::option::Option::Some(1),
+                    Self::Mp3 => std::option::Option::Some(2),
+                    Self::Ogg => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("AUDIO_FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MULAW"),
-                    2 => std::borrow::Cow::Borrowed("MP3"),
-                    3 => std::borrow::Cow::Borrowed("OGG"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("AUDIO_FORMAT_UNSPECIFIED"),
+                    Self::Mulaw => std::option::Option::Some("MULAW"),
+                    Self::Mp3 => std::option::Option::Some("MP3"),
+                    Self::Ogg => std::option::Option::Some("OGG"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "AUDIO_FORMAT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::AUDIO_FORMAT_UNSPECIFIED)
-                    }
-                    "MULAW" => std::option::Option::Some(Self::MULAW),
-                    "MP3" => std::option::Option::Some(Self::MP3),
-                    "OGG" => std::option::Option::Some(Self::OGG),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for AudioFormat {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for AudioFormat {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for AudioFormat {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for AudioFormat {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Mulaw,
+                    2 => Self::Mp3,
+                    3 => Self::Ogg,
+                    _ => Self::UnknownValue(audio_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for AudioFormat {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "AUDIO_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "MULAW" => Self::Mulaw,
+                    "MP3" => Self::Mp3,
+                    "OGG" => Self::Ogg,
+                    _ => Self::UnknownValue(audio_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for AudioFormat {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Mulaw => serializer.serialize_i32(1),
+                    Self::Mp3 => serializer.serialize_i32(2),
+                    Self::Ogg => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for AudioFormat {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AudioFormat>::new(
+                    ".google.cloud.dialogflow.cx.v3.SecuritySettings.AudioExportSettings.AudioFormat"))
             }
         }
     }
@@ -17217,225 +18570,453 @@ pub mod security_settings {
     }
 
     /// Defines how we redact data.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedactionStrategy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RedactionStrategy {
+        /// Do not redact.
+        Unspecified,
+        /// Call redaction service to clean up the data to be persisted.
+        RedactWithService,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RedactionStrategy::value] or
+        /// [RedactionStrategy::name].
+        UnknownValue(redaction_strategy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod redaction_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RedactionStrategy {
-        /// Do not redact.
-        pub const REDACTION_STRATEGY_UNSPECIFIED: RedactionStrategy = RedactionStrategy::new(0);
-
-        /// Call redaction service to clean up the data to be persisted.
-        pub const REDACT_WITH_SERVICE: RedactionStrategy = RedactionStrategy::new(1);
-
-        /// Creates a new RedactionStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RedactWithService => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REDACTION_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REDACT_WITH_SERVICE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REDACTION_STRATEGY_UNSPECIFIED"),
+                Self::RedactWithService => std::option::Option::Some("REDACT_WITH_SERVICE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REDACTION_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REDACTION_STRATEGY_UNSPECIFIED)
-                }
-                "REDACT_WITH_SERVICE" => std::option::Option::Some(Self::REDACT_WITH_SERVICE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RedactionStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RedactionStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RedactionStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RedactionStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RedactWithService,
+                _ => Self::UnknownValue(redaction_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RedactionStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REDACTION_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "REDACT_WITH_SERVICE" => Self::RedactWithService,
+                _ => Self::UnknownValue(redaction_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RedactionStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RedactWithService => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RedactionStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RedactionStrategy>::new(
+                ".google.cloud.dialogflow.cx.v3.SecuritySettings.RedactionStrategy",
+            ))
         }
     }
 
     /// Defines what types of data to redact.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedactionScope(i32);
-
-    impl RedactionScope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RedactionScope {
         /// Don't redact any kind of data.
-        pub const REDACTION_SCOPE_UNSPECIFIED: RedactionScope = RedactionScope::new(0);
-
+        Unspecified,
         /// On data to be written to disk or similar devices that are capable of
         /// holding data even if power is disconnected. This includes data that are
         /// temporarily saved on disk.
-        pub const REDACT_DISK_STORAGE: RedactionScope = RedactionScope::new(2);
+        RedactDiskStorage,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RedactionScope::value] or
+        /// [RedactionScope::name].
+        UnknownValue(redaction_scope::UnknownValue),
+    }
 
-        /// Creates a new RedactionScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod redaction_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RedactionScope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RedactDiskStorage => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REDACTION_SCOPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("REDACT_DISK_STORAGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REDACTION_SCOPE_UNSPECIFIED"),
+                Self::RedactDiskStorage => std::option::Option::Some("REDACT_DISK_STORAGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REDACTION_SCOPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REDACTION_SCOPE_UNSPECIFIED)
-                }
-                "REDACT_DISK_STORAGE" => std::option::Option::Some(Self::REDACT_DISK_STORAGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RedactionScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RedactionScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RedactionScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RedactionScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::RedactDiskStorage,
+                _ => Self::UnknownValue(redaction_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RedactionScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REDACTION_SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "REDACT_DISK_STORAGE" => Self::RedactDiskStorage,
+                _ => Self::UnknownValue(redaction_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RedactionScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RedactDiskStorage => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RedactionScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RedactionScope>::new(
+                ".google.cloud.dialogflow.cx.v3.SecuritySettings.RedactionScope",
+            ))
         }
     }
 
     /// Defines how long we retain persisted data that contains sensitive info.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetentionStrategy(i32);
-
-    impl RetentionStrategy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RetentionStrategy {
         /// Retains the persisted data with Dialogflow's internal default 365d TTLs.
-        pub const RETENTION_STRATEGY_UNSPECIFIED: RetentionStrategy = RetentionStrategy::new(0);
-
+        Unspecified,
         /// Removes data when the conversation ends. If there is no [Conversation][]
         /// explicitly established, a default conversation ends when the
         /// corresponding Dialogflow session ends.
-        pub const REMOVE_AFTER_CONVERSATION: RetentionStrategy = RetentionStrategy::new(1);
+        RemoveAfterConversation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RetentionStrategy::value] or
+        /// [RetentionStrategy::name].
+        UnknownValue(retention_strategy::UnknownValue),
+    }
 
-        /// Creates a new RetentionStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod retention_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RetentionStrategy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RemoveAfterConversation => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RETENTION_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REMOVE_AFTER_CONVERSATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RETENTION_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RETENTION_STRATEGY_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RETENTION_STRATEGY_UNSPECIFIED"),
+                Self::RemoveAfterConversation => {
+                    std::option::Option::Some("REMOVE_AFTER_CONVERSATION")
                 }
-                "REMOVE_AFTER_CONVERSATION" => {
-                    std::option::Option::Some(Self::REMOVE_AFTER_CONVERSATION)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for RetentionStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RetentionStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RetentionStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RetentionStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RemoveAfterConversation,
+                _ => Self::UnknownValue(retention_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RetentionStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RETENTION_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "REMOVE_AFTER_CONVERSATION" => Self::RemoveAfterConversation,
+                _ => Self::UnknownValue(retention_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RetentionStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RemoveAfterConversation => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RetentionStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RetentionStrategy>::new(
+                ".google.cloud.dialogflow.cx.v3.SecuritySettings.RetentionStrategy",
+            ))
         }
     }
 
     /// Type of data we purge after retention settings triggers purge.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PurgeDataType(i32);
-
-    impl PurgeDataType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PurgeDataType {
         /// Unspecified. Do not use.
-        pub const PURGE_DATA_TYPE_UNSPECIFIED: PurgeDataType = PurgeDataType::new(0);
-
+        Unspecified,
         /// Dialogflow history. This does not include Cloud logging, which is
         /// owned by the user - not Dialogflow.
-        pub const DIALOGFLOW_HISTORY: PurgeDataType = PurgeDataType::new(1);
+        DialogflowHistory,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PurgeDataType::value] or
+        /// [PurgeDataType::name].
+        UnknownValue(purge_data_type::UnknownValue),
+    }
 
-        /// Creates a new PurgeDataType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod purge_data_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PurgeDataType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DialogflowHistory => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PURGE_DATA_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIALOGFLOW_HISTORY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PURGE_DATA_TYPE_UNSPECIFIED"),
+                Self::DialogflowHistory => std::option::Option::Some("DIALOGFLOW_HISTORY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PURGE_DATA_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PURGE_DATA_TYPE_UNSPECIFIED)
-                }
-                "DIALOGFLOW_HISTORY" => std::option::Option::Some(Self::DIALOGFLOW_HISTORY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PurgeDataType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PurgeDataType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PurgeDataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PurgeDataType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DialogflowHistory,
+                _ => Self::UnknownValue(purge_data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PurgeDataType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PURGE_DATA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DIALOGFLOW_HISTORY" => Self::DialogflowHistory,
+                _ => Self::UnknownValue(purge_data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PurgeDataType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DialogflowHistory => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PurgeDataType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PurgeDataType>::new(
+                ".google.cloud.dialogflow.cx.v3.SecuritySettings.PurgeDataType",
+            ))
         }
     }
 
@@ -17581,59 +19162,120 @@ pub mod answer_feedback {
     }
 
     /// Represents thumbs up/down rating provided by user about a response.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Rating(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Rating {
+        /// Rating not specified.
+        Unspecified,
+        /// Thumbs up feedback from user.
+        ThumbsUp,
+        /// Thumbs down feedback from user.
+        ThumbsDown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Rating::value] or
+        /// [Rating::name].
+        UnknownValue(rating::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod rating {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Rating {
-        /// Rating not specified.
-        pub const RATING_UNSPECIFIED: Rating = Rating::new(0);
-
-        /// Thumbs up feedback from user.
-        pub const THUMBS_UP: Rating = Rating::new(1);
-
-        /// Thumbs down feedback from user.
-        pub const THUMBS_DOWN: Rating = Rating::new(2);
-
-        /// Creates a new Rating instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ThumbsUp => std::option::Option::Some(1),
+                Self::ThumbsDown => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RATING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("THUMBS_UP"),
-                2 => std::borrow::Cow::Borrowed("THUMBS_DOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RATING_UNSPECIFIED"),
+                Self::ThumbsUp => std::option::Option::Some("THUMBS_UP"),
+                Self::ThumbsDown => std::option::Option::Some("THUMBS_DOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RATING_UNSPECIFIED" => std::option::Option::Some(Self::RATING_UNSPECIFIED),
-                "THUMBS_UP" => std::option::Option::Some(Self::THUMBS_UP),
-                "THUMBS_DOWN" => std::option::Option::Some(Self::THUMBS_DOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Rating {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Rating {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Rating {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Rating {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ThumbsUp,
+                2 => Self::ThumbsDown,
+                _ => Self::UnknownValue(rating::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Rating {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RATING_UNSPECIFIED" => Self::Unspecified,
+                "THUMBS_UP" => Self::ThumbsUp,
+                "THUMBS_DOWN" => Self::ThumbsDown,
+                _ => Self::UnknownValue(rating::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Rating {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ThumbsUp => serializer.serialize_i32(1),
+                Self::ThumbsDown => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Rating {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Rating>::new(
+                ".google.cloud.dialogflow.cx.v3.AnswerFeedback.Rating",
+            ))
         }
     }
 }
@@ -17919,63 +19561,122 @@ pub mod detect_intent_response {
     use super::*;
 
     /// Represents different DetectIntentResponse types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseType(i32);
-
-    impl ResponseType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResponseType {
         /// Not specified. This should never happen.
-        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType = ResponseType::new(0);
-
+        Unspecified,
         /// Partial response. e.g. Aggregated responses in a Fulfillment that enables
         /// `return_partial_response` can be returned as partial response.
         /// WARNING: partial response is not eligible for barge-in.
-        pub const PARTIAL: ResponseType = ResponseType::new(1);
-
+        Partial,
         /// Final response.
-        pub const FINAL: ResponseType = ResponseType::new(2);
+        Final,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResponseType::value] or
+        /// [ResponseType::name].
+        UnknownValue(response_type::UnknownValue),
+    }
 
-        /// Creates a new ResponseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod response_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ResponseType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Partial => std::option::Option::Some(1),
+                Self::Final => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESPONSE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PARTIAL"),
-                2 => std::borrow::Cow::Borrowed("FINAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESPONSE_TYPE_UNSPECIFIED"),
+                Self::Partial => std::option::Option::Some("PARTIAL"),
+                Self::Final => std::option::Option::Some("FINAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESPONSE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESPONSE_TYPE_UNSPECIFIED)
-                }
-                "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
-                "FINAL" => std::option::Option::Some(Self::FINAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResponseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResponseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResponseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Partial,
+                2 => Self::Final,
+                _ => Self::UnknownValue(response_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResponseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESPONSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PARTIAL" => Self::Partial,
+                "FINAL" => Self::Final,
+                _ => Self::UnknownValue(response_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResponseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Partial => serializer.serialize_i32(1),
+                Self::Final => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResponseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseType>::new(
+                ".google.cloud.dialogflow.cx.v3.DetectIntentResponse.ResponseType",
+            ))
         }
     }
 }
@@ -18744,16 +20445,13 @@ pub mod streaming_recognition_result {
     use super::*;
 
     /// Type of the response message.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageType(i32);
-
-    impl MessageType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MessageType {
         /// Not specified. Should never be used.
-        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType = MessageType::new(0);
-
+        Unspecified,
         /// Message contains a (possibly partial) transcript.
-        pub const TRANSCRIPT: MessageType = MessageType::new(1);
-
+        Transcript,
         /// This event indicates that the server has detected the end of the user's
         /// speech utterance and expects no additional speech. Therefore, the server
         /// will not process additional audio (although it may subsequently return
@@ -18764,52 +20462,112 @@ pub mod streaming_recognition_result {
         /// was set to `true`, and is not used otherwise.
         ///
         /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.single_utterance]: crate::model::InputAudioConfig::single_utterance
-        pub const END_OF_SINGLE_UTTERANCE: MessageType = MessageType::new(2);
+        EndOfSingleUtterance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MessageType::value] or
+        /// [MessageType::name].
+        UnknownValue(message_type::UnknownValue),
+    }
 
-        /// Creates a new MessageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod message_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MessageType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Transcript => std::option::Option::Some(1),
+                Self::EndOfSingleUtterance => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MESSAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRANSCRIPT"),
-                2 => std::borrow::Cow::Borrowed("END_OF_SINGLE_UTTERANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MESSAGE_TYPE_UNSPECIFIED"),
+                Self::Transcript => std::option::Option::Some("TRANSCRIPT"),
+                Self::EndOfSingleUtterance => std::option::Option::Some("END_OF_SINGLE_UTTERANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MESSAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MESSAGE_TYPE_UNSPECIFIED)
-                }
-                "TRANSCRIPT" => std::option::Option::Some(Self::TRANSCRIPT),
-                "END_OF_SINGLE_UTTERANCE" => {
-                    std::option::Option::Some(Self::END_OF_SINGLE_UTTERANCE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MessageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MessageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MessageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Transcript,
+                2 => Self::EndOfSingleUtterance,
+                _ => Self::UnknownValue(message_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MessageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MESSAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TRANSCRIPT" => Self::Transcript,
+                "END_OF_SINGLE_UTTERANCE" => Self::EndOfSingleUtterance,
+                _ => Self::UnknownValue(message_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MessageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Transcript => serializer.serialize_i32(1),
+                Self::EndOfSingleUtterance => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MessageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MessageType>::new(
+                ".google.cloud.dialogflow.cx.v3.StreamingRecognitionResult.MessageType",
+            ))
         }
     }
 }
@@ -19473,126 +21231,249 @@ pub mod boost_spec {
 
             /// The attribute(or function) for which the custom ranking is to be
             /// applied.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct AttributeType(i32);
-
-            impl AttributeType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum AttributeType {
                 /// Unspecified AttributeType.
-                pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType = AttributeType::new(0);
-
+                Unspecified,
                 /// The value of the numerical field will be used to dynamically update
                 /// the boost amount. In this case, the attribute_value (the x value)
                 /// of the control point will be the actual value of the numerical
                 /// field for which the boost_amount is specified.
-                pub const NUMERICAL: AttributeType = AttributeType::new(1);
-
+                Numerical,
                 /// For the freshness use case the attribute value will be the duration
                 /// between the current time and the date in the datetime field
                 /// specified. The value must be formatted as an XSD `dayTimeDuration`
                 /// value (a restricted subset of an ISO 8601 duration value). The
                 /// pattern for this is: `[nD][T[nH][nM][nS]]`.
                 /// E.g. `5D`, `3DT12H30M`, `T24H`.
-                pub const FRESHNESS: AttributeType = AttributeType::new(2);
+                Freshness,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [AttributeType::value] or
+                /// [AttributeType::name].
+                UnknownValue(attribute_type::UnknownValue),
+            }
 
-                /// Creates a new AttributeType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod attribute_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl AttributeType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Numerical => std::option::Option::Some(1),
+                        Self::Freshness => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("NUMERICAL"),
-                        2 => std::borrow::Cow::Borrowed("FRESHNESS"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "ATTRIBUTE_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("ATTRIBUTE_TYPE_UNSPECIFIED")
                         }
-                        "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
-                        "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
-                        _ => std::option::Option::None,
+                        Self::Numerical => std::option::Option::Some("NUMERICAL"),
+                        Self::Freshness => std::option::Option::Some("FRESHNESS"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for AttributeType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for AttributeType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for AttributeType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for AttributeType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Numerical,
+                        2 => Self::Freshness,
+                        _ => Self::UnknownValue(attribute_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for AttributeType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "ATTRIBUTE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "NUMERICAL" => Self::Numerical,
+                        "FRESHNESS" => Self::Freshness,
+                        _ => Self::UnknownValue(attribute_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for AttributeType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Numerical => serializer.serialize_i32(1),
+                        Self::Freshness => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for AttributeType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttributeType>::new(
+                        ".google.cloud.dialogflow.cx.v3.BoostSpec.ConditionBoostSpec.BoostControlSpec.AttributeType"))
                 }
             }
 
             /// The interpolation type to be applied. Default will be linear
             /// (Piecewise Linear).
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct InterpolationType(i32);
-
-            impl InterpolationType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum InterpolationType {
                 /// Interpolation type is unspecified. In this case, it defaults to
                 /// Linear.
-                pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                    InterpolationType::new(0);
-
+                Unspecified,
                 /// Piecewise linear interpolation will be applied.
-                pub const LINEAR: InterpolationType = InterpolationType::new(1);
+                Linear,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [InterpolationType::value] or
+                /// [InterpolationType::name].
+                UnknownValue(interpolation_type::UnknownValue),
+            }
 
-                /// Creates a new InterpolationType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod interpolation_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl InterpolationType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Linear => std::option::Option::Some(1),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("LINEAR"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "INTERPOLATION_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::INTERPOLATION_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("INTERPOLATION_TYPE_UNSPECIFIED")
                         }
-                        "LINEAR" => std::option::Option::Some(Self::LINEAR),
-                        _ => std::option::Option::None,
+                        Self::Linear => std::option::Option::Some("LINEAR"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for InterpolationType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for InterpolationType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for InterpolationType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for InterpolationType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Linear,
+                        _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for InterpolationType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "INTERPOLATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "LINEAR" => Self::Linear,
+                        _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for InterpolationType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Linear => serializer.serialize_i32(1),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for InterpolationType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterpolationType>::new(
+                        ".google.cloud.dialogflow.cx.v3.BoostSpec.ConditionBoostSpec.BoostControlSpec.InterpolationType"))
                 }
             }
         }
@@ -20773,89 +22654,162 @@ pub mod r#match {
     use super::*;
 
     /// Type of a Match.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MatchType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MatchType {
+        /// Not specified. Should never be used.
+        Unspecified,
+        /// The query was matched to an intent.
+        Intent,
+        /// The query directly triggered an intent.
+        DirectIntent,
+        /// The query was used for parameter filling.
+        ParameterFilling,
+        /// No match was found for the query.
+        NoMatch,
+        /// Indicates an empty query.
+        NoInput,
+        /// The query directly triggered an event.
+        Event,
+        /// The query was matched to a Knowledge Connector answer.
+        KnowledgeConnector,
+        /// The query was handled by a [`Playbook`][Playbook].
+        Playbook,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MatchType::value] or
+        /// [MatchType::name].
+        UnknownValue(match_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod match_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MatchType {
-        /// Not specified. Should never be used.
-        pub const MATCH_TYPE_UNSPECIFIED: MatchType = MatchType::new(0);
-
-        /// The query was matched to an intent.
-        pub const INTENT: MatchType = MatchType::new(1);
-
-        /// The query directly triggered an intent.
-        pub const DIRECT_INTENT: MatchType = MatchType::new(2);
-
-        /// The query was used for parameter filling.
-        pub const PARAMETER_FILLING: MatchType = MatchType::new(3);
-
-        /// No match was found for the query.
-        pub const NO_MATCH: MatchType = MatchType::new(4);
-
-        /// Indicates an empty query.
-        pub const NO_INPUT: MatchType = MatchType::new(5);
-
-        /// The query directly triggered an event.
-        pub const EVENT: MatchType = MatchType::new(6);
-
-        /// The query was matched to a Knowledge Connector answer.
-        pub const KNOWLEDGE_CONNECTOR: MatchType = MatchType::new(8);
-
-        /// The query was handled by a [`Playbook`][Playbook].
-        pub const PLAYBOOK: MatchType = MatchType::new(9);
-
-        /// Creates a new MatchType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Intent => std::option::Option::Some(1),
+                Self::DirectIntent => std::option::Option::Some(2),
+                Self::ParameterFilling => std::option::Option::Some(3),
+                Self::NoMatch => std::option::Option::Some(4),
+                Self::NoInput => std::option::Option::Some(5),
+                Self::Event => std::option::Option::Some(6),
+                Self::KnowledgeConnector => std::option::Option::Some(8),
+                Self::Playbook => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MATCH_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTENT"),
-                2 => std::borrow::Cow::Borrowed("DIRECT_INTENT"),
-                3 => std::borrow::Cow::Borrowed("PARAMETER_FILLING"),
-                4 => std::borrow::Cow::Borrowed("NO_MATCH"),
-                5 => std::borrow::Cow::Borrowed("NO_INPUT"),
-                6 => std::borrow::Cow::Borrowed("EVENT"),
-                8 => std::borrow::Cow::Borrowed("KNOWLEDGE_CONNECTOR"),
-                9 => std::borrow::Cow::Borrowed("PLAYBOOK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MATCH_TYPE_UNSPECIFIED"),
+                Self::Intent => std::option::Option::Some("INTENT"),
+                Self::DirectIntent => std::option::Option::Some("DIRECT_INTENT"),
+                Self::ParameterFilling => std::option::Option::Some("PARAMETER_FILLING"),
+                Self::NoMatch => std::option::Option::Some("NO_MATCH"),
+                Self::NoInput => std::option::Option::Some("NO_INPUT"),
+                Self::Event => std::option::Option::Some("EVENT"),
+                Self::KnowledgeConnector => std::option::Option::Some("KNOWLEDGE_CONNECTOR"),
+                Self::Playbook => std::option::Option::Some("PLAYBOOK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MATCH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MATCH_TYPE_UNSPECIFIED),
-                "INTENT" => std::option::Option::Some(Self::INTENT),
-                "DIRECT_INTENT" => std::option::Option::Some(Self::DIRECT_INTENT),
-                "PARAMETER_FILLING" => std::option::Option::Some(Self::PARAMETER_FILLING),
-                "NO_MATCH" => std::option::Option::Some(Self::NO_MATCH),
-                "NO_INPUT" => std::option::Option::Some(Self::NO_INPUT),
-                "EVENT" => std::option::Option::Some(Self::EVENT),
-                "KNOWLEDGE_CONNECTOR" => std::option::Option::Some(Self::KNOWLEDGE_CONNECTOR),
-                "PLAYBOOK" => std::option::Option::Some(Self::PLAYBOOK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MatchType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MatchType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MatchType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MatchType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Intent,
+                2 => Self::DirectIntent,
+                3 => Self::ParameterFilling,
+                4 => Self::NoMatch,
+                5 => Self::NoInput,
+                6 => Self::Event,
+                8 => Self::KnowledgeConnector,
+                9 => Self::Playbook,
+                _ => Self::UnknownValue(match_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MatchType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MATCH_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INTENT" => Self::Intent,
+                "DIRECT_INTENT" => Self::DirectIntent,
+                "PARAMETER_FILLING" => Self::ParameterFilling,
+                "NO_MATCH" => Self::NoMatch,
+                "NO_INPUT" => Self::NoInput,
+                "EVENT" => Self::Event,
+                "KNOWLEDGE_CONNECTOR" => Self::KnowledgeConnector,
+                "PLAYBOOK" => Self::Playbook,
+                _ => Self::UnknownValue(match_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MatchType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Intent => serializer.serialize_i32(1),
+                Self::DirectIntent => serializer.serialize_i32(2),
+                Self::ParameterFilling => serializer.serialize_i32(3),
+                Self::NoMatch => serializer.serialize_i32(4),
+                Self::NoInput => serializer.serialize_i32(5),
+                Self::Event => serializer.serialize_i32(6),
+                Self::KnowledgeConnector => serializer.serialize_i32(8),
+                Self::Playbook => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MatchType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MatchType>::new(
+                ".google.cloud.dialogflow.cx.v3.Match.MatchType",
+            ))
         }
     }
 }
@@ -21435,17 +23389,14 @@ pub mod session_entity_type {
     use super::*;
 
     /// The types of modifications for the session entity type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityOverrideMode(i32);
-
-    impl EntityOverrideMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EntityOverrideMode {
         /// Not specified. This value should be never used.
-        pub const ENTITY_OVERRIDE_MODE_UNSPECIFIED: EntityOverrideMode = EntityOverrideMode::new(0);
-
+        Unspecified,
         /// The collection of session entities overrides the collection of entities
         /// in the corresponding custom entity type.
-        pub const ENTITY_OVERRIDE_MODE_OVERRIDE: EntityOverrideMode = EntityOverrideMode::new(1);
-
+        Override,
         /// The collection of session entities extends the collection of entities in
         /// the corresponding custom entity type.
         ///
@@ -21458,54 +23409,112 @@ pub mod session_entity_type {
         /// on the custom entity type and merge.
         ///
         /// [google.cloud.dialogflow.cx.v3.EntityTypes.GetEntityType]: crate::client::EntityTypes::get_entity_type
-        pub const ENTITY_OVERRIDE_MODE_SUPPLEMENT: EntityOverrideMode = EntityOverrideMode::new(2);
+        Supplement,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EntityOverrideMode::value] or
+        /// [EntityOverrideMode::name].
+        UnknownValue(entity_override_mode::UnknownValue),
+    }
 
-        /// Creates a new EntityOverrideMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod entity_override_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EntityOverrideMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Override => std::option::Option::Some(1),
+                Self::Supplement => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_OVERRIDE"),
-                2 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_SUPPLEMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENTITY_OVERRIDE_MODE_UNSPECIFIED"),
+                Self::Override => std::option::Option::Some("ENTITY_OVERRIDE_MODE_OVERRIDE"),
+                Self::Supplement => std::option::Option::Some("ENTITY_OVERRIDE_MODE_SUPPLEMENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENTITY_OVERRIDE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_UNSPECIFIED)
-                }
-                "ENTITY_OVERRIDE_MODE_OVERRIDE" => {
-                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_OVERRIDE)
-                }
-                "ENTITY_OVERRIDE_MODE_SUPPLEMENT" => {
-                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_SUPPLEMENT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EntityOverrideMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityOverrideMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EntityOverrideMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EntityOverrideMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Override,
+                2 => Self::Supplement,
+                _ => Self::UnknownValue(entity_override_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EntityOverrideMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENTITY_OVERRIDE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ENTITY_OVERRIDE_MODE_OVERRIDE" => Self::Override,
+                "ENTITY_OVERRIDE_MODE_SUPPLEMENT" => Self::Supplement,
+                _ => Self::UnknownValue(entity_override_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EntityOverrideMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Override => serializer.serialize_i32(1),
+                Self::Supplement => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EntityOverrideMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityOverrideMode>::new(
+                ".google.cloud.dialogflow.cx.v3.SessionEntityType.EntityOverrideMode",
+            ))
         }
     }
 }
@@ -22450,74 +24459,141 @@ pub mod test_run_difference {
     use super::*;
 
     /// What part of the message replay differs from the test case.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiffType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiffType {
+        /// Should never be used.
+        Unspecified,
+        /// The intent.
+        Intent,
+        /// The page.
+        Page,
+        /// The parameters.
+        Parameters,
+        /// The message utterance.
+        Utterance,
+        /// The flow.
+        Flow,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiffType::value] or
+        /// [DiffType::name].
+        UnknownValue(diff_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod diff_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiffType {
-        /// Should never be used.
-        pub const DIFF_TYPE_UNSPECIFIED: DiffType = DiffType::new(0);
-
-        /// The intent.
-        pub const INTENT: DiffType = DiffType::new(1);
-
-        /// The page.
-        pub const PAGE: DiffType = DiffType::new(2);
-
-        /// The parameters.
-        pub const PARAMETERS: DiffType = DiffType::new(3);
-
-        /// The message utterance.
-        pub const UTTERANCE: DiffType = DiffType::new(4);
-
-        /// The flow.
-        pub const FLOW: DiffType = DiffType::new(5);
-
-        /// Creates a new DiffType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Intent => std::option::Option::Some(1),
+                Self::Page => std::option::Option::Some(2),
+                Self::Parameters => std::option::Option::Some(3),
+                Self::Utterance => std::option::Option::Some(4),
+                Self::Flow => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIFF_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTENT"),
-                2 => std::borrow::Cow::Borrowed("PAGE"),
-                3 => std::borrow::Cow::Borrowed("PARAMETERS"),
-                4 => std::borrow::Cow::Borrowed("UTTERANCE"),
-                5 => std::borrow::Cow::Borrowed("FLOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIFF_TYPE_UNSPECIFIED"),
+                Self::Intent => std::option::Option::Some("INTENT"),
+                Self::Page => std::option::Option::Some("PAGE"),
+                Self::Parameters => std::option::Option::Some("PARAMETERS"),
+                Self::Utterance => std::option::Option::Some("UTTERANCE"),
+                Self::Flow => std::option::Option::Some("FLOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIFF_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DIFF_TYPE_UNSPECIFIED),
-                "INTENT" => std::option::Option::Some(Self::INTENT),
-                "PAGE" => std::option::Option::Some(Self::PAGE),
-                "PARAMETERS" => std::option::Option::Some(Self::PARAMETERS),
-                "UTTERANCE" => std::option::Option::Some(Self::UTTERANCE),
-                "FLOW" => std::option::Option::Some(Self::FLOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiffType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiffType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiffType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiffType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Intent,
+                2 => Self::Page,
+                3 => Self::Parameters,
+                4 => Self::Utterance,
+                5 => Self::Flow,
+                _ => Self::UnknownValue(diff_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiffType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIFF_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INTENT" => Self::Intent,
+                "PAGE" => Self::Page,
+                "PARAMETERS" => Self::Parameters,
+                "UTTERANCE" => Self::Utterance,
+                "FLOW" => Self::Flow,
+                _ => Self::UnknownValue(diff_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiffType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Intent => serializer.serialize_i32(1),
+                Self::Page => serializer.serialize_i32(2),
+                Self::Parameters => serializer.serialize_i32(3),
+                Self::Utterance => serializer.serialize_i32(4),
+                Self::Flow => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiffType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiffType>::new(
+                ".google.cloud.dialogflow.cx.v3.TestRunDifference.DiffType",
+            ))
         }
     }
 }
@@ -23206,66 +25282,127 @@ pub mod calculate_coverage_request {
     use super::*;
 
     /// The type of coverage score requested.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CoverageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CoverageType {
+        /// Should never be used.
+        Unspecified,
+        /// Intent coverage.
+        Intent,
+        /// Page transition coverage.
+        PageTransition,
+        /// Transition route group coverage.
+        TransitionRouteGroup,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CoverageType::value] or
+        /// [CoverageType::name].
+        UnknownValue(coverage_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod coverage_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CoverageType {
-        /// Should never be used.
-        pub const COVERAGE_TYPE_UNSPECIFIED: CoverageType = CoverageType::new(0);
-
-        /// Intent coverage.
-        pub const INTENT: CoverageType = CoverageType::new(1);
-
-        /// Page transition coverage.
-        pub const PAGE_TRANSITION: CoverageType = CoverageType::new(2);
-
-        /// Transition route group coverage.
-        pub const TRANSITION_ROUTE_GROUP: CoverageType = CoverageType::new(3);
-
-        /// Creates a new CoverageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Intent => std::option::Option::Some(1),
+                Self::PageTransition => std::option::Option::Some(2),
+                Self::TransitionRouteGroup => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COVERAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTENT"),
-                2 => std::borrow::Cow::Borrowed("PAGE_TRANSITION"),
-                3 => std::borrow::Cow::Borrowed("TRANSITION_ROUTE_GROUP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COVERAGE_TYPE_UNSPECIFIED"),
+                Self::Intent => std::option::Option::Some("INTENT"),
+                Self::PageTransition => std::option::Option::Some("PAGE_TRANSITION"),
+                Self::TransitionRouteGroup => std::option::Option::Some("TRANSITION_ROUTE_GROUP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COVERAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COVERAGE_TYPE_UNSPECIFIED)
-                }
-                "INTENT" => std::option::Option::Some(Self::INTENT),
-                "PAGE_TRANSITION" => std::option::Option::Some(Self::PAGE_TRANSITION),
-                "TRANSITION_ROUTE_GROUP" => std::option::Option::Some(Self::TRANSITION_ROUTE_GROUP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CoverageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CoverageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CoverageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CoverageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Intent,
+                2 => Self::PageTransition,
+                3 => Self::TransitionRouteGroup,
+                _ => Self::UnknownValue(coverage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CoverageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COVERAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INTENT" => Self::Intent,
+                "PAGE_TRANSITION" => Self::PageTransition,
+                "TRANSITION_ROUTE_GROUP" => Self::TransitionRouteGroup,
+                _ => Self::UnknownValue(coverage_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CoverageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Intent => serializer.serialize_i32(1),
+                Self::PageTransition => serializer.serialize_i32(2),
+                Self::TransitionRouteGroup => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CoverageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CoverageType>::new(
+                ".google.cloud.dialogflow.cx.v3.CalculateCoverageRequest.CoverageType",
+            ))
         }
     }
 }
@@ -23517,63 +25654,122 @@ pub mod list_test_cases_request {
     use super::*;
 
     /// Specifies how much test case information to include in the response.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TestCaseView(i32);
-
-    impl TestCaseView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TestCaseView {
         /// The default / unset value.
         /// The API will default to the BASIC view.
-        pub const TEST_CASE_VIEW_UNSPECIFIED: TestCaseView = TestCaseView::new(0);
-
+        Unspecified,
         /// Include basic metadata about the test case, but not the conversation
         /// turns. This is the default value.
-        pub const BASIC: TestCaseView = TestCaseView::new(1);
-
+        Basic,
         /// Include everything.
-        pub const FULL: TestCaseView = TestCaseView::new(2);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TestCaseView::value] or
+        /// [TestCaseView::name].
+        UnknownValue(test_case_view::UnknownValue),
+    }
 
-        /// Creates a new TestCaseView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod test_case_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TestCaseView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TEST_CASE_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TEST_CASE_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TEST_CASE_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TEST_CASE_VIEW_UNSPECIFIED)
-                }
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TestCaseView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TestCaseView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TestCaseView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TestCaseView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Full,
+                _ => Self::UnknownValue(test_case_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TestCaseView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TEST_CASE_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(test_case_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TestCaseView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TestCaseView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TestCaseView>::new(
+                ".google.cloud.dialogflow.cx.v3.ListTestCasesRequest.TestCaseView",
+            ))
         }
     }
 }
@@ -24539,61 +26735,120 @@ pub mod export_test_cases_request {
     use super::*;
 
     /// Data format of the exported test cases.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataFormat {
+        /// Unspecified format.
+        Unspecified,
+        /// Raw bytes.
+        Blob,
+        /// JSON format.
+        Json,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataFormat::value] or
+        /// [DataFormat::name].
+        UnknownValue(data_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataFormat {
-        /// Unspecified format.
-        pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
-        /// Raw bytes.
-        pub const BLOB: DataFormat = DataFormat::new(1);
-
-        /// JSON format.
-        pub const JSON: DataFormat = DataFormat::new(2);
-
-        /// Creates a new DataFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Blob => std::option::Option::Some(1),
+                Self::Json => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BLOB"),
-                2 => std::borrow::Cow::Borrowed("JSON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+                Self::Blob => std::option::Option::Some("BLOB"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED)
-                }
-                "BLOB" => std::option::Option::Some(Self::BLOB),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Blob,
+                2 => Self::Json,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "BLOB" => Self::Blob,
+                "JSON" => Self::Json,
+                _ => Self::UnknownValue(data_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Blob => serializer.serialize_i32(1),
+                Self::Json => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+                ".google.cloud.dialogflow.cx.v3.ExportTestCasesRequest.DataFormat",
+            ))
         }
     }
 
@@ -25539,187 +27794,331 @@ pub mod validation_message {
     use super::*;
 
     /// Resource types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResourceType {
+        /// Unspecified.
+        Unspecified,
+        /// Agent.
+        Agent,
+        /// Intent.
+        Intent,
+        /// Intent training phrase.
+        IntentTrainingPhrase,
+        /// Intent parameter.
+        IntentParameter,
+        /// Multiple intents.
+        Intents,
+        /// Multiple training phrases.
+        IntentTrainingPhrases,
+        /// Entity type.
+        EntityType,
+        /// Multiple entity types.
+        EntityTypes,
+        /// Webhook.
+        Webhook,
+        /// Flow.
+        Flow,
+        /// Page.
+        Page,
+        /// Multiple pages.
+        Pages,
+        /// Transition route group.
+        TransitionRouteGroup,
+        /// Agent transition route group.
+        AgentTransitionRouteGroup,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResourceType::value] or
+        /// [ResourceType::name].
+        UnknownValue(resource_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod resource_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ResourceType {
-        /// Unspecified.
-        pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
-
-        /// Agent.
-        pub const AGENT: ResourceType = ResourceType::new(1);
-
-        /// Intent.
-        pub const INTENT: ResourceType = ResourceType::new(2);
-
-        /// Intent training phrase.
-        pub const INTENT_TRAINING_PHRASE: ResourceType = ResourceType::new(8);
-
-        /// Intent parameter.
-        pub const INTENT_PARAMETER: ResourceType = ResourceType::new(9);
-
-        /// Multiple intents.
-        pub const INTENTS: ResourceType = ResourceType::new(10);
-
-        /// Multiple training phrases.
-        pub const INTENT_TRAINING_PHRASES: ResourceType = ResourceType::new(11);
-
-        /// Entity type.
-        pub const ENTITY_TYPE: ResourceType = ResourceType::new(3);
-
-        /// Multiple entity types.
-        pub const ENTITY_TYPES: ResourceType = ResourceType::new(12);
-
-        /// Webhook.
-        pub const WEBHOOK: ResourceType = ResourceType::new(4);
-
-        /// Flow.
-        pub const FLOW: ResourceType = ResourceType::new(5);
-
-        /// Page.
-        pub const PAGE: ResourceType = ResourceType::new(6);
-
-        /// Multiple pages.
-        pub const PAGES: ResourceType = ResourceType::new(13);
-
-        /// Transition route group.
-        pub const TRANSITION_ROUTE_GROUP: ResourceType = ResourceType::new(7);
-
-        /// Agent transition route group.
-        pub const AGENT_TRANSITION_ROUTE_GROUP: ResourceType = ResourceType::new(14);
-
-        /// Creates a new ResourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Agent => std::option::Option::Some(1),
+                Self::Intent => std::option::Option::Some(2),
+                Self::IntentTrainingPhrase => std::option::Option::Some(8),
+                Self::IntentParameter => std::option::Option::Some(9),
+                Self::Intents => std::option::Option::Some(10),
+                Self::IntentTrainingPhrases => std::option::Option::Some(11),
+                Self::EntityType => std::option::Option::Some(3),
+                Self::EntityTypes => std::option::Option::Some(12),
+                Self::Webhook => std::option::Option::Some(4),
+                Self::Flow => std::option::Option::Some(5),
+                Self::Page => std::option::Option::Some(6),
+                Self::Pages => std::option::Option::Some(13),
+                Self::TransitionRouteGroup => std::option::Option::Some(7),
+                Self::AgentTransitionRouteGroup => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AGENT"),
-                2 => std::borrow::Cow::Borrowed("INTENT"),
-                3 => std::borrow::Cow::Borrowed("ENTITY_TYPE"),
-                4 => std::borrow::Cow::Borrowed("WEBHOOK"),
-                5 => std::borrow::Cow::Borrowed("FLOW"),
-                6 => std::borrow::Cow::Borrowed("PAGE"),
-                7 => std::borrow::Cow::Borrowed("TRANSITION_ROUTE_GROUP"),
-                8 => std::borrow::Cow::Borrowed("INTENT_TRAINING_PHRASE"),
-                9 => std::borrow::Cow::Borrowed("INTENT_PARAMETER"),
-                10 => std::borrow::Cow::Borrowed("INTENTS"),
-                11 => std::borrow::Cow::Borrowed("INTENT_TRAINING_PHRASES"),
-                12 => std::borrow::Cow::Borrowed("ENTITY_TYPES"),
-                13 => std::borrow::Cow::Borrowed("PAGES"),
-                14 => std::borrow::Cow::Borrowed("AGENT_TRANSITION_ROUTE_GROUP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESOURCE_TYPE_UNSPECIFIED"),
+                Self::Agent => std::option::Option::Some("AGENT"),
+                Self::Intent => std::option::Option::Some("INTENT"),
+                Self::IntentTrainingPhrase => std::option::Option::Some("INTENT_TRAINING_PHRASE"),
+                Self::IntentParameter => std::option::Option::Some("INTENT_PARAMETER"),
+                Self::Intents => std::option::Option::Some("INTENTS"),
+                Self::IntentTrainingPhrases => std::option::Option::Some("INTENT_TRAINING_PHRASES"),
+                Self::EntityType => std::option::Option::Some("ENTITY_TYPE"),
+                Self::EntityTypes => std::option::Option::Some("ENTITY_TYPES"),
+                Self::Webhook => std::option::Option::Some("WEBHOOK"),
+                Self::Flow => std::option::Option::Some("FLOW"),
+                Self::Page => std::option::Option::Some("PAGE"),
+                Self::Pages => std::option::Option::Some("PAGES"),
+                Self::TransitionRouteGroup => std::option::Option::Some("TRANSITION_ROUTE_GROUP"),
+                Self::AgentTransitionRouteGroup => {
+                    std::option::Option::Some("AGENT_TRANSITION_ROUTE_GROUP")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
-                }
-                "AGENT" => std::option::Option::Some(Self::AGENT),
-                "INTENT" => std::option::Option::Some(Self::INTENT),
-                "INTENT_TRAINING_PHRASE" => std::option::Option::Some(Self::INTENT_TRAINING_PHRASE),
-                "INTENT_PARAMETER" => std::option::Option::Some(Self::INTENT_PARAMETER),
-                "INTENTS" => std::option::Option::Some(Self::INTENTS),
-                "INTENT_TRAINING_PHRASES" => {
-                    std::option::Option::Some(Self::INTENT_TRAINING_PHRASES)
-                }
-                "ENTITY_TYPE" => std::option::Option::Some(Self::ENTITY_TYPE),
-                "ENTITY_TYPES" => std::option::Option::Some(Self::ENTITY_TYPES),
-                "WEBHOOK" => std::option::Option::Some(Self::WEBHOOK),
-                "FLOW" => std::option::Option::Some(Self::FLOW),
-                "PAGE" => std::option::Option::Some(Self::PAGE),
-                "PAGES" => std::option::Option::Some(Self::PAGES),
-                "TRANSITION_ROUTE_GROUP" => std::option::Option::Some(Self::TRANSITION_ROUTE_GROUP),
-                "AGENT_TRANSITION_ROUTE_GROUP" => {
-                    std::option::Option::Some(Self::AGENT_TRANSITION_ROUTE_GROUP)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Agent,
+                2 => Self::Intent,
+                3 => Self::EntityType,
+                4 => Self::Webhook,
+                5 => Self::Flow,
+                6 => Self::Page,
+                7 => Self::TransitionRouteGroup,
+                8 => Self::IntentTrainingPhrase,
+                9 => Self::IntentParameter,
+                10 => Self::Intents,
+                11 => Self::IntentTrainingPhrases,
+                12 => Self::EntityTypes,
+                13 => Self::Pages,
+                14 => Self::AgentTransitionRouteGroup,
+                _ => Self::UnknownValue(resource_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AGENT" => Self::Agent,
+                "INTENT" => Self::Intent,
+                "INTENT_TRAINING_PHRASE" => Self::IntentTrainingPhrase,
+                "INTENT_PARAMETER" => Self::IntentParameter,
+                "INTENTS" => Self::Intents,
+                "INTENT_TRAINING_PHRASES" => Self::IntentTrainingPhrases,
+                "ENTITY_TYPE" => Self::EntityType,
+                "ENTITY_TYPES" => Self::EntityTypes,
+                "WEBHOOK" => Self::Webhook,
+                "FLOW" => Self::Flow,
+                "PAGE" => Self::Page,
+                "PAGES" => Self::Pages,
+                "TRANSITION_ROUTE_GROUP" => Self::TransitionRouteGroup,
+                "AGENT_TRANSITION_ROUTE_GROUP" => Self::AgentTransitionRouteGroup,
+                _ => Self::UnknownValue(resource_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Agent => serializer.serialize_i32(1),
+                Self::Intent => serializer.serialize_i32(2),
+                Self::IntentTrainingPhrase => serializer.serialize_i32(8),
+                Self::IntentParameter => serializer.serialize_i32(9),
+                Self::Intents => serializer.serialize_i32(10),
+                Self::IntentTrainingPhrases => serializer.serialize_i32(11),
+                Self::EntityType => serializer.serialize_i32(3),
+                Self::EntityTypes => serializer.serialize_i32(12),
+                Self::Webhook => serializer.serialize_i32(4),
+                Self::Flow => serializer.serialize_i32(5),
+                Self::Page => serializer.serialize_i32(6),
+                Self::Pages => serializer.serialize_i32(13),
+                Self::TransitionRouteGroup => serializer.serialize_i32(7),
+                Self::AgentTransitionRouteGroup => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceType>::new(
+                ".google.cloud.dialogflow.cx.v3.ValidationMessage.ResourceType",
+            ))
         }
     }
 
     /// Severity level.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Unspecified.
+        Unspecified,
+        /// The agent doesn't follow Dialogflow best practices.
+        Info,
+        /// The agent may not behave as expected.
+        Warning,
+        /// The agent may experience failures.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Unspecified.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// The agent doesn't follow Dialogflow best practices.
-        pub const INFO: Severity = Severity::new(1);
-
-        /// The agent may not behave as expected.
-        pub const WARNING: Severity = Severity::new(2);
-
-        /// The agent may experience failures.
-        pub const ERROR: Severity = Severity::new(3);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Info => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INFO"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Info,
+                2 => Self::Warning,
+                3 => Self::Error,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "INFO" => Self::Info,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Info => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.dialogflow.cx.v3.ValidationMessage.Severity",
+            ))
         }
     }
 }
@@ -25903,64 +28302,127 @@ pub mod version {
     use super::*;
 
     /// The state of the version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not specified. This value is not used.
+        Unspecified,
+        /// Version is not ready to serve (e.g. training is running).
+        Running,
+        /// Training has succeeded and this version is ready to serve.
+        Succeeded,
+        /// Version training failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not specified. This value is not used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Version is not ready to serve (e.g. training is running).
-        pub const RUNNING: State = State::new(1);
-
-        /// Training has succeeded and this version is ready to serve.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// Version training failed.
-        pub const FAILED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.cx.v3.Version.State",
+            ))
         }
     }
 }
@@ -26901,217 +29363,417 @@ pub mod webhook {
 
         /// Indicate the auth token type generated from the [Diglogflow service
         /// agent](https://cloud.google.com/iam/docs/service-agents#dialogflow-service-agent).
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ServiceAgentAuth(i32);
-
-        impl ServiceAgentAuth {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ServiceAgentAuth {
             /// Service agent auth type unspecified. Default to ID_TOKEN.
-            pub const SERVICE_AGENT_AUTH_UNSPECIFIED: ServiceAgentAuth = ServiceAgentAuth::new(0);
-
+            Unspecified,
             /// No token used.
-            pub const NONE: ServiceAgentAuth = ServiceAgentAuth::new(1);
-
+            None,
             /// Use [ID
             /// token](https://cloud.google.com/docs/authentication/token-types#id)
             /// generated from service agent. This can be used to access Cloud Function
             /// and Cloud Run after you grant Invoker role to
             /// `service-<PROJECT-NUMBER>@gcp-sa-dialogflow.iam.gserviceaccount.com`.
-            pub const ID_TOKEN: ServiceAgentAuth = ServiceAgentAuth::new(2);
-
+            IdToken,
             /// Use [access
             /// token](https://cloud.google.com/docs/authentication/token-types#access)
             /// generated from service agent. This can be used to access other Google
             /// Cloud APIs after you grant required roles to
             /// `service-<PROJECT-NUMBER>@gcp-sa-dialogflow.iam.gserviceaccount.com`.
-            pub const ACCESS_TOKEN: ServiceAgentAuth = ServiceAgentAuth::new(3);
+            AccessToken,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ServiceAgentAuth::value] or
+            /// [ServiceAgentAuth::name].
+            UnknownValue(service_agent_auth::UnknownValue),
+        }
 
-            /// Creates a new ServiceAgentAuth instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod service_agent_auth {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ServiceAgentAuth {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::None => std::option::Option::Some(1),
+                    Self::IdToken => std::option::Option::Some(2),
+                    Self::AccessToken => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SERVICE_AGENT_AUTH_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NONE"),
-                    2 => std::borrow::Cow::Borrowed("ID_TOKEN"),
-                    3 => std::borrow::Cow::Borrowed("ACCESS_TOKEN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SERVICE_AGENT_AUTH_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SERVICE_AGENT_AUTH_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SERVICE_AGENT_AUTH_UNSPECIFIED")
                     }
-                    "NONE" => std::option::Option::Some(Self::NONE),
-                    "ID_TOKEN" => std::option::Option::Some(Self::ID_TOKEN),
-                    "ACCESS_TOKEN" => std::option::Option::Some(Self::ACCESS_TOKEN),
-                    _ => std::option::Option::None,
+                    Self::None => std::option::Option::Some("NONE"),
+                    Self::IdToken => std::option::Option::Some("ID_TOKEN"),
+                    Self::AccessToken => std::option::Option::Some("ACCESS_TOKEN"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ServiceAgentAuth {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ServiceAgentAuth {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ServiceAgentAuth {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ServiceAgentAuth {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::None,
+                    2 => Self::IdToken,
+                    3 => Self::AccessToken,
+                    _ => Self::UnknownValue(service_agent_auth::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ServiceAgentAuth {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SERVICE_AGENT_AUTH_UNSPECIFIED" => Self::Unspecified,
+                    "NONE" => Self::None,
+                    "ID_TOKEN" => Self::IdToken,
+                    "ACCESS_TOKEN" => Self::AccessToken,
+                    _ => Self::UnknownValue(service_agent_auth::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ServiceAgentAuth {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::None => serializer.serialize_i32(1),
+                    Self::IdToken => serializer.serialize_i32(2),
+                    Self::AccessToken => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ServiceAgentAuth {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceAgentAuth>::new(
+                    ".google.cloud.dialogflow.cx.v3.Webhook.GenericWebService.ServiceAgentAuth",
+                ))
             }
         }
 
         /// Represents the type of webhook configuration.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct WebhookType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum WebhookType {
+            /// Default value. This value is unused.
+            Unspecified,
+            /// Represents a standard webhook.
+            Standard,
+            /// Represents a flexible webhook.
+            Flexible,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [WebhookType::value] or
+            /// [WebhookType::name].
+            UnknownValue(webhook_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod webhook_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl WebhookType {
-            /// Default value. This value is unused.
-            pub const WEBHOOK_TYPE_UNSPECIFIED: WebhookType = WebhookType::new(0);
-
-            /// Represents a standard webhook.
-            pub const STANDARD: WebhookType = WebhookType::new(1);
-
-            /// Represents a flexible webhook.
-            pub const FLEXIBLE: WebhookType = WebhookType::new(2);
-
-            /// Creates a new WebhookType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Standard => std::option::Option::Some(1),
+                    Self::Flexible => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("WEBHOOK_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("STANDARD"),
-                    2 => std::borrow::Cow::Borrowed("FLEXIBLE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("WEBHOOK_TYPE_UNSPECIFIED"),
+                    Self::Standard => std::option::Option::Some("STANDARD"),
+                    Self::Flexible => std::option::Option::Some("FLEXIBLE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "WEBHOOK_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::WEBHOOK_TYPE_UNSPECIFIED)
-                    }
-                    "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                    "FLEXIBLE" => std::option::Option::Some(Self::FLEXIBLE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for WebhookType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for WebhookType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for WebhookType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for WebhookType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Standard,
+                    2 => Self::Flexible,
+                    _ => Self::UnknownValue(webhook_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for WebhookType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "WEBHOOK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "STANDARD" => Self::Standard,
+                    "FLEXIBLE" => Self::Flexible,
+                    _ => Self::UnknownValue(webhook_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for WebhookType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Standard => serializer.serialize_i32(1),
+                    Self::Flexible => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for WebhookType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<WebhookType>::new(
+                    ".google.cloud.dialogflow.cx.v3.Webhook.GenericWebService.WebhookType",
+                ))
             }
         }
 
         /// HTTP method to use when calling webhooks.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct HttpMethod(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum HttpMethod {
+            /// HTTP method not specified.
+            Unspecified,
+            /// HTTP POST Method.
+            Post,
+            /// HTTP GET Method.
+            Get,
+            /// HTTP HEAD Method.
+            Head,
+            /// HTTP PUT Method.
+            Put,
+            /// HTTP DELETE Method.
+            Delete,
+            /// HTTP PATCH Method.
+            Patch,
+            /// HTTP OPTIONS Method.
+            Options,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [HttpMethod::value] or
+            /// [HttpMethod::name].
+            UnknownValue(http_method::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod http_method {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl HttpMethod {
-            /// HTTP method not specified.
-            pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new(0);
-
-            /// HTTP POST Method.
-            pub const POST: HttpMethod = HttpMethod::new(1);
-
-            /// HTTP GET Method.
-            pub const GET: HttpMethod = HttpMethod::new(2);
-
-            /// HTTP HEAD Method.
-            pub const HEAD: HttpMethod = HttpMethod::new(3);
-
-            /// HTTP PUT Method.
-            pub const PUT: HttpMethod = HttpMethod::new(4);
-
-            /// HTTP DELETE Method.
-            pub const DELETE: HttpMethod = HttpMethod::new(5);
-
-            /// HTTP PATCH Method.
-            pub const PATCH: HttpMethod = HttpMethod::new(6);
-
-            /// HTTP OPTIONS Method.
-            pub const OPTIONS: HttpMethod = HttpMethod::new(7);
-
-            /// Creates a new HttpMethod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Post => std::option::Option::Some(1),
+                    Self::Get => std::option::Option::Some(2),
+                    Self::Head => std::option::Option::Some(3),
+                    Self::Put => std::option::Option::Some(4),
+                    Self::Delete => std::option::Option::Some(5),
+                    Self::Patch => std::option::Option::Some(6),
+                    Self::Options => std::option::Option::Some(7),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("HTTP_METHOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("POST"),
-                    2 => std::borrow::Cow::Borrowed("GET"),
-                    3 => std::borrow::Cow::Borrowed("HEAD"),
-                    4 => std::borrow::Cow::Borrowed("PUT"),
-                    5 => std::borrow::Cow::Borrowed("DELETE"),
-                    6 => std::borrow::Cow::Borrowed("PATCH"),
-                    7 => std::borrow::Cow::Borrowed("OPTIONS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("HTTP_METHOD_UNSPECIFIED"),
+                    Self::Post => std::option::Option::Some("POST"),
+                    Self::Get => std::option::Option::Some("GET"),
+                    Self::Head => std::option::Option::Some("HEAD"),
+                    Self::Put => std::option::Option::Some("PUT"),
+                    Self::Delete => std::option::Option::Some("DELETE"),
+                    Self::Patch => std::option::Option::Some("PATCH"),
+                    Self::Options => std::option::Option::Some("OPTIONS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "HTTP_METHOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::HTTP_METHOD_UNSPECIFIED)
-                    }
-                    "POST" => std::option::Option::Some(Self::POST),
-                    "GET" => std::option::Option::Some(Self::GET),
-                    "HEAD" => std::option::Option::Some(Self::HEAD),
-                    "PUT" => std::option::Option::Some(Self::PUT),
-                    "DELETE" => std::option::Option::Some(Self::DELETE),
-                    "PATCH" => std::option::Option::Some(Self::PATCH),
-                    "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for HttpMethod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for HttpMethod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for HttpMethod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for HttpMethod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Post,
+                    2 => Self::Get,
+                    3 => Self::Head,
+                    4 => Self::Put,
+                    5 => Self::Delete,
+                    6 => Self::Patch,
+                    7 => Self::Options,
+                    _ => Self::UnknownValue(http_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for HttpMethod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "HTTP_METHOD_UNSPECIFIED" => Self::Unspecified,
+                    "POST" => Self::Post,
+                    "GET" => Self::Get,
+                    "HEAD" => Self::Head,
+                    "PUT" => Self::Put,
+                    "DELETE" => Self::Delete,
+                    "PATCH" => Self::Patch,
+                    "OPTIONS" => Self::Options,
+                    _ => Self::UnknownValue(http_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for HttpMethod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Post => serializer.serialize_i32(1),
+                    Self::Get => serializer.serialize_i32(2),
+                    Self::Head => serializer.serialize_i32(3),
+                    Self::Put => serializer.serialize_i32(4),
+                    Self::Delete => serializer.serialize_i32(5),
+                    Self::Patch => serializer.serialize_i32(6),
+                    Self::Options => serializer.serialize_i32(7),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for HttpMethod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<HttpMethod>::new(
+                    ".google.cloud.dialogflow.cx.v3.Webhook.GenericWebService.HttpMethod",
+                ))
             }
         }
     }
@@ -28303,63 +30965,124 @@ pub mod webhook_response {
         use super::*;
 
         /// Defines merge behavior for `messages`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MergeBehavior(i32);
-
-        impl MergeBehavior {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MergeBehavior {
             /// Not specified. `APPEND` will be used.
-            pub const MERGE_BEHAVIOR_UNSPECIFIED: MergeBehavior = MergeBehavior::new(0);
-
+            Unspecified,
             /// `messages` will be appended to the list of messages waiting to be sent
             /// to the user.
-            pub const APPEND: MergeBehavior = MergeBehavior::new(1);
-
+            Append,
             /// `messages` will replace the list of messages waiting to be sent to the
             /// user.
-            pub const REPLACE: MergeBehavior = MergeBehavior::new(2);
+            Replace,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MergeBehavior::value] or
+            /// [MergeBehavior::name].
+            UnknownValue(merge_behavior::UnknownValue),
+        }
 
-            /// Creates a new MergeBehavior instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod merge_behavior {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl MergeBehavior {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Append => std::option::Option::Some(1),
+                    Self::Replace => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MERGE_BEHAVIOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("APPEND"),
-                    2 => std::borrow::Cow::Borrowed("REPLACE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MERGE_BEHAVIOR_UNSPECIFIED"),
+                    Self::Append => std::option::Option::Some("APPEND"),
+                    Self::Replace => std::option::Option::Some("REPLACE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MERGE_BEHAVIOR_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::MERGE_BEHAVIOR_UNSPECIFIED)
-                    }
-                    "APPEND" => std::option::Option::Some(Self::APPEND),
-                    "REPLACE" => std::option::Option::Some(Self::REPLACE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MergeBehavior {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MergeBehavior {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MergeBehavior {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MergeBehavior {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Append,
+                    2 => Self::Replace,
+                    _ => Self::UnknownValue(merge_behavior::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MergeBehavior {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MERGE_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+                    "APPEND" => Self::Append,
+                    "REPLACE" => Self::Replace,
+                    _ => Self::UnknownValue(merge_behavior::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MergeBehavior {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Append => serializer.serialize_i32(1),
+                    Self::Replace => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MergeBehavior {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MergeBehavior>::new(
+                    ".google.cloud.dialogflow.cx.v3.WebhookResponse.FulfillmentResponse.MergeBehavior"))
             }
         }
     }
@@ -28551,7 +31274,7 @@ pub mod page_info {
             /// by the webhook to invalidate the parameter; other values set by the
             /// webhook will be ignored.
             ///
-            /// [google.cloud.dialogflow.cx.v3.PageInfo.FormInfo.ParameterInfo.ParameterState.INVALID]: crate::model::page_info::form_info::parameter_info::parameter_state::INVALID
+            /// [google.cloud.dialogflow.cx.v3.PageInfo.FormInfo.ParameterInfo.ParameterState.INVALID]: crate::model::page_info::form_info::parameter_info::ParameterState::Invalid
             /// [google.cloud.dialogflow.cx.v3.WebhookRequest]: crate::model::WebhookRequest
             /// [google.cloud.dialogflow.cx.v3.WebhookResponse]: crate::model::WebhookResponse
             pub state: crate::model::page_info::form_info::parameter_info::ParameterState,
@@ -28643,68 +31366,133 @@ pub mod page_info {
             use super::*;
 
             /// Represents the state of a parameter.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ParameterState(i32);
-
-            impl ParameterState {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ParameterState {
                 /// Not specified. This value should be never used.
-                pub const PARAMETER_STATE_UNSPECIFIED: ParameterState = ParameterState::new(0);
-
+                Unspecified,
                 /// Indicates that the parameter does not have a value.
-                pub const EMPTY: ParameterState = ParameterState::new(1);
-
+                Empty,
                 /// Indicates that the parameter value is invalid. This field can be used
                 /// by the webhook to invalidate the parameter and ask the server to
                 /// collect it from the user again.
-                pub const INVALID: ParameterState = ParameterState::new(2);
-
+                Invalid,
                 /// Indicates that the parameter has a value.
-                pub const FILLED: ParameterState = ParameterState::new(3);
+                Filled,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ParameterState::value] or
+                /// [ParameterState::name].
+                UnknownValue(parameter_state::UnknownValue),
+            }
 
-                /// Creates a new ParameterState instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod parameter_state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl ParameterState {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Empty => std::option::Option::Some(1),
+                        Self::Invalid => std::option::Option::Some(2),
+                        Self::Filled => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("PARAMETER_STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("EMPTY"),
-                        2 => std::borrow::Cow::Borrowed("INVALID"),
-                        3 => std::borrow::Cow::Borrowed("FILLED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "PARAMETER_STATE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::PARAMETER_STATE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("PARAMETER_STATE_UNSPECIFIED")
                         }
-                        "EMPTY" => std::option::Option::Some(Self::EMPTY),
-                        "INVALID" => std::option::Option::Some(Self::INVALID),
-                        "FILLED" => std::option::Option::Some(Self::FILLED),
-                        _ => std::option::Option::None,
+                        Self::Empty => std::option::Option::Some("EMPTY"),
+                        Self::Invalid => std::option::Option::Some("INVALID"),
+                        Self::Filled => std::option::Option::Some("FILLED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for ParameterState {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ParameterState {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ParameterState {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ParameterState {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Empty,
+                        2 => Self::Invalid,
+                        3 => Self::Filled,
+                        _ => Self::UnknownValue(parameter_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ParameterState {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "PARAMETER_STATE_UNSPECIFIED" => Self::Unspecified,
+                        "EMPTY" => Self::Empty,
+                        "INVALID" => Self::Invalid,
+                        "FILLED" => Self::Filled,
+                        _ => Self::UnknownValue(parameter_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ParameterState {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Empty => serializer.serialize_i32(1),
+                        Self::Invalid => serializer.serialize_i32(2),
+                        Self::Filled => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ParameterState {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ParameterState>::new(
+                        ".google.cloud.dialogflow.cx.v3.PageInfo.FormInfo.ParameterInfo.ParameterState"))
                 }
             }
         }
@@ -28850,37 +31638,29 @@ impl wkt::message::Message for LanguageInfo {
 /// [Cloud Speech API
 /// documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
 /// details.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AudioEncoding(i32);
-
-impl AudioEncoding {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AudioEncoding {
     /// Not specified.
-    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
-
+    Unspecified,
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
-    pub const AUDIO_ENCODING_LINEAR_16: AudioEncoding = AudioEncoding::new(1);
-
+    Linear16,
     /// [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
     /// Codec) is the recommended encoding because it is lossless (therefore
     /// recognition is not compromised) and requires only about half the
     /// bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
     /// 24-bit samples, however, not all fields in `STREAMINFO` are supported.
-    pub const AUDIO_ENCODING_FLAC: AudioEncoding = AudioEncoding::new(2);
-
+    Flac,
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const AUDIO_ENCODING_MULAW: AudioEncoding = AudioEncoding::new(3);
-
+    Mulaw,
     /// Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
-    pub const AUDIO_ENCODING_AMR: AudioEncoding = AudioEncoding::new(4);
-
+    Amr,
     /// Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_AMR_WB: AudioEncoding = AudioEncoding::new(5);
-
+    AmrWb,
     /// Opus encoded audio frames in Ogg container
     /// ([OggOpus](https://wiki.xiph.org/OggOpus)).
     /// `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_OGG_OPUS: AudioEncoding = AudioEncoding::new(6);
-
+    OggOpus,
     /// Although the use of lossy encodings is not recommended, if a very low
     /// bitrate encoding is required, `OGG_OPUS` is highly preferred over
     /// Speex encoding. The [Speex](https://speex.org/) encoding supported by
@@ -28894,67 +31674,146 @@ impl AudioEncoding {
     /// bytes (octets) as specified in RFC 5574. In other words, each RTP header
     /// is replaced with a single byte containing the block length. Only Speex
     /// wideband is supported. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE: AudioEncoding = AudioEncoding::new(7);
-
+    SpeexWithHeaderByte,
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const AUDIO_ENCODING_ALAW: AudioEncoding = AudioEncoding::new(8);
+    Alaw,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AudioEncoding::value] or
+    /// [AudioEncoding::name].
+    UnknownValue(audio_encoding::UnknownValue),
+}
 
-    /// Creates a new AudioEncoding instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod audio_encoding {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AudioEncoding {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linear16 => std::option::Option::Some(1),
+            Self::Flac => std::option::Option::Some(2),
+            Self::Mulaw => std::option::Option::Some(3),
+            Self::Amr => std::option::Option::Some(4),
+            Self::AmrWb => std::option::Option::Some(5),
+            Self::OggOpus => std::option::Option::Some(6),
+            Self::SpeexWithHeaderByte => std::option::Option::Some(7),
+            Self::Alaw => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_LINEAR_16"),
-            2 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_FLAC"),
-            3 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_MULAW"),
-            4 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR"),
-            5 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR_WB"),
-            6 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_OGG_OPUS"),
-            7 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE"),
-            8 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_ALAW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUDIO_ENCODING_UNSPECIFIED" => {
-                std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AUDIO_ENCODING_UNSPECIFIED"),
+            Self::Linear16 => std::option::Option::Some("AUDIO_ENCODING_LINEAR_16"),
+            Self::Flac => std::option::Option::Some("AUDIO_ENCODING_FLAC"),
+            Self::Mulaw => std::option::Option::Some("AUDIO_ENCODING_MULAW"),
+            Self::Amr => std::option::Option::Some("AUDIO_ENCODING_AMR"),
+            Self::AmrWb => std::option::Option::Some("AUDIO_ENCODING_AMR_WB"),
+            Self::OggOpus => std::option::Option::Some("AUDIO_ENCODING_OGG_OPUS"),
+            Self::SpeexWithHeaderByte => {
+                std::option::Option::Some("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE")
             }
-            "AUDIO_ENCODING_LINEAR_16" => std::option::Option::Some(Self::AUDIO_ENCODING_LINEAR_16),
-            "AUDIO_ENCODING_FLAC" => std::option::Option::Some(Self::AUDIO_ENCODING_FLAC),
-            "AUDIO_ENCODING_MULAW" => std::option::Option::Some(Self::AUDIO_ENCODING_MULAW),
-            "AUDIO_ENCODING_AMR" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR),
-            "AUDIO_ENCODING_AMR_WB" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR_WB),
-            "AUDIO_ENCODING_OGG_OPUS" => std::option::Option::Some(Self::AUDIO_ENCODING_OGG_OPUS),
-            "AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE" => {
-                std::option::Option::Some(Self::AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE)
-            }
-            "AUDIO_ENCODING_ALAW" => std::option::Option::Some(Self::AUDIO_ENCODING_ALAW),
-            _ => std::option::Option::None,
+            Self::Alaw => std::option::Option::Some("AUDIO_ENCODING_ALAW"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for AudioEncoding {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AudioEncoding {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AudioEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AudioEncoding {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linear16,
+            2 => Self::Flac,
+            3 => Self::Mulaw,
+            4 => Self::Amr,
+            5 => Self::AmrWb,
+            6 => Self::OggOpus,
+            7 => Self::SpeexWithHeaderByte,
+            8 => Self::Alaw,
+            _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AudioEncoding {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUDIO_ENCODING_UNSPECIFIED" => Self::Unspecified,
+            "AUDIO_ENCODING_LINEAR_16" => Self::Linear16,
+            "AUDIO_ENCODING_FLAC" => Self::Flac,
+            "AUDIO_ENCODING_MULAW" => Self::Mulaw,
+            "AUDIO_ENCODING_AMR" => Self::Amr,
+            "AUDIO_ENCODING_AMR_WB" => Self::AmrWb,
+            "AUDIO_ENCODING_OGG_OPUS" => Self::OggOpus,
+            "AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE" => Self::SpeexWithHeaderByte,
+            "AUDIO_ENCODING_ALAW" => Self::Alaw,
+            _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AudioEncoding {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linear16 => serializer.serialize_i32(1),
+            Self::Flac => serializer.serialize_i32(2),
+            Self::Mulaw => serializer.serialize_i32(3),
+            Self::Amr => serializer.serialize_i32(4),
+            Self::AmrWb => serializer.serialize_i32(5),
+            Self::OggOpus => serializer.serialize_i32(6),
+            Self::SpeexWithHeaderByte => serializer.serialize_i32(7),
+            Self::Alaw => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AudioEncoding {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AudioEncoding>::new(
+            ".google.cloud.dialogflow.cx.v3.AudioEncoding",
+        ))
     }
 }
 
@@ -28968,26 +31827,22 @@ impl std::default::Default for AudioEncoding {
 /// you will generally receive higher quality results than for a standard model.
 ///
 /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SpeechModelVariant(i32);
-
-impl SpeechModelVariant {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SpeechModelVariant {
     /// No model variant specified. In this case Dialogflow defaults to
     /// USE_BEST_AVAILABLE.
-    pub const SPEECH_MODEL_VARIANT_UNSPECIFIED: SpeechModelVariant = SpeechModelVariant::new(0);
-
+    Unspecified,
     /// Use the best available variant of the [Speech
     /// model][InputAudioConfig.model] that the caller is eligible for.
     ///
     /// [InputAudioConfig.model]: crate::model::InputAudioConfig::model
-    pub const USE_BEST_AVAILABLE: SpeechModelVariant = SpeechModelVariant::new(1);
-
+    UseBestAvailable,
     /// Use standard model variant even if an enhanced model is available.  See the
     /// [Cloud Speech
     /// documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
     /// for details about enhanced models.
-    pub const USE_STANDARD: SpeechModelVariant = SpeechModelVariant::new(2);
-
+    UseStandard,
     /// Use an enhanced model variant:
     ///
     /// * If an enhanced variant does not exist for the given
@@ -29000,541 +31855,1022 @@ impl SpeechModelVariant {
     ///
     ///
     /// [google.cloud.dialogflow.cx.v3.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-    pub const USE_ENHANCED: SpeechModelVariant = SpeechModelVariant::new(3);
+    UseEnhanced,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SpeechModelVariant::value] or
+    /// [SpeechModelVariant::name].
+    UnknownValue(speech_model_variant::UnknownValue),
+}
 
-    /// Creates a new SpeechModelVariant instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod speech_model_variant {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SpeechModelVariant {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::UseBestAvailable => std::option::Option::Some(1),
+            Self::UseStandard => std::option::Option::Some(2),
+            Self::UseEnhanced => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SPEECH_MODEL_VARIANT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("USE_BEST_AVAILABLE"),
-            2 => std::borrow::Cow::Borrowed("USE_STANDARD"),
-            3 => std::borrow::Cow::Borrowed("USE_ENHANCED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SPEECH_MODEL_VARIANT_UNSPECIFIED"),
+            Self::UseBestAvailable => std::option::Option::Some("USE_BEST_AVAILABLE"),
+            Self::UseStandard => std::option::Option::Some("USE_STANDARD"),
+            Self::UseEnhanced => std::option::Option::Some("USE_ENHANCED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SPEECH_MODEL_VARIANT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SPEECH_MODEL_VARIANT_UNSPECIFIED)
-            }
-            "USE_BEST_AVAILABLE" => std::option::Option::Some(Self::USE_BEST_AVAILABLE),
-            "USE_STANDARD" => std::option::Option::Some(Self::USE_STANDARD),
-            "USE_ENHANCED" => std::option::Option::Some(Self::USE_ENHANCED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SpeechModelVariant {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SpeechModelVariant {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SpeechModelVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SpeechModelVariant {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::UseBestAvailable,
+            2 => Self::UseStandard,
+            3 => Self::UseEnhanced,
+            _ => Self::UnknownValue(speech_model_variant::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SpeechModelVariant {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SPEECH_MODEL_VARIANT_UNSPECIFIED" => Self::Unspecified,
+            "USE_BEST_AVAILABLE" => Self::UseBestAvailable,
+            "USE_STANDARD" => Self::UseStandard,
+            "USE_ENHANCED" => Self::UseEnhanced,
+            _ => Self::UnknownValue(speech_model_variant::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SpeechModelVariant {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::UseBestAvailable => serializer.serialize_i32(1),
+            Self::UseStandard => serializer.serialize_i32(2),
+            Self::UseEnhanced => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SpeechModelVariant {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SpeechModelVariant>::new(
+            ".google.cloud.dialogflow.cx.v3.SpeechModelVariant",
+        ))
     }
 }
 
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SsmlVoiceGender(i32);
-
-impl SsmlVoiceGender {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SsmlVoiceGender {
     /// An unspecified gender, which means that the client doesn't care which
     /// gender the selected voice will have.
-    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender = SsmlVoiceGender::new(0);
-
+    Unspecified,
     /// A male voice.
-    pub const SSML_VOICE_GENDER_MALE: SsmlVoiceGender = SsmlVoiceGender::new(1);
-
+    Male,
     /// A female voice.
-    pub const SSML_VOICE_GENDER_FEMALE: SsmlVoiceGender = SsmlVoiceGender::new(2);
-
+    Female,
     /// A gender-neutral voice.
-    pub const SSML_VOICE_GENDER_NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new(3);
+    Neutral,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SsmlVoiceGender::value] or
+    /// [SsmlVoiceGender::name].
+    UnknownValue(ssml_voice_gender::UnknownValue),
+}
 
-    /// Creates a new SsmlVoiceGender instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod ssml_voice_gender {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SsmlVoiceGender {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Male => std::option::Option::Some(1),
+            Self::Female => std::option::Option::Some(2),
+            Self::Neutral => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_MALE"),
-            2 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_FEMALE"),
-            3 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_NEUTRAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SSML_VOICE_GENDER_UNSPECIFIED"),
+            Self::Male => std::option::Option::Some("SSML_VOICE_GENDER_MALE"),
+            Self::Female => std::option::Option::Some("SSML_VOICE_GENDER_FEMALE"),
+            Self::Neutral => std::option::Option::Some("SSML_VOICE_GENDER_NEUTRAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SSML_VOICE_GENDER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SSML_VOICE_GENDER_UNSPECIFIED)
-            }
-            "SSML_VOICE_GENDER_MALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_MALE),
-            "SSML_VOICE_GENDER_FEMALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_FEMALE),
-            "SSML_VOICE_GENDER_NEUTRAL" => {
-                std::option::Option::Some(Self::SSML_VOICE_GENDER_NEUTRAL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SsmlVoiceGender {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SsmlVoiceGender {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SsmlVoiceGender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SsmlVoiceGender {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Male,
+            2 => Self::Female,
+            3 => Self::Neutral,
+            _ => Self::UnknownValue(ssml_voice_gender::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SsmlVoiceGender {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SSML_VOICE_GENDER_UNSPECIFIED" => Self::Unspecified,
+            "SSML_VOICE_GENDER_MALE" => Self::Male,
+            "SSML_VOICE_GENDER_FEMALE" => Self::Female,
+            "SSML_VOICE_GENDER_NEUTRAL" => Self::Neutral,
+            _ => Self::UnknownValue(ssml_voice_gender::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SsmlVoiceGender {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Male => serializer.serialize_i32(1),
+            Self::Female => serializer.serialize_i32(2),
+            Self::Neutral => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SsmlVoiceGender {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SsmlVoiceGender>::new(
+            ".google.cloud.dialogflow.cx.v3.SsmlVoiceGender",
+        ))
     }
 }
 
 /// Audio encoding of the output audio format in Text-To-Speech.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OutputAudioEncoding(i32);
-
-impl OutputAudioEncoding {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OutputAudioEncoding {
     /// Not specified.
-    pub const OUTPUT_AUDIO_ENCODING_UNSPECIFIED: OutputAudioEncoding = OutputAudioEncoding::new(0);
-
+    Unspecified,
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Audio content returned as LINEAR16 also contains a WAV header.
-    pub const OUTPUT_AUDIO_ENCODING_LINEAR_16: OutputAudioEncoding = OutputAudioEncoding::new(1);
-
+    Linear16,
     /// MP3 audio at 32kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3: OutputAudioEncoding = OutputAudioEncoding::new(2);
-
+    Mp3,
     /// MP3 audio at 64kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3_64_KBPS: OutputAudioEncoding = OutputAudioEncoding::new(4);
-
+    Mp364Kbps,
     /// Opus encoded audio wrapped in an ogg container. The result will be a
     /// file which can be played natively on Android, and in browsers (at least
     /// Chrome and Firefox). The quality of the encoding is considerably higher
     /// than MP3 while using approximately the same bitrate.
-    pub const OUTPUT_AUDIO_ENCODING_OGG_OPUS: OutputAudioEncoding = OutputAudioEncoding::new(3);
-
+    OggOpus,
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const OUTPUT_AUDIO_ENCODING_MULAW: OutputAudioEncoding = OutputAudioEncoding::new(5);
-
+    Mulaw,
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const OUTPUT_AUDIO_ENCODING_ALAW: OutputAudioEncoding = OutputAudioEncoding::new(6);
+    Alaw,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OutputAudioEncoding::value] or
+    /// [OutputAudioEncoding::name].
+    UnknownValue(output_audio_encoding::UnknownValue),
+}
 
-    /// Creates a new OutputAudioEncoding instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod output_audio_encoding {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl OutputAudioEncoding {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linear16 => std::option::Option::Some(1),
+            Self::Mp3 => std::option::Option::Some(2),
+            Self::Mp364Kbps => std::option::Option::Some(4),
+            Self::OggOpus => std::option::Option::Some(3),
+            Self::Mulaw => std::option::Option::Some(5),
+            Self::Alaw => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_LINEAR_16"),
-            2 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3"),
-            3 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_OGG_OPUS"),
-            4 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS"),
-            5 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MULAW"),
-            6 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_ALAW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_UNSPECIFIED"),
+            Self::Linear16 => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_LINEAR_16"),
+            Self::Mp3 => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_MP3"),
+            Self::Mp364Kbps => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS"),
+            Self::OggOpus => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_OGG_OPUS"),
+            Self::Mulaw => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_MULAW"),
+            Self::Alaw => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_ALAW"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OUTPUT_AUDIO_ENCODING_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_UNSPECIFIED)
-            }
-            "OUTPUT_AUDIO_ENCODING_LINEAR_16" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_LINEAR_16)
-            }
-            "OUTPUT_AUDIO_ENCODING_MP3" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3)
-            }
-            "OUTPUT_AUDIO_ENCODING_MP3_64_KBPS" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3_64_KBPS)
-            }
-            "OUTPUT_AUDIO_ENCODING_OGG_OPUS" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_OGG_OPUS)
-            }
-            "OUTPUT_AUDIO_ENCODING_MULAW" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MULAW)
-            }
-            "OUTPUT_AUDIO_ENCODING_ALAW" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_ALAW)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OutputAudioEncoding {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OutputAudioEncoding {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OutputAudioEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OutputAudioEncoding {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linear16,
+            2 => Self::Mp3,
+            3 => Self::OggOpus,
+            4 => Self::Mp364Kbps,
+            5 => Self::Mulaw,
+            6 => Self::Alaw,
+            _ => Self::UnknownValue(output_audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OutputAudioEncoding {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OUTPUT_AUDIO_ENCODING_UNSPECIFIED" => Self::Unspecified,
+            "OUTPUT_AUDIO_ENCODING_LINEAR_16" => Self::Linear16,
+            "OUTPUT_AUDIO_ENCODING_MP3" => Self::Mp3,
+            "OUTPUT_AUDIO_ENCODING_MP3_64_KBPS" => Self::Mp364Kbps,
+            "OUTPUT_AUDIO_ENCODING_OGG_OPUS" => Self::OggOpus,
+            "OUTPUT_AUDIO_ENCODING_MULAW" => Self::Mulaw,
+            "OUTPUT_AUDIO_ENCODING_ALAW" => Self::Alaw,
+            _ => Self::UnknownValue(output_audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OutputAudioEncoding {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linear16 => serializer.serialize_i32(1),
+            Self::Mp3 => serializer.serialize_i32(2),
+            Self::Mp364Kbps => serializer.serialize_i32(4),
+            Self::OggOpus => serializer.serialize_i32(3),
+            Self::Mulaw => serializer.serialize_i32(5),
+            Self::Alaw => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OutputAudioEncoding {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OutputAudioEncoding>::new(
+            ".google.cloud.dialogflow.cx.v3.OutputAudioEncoding",
+        ))
     }
 }
 
 /// Type of a data store.
 /// Determines how search is performed in the data store.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataStoreType(i32);
-
-impl DataStoreType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DataStoreType {
     /// Not specified. This value indicates that the data store type is not
     /// specified, so it will not be used during search.
-    pub const DATA_STORE_TYPE_UNSPECIFIED: DataStoreType = DataStoreType::new(0);
-
+    Unspecified,
     /// A data store that contains public web content.
-    pub const PUBLIC_WEB: DataStoreType = DataStoreType::new(1);
-
+    PublicWeb,
     /// A data store that contains unstructured private data.
-    pub const UNSTRUCTURED: DataStoreType = DataStoreType::new(2);
-
+    Unstructured,
     /// A data store that contains structured data (for example FAQ).
-    pub const STRUCTURED: DataStoreType = DataStoreType::new(3);
+    Structured,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DataStoreType::value] or
+    /// [DataStoreType::name].
+    UnknownValue(data_store_type::UnknownValue),
+}
 
-    /// Creates a new DataStoreType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod data_store_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DataStoreType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PublicWeb => std::option::Option::Some(1),
+            Self::Unstructured => std::option::Option::Some(2),
+            Self::Structured => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATA_STORE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PUBLIC_WEB"),
-            2 => std::borrow::Cow::Borrowed("UNSTRUCTURED"),
-            3 => std::borrow::Cow::Borrowed("STRUCTURED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATA_STORE_TYPE_UNSPECIFIED"),
+            Self::PublicWeb => std::option::Option::Some("PUBLIC_WEB"),
+            Self::Unstructured => std::option::Option::Some("UNSTRUCTURED"),
+            Self::Structured => std::option::Option::Some("STRUCTURED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATA_STORE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATA_STORE_TYPE_UNSPECIFIED)
-            }
-            "PUBLIC_WEB" => std::option::Option::Some(Self::PUBLIC_WEB),
-            "UNSTRUCTURED" => std::option::Option::Some(Self::UNSTRUCTURED),
-            "STRUCTURED" => std::option::Option::Some(Self::STRUCTURED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DataStoreType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DataStoreType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DataStoreType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DataStoreType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PublicWeb,
+            2 => Self::Unstructured,
+            3 => Self::Structured,
+            _ => Self::UnknownValue(data_store_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DataStoreType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATA_STORE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PUBLIC_WEB" => Self::PublicWeb,
+            "UNSTRUCTURED" => Self::Unstructured,
+            "STRUCTURED" => Self::Structured,
+            _ => Self::UnknownValue(data_store_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DataStoreType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PublicWeb => serializer.serialize_i32(1),
+            Self::Unstructured => serializer.serialize_i32(2),
+            Self::Structured => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DataStoreType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataStoreType>::new(
+            ".google.cloud.dialogflow.cx.v3.DataStoreType",
+        ))
     }
 }
 
 /// The document processing mode of the data store.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DocumentProcessingMode(i32);
-
-impl DocumentProcessingMode {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DocumentProcessingMode {
     /// Not specified. This should be set for STRUCTURED type data stores. Due to
     /// legacy reasons this is considered as DOCUMENTS for STRUCTURED and
     /// PUBLIC_WEB data stores.
-    pub const DOCUMENT_PROCESSING_MODE_UNSPECIFIED: DocumentProcessingMode =
-        DocumentProcessingMode::new(0);
-
+    Unspecified,
     /// Documents are processed as documents.
-    pub const DOCUMENTS: DocumentProcessingMode = DocumentProcessingMode::new(1);
-
+    Documents,
     /// Documents are converted to chunks.
-    pub const CHUNKS: DocumentProcessingMode = DocumentProcessingMode::new(2);
+    Chunks,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DocumentProcessingMode::value] or
+    /// [DocumentProcessingMode::name].
+    UnknownValue(document_processing_mode::UnknownValue),
+}
 
-    /// Creates a new DocumentProcessingMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod document_processing_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DocumentProcessingMode {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Documents => std::option::Option::Some(1),
+            Self::Chunks => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DOCUMENT_PROCESSING_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DOCUMENTS"),
-            2 => std::borrow::Cow::Borrowed("CHUNKS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DOCUMENT_PROCESSING_MODE_UNSPECIFIED"),
+            Self::Documents => std::option::Option::Some("DOCUMENTS"),
+            Self::Chunks => std::option::Option::Some("CHUNKS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DOCUMENT_PROCESSING_MODE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DOCUMENT_PROCESSING_MODE_UNSPECIFIED)
-            }
-            "DOCUMENTS" => std::option::Option::Some(Self::DOCUMENTS),
-            "CHUNKS" => std::option::Option::Some(Self::CHUNKS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DocumentProcessingMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DocumentProcessingMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DocumentProcessingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DocumentProcessingMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Documents,
+            2 => Self::Chunks,
+            _ => Self::UnknownValue(document_processing_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DocumentProcessingMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DOCUMENT_PROCESSING_MODE_UNSPECIFIED" => Self::Unspecified,
+            "DOCUMENTS" => Self::Documents,
+            "CHUNKS" => Self::Chunks,
+            _ => Self::UnknownValue(document_processing_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DocumentProcessingMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Documents => serializer.serialize_i32(1),
+            Self::Chunks => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DocumentProcessingMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DocumentProcessingMode>::new(
+            ".google.cloud.dialogflow.cx.v3.DocumentProcessingMode",
+        ))
     }
 }
 
 /// Import strategies for the conflict resolution of resources (i.e. intents,
 /// entities, and webhooks) with identical display names during import
 /// operations.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportStrategy(i32);
-
-impl ImportStrategy {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ImportStrategy {
     /// Unspecified. Treated as 'CREATE_NEW'.
-    pub const IMPORT_STRATEGY_UNSPECIFIED: ImportStrategy = ImportStrategy::new(0);
-
+    Unspecified,
     /// Create a new resource with a numeric suffix appended to the end of the
     /// existing display name.
-    pub const IMPORT_STRATEGY_CREATE_NEW: ImportStrategy = ImportStrategy::new(1);
-
+    CreateNew,
     /// Replace existing resource with incoming resource in the content to be
     /// imported.
-    pub const IMPORT_STRATEGY_REPLACE: ImportStrategy = ImportStrategy::new(2);
-
+    Replace,
     /// Keep existing resource and discard incoming resource in the content to be
     /// imported.
-    pub const IMPORT_STRATEGY_KEEP: ImportStrategy = ImportStrategy::new(3);
-
+    Keep,
     /// Combine existing and incoming resources when a conflict is encountered.
-    pub const IMPORT_STRATEGY_MERGE: ImportStrategy = ImportStrategy::new(4);
-
+    Merge,
     /// Throw error if a conflict is encountered.
-    pub const IMPORT_STRATEGY_THROW_ERROR: ImportStrategy = ImportStrategy::new(5);
+    ThrowError,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ImportStrategy::value] or
+    /// [ImportStrategy::name].
+    UnknownValue(import_strategy::UnknownValue),
+}
 
-    /// Creates a new ImportStrategy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod import_strategy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ImportStrategy {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::CreateNew => std::option::Option::Some(1),
+            Self::Replace => std::option::Option::Some(2),
+            Self::Keep => std::option::Option::Some(3),
+            Self::Merge => std::option::Option::Some(4),
+            Self::ThrowError => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_CREATE_NEW"),
-            2 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_REPLACE"),
-            3 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_KEEP"),
-            4 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_MERGE"),
-            5 => std::borrow::Cow::Borrowed("IMPORT_STRATEGY_THROW_ERROR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("IMPORT_STRATEGY_UNSPECIFIED"),
+            Self::CreateNew => std::option::Option::Some("IMPORT_STRATEGY_CREATE_NEW"),
+            Self::Replace => std::option::Option::Some("IMPORT_STRATEGY_REPLACE"),
+            Self::Keep => std::option::Option::Some("IMPORT_STRATEGY_KEEP"),
+            Self::Merge => std::option::Option::Some("IMPORT_STRATEGY_MERGE"),
+            Self::ThrowError => std::option::Option::Some("IMPORT_STRATEGY_THROW_ERROR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IMPORT_STRATEGY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::IMPORT_STRATEGY_UNSPECIFIED)
-            }
-            "IMPORT_STRATEGY_CREATE_NEW" => {
-                std::option::Option::Some(Self::IMPORT_STRATEGY_CREATE_NEW)
-            }
-            "IMPORT_STRATEGY_REPLACE" => std::option::Option::Some(Self::IMPORT_STRATEGY_REPLACE),
-            "IMPORT_STRATEGY_KEEP" => std::option::Option::Some(Self::IMPORT_STRATEGY_KEEP),
-            "IMPORT_STRATEGY_MERGE" => std::option::Option::Some(Self::IMPORT_STRATEGY_MERGE),
-            "IMPORT_STRATEGY_THROW_ERROR" => {
-                std::option::Option::Some(Self::IMPORT_STRATEGY_THROW_ERROR)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ImportStrategy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportStrategy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ImportStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ImportStrategy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::CreateNew,
+            2 => Self::Replace,
+            3 => Self::Keep,
+            4 => Self::Merge,
+            5 => Self::ThrowError,
+            _ => Self::UnknownValue(import_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ImportStrategy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IMPORT_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+            "IMPORT_STRATEGY_CREATE_NEW" => Self::CreateNew,
+            "IMPORT_STRATEGY_REPLACE" => Self::Replace,
+            "IMPORT_STRATEGY_KEEP" => Self::Keep,
+            "IMPORT_STRATEGY_MERGE" => Self::Merge,
+            "IMPORT_STRATEGY_THROW_ERROR" => Self::ThrowError,
+            _ => Self::UnknownValue(import_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ImportStrategy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::CreateNew => serializer.serialize_i32(1),
+            Self::Replace => serializer.serialize_i32(2),
+            Self::Keep => serializer.serialize_i32(3),
+            Self::Merge => serializer.serialize_i32(4),
+            Self::ThrowError => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ImportStrategy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportStrategy>::new(
+            ".google.cloud.dialogflow.cx.v3.ImportStrategy",
+        ))
     }
 }
 
 /// Represents the options for views of an intent.
 /// An intent can be a sizable object. Therefore, we provide a resource view that
 /// does not return training phrases in the response.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IntentView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IntentView {
+    /// Not specified. Treated as INTENT_VIEW_FULL.
+    Unspecified,
+    /// Training phrases field is not populated in the response.
+    Partial,
+    /// All fields are populated.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IntentView::value] or
+    /// [IntentView::name].
+    UnknownValue(intent_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod intent_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl IntentView {
-    /// Not specified. Treated as INTENT_VIEW_FULL.
-    pub const INTENT_VIEW_UNSPECIFIED: IntentView = IntentView::new(0);
-
-    /// Training phrases field is not populated in the response.
-    pub const INTENT_VIEW_PARTIAL: IntentView = IntentView::new(1);
-
-    /// All fields are populated.
-    pub const INTENT_VIEW_FULL: IntentView = IntentView::new(2);
-
-    /// Creates a new IntentView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Partial => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INTENT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INTENT_VIEW_PARTIAL"),
-            2 => std::borrow::Cow::Borrowed("INTENT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INTENT_VIEW_UNSPECIFIED"),
+            Self::Partial => std::option::Option::Some("INTENT_VIEW_PARTIAL"),
+            Self::Full => std::option::Option::Some("INTENT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INTENT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::INTENT_VIEW_UNSPECIFIED),
-            "INTENT_VIEW_PARTIAL" => std::option::Option::Some(Self::INTENT_VIEW_PARTIAL),
-            "INTENT_VIEW_FULL" => std::option::Option::Some(Self::INTENT_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IntentView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IntentView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IntentView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IntentView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Partial,
+            2 => Self::Full,
+            _ => Self::UnknownValue(intent_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IntentView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INTENT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "INTENT_VIEW_PARTIAL" => Self::Partial,
+            "INTENT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(intent_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IntentView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Partial => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IntentView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IntentView>::new(
+            ".google.cloud.dialogflow.cx.v3.IntentView",
+        ))
     }
 }
 
 /// The test result for a test case and an agent environment.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TestResult(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TestResult {
+    /// Not specified. Should never be used.
+    Unspecified,
+    /// The test passed.
+    Passed,
+    /// The test did not pass.
+    Failed,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TestResult::value] or
+    /// [TestResult::name].
+    UnknownValue(test_result::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod test_result {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TestResult {
-    /// Not specified. Should never be used.
-    pub const TEST_RESULT_UNSPECIFIED: TestResult = TestResult::new(0);
-
-    /// The test passed.
-    pub const PASSED: TestResult = TestResult::new(1);
-
-    /// The test did not pass.
-    pub const FAILED: TestResult = TestResult::new(2);
-
-    /// Creates a new TestResult instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Passed => std::option::Option::Some(1),
+            Self::Failed => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TEST_RESULT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PASSED"),
-            2 => std::borrow::Cow::Borrowed("FAILED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TEST_RESULT_UNSPECIFIED"),
+            Self::Passed => std::option::Option::Some("PASSED"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TEST_RESULT_UNSPECIFIED" => std::option::Option::Some(Self::TEST_RESULT_UNSPECIFIED),
-            "PASSED" => std::option::Option::Some(Self::PASSED),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TestResult {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TestResult {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TestResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TestResult {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Passed,
+            2 => Self::Failed,
+            _ => Self::UnknownValue(test_result::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TestResult {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TEST_RESULT_UNSPECIFIED" => Self::Unspecified,
+            "PASSED" => Self::Passed,
+            "FAILED" => Self::Failed,
+            _ => Self::UnknownValue(test_result::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TestResult {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Passed => serializer.serialize_i32(1),
+            Self::Failed => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TestResult {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TestResult>::new(
+            ".google.cloud.dialogflow.cx.v3.TestResult",
+        ))
     }
 }

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -2325,7 +2325,7 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        let builder = builder.query(&[("intentView", &req.intent_view.value())]);
+        let builder = builder.query(&[("intentView", &req.intent_view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -3585,7 +3585,7 @@ impl super::stub::TestCases for TestCases {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -3745,7 +3745,7 @@ impl super::stub::TestCases for TestCases {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("type", &req.r#type.value())]);
+        let builder = builder.query(&[("type", &req.r#type)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -224,188 +224,373 @@ pub mod agent {
     use super::*;
 
     /// Match mode determines how intents are detected from user queries.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MatchMode(i32);
-
-    impl MatchMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MatchMode {
         /// Not specified.
-        pub const MATCH_MODE_UNSPECIFIED: MatchMode = MatchMode::new(0);
-
+        Unspecified,
         /// Best for agents with a small number of examples in intents and/or wide
         /// use of templates syntax and composite entities.
-        pub const MATCH_MODE_HYBRID: MatchMode = MatchMode::new(1);
-
+        Hybrid,
         /// Can be used for agents with a large number of examples in intents,
         /// especially the ones using @sys.any or very large custom entities.
-        pub const MATCH_MODE_ML_ONLY: MatchMode = MatchMode::new(2);
+        MlOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MatchMode::value] or
+        /// [MatchMode::name].
+        UnknownValue(match_mode::UnknownValue),
+    }
 
-        /// Creates a new MatchMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod match_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MatchMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hybrid => std::option::Option::Some(1),
+                Self::MlOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MATCH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MATCH_MODE_HYBRID"),
-                2 => std::borrow::Cow::Borrowed("MATCH_MODE_ML_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MATCH_MODE_UNSPECIFIED"),
+                Self::Hybrid => std::option::Option::Some("MATCH_MODE_HYBRID"),
+                Self::MlOnly => std::option::Option::Some("MATCH_MODE_ML_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MATCH_MODE_UNSPECIFIED" => std::option::Option::Some(Self::MATCH_MODE_UNSPECIFIED),
-                "MATCH_MODE_HYBRID" => std::option::Option::Some(Self::MATCH_MODE_HYBRID),
-                "MATCH_MODE_ML_ONLY" => std::option::Option::Some(Self::MATCH_MODE_ML_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MatchMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MatchMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MatchMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MatchMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hybrid,
+                2 => Self::MlOnly,
+                _ => Self::UnknownValue(match_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MatchMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MATCH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MATCH_MODE_HYBRID" => Self::Hybrid,
+                "MATCH_MODE_ML_ONLY" => Self::MlOnly,
+                _ => Self::UnknownValue(match_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MatchMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hybrid => serializer.serialize_i32(1),
+                Self::MlOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MatchMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MatchMode>::new(
+                ".google.cloud.dialogflow.v2.Agent.MatchMode",
+            ))
         }
     }
 
     /// API version for the agent.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiVersion(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ApiVersion {
+        /// Not specified.
+        Unspecified,
+        /// Legacy V1 API.
+        V1,
+        /// V2 API.
+        V2,
+        /// V2beta1 API.
+        V2Beta1,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ApiVersion::value] or
+        /// [ApiVersion::name].
+        UnknownValue(api_version::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod api_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ApiVersion {
-        /// Not specified.
-        pub const API_VERSION_UNSPECIFIED: ApiVersion = ApiVersion::new(0);
-
-        /// Legacy V1 API.
-        pub const API_VERSION_V1: ApiVersion = ApiVersion::new(1);
-
-        /// V2 API.
-        pub const API_VERSION_V2: ApiVersion = ApiVersion::new(2);
-
-        /// V2beta1 API.
-        pub const API_VERSION_V2_BETA_1: ApiVersion = ApiVersion::new(3);
-
-        /// Creates a new ApiVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V1 => std::option::Option::Some(1),
+                Self::V2 => std::option::Option::Some(2),
+                Self::V2Beta1 => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("API_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("API_VERSION_V1"),
-                2 => std::borrow::Cow::Borrowed("API_VERSION_V2"),
-                3 => std::borrow::Cow::Borrowed("API_VERSION_V2_BETA_1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("API_VERSION_UNSPECIFIED"),
+                Self::V1 => std::option::Option::Some("API_VERSION_V1"),
+                Self::V2 => std::option::Option::Some("API_VERSION_V2"),
+                Self::V2Beta1 => std::option::Option::Some("API_VERSION_V2_BETA_1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "API_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::API_VERSION_UNSPECIFIED)
-                }
-                "API_VERSION_V1" => std::option::Option::Some(Self::API_VERSION_V1),
-                "API_VERSION_V2" => std::option::Option::Some(Self::API_VERSION_V2),
-                "API_VERSION_V2_BETA_1" => std::option::Option::Some(Self::API_VERSION_V2_BETA_1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ApiVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ApiVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ApiVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::V1,
+                2 => Self::V2,
+                3 => Self::V2Beta1,
+                _ => Self::UnknownValue(api_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ApiVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "API_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "API_VERSION_V1" => Self::V1,
+                "API_VERSION_V2" => Self::V2,
+                "API_VERSION_V2_BETA_1" => Self::V2Beta1,
+                _ => Self::UnknownValue(api_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ApiVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V1 => serializer.serialize_i32(1),
+                Self::V2 => serializer.serialize_i32(2),
+                Self::V2Beta1 => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ApiVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ApiVersion>::new(
+                ".google.cloud.dialogflow.v2.Agent.ApiVersion",
+            ))
         }
     }
 
     /// Represents the agent tier.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
-
-    impl Tier {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
         /// Not specified. This value should never be used.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
+        Unspecified,
         /// Trial Edition, previously known as Standard Edition.
-        pub const TIER_STANDARD: Tier = Tier::new(1);
-
+        Standard,
         /// Essentials Edition, previously known as Enterprise Essential Edition.
-        pub const TIER_ENTERPRISE: Tier = Tier::new(2);
-
+        Enterprise,
         /// Essentials Edition (same as TIER_ENTERPRISE), previously known as
         /// Enterprise Plus Edition.
-        pub const TIER_ENTERPRISE_PLUS: Tier = Tier::new(3);
+        EnterprisePlus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
 
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Tier {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::EnterprisePlus => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TIER_STANDARD"),
-                2 => std::borrow::Cow::Borrowed("TIER_ENTERPRISE"),
-                3 => std::borrow::Cow::Borrowed("TIER_ENTERPRISE_PLUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("TIER_STANDARD"),
+                Self::Enterprise => std::option::Option::Some("TIER_ENTERPRISE"),
+                Self::EnterprisePlus => std::option::Option::Some("TIER_ENTERPRISE_PLUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "TIER_STANDARD" => std::option::Option::Some(Self::TIER_STANDARD),
-                "TIER_ENTERPRISE" => std::option::Option::Some(Self::TIER_ENTERPRISE),
-                "TIER_ENTERPRISE_PLUS" => std::option::Option::Some(Self::TIER_ENTERPRISE_PLUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Enterprise,
+                3 => Self::EnterprisePlus,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "TIER_STANDARD" => Self::Standard,
+                "TIER_ENTERPRISE" => Self::Enterprise,
+                "TIER_ENTERPRISE_PLUS" => Self::EnterprisePlus,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::EnterprisePlus => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.dialogflow.v2.Agent.Tier",
+            ))
         }
     }
 }
@@ -1666,66 +1851,127 @@ pub mod answer_feedback {
     use super::*;
 
     /// The correctness level of an answer.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CorrectnessLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CorrectnessLevel {
+        /// Correctness level unspecified.
+        Unspecified,
+        /// Answer is totally wrong.
+        NotCorrect,
+        /// Answer is partially correct.
+        PartiallyCorrect,
+        /// Answer is fully correct.
+        FullyCorrect,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CorrectnessLevel::value] or
+        /// [CorrectnessLevel::name].
+        UnknownValue(correctness_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod correctness_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CorrectnessLevel {
-        /// Correctness level unspecified.
-        pub const CORRECTNESS_LEVEL_UNSPECIFIED: CorrectnessLevel = CorrectnessLevel::new(0);
-
-        /// Answer is totally wrong.
-        pub const NOT_CORRECT: CorrectnessLevel = CorrectnessLevel::new(1);
-
-        /// Answer is partially correct.
-        pub const PARTIALLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(2);
-
-        /// Answer is fully correct.
-        pub const FULLY_CORRECT: CorrectnessLevel = CorrectnessLevel::new(3);
-
-        /// Creates a new CorrectnessLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotCorrect => std::option::Option::Some(1),
+                Self::PartiallyCorrect => std::option::Option::Some(2),
+                Self::FullyCorrect => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CORRECTNESS_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_CORRECT"),
-                2 => std::borrow::Cow::Borrowed("PARTIALLY_CORRECT"),
-                3 => std::borrow::Cow::Borrowed("FULLY_CORRECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CORRECTNESS_LEVEL_UNSPECIFIED"),
+                Self::NotCorrect => std::option::Option::Some("NOT_CORRECT"),
+                Self::PartiallyCorrect => std::option::Option::Some("PARTIALLY_CORRECT"),
+                Self::FullyCorrect => std::option::Option::Some("FULLY_CORRECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CORRECTNESS_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CORRECTNESS_LEVEL_UNSPECIFIED)
-                }
-                "NOT_CORRECT" => std::option::Option::Some(Self::NOT_CORRECT),
-                "PARTIALLY_CORRECT" => std::option::Option::Some(Self::PARTIALLY_CORRECT),
-                "FULLY_CORRECT" => std::option::Option::Some(Self::FULLY_CORRECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CorrectnessLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CorrectnessLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CorrectnessLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CorrectnessLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotCorrect,
+                2 => Self::PartiallyCorrect,
+                3 => Self::FullyCorrect,
+                _ => Self::UnknownValue(correctness_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CorrectnessLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CORRECTNESS_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "NOT_CORRECT" => Self::NotCorrect,
+                "PARTIALLY_CORRECT" => Self::PartiallyCorrect,
+                "FULLY_CORRECT" => Self::FullyCorrect,
+                _ => Self::UnknownValue(correctness_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CorrectnessLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotCorrect => serializer.serialize_i32(1),
+                Self::PartiallyCorrect => serializer.serialize_i32(2),
+                Self::FullyCorrect => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CorrectnessLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CorrectnessLevel>::new(
+                ".google.cloud.dialogflow.v2.AnswerFeedback.CorrectnessLevel",
+            ))
         }
     }
 
@@ -1754,7 +2000,7 @@ pub struct AgentAssistantFeedback {
     ///   days of the purchase date."
     /// * [answer_relevance][google.cloud.dialogflow.v2.AgentAssistantFeedback.answer_relevance]: [AnswerRelevance.IRRELEVANT][google.cloud.dialogflow.v2.AgentAssistantFeedback.AnswerRelevance.IRRELEVANT]
     ///
-    /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.AnswerRelevance.IRRELEVANT]: crate::model::agent_assistant_feedback::answer_relevance::IRRELEVANT
+    /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.AnswerRelevance.IRRELEVANT]: crate::model::agent_assistant_feedback::AnswerRelevance::Irrelevant
     /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.answer_relevance]: crate::model::AgentAssistantFeedback::answer_relevance
     pub answer_relevance: crate::model::agent_assistant_feedback::AnswerRelevance,
 
@@ -1768,7 +2014,7 @@ pub struct AgentAssistantFeedback {
     /// * Ground truth: "No return or exchange is allowed."
     /// * [document_correctness][google.cloud.dialogflow.v2.AgentAssistantFeedback.document_correctness]: [INCORRECT][google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentCorrectness.INCORRECT]
     ///
-    /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentCorrectness.INCORRECT]: crate::model::agent_assistant_feedback::document_correctness::INCORRECT
+    /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentCorrectness.INCORRECT]: crate::model::agent_assistant_feedback::DocumentCorrectness::Incorrect
     /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.document_correctness]: crate::model::AgentAssistantFeedback::document_correctness
     pub document_correctness: crate::model::agent_assistant_feedback::DocumentCorrectness,
 
@@ -1779,7 +2025,7 @@ pub struct AgentAssistantFeedback {
     /// is
     /// [DocumentEfficiency.INEFFICIENT][google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentEfficiency.INEFFICIENT].
     ///
-    /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentEfficiency.INEFFICIENT]: crate::model::agent_assistant_feedback::document_efficiency::INEFFICIENT
+    /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentEfficiency.INEFFICIENT]: crate::model::agent_assistant_feedback::DocumentEfficiency::Inefficient
     /// [google.cloud.dialogflow.v2.AgentAssistantFeedback.document_efficiency]: crate::model::AgentAssistantFeedback::document_efficiency
     pub document_efficiency: crate::model::agent_assistant_feedback::DocumentEfficiency,
 
@@ -2090,180 +2336,356 @@ pub mod agent_assistant_feedback {
     }
 
     /// Relevance of an answer.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnswerRelevance(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AnswerRelevance {
+        /// Answer relevance unspecified.
+        Unspecified,
+        /// Answer is irrelevant to query.
+        Irrelevant,
+        /// Answer is relevant to query.
+        Relevant,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AnswerRelevance::value] or
+        /// [AnswerRelevance::name].
+        UnknownValue(answer_relevance::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod answer_relevance {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AnswerRelevance {
-        /// Answer relevance unspecified.
-        pub const ANSWER_RELEVANCE_UNSPECIFIED: AnswerRelevance = AnswerRelevance::new(0);
-
-        /// Answer is irrelevant to query.
-        pub const IRRELEVANT: AnswerRelevance = AnswerRelevance::new(1);
-
-        /// Answer is relevant to query.
-        pub const RELEVANT: AnswerRelevance = AnswerRelevance::new(2);
-
-        /// Creates a new AnswerRelevance instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Irrelevant => std::option::Option::Some(1),
+                Self::Relevant => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANSWER_RELEVANCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IRRELEVANT"),
-                2 => std::borrow::Cow::Borrowed("RELEVANT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANSWER_RELEVANCE_UNSPECIFIED"),
+                Self::Irrelevant => std::option::Option::Some("IRRELEVANT"),
+                Self::Relevant => std::option::Option::Some("RELEVANT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANSWER_RELEVANCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ANSWER_RELEVANCE_UNSPECIFIED)
-                }
-                "IRRELEVANT" => std::option::Option::Some(Self::IRRELEVANT),
-                "RELEVANT" => std::option::Option::Some(Self::RELEVANT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AnswerRelevance {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AnswerRelevance {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AnswerRelevance {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AnswerRelevance {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Irrelevant,
+                2 => Self::Relevant,
+                _ => Self::UnknownValue(answer_relevance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AnswerRelevance {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANSWER_RELEVANCE_UNSPECIFIED" => Self::Unspecified,
+                "IRRELEVANT" => Self::Irrelevant,
+                "RELEVANT" => Self::Relevant,
+                _ => Self::UnknownValue(answer_relevance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AnswerRelevance {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Irrelevant => serializer.serialize_i32(1),
+                Self::Relevant => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AnswerRelevance {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AnswerRelevance>::new(
+                ".google.cloud.dialogflow.v2.AgentAssistantFeedback.AnswerRelevance",
+            ))
         }
     }
 
     /// Correctness of document.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DocumentCorrectness(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DocumentCorrectness {
+        /// Document correctness unspecified.
+        Unspecified,
+        /// Information in document is incorrect.
+        Incorrect,
+        /// Information in document is correct.
+        Correct,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DocumentCorrectness::value] or
+        /// [DocumentCorrectness::name].
+        UnknownValue(document_correctness::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod document_correctness {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DocumentCorrectness {
-        /// Document correctness unspecified.
-        pub const DOCUMENT_CORRECTNESS_UNSPECIFIED: DocumentCorrectness =
-            DocumentCorrectness::new(0);
-
-        /// Information in document is incorrect.
-        pub const INCORRECT: DocumentCorrectness = DocumentCorrectness::new(1);
-
-        /// Information in document is correct.
-        pub const CORRECT: DocumentCorrectness = DocumentCorrectness::new(2);
-
-        /// Creates a new DocumentCorrectness instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incorrect => std::option::Option::Some(1),
+                Self::Correct => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DOCUMENT_CORRECTNESS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCORRECT"),
-                2 => std::borrow::Cow::Borrowed("CORRECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DOCUMENT_CORRECTNESS_UNSPECIFIED"),
+                Self::Incorrect => std::option::Option::Some("INCORRECT"),
+                Self::Correct => std::option::Option::Some("CORRECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DOCUMENT_CORRECTNESS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DOCUMENT_CORRECTNESS_UNSPECIFIED)
-                }
-                "INCORRECT" => std::option::Option::Some(Self::INCORRECT),
-                "CORRECT" => std::option::Option::Some(Self::CORRECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DocumentCorrectness {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DocumentCorrectness {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DocumentCorrectness {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DocumentCorrectness {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Incorrect,
+                2 => Self::Correct,
+                _ => Self::UnknownValue(document_correctness::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DocumentCorrectness {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DOCUMENT_CORRECTNESS_UNSPECIFIED" => Self::Unspecified,
+                "INCORRECT" => Self::Incorrect,
+                "CORRECT" => Self::Correct,
+                _ => Self::UnknownValue(document_correctness::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DocumentCorrectness {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incorrect => serializer.serialize_i32(1),
+                Self::Correct => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DocumentCorrectness {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DocumentCorrectness>::new(
+                ".google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentCorrectness",
+            ))
         }
     }
 
     /// Efficiency of document.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DocumentEfficiency(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DocumentEfficiency {
+        /// Document efficiency unspecified.
+        Unspecified,
+        /// Document is inefficient.
+        Inefficient,
+        /// Document is efficient.
+        Efficient,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DocumentEfficiency::value] or
+        /// [DocumentEfficiency::name].
+        UnknownValue(document_efficiency::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod document_efficiency {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DocumentEfficiency {
-        /// Document efficiency unspecified.
-        pub const DOCUMENT_EFFICIENCY_UNSPECIFIED: DocumentEfficiency = DocumentEfficiency::new(0);
-
-        /// Document is inefficient.
-        pub const INEFFICIENT: DocumentEfficiency = DocumentEfficiency::new(1);
-
-        /// Document is efficient.
-        pub const EFFICIENT: DocumentEfficiency = DocumentEfficiency::new(2);
-
-        /// Creates a new DocumentEfficiency instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Inefficient => std::option::Option::Some(1),
+                Self::Efficient => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DOCUMENT_EFFICIENCY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INEFFICIENT"),
-                2 => std::borrow::Cow::Borrowed("EFFICIENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DOCUMENT_EFFICIENCY_UNSPECIFIED"),
+                Self::Inefficient => std::option::Option::Some("INEFFICIENT"),
+                Self::Efficient => std::option::Option::Some("EFFICIENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DOCUMENT_EFFICIENCY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DOCUMENT_EFFICIENCY_UNSPECIFIED)
-                }
-                "INEFFICIENT" => std::option::Option::Some(Self::INEFFICIENT),
-                "EFFICIENT" => std::option::Option::Some(Self::EFFICIENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DocumentEfficiency {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DocumentEfficiency {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DocumentEfficiency {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DocumentEfficiency {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Inefficient,
+                2 => Self::Efficient,
+                _ => Self::UnknownValue(document_efficiency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DocumentEfficiency {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DOCUMENT_EFFICIENCY_UNSPECIFIED" => Self::Unspecified,
+                "INEFFICIENT" => Self::Inefficient,
+                "EFFICIENT" => Self::Efficient,
+                _ => Self::UnknownValue(document_efficiency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DocumentEfficiency {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Inefficient => serializer.serialize_i32(1),
+                Self::Efficient => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DocumentEfficiency {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DocumentEfficiency>::new(
+                ".google.cloud.dialogflow.v2.AgentAssistantFeedback.DocumentEfficiency",
+            ))
         }
     }
 }
@@ -3718,8 +4140,8 @@ pub struct Conversation {
     /// stage and directly goes to
     /// [ConversationStage.HUMAN_ASSIST_STAGE][google.cloud.dialogflow.v2.Conversation.ConversationStage.HUMAN_ASSIST_STAGE].
     ///
-    /// [google.cloud.dialogflow.v2.Conversation.ConversationStage.HUMAN_ASSIST_STAGE]: crate::model::conversation::conversation_stage::HUMAN_ASSIST_STAGE
-    /// [google.cloud.dialogflow.v2.Conversation.ConversationStage.VIRTUAL_AGENT_STAGE]: crate::model::conversation::conversation_stage::VIRTUAL_AGENT_STAGE
+    /// [google.cloud.dialogflow.v2.Conversation.ConversationStage.HUMAN_ASSIST_STAGE]: crate::model::conversation::ConversationStage::HumanAssistStage
+    /// [google.cloud.dialogflow.v2.Conversation.ConversationStage.VIRTUAL_AGENT_STAGE]: crate::model::conversation::ConversationStage::VirtualAgentStage
     pub conversation_stage: crate::model::conversation::ConversationStage,
 
     /// Output only. The telephony connection information.
@@ -4170,245 +4592,488 @@ pub mod conversation {
             use super::*;
 
             /// Represents the format of the ingested string.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ContentFormat(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ContentFormat {
+                /// Unspecified content format.
+                Unspecified,
+                /// Content was provided in JSON format.
+                Json,
+                /// Content was provided as plain text.
+                PlainText,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ContentFormat::value] or
+                /// [ContentFormat::name].
+                UnknownValue(content_format::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod content_format {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl ContentFormat {
-                /// Unspecified content format.
-                pub const CONTENT_FORMAT_UNSPECIFIED: ContentFormat = ContentFormat::new(0);
-
-                /// Content was provided in JSON format.
-                pub const JSON: ContentFormat = ContentFormat::new(1);
-
-                /// Content was provided as plain text.
-                pub const PLAIN_TEXT: ContentFormat = ContentFormat::new(2);
-
-                /// Creates a new ContentFormat instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Json => std::option::Option::Some(1),
+                        Self::PlainText => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("CONTENT_FORMAT_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("JSON"),
-                        2 => std::borrow::Cow::Borrowed("PLAIN_TEXT"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "CONTENT_FORMAT_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::CONTENT_FORMAT_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("CONTENT_FORMAT_UNSPECIFIED")
                         }
-                        "JSON" => std::option::Option::Some(Self::JSON),
-                        "PLAIN_TEXT" => std::option::Option::Some(Self::PLAIN_TEXT),
-                        _ => std::option::Option::None,
+                        Self::Json => std::option::Option::Some("JSON"),
+                        Self::PlainText => std::option::Option::Some("PLAIN_TEXT"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for ContentFormat {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ContentFormat {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ContentFormat {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ContentFormat {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Json,
+                        2 => Self::PlainText,
+                        _ => Self::UnknownValue(content_format::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ContentFormat {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "CONTENT_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                        "JSON" => Self::Json,
+                        "PLAIN_TEXT" => Self::PlainText,
+                        _ => Self::UnknownValue(content_format::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ContentFormat {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Json => serializer.serialize_i32(1),
+                        Self::PlainText => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ContentFormat {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentFormat>::new(
+                        ".google.cloud.dialogflow.v2.Conversation.ContextReference.ContextContent.ContentFormat"))
                 }
             }
         }
 
         /// Represents the mode in which context reference contents are updated.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct UpdateMode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum UpdateMode {
+            /// Unspecified update mode.
+            Unspecified,
+            /// Context content updates are applied in append mode.
+            Append,
+            /// Context content updates are applied in overwrite mode.
+            Overwrite,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [UpdateMode::value] or
+            /// [UpdateMode::name].
+            UnknownValue(update_mode::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod update_mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl UpdateMode {
-            /// Unspecified update mode.
-            pub const UPDATE_MODE_UNSPECIFIED: UpdateMode = UpdateMode::new(0);
-
-            /// Context content updates are applied in append mode.
-            pub const APPEND: UpdateMode = UpdateMode::new(1);
-
-            /// Context content updates are applied in overwrite mode.
-            pub const OVERWRITE: UpdateMode = UpdateMode::new(2);
-
-            /// Creates a new UpdateMode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Append => std::option::Option::Some(1),
+                    Self::Overwrite => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UPDATE_MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("APPEND"),
-                    2 => std::borrow::Cow::Borrowed("OVERWRITE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("UPDATE_MODE_UNSPECIFIED"),
+                    Self::Append => std::option::Option::Some("APPEND"),
+                    Self::Overwrite => std::option::Option::Some("OVERWRITE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UPDATE_MODE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::UPDATE_MODE_UNSPECIFIED)
-                    }
-                    "APPEND" => std::option::Option::Some(Self::APPEND),
-                    "OVERWRITE" => std::option::Option::Some(Self::OVERWRITE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for UpdateMode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for UpdateMode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for UpdateMode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for UpdateMode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Append,
+                    2 => Self::Overwrite,
+                    _ => Self::UnknownValue(update_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for UpdateMode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UPDATE_MODE_UNSPECIFIED" => Self::Unspecified,
+                    "APPEND" => Self::Append,
+                    "OVERWRITE" => Self::Overwrite,
+                    _ => Self::UnknownValue(update_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for UpdateMode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Append => serializer.serialize_i32(1),
+                    Self::Overwrite => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for UpdateMode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<UpdateMode>::new(
+                    ".google.cloud.dialogflow.v2.Conversation.ContextReference.UpdateMode",
+                ))
             }
         }
     }
 
     /// Enumeration of the completion status of the conversation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LifecycleState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LifecycleState {
+        /// Unknown.
+        Unspecified,
+        /// Conversation is currently open for media analysis.
+        InProgress,
+        /// Conversation has been completed.
+        Completed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LifecycleState::value] or
+        /// [LifecycleState::name].
+        UnknownValue(lifecycle_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod lifecycle_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LifecycleState {
-        /// Unknown.
-        pub const LIFECYCLE_STATE_UNSPECIFIED: LifecycleState = LifecycleState::new(0);
-
-        /// Conversation is currently open for media analysis.
-        pub const IN_PROGRESS: LifecycleState = LifecycleState::new(1);
-
-        /// Conversation has been completed.
-        pub const COMPLETED: LifecycleState = LifecycleState::new(2);
-
-        /// Creates a new LifecycleState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Completed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LIFECYCLE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("COMPLETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LIFECYCLE_STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LIFECYCLE_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LIFECYCLE_STATE_UNSPECIFIED)
-                }
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LifecycleState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LifecycleState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LifecycleState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LifecycleState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Completed,
+                _ => Self::UnknownValue(lifecycle_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LifecycleState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LIFECYCLE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "COMPLETED" => Self::Completed,
+                _ => Self::UnknownValue(lifecycle_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LifecycleState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Completed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LifecycleState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LifecycleState>::new(
+                ".google.cloud.dialogflow.v2.Conversation.LifecycleState",
+            ))
         }
     }
 
     /// Enumeration of the different conversation stages a conversation can be in.
     /// Reference:
     /// <https://cloud.google.com/agent-assist/docs/basics#conversation_stages>
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConversationStage(i32);
-
-    impl ConversationStage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConversationStage {
         /// Unknown. Should never be used after a conversation is successfully
         /// created.
-        pub const CONVERSATION_STAGE_UNSPECIFIED: ConversationStage = ConversationStage::new(0);
-
+        Unspecified,
         /// The conversation should return virtual agent responses into the
         /// conversation.
-        pub const VIRTUAL_AGENT_STAGE: ConversationStage = ConversationStage::new(1);
-
+        VirtualAgentStage,
         /// The conversation should not provide responses, just listen and provide
         /// suggestions.
-        pub const HUMAN_ASSIST_STAGE: ConversationStage = ConversationStage::new(2);
+        HumanAssistStage,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConversationStage::value] or
+        /// [ConversationStage::name].
+        UnknownValue(conversation_stage::UnknownValue),
+    }
 
-        /// Creates a new ConversationStage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod conversation_stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConversationStage {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VirtualAgentStage => std::option::Option::Some(1),
+                Self::HumanAssistStage => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONVERSATION_STAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VIRTUAL_AGENT_STAGE"),
-                2 => std::borrow::Cow::Borrowed("HUMAN_ASSIST_STAGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONVERSATION_STAGE_UNSPECIFIED"),
+                Self::VirtualAgentStage => std::option::Option::Some("VIRTUAL_AGENT_STAGE"),
+                Self::HumanAssistStage => std::option::Option::Some("HUMAN_ASSIST_STAGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONVERSATION_STAGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONVERSATION_STAGE_UNSPECIFIED)
-                }
-                "VIRTUAL_AGENT_STAGE" => std::option::Option::Some(Self::VIRTUAL_AGENT_STAGE),
-                "HUMAN_ASSIST_STAGE" => std::option::Option::Some(Self::HUMAN_ASSIST_STAGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConversationStage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConversationStage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConversationStage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConversationStage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VirtualAgentStage,
+                2 => Self::HumanAssistStage,
+                _ => Self::UnknownValue(conversation_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConversationStage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONVERSATION_STAGE_UNSPECIFIED" => Self::Unspecified,
+                "VIRTUAL_AGENT_STAGE" => Self::VirtualAgentStage,
+                "HUMAN_ASSIST_STAGE" => Self::HumanAssistStage,
+                _ => Self::UnknownValue(conversation_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConversationStage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VirtualAgentStage => serializer.serialize_i32(1),
+                Self::HumanAssistStage => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConversationStage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConversationStage>::new(
+                ".google.cloud.dialogflow.v2.Conversation.ConversationStage",
+            ))
         }
     }
 }
@@ -6338,135 +7003,261 @@ pub mod search_knowledge_request {
 
                         /// The attribute(or function) for which the custom ranking is to be
                         /// applied.
-                        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                        pub struct AttributeType(i32);
-
-                        impl AttributeType {
+                        #[derive(Clone, Debug, PartialEq)]
+                        #[non_exhaustive]
+                        pub enum AttributeType {
                             /// Unspecified AttributeType.
-                            pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType =
-                                AttributeType::new(0);
-
+                            Unspecified,
                             /// The value of the numerical field will be used to dynamically
                             /// update the boost amount. In this case, the attribute_value (the
                             /// x value) of the control point will be the actual value of the
                             /// numerical field for which the boost_amount is specified.
-                            pub const NUMERICAL: AttributeType = AttributeType::new(1);
-
+                            Numerical,
                             /// For the freshness use case the attribute value will be the
                             /// duration between the current time and the date in the datetime
                             /// field specified. The value must be formatted as an XSD
                             /// `dayTimeDuration` value (a restricted subset of an ISO 8601
                             /// duration value). The pattern for this is:
                             /// `[nD][T[nH][nM][nS]]`. E.g. `5D`, `3DT12H30M`, `T24H`.
-                            pub const FRESHNESS: AttributeType = AttributeType::new(2);
+                            Freshness,
+                            /// If set, the enum was initialized with an unknown value.
+                            ///
+                            /// Applications can examine the value using [AttributeType::value] or
+                            /// [AttributeType::name].
+                            UnknownValue(attribute_type::UnknownValue),
+                        }
 
-                            /// Creates a new AttributeType instance.
-                            pub(crate) const fn new(value: i32) -> Self {
-                                Self(value)
-                            }
+                        #[doc(hidden)]
+                        pub mod attribute_type {
+                            #[allow(unused_imports)]
+                            use super::*;
+                            #[derive(Clone, Debug, PartialEq)]
+                            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                        }
 
+                        impl AttributeType {
                             /// Gets the enum value.
-                            pub fn value(&self) -> i32 {
-                                self.0
+                            ///
+                            /// Returns `None` if the enum contains an unknown value deserialized from
+                            /// the string representation of enums.
+                            pub fn value(&self) -> std::option::Option<i32> {
+                                match self {
+                                    Self::Unspecified => std::option::Option::Some(0),
+                                    Self::Numerical => std::option::Option::Some(1),
+                                    Self::Freshness => std::option::Option::Some(2),
+                                    Self::UnknownValue(u) => u.0.value(),
+                                }
                             }
 
                             /// Gets the enum value as a string.
-                            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                                match self.0 {
-                                    0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
-                                    1 => std::borrow::Cow::Borrowed("NUMERICAL"),
-                                    2 => std::borrow::Cow::Borrowed("FRESHNESS"),
-                                    _ => std::borrow::Cow::Owned(std::format!(
-                                        "UNKNOWN-VALUE:{}",
-                                        self.0
-                                    )),
-                                }
-                            }
-
-                            /// Creates an enum value from the value name.
-                            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                                match name {
-                                    "ATTRIBUTE_TYPE_UNSPECIFIED" => {
-                                        std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                            ///
+                            /// Returns `None` if the enum contains an unknown value deserialized from
+                            /// the integer representation of enums.
+                            pub fn name(&self) -> std::option::Option<&str> {
+                                match self {
+                                    Self::Unspecified => {
+                                        std::option::Option::Some("ATTRIBUTE_TYPE_UNSPECIFIED")
                                     }
-                                    "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
-                                    "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
-                                    _ => std::option::Option::None,
+                                    Self::Numerical => std::option::Option::Some("NUMERICAL"),
+                                    Self::Freshness => std::option::Option::Some("FRESHNESS"),
+                                    Self::UnknownValue(u) => u.0.name(),
                                 }
-                            }
-                        }
-
-                        impl std::convert::From<i32> for AttributeType {
-                            fn from(value: i32) -> Self {
-                                Self::new(value)
                             }
                         }
 
                         impl std::default::Default for AttributeType {
                             fn default() -> Self {
-                                Self::new(0)
+                                use std::convert::From;
+                                Self::from(0)
+                            }
+                        }
+
+                        impl std::fmt::Display for AttributeType {
+                            fn fmt(
+                                &self,
+                                f: &mut std::fmt::Formatter<'_>,
+                            ) -> std::result::Result<(), std::fmt::Error>
+                            {
+                                wkt::internal::display_enum(f, self.name(), self.value())
+                            }
+                        }
+
+                        impl std::convert::From<i32> for AttributeType {
+                            fn from(value: i32) -> Self {
+                                match value {
+                                    0 => Self::Unspecified,
+                                    1 => Self::Numerical,
+                                    2 => Self::Freshness,
+                                    _ => Self::UnknownValue(attribute_type::UnknownValue(
+                                        wkt::internal::UnknownEnumValue::Integer(value),
+                                    )),
+                                }
+                            }
+                        }
+
+                        impl std::convert::From<&str> for AttributeType {
+                            fn from(value: &str) -> Self {
+                                use std::string::ToString;
+                                match value {
+                                    "ATTRIBUTE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                                    "NUMERICAL" => Self::Numerical,
+                                    "FRESHNESS" => Self::Freshness,
+                                    _ => Self::UnknownValue(attribute_type::UnknownValue(
+                                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                                    )),
+                                }
+                            }
+                        }
+
+                        impl serde::ser::Serialize for AttributeType {
+                            fn serialize<S>(
+                                &self,
+                                serializer: S,
+                            ) -> std::result::Result<S::Ok, S::Error>
+                            where
+                                S: serde::Serializer,
+                            {
+                                match self {
+                                    Self::Unspecified => serializer.serialize_i32(0),
+                                    Self::Numerical => serializer.serialize_i32(1),
+                                    Self::Freshness => serializer.serialize_i32(2),
+                                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                                }
+                            }
+                        }
+
+                        impl<'de> serde::de::Deserialize<'de> for AttributeType {
+                            fn deserialize<D>(
+                                deserializer: D,
+                            ) -> std::result::Result<Self, D::Error>
+                            where
+                                D: serde::Deserializer<'de>,
+                            {
+                                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttributeType>::new(
+                                    ".google.cloud.dialogflow.v2.SearchKnowledgeRequest.SearchConfig.BoostSpecs.BoostSpec.ConditionBoostSpec.BoostControlSpec.AttributeType"))
                             }
                         }
 
                         /// The interpolation type to be applied. Default will be linear
                         /// (Piecewise Linear).
-                        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                        pub struct InterpolationType(i32);
-
-                        impl InterpolationType {
+                        #[derive(Clone, Debug, PartialEq)]
+                        #[non_exhaustive]
+                        pub enum InterpolationType {
                             /// Interpolation type is unspecified. In this case, it defaults to
                             /// Linear.
-                            pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                                InterpolationType::new(0);
-
+                            Unspecified,
                             /// Piecewise linear interpolation will be applied.
-                            pub const LINEAR: InterpolationType = InterpolationType::new(1);
+                            Linear,
+                            /// If set, the enum was initialized with an unknown value.
+                            ///
+                            /// Applications can examine the value using [InterpolationType::value] or
+                            /// [InterpolationType::name].
+                            UnknownValue(interpolation_type::UnknownValue),
+                        }
 
-                            /// Creates a new InterpolationType instance.
-                            pub(crate) const fn new(value: i32) -> Self {
-                                Self(value)
-                            }
+                        #[doc(hidden)]
+                        pub mod interpolation_type {
+                            #[allow(unused_imports)]
+                            use super::*;
+                            #[derive(Clone, Debug, PartialEq)]
+                            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                        }
 
+                        impl InterpolationType {
                             /// Gets the enum value.
-                            pub fn value(&self) -> i32 {
-                                self.0
+                            ///
+                            /// Returns `None` if the enum contains an unknown value deserialized from
+                            /// the string representation of enums.
+                            pub fn value(&self) -> std::option::Option<i32> {
+                                match self {
+                                    Self::Unspecified => std::option::Option::Some(0),
+                                    Self::Linear => std::option::Option::Some(1),
+                                    Self::UnknownValue(u) => u.0.value(),
+                                }
                             }
 
                             /// Gets the enum value as a string.
-                            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                                match self.0 {
-                                    0 => {
-                                        std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED")
+                            ///
+                            /// Returns `None` if the enum contains an unknown value deserialized from
+                            /// the integer representation of enums.
+                            pub fn name(&self) -> std::option::Option<&str> {
+                                match self {
+                                    Self::Unspecified => {
+                                        std::option::Option::Some("INTERPOLATION_TYPE_UNSPECIFIED")
                                     }
-                                    1 => std::borrow::Cow::Borrowed("LINEAR"),
-                                    _ => std::borrow::Cow::Owned(std::format!(
-                                        "UNKNOWN-VALUE:{}",
-                                        self.0
-                                    )),
+                                    Self::Linear => std::option::Option::Some("LINEAR"),
+                                    Self::UnknownValue(u) => u.0.name(),
                                 }
-                            }
-
-                            /// Creates an enum value from the value name.
-                            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                                match name {
-                                    "INTERPOLATION_TYPE_UNSPECIFIED" => std::option::Option::Some(
-                                        Self::INTERPOLATION_TYPE_UNSPECIFIED,
-                                    ),
-                                    "LINEAR" => std::option::Option::Some(Self::LINEAR),
-                                    _ => std::option::Option::None,
-                                }
-                            }
-                        }
-
-                        impl std::convert::From<i32> for InterpolationType {
-                            fn from(value: i32) -> Self {
-                                Self::new(value)
                             }
                         }
 
                         impl std::default::Default for InterpolationType {
                             fn default() -> Self {
-                                Self::new(0)
+                                use std::convert::From;
+                                Self::from(0)
+                            }
+                        }
+
+                        impl std::fmt::Display for InterpolationType {
+                            fn fmt(
+                                &self,
+                                f: &mut std::fmt::Formatter<'_>,
+                            ) -> std::result::Result<(), std::fmt::Error>
+                            {
+                                wkt::internal::display_enum(f, self.name(), self.value())
+                            }
+                        }
+
+                        impl std::convert::From<i32> for InterpolationType {
+                            fn from(value: i32) -> Self {
+                                match value {
+                                    0 => Self::Unspecified,
+                                    1 => Self::Linear,
+                                    _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                                        wkt::internal::UnknownEnumValue::Integer(value),
+                                    )),
+                                }
+                            }
+                        }
+
+                        impl std::convert::From<&str> for InterpolationType {
+                            fn from(value: &str) -> Self {
+                                use std::string::ToString;
+                                match value {
+                                    "INTERPOLATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                                    "LINEAR" => Self::Linear,
+                                    _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                                    )),
+                                }
+                            }
+                        }
+
+                        impl serde::ser::Serialize for InterpolationType {
+                            fn serialize<S>(
+                                &self,
+                                serializer: S,
+                            ) -> std::result::Result<S::Ok, S::Error>
+                            where
+                                S: serde::Serializer,
+                            {
+                                match self {
+                                    Self::Unspecified => serializer.serialize_i32(0),
+                                    Self::Linear => serializer.serialize_i32(1),
+                                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                                }
+                            }
+                        }
+
+                        impl<'de> serde::de::Deserialize<'de> for InterpolationType {
+                            fn deserialize<D>(
+                                deserializer: D,
+                            ) -> std::result::Result<Self, D::Error>
+                            where
+                                D: serde::Deserializer<'de>,
+                            {
+                                deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterpolationType>::new(
+                                    ".google.cloud.dialogflow.v2.SearchKnowledgeRequest.SearchConfig.BoostSpecs.BoostSpec.ConditionBoostSpec.BoostControlSpec.InterpolationType"))
                             }
                         }
                     }
@@ -6534,64 +7325,123 @@ pub mod search_knowledge_request {
     /// of a SuggestKnowledgeAssist call.
     ///
     /// [google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist]: crate::client::Participants::suggest_knowledge_assist
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QuerySource(i32);
-
-    impl QuerySource {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum QuerySource {
         /// Unknown query source.
-        pub const QUERY_SOURCE_UNSPECIFIED: QuerySource = QuerySource::new(0);
-
+        Unspecified,
         /// The query is from agents.
-        pub const AGENT_QUERY: QuerySource = QuerySource::new(1);
-
+        AgentQuery,
         /// The query is a suggested query from
         /// [Participants.SuggestKnowledgeAssist][google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist].
         ///
         /// [google.cloud.dialogflow.v2.Participants.SuggestKnowledgeAssist]: crate::client::Participants::suggest_knowledge_assist
-        pub const SUGGESTED_QUERY: QuerySource = QuerySource::new(2);
+        SuggestedQuery,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [QuerySource::value] or
+        /// [QuerySource::name].
+        UnknownValue(query_source::UnknownValue),
+    }
 
-        /// Creates a new QuerySource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod query_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl QuerySource {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AgentQuery => std::option::Option::Some(1),
+                Self::SuggestedQuery => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("QUERY_SOURCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AGENT_QUERY"),
-                2 => std::borrow::Cow::Borrowed("SUGGESTED_QUERY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("QUERY_SOURCE_UNSPECIFIED"),
+                Self::AgentQuery => std::option::Option::Some("AGENT_QUERY"),
+                Self::SuggestedQuery => std::option::Option::Some("SUGGESTED_QUERY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "QUERY_SOURCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::QUERY_SOURCE_UNSPECIFIED)
-                }
-                "AGENT_QUERY" => std::option::Option::Some(Self::AGENT_QUERY),
-                "SUGGESTED_QUERY" => std::option::Option::Some(Self::SUGGESTED_QUERY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for QuerySource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for QuerySource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for QuerySource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for QuerySource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AgentQuery,
+                2 => Self::SuggestedQuery,
+                _ => Self::UnknownValue(query_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for QuerySource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "QUERY_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "AGENT_QUERY" => Self::AgentQuery,
+                "SUGGESTED_QUERY" => Self::SuggestedQuery,
+                _ => Self::UnknownValue(query_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for QuerySource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AgentQuery => serializer.serialize_i32(1),
+                Self::SuggestedQuery => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for QuerySource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<QuerySource>::new(
+                ".google.cloud.dialogflow.v2.SearchKnowledgeRequest.QuerySource",
+            ))
         }
     }
 }
@@ -6792,66 +7642,127 @@ pub mod search_knowledge_answer {
     }
 
     /// The type of the answer.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnswerType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AnswerType {
+        /// The answer has a unspecified type.
+        Unspecified,
+        /// The answer is from FAQ documents.
+        Faq,
+        /// The answer is from generative model.
+        Generative,
+        /// The answer is from intent matching.
+        Intent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AnswerType::value] or
+        /// [AnswerType::name].
+        UnknownValue(answer_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod answer_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AnswerType {
-        /// The answer has a unspecified type.
-        pub const ANSWER_TYPE_UNSPECIFIED: AnswerType = AnswerType::new(0);
-
-        /// The answer is from FAQ documents.
-        pub const FAQ: AnswerType = AnswerType::new(1);
-
-        /// The answer is from generative model.
-        pub const GENERATIVE: AnswerType = AnswerType::new(2);
-
-        /// The answer is from intent matching.
-        pub const INTENT: AnswerType = AnswerType::new(3);
-
-        /// Creates a new AnswerType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Faq => std::option::Option::Some(1),
+                Self::Generative => std::option::Option::Some(2),
+                Self::Intent => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANSWER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FAQ"),
-                2 => std::borrow::Cow::Borrowed("GENERATIVE"),
-                3 => std::borrow::Cow::Borrowed("INTENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANSWER_TYPE_UNSPECIFIED"),
+                Self::Faq => std::option::Option::Some("FAQ"),
+                Self::Generative => std::option::Option::Some("GENERATIVE"),
+                Self::Intent => std::option::Option::Some("INTENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANSWER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ANSWER_TYPE_UNSPECIFIED)
-                }
-                "FAQ" => std::option::Option::Some(Self::FAQ),
-                "GENERATIVE" => std::option::Option::Some(Self::GENERATIVE),
-                "INTENT" => std::option::Option::Some(Self::INTENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AnswerType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AnswerType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AnswerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AnswerType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Faq,
+                2 => Self::Generative,
+                3 => Self::Intent,
+                _ => Self::UnknownValue(answer_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AnswerType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANSWER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FAQ" => Self::Faq,
+                "GENERATIVE" => Self::Generative,
+                "INTENT" => Self::Intent,
+                _ => Self::UnknownValue(answer_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AnswerType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Faq => serializer.serialize_i32(1),
+                Self::Generative => serializer.serialize_i32(2),
+                Self::Intent => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AnswerType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AnswerType>::new(
+                ".google.cloud.dialogflow.v2.SearchKnowledgeAnswer.AnswerType",
+            ))
         }
     }
 }
@@ -7811,38 +8722,31 @@ pub mod conversation_event {
     use super::*;
 
     /// Enumeration of the types of events available.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Type not set.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// A new conversation has been opened. This is fired when a telephone call
         /// is answered, or a conversation is created via the API.
-        pub const CONVERSATION_STARTED: Type = Type::new(1);
-
+        ConversationStarted,
         /// An existing conversation has closed. This is fired when a telephone call
         /// is terminated, or a conversation is closed via the API.
-        pub const CONVERSATION_FINISHED: Type = Type::new(2);
-
+        ConversationFinished,
         /// An existing conversation has received notification from Dialogflow that
         /// human intervention is required.
-        pub const HUMAN_INTERVENTION_NEEDED: Type = Type::new(3);
-
+        HumanInterventionNeeded,
         /// An existing conversation has received a new message, either from API or
         /// telephony. It is configured in
         /// [ConversationProfile.new_message_event_notification_config][google.cloud.dialogflow.v2.ConversationProfile.new_message_event_notification_config]
         ///
         /// [google.cloud.dialogflow.v2.ConversationProfile.new_message_event_notification_config]: crate::model::ConversationProfile::new_message_event_notification_config
-        pub const NEW_MESSAGE: Type = Type::new(5);
-
+        NewMessage,
         /// An existing conversation has received a new speech recognition result.
         /// This is mainly for delivering intermediate transcripts. The notification
         /// is configured in
         /// [ConversationProfile.new_recognition_event_notification_config][].
-        pub const NEW_RECOGNITION_RESULT: Type = Type::new(7);
-
+        NewRecognitionResult,
         /// Unrecoverable error during a telephone call.
         ///
         /// In general non-recoverable errors only occur if something was
@@ -7853,58 +8757,134 @@ pub mod conversation_event {
         ///
         /// * in an API call because we can directly return the error, or,
         /// * when we can recover from an error.
-        pub const UNRECOVERABLE_ERROR: Type = Type::new(4);
+        UnrecoverableError,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConversationStarted => std::option::Option::Some(1),
+                Self::ConversationFinished => std::option::Option::Some(2),
+                Self::HumanInterventionNeeded => std::option::Option::Some(3),
+                Self::NewMessage => std::option::Option::Some(5),
+                Self::NewRecognitionResult => std::option::Option::Some(7),
+                Self::UnrecoverableError => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONVERSATION_STARTED"),
-                2 => std::borrow::Cow::Borrowed("CONVERSATION_FINISHED"),
-                3 => std::borrow::Cow::Borrowed("HUMAN_INTERVENTION_NEEDED"),
-                4 => std::borrow::Cow::Borrowed("UNRECOVERABLE_ERROR"),
-                5 => std::borrow::Cow::Borrowed("NEW_MESSAGE"),
-                7 => std::borrow::Cow::Borrowed("NEW_RECOGNITION_RESULT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CONVERSATION_STARTED" => std::option::Option::Some(Self::CONVERSATION_STARTED),
-                "CONVERSATION_FINISHED" => std::option::Option::Some(Self::CONVERSATION_FINISHED),
-                "HUMAN_INTERVENTION_NEEDED" => {
-                    std::option::Option::Some(Self::HUMAN_INTERVENTION_NEEDED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::ConversationStarted => std::option::Option::Some("CONVERSATION_STARTED"),
+                Self::ConversationFinished => std::option::Option::Some("CONVERSATION_FINISHED"),
+                Self::HumanInterventionNeeded => {
+                    std::option::Option::Some("HUMAN_INTERVENTION_NEEDED")
                 }
-                "NEW_MESSAGE" => std::option::Option::Some(Self::NEW_MESSAGE),
-                "NEW_RECOGNITION_RESULT" => std::option::Option::Some(Self::NEW_RECOGNITION_RESULT),
-                "UNRECOVERABLE_ERROR" => std::option::Option::Some(Self::UNRECOVERABLE_ERROR),
-                _ => std::option::Option::None,
+                Self::NewMessage => std::option::Option::Some("NEW_MESSAGE"),
+                Self::NewRecognitionResult => std::option::Option::Some("NEW_RECOGNITION_RESULT"),
+                Self::UnrecoverableError => std::option::Option::Some("UNRECOVERABLE_ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConversationStarted,
+                2 => Self::ConversationFinished,
+                3 => Self::HumanInterventionNeeded,
+                4 => Self::UnrecoverableError,
+                5 => Self::NewMessage,
+                7 => Self::NewRecognitionResult,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CONVERSATION_STARTED" => Self::ConversationStarted,
+                "CONVERSATION_FINISHED" => Self::ConversationFinished,
+                "HUMAN_INTERVENTION_NEEDED" => Self::HumanInterventionNeeded,
+                "NEW_MESSAGE" => Self::NewMessage,
+                "NEW_RECOGNITION_RESULT" => Self::NewRecognitionResult,
+                "UNRECOVERABLE_ERROR" => Self::UnrecoverableError,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConversationStarted => serializer.serialize_i32(1),
+                Self::ConversationFinished => serializer.serialize_i32(2),
+                Self::HumanInterventionNeeded => serializer.serialize_i32(3),
+                Self::NewMessage => serializer.serialize_i32(5),
+                Self::NewRecognitionResult => serializer.serialize_i32(7),
+                Self::UnrecoverableError => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dialogflow.v2.ConversationEvent.Type",
+            ))
         }
     }
 
@@ -8138,150 +9118,284 @@ pub mod conversation_model {
     use super::*;
 
     /// State of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Should not be used, an un-set enum has this value by default.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Model being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Model is not deployed but ready to deploy.
-        pub const UNDEPLOYED: State = State::new(2);
-
+        Undeployed,
         /// Model is deploying.
-        pub const DEPLOYING: State = State::new(3);
-
+        Deploying,
         /// Model is deployed and ready to use.
-        pub const DEPLOYED: State = State::new(4);
-
+        Deployed,
         /// Model is undeploying.
-        pub const UNDEPLOYING: State = State::new(5);
-
+        Undeploying,
         /// Model is deleting.
-        pub const DELETING: State = State::new(6);
-
+        Deleting,
         /// Model is in error state. Not ready to deploy and use.
-        pub const FAILED: State = State::new(7);
-
+        Failed,
         /// Model is being created but the training has not started,
         /// The model may remain in this state until there is enough capacity to
         /// start training.
-        pub const PENDING: State = State::new(8);
+        Pending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Undeployed => std::option::Option::Some(2),
+                Self::Deploying => std::option::Option::Some(3),
+                Self::Deployed => std::option::Option::Some(4),
+                Self::Undeploying => std::option::Option::Some(5),
+                Self::Deleting => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::Pending => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UNDEPLOYED"),
-                3 => std::borrow::Cow::Borrowed("DEPLOYING"),
-                4 => std::borrow::Cow::Borrowed("DEPLOYED"),
-                5 => std::borrow::Cow::Borrowed("UNDEPLOYING"),
-                6 => std::borrow::Cow::Borrowed("DELETING"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                8 => std::borrow::Cow::Borrowed("PENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Undeployed => std::option::Option::Some("UNDEPLOYED"),
+                Self::Deploying => std::option::Option::Some("DEPLOYING"),
+                Self::Deployed => std::option::Option::Some("DEPLOYED"),
+                Self::Undeploying => std::option::Option::Some("UNDEPLOYING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UNDEPLOYED" => std::option::Option::Some(Self::UNDEPLOYED),
-                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
-                "DEPLOYED" => std::option::Option::Some(Self::DEPLOYED),
-                "UNDEPLOYING" => std::option::Option::Some(Self::UNDEPLOYING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Undeployed,
+                3 => Self::Deploying,
+                4 => Self::Deployed,
+                5 => Self::Undeploying,
+                6 => Self::Deleting,
+                7 => Self::Failed,
+                8 => Self::Pending,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UNDEPLOYED" => Self::Undeployed,
+                "DEPLOYING" => Self::Deploying,
+                "DEPLOYED" => Self::Deployed,
+                "UNDEPLOYING" => Self::Undeploying,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "PENDING" => Self::Pending,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Undeployed => serializer.serialize_i32(2),
+                Self::Deploying => serializer.serialize_i32(3),
+                Self::Deployed => serializer.serialize_i32(4),
+                Self::Undeploying => serializer.serialize_i32(5),
+                Self::Deleting => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::Pending => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.v2.ConversationModel.State",
+            ))
         }
     }
 
     /// Model type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelType {
+        /// ModelType unspecified.
+        Unspecified,
+        /// ModelType smart reply dual encoder model.
+        SmartReplyDualEncoderModel,
+        /// ModelType smart reply bert model.
+        SmartReplyBertModel,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelType::value] or
+        /// [ModelType::name].
+        UnknownValue(model_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod model_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ModelType {
-        /// ModelType unspecified.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
-
-        /// ModelType smart reply dual encoder model.
-        pub const SMART_REPLY_DUAL_ENCODER_MODEL: ModelType = ModelType::new(2);
-
-        /// ModelType smart reply bert model.
-        pub const SMART_REPLY_BERT_MODEL: ModelType = ModelType::new(6);
-
-        /// Creates a new ModelType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SmartReplyDualEncoderModel => std::option::Option::Some(2),
+                Self::SmartReplyBertModel => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("SMART_REPLY_DUAL_ENCODER_MODEL"),
-                6 => std::borrow::Cow::Borrowed("SMART_REPLY_BERT_MODEL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
-                "SMART_REPLY_DUAL_ENCODER_MODEL" => {
-                    std::option::Option::Some(Self::SMART_REPLY_DUAL_ENCODER_MODEL)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_TYPE_UNSPECIFIED"),
+                Self::SmartReplyDualEncoderModel => {
+                    std::option::Option::Some("SMART_REPLY_DUAL_ENCODER_MODEL")
                 }
-                "SMART_REPLY_BERT_MODEL" => std::option::Option::Some(Self::SMART_REPLY_BERT_MODEL),
-                _ => std::option::Option::None,
+                Self::SmartReplyBertModel => std::option::Option::Some("SMART_REPLY_BERT_MODEL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::SmartReplyDualEncoderModel,
+                6 => Self::SmartReplyBertModel,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SMART_REPLY_DUAL_ENCODER_MODEL" => Self::SmartReplyDualEncoderModel,
+                "SMART_REPLY_BERT_MODEL" => Self::SmartReplyBertModel,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SmartReplyDualEncoderModel => serializer.serialize_i32(2),
+                Self::SmartReplyBertModel => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelType>::new(
+                ".google.cloud.dialogflow.v2.ConversationModel.ModelType",
+            ))
         }
     }
 
@@ -9533,81 +10647,150 @@ pub mod create_conversation_model_operation_metadata {
     use super::*;
 
     /// State of CreateConversationModel operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is submitted, but training has not started yet.
         /// The model may remain in this state until there is enough capacity to
         /// start training.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The training has succeeded.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// The training has succeeded.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// The training has been cancelled.
-        pub const CANCELLED: State = State::new(4);
-
+        Cancelled,
         /// The training is in cancelling state.
-        pub const CANCELLING: State = State::new(5);
-
+        Cancelling,
         /// Custom model is training.
-        pub const TRAINING: State = State::new(6);
+        Training,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::Cancelling => std::option::Option::Some(5),
+                Self::Training => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLING"),
-                6 => std::borrow::Cow::Borrowed("TRAINING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Training => std::option::Option::Some("TRAINING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "TRAINING" => std::option::Option::Some(Self::TRAINING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelled,
+                5 => Self::Cancelling,
+                6 => Self::Training,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                "CANCELLING" => Self::Cancelling,
+                "TRAINING" => Self::Training,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::Cancelling => serializer.serialize_i32(5),
+                Self::Training => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.v2.CreateConversationModelOperationMetadata.State",
+            ))
         }
     }
 }
@@ -9866,74 +11049,140 @@ pub mod create_conversation_model_evaluation_operation_metadata {
     use super::*;
 
     /// State of CreateConversationModel operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Operation status not specified.
+        Unspecified,
+        /// The operation is being prepared.
+        Initializing,
+        /// The operation is running.
+        Running,
+        /// The operation is cancelled.
+        Cancelled,
+        /// The operation has succeeded.
+        Succeeded,
+        /// The operation has failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Operation status not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The operation is being prepared.
-        pub const INITIALIZING: State = State::new(1);
-
-        /// The operation is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The operation is cancelled.
-        pub const CANCELLED: State = State::new(3);
-
-        /// The operation has succeeded.
-        pub const SUCCEEDED: State = State::new(4);
-
-        /// The operation has failed.
-        pub const FAILED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Initializing => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INITIALIZING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Initializing => std::option::Option::Some("INITIALIZING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Initializing,
+                2 => Self::Running,
+                3 => Self::Cancelled,
+                4 => Self::Succeeded,
+                5 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INITIALIZING" => Self::Initializing,
+                "RUNNING" => Self::Running,
+                "CANCELLED" => Self::Cancelled,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Initializing => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.v2.CreateConversationModelEvaluationOperationMetadata.State"))
         }
     }
 }
@@ -11487,95 +12736,164 @@ pub mod human_agent_assistant_config {
 
             /// Selectable sections to return when requesting a summary of a
             /// conversation.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct SectionType(i32);
-
-            impl SectionType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum SectionType {
                 /// Undefined section type, does not return anything.
-                pub const SECTION_TYPE_UNSPECIFIED: SectionType = SectionType::new(0);
-
+                Unspecified,
                 /// What the customer needs help with or has question about.
                 /// Section name: "situation".
-                pub const SITUATION: SectionType = SectionType::new(1);
-
+                Situation,
                 /// What the agent does to help the customer.
                 /// Section name: "action".
-                pub const ACTION: SectionType = SectionType::new(2);
-
+                Action,
                 /// Result of the customer service. A single word describing the result
                 /// of the conversation.
                 /// Section name: "resolution".
-                pub const RESOLUTION: SectionType = SectionType::new(3);
-
+                Resolution,
                 /// Reason for cancellation if the customer requests for a cancellation.
                 /// "N/A" otherwise.
                 /// Section name: "reason_for_cancellation".
-                pub const REASON_FOR_CANCELLATION: SectionType = SectionType::new(4);
-
+                ReasonForCancellation,
                 /// "Unsatisfied" or "Satisfied" depending on the customer's feelings at
                 /// the end of the conversation.
                 /// Section name: "customer_satisfaction".
-                pub const CUSTOMER_SATISFACTION: SectionType = SectionType::new(5);
-
+                CustomerSatisfaction,
                 /// Key entities extracted from the conversation, such as ticket number,
                 /// order number, dollar amount, etc.
                 /// Section names are prefixed by "entities/".
-                pub const ENTITIES: SectionType = SectionType::new(6);
+                Entities,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [SectionType::value] or
+                /// [SectionType::name].
+                UnknownValue(section_type::UnknownValue),
+            }
 
-                /// Creates a new SectionType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod section_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl SectionType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Situation => std::option::Option::Some(1),
+                        Self::Action => std::option::Option::Some(2),
+                        Self::Resolution => std::option::Option::Some(3),
+                        Self::ReasonForCancellation => std::option::Option::Some(4),
+                        Self::CustomerSatisfaction => std::option::Option::Some(5),
+                        Self::Entities => std::option::Option::Some(6),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("SECTION_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("SITUATION"),
-                        2 => std::borrow::Cow::Borrowed("ACTION"),
-                        3 => std::borrow::Cow::Borrowed("RESOLUTION"),
-                        4 => std::borrow::Cow::Borrowed("REASON_FOR_CANCELLATION"),
-                        5 => std::borrow::Cow::Borrowed("CUSTOMER_SATISFACTION"),
-                        6 => std::borrow::Cow::Borrowed("ENTITIES"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("SECTION_TYPE_UNSPECIFIED"),
+                        Self::Situation => std::option::Option::Some("SITUATION"),
+                        Self::Action => std::option::Option::Some("ACTION"),
+                        Self::Resolution => std::option::Option::Some("RESOLUTION"),
+                        Self::ReasonForCancellation => {
+                            std::option::Option::Some("REASON_FOR_CANCELLATION")
+                        }
+                        Self::CustomerSatisfaction => {
+                            std::option::Option::Some("CUSTOMER_SATISFACTION")
+                        }
+                        Self::Entities => std::option::Option::Some("ENTITIES"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "SECTION_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::SECTION_TYPE_UNSPECIFIED)
-                        }
-                        "SITUATION" => std::option::Option::Some(Self::SITUATION),
-                        "ACTION" => std::option::Option::Some(Self::ACTION),
-                        "RESOLUTION" => std::option::Option::Some(Self::RESOLUTION),
-                        "REASON_FOR_CANCELLATION" => {
-                            std::option::Option::Some(Self::REASON_FOR_CANCELLATION)
-                        }
-                        "CUSTOMER_SATISFACTION" => {
-                            std::option::Option::Some(Self::CUSTOMER_SATISFACTION)
-                        }
-                        "ENTITIES" => std::option::Option::Some(Self::ENTITIES),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for SectionType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for SectionType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for SectionType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for SectionType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Situation,
+                        2 => Self::Action,
+                        3 => Self::Resolution,
+                        4 => Self::ReasonForCancellation,
+                        5 => Self::CustomerSatisfaction,
+                        6 => Self::Entities,
+                        _ => Self::UnknownValue(section_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for SectionType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "SECTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "SITUATION" => Self::Situation,
+                        "ACTION" => Self::Action,
+                        "RESOLUTION" => Self::Resolution,
+                        "REASON_FOR_CANCELLATION" => Self::ReasonForCancellation,
+                        "CUSTOMER_SATISFACTION" => Self::CustomerSatisfaction,
+                        "ENTITIES" => Self::Entities,
+                        _ => Self::UnknownValue(section_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for SectionType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Situation => serializer.serialize_i32(1),
+                        Self::Action => serializer.serialize_i32(2),
+                        Self::Resolution => serializer.serialize_i32(3),
+                        Self::ReasonForCancellation => serializer.serialize_i32(4),
+                        Self::CustomerSatisfaction => serializer.serialize_i32(5),
+                        Self::Entities => serializer.serialize_i32(6),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for SectionType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<SectionType>::new(
+                        ".google.cloud.dialogflow.v2.HumanAgentAssistantConfig.SuggestionQueryConfig.Sections.SectionType"))
                 }
             }
         }
@@ -12038,7 +13356,7 @@ pub struct NotificationConfig {
     /// Format: `projects/<Project ID>/locations/<Location ID>/topics/<Topic ID>`.
     ///
     /// [google.cloud.dialogflow.v2.ConversationEvent]: crate::model::ConversationEvent
-    /// [google.cloud.dialogflow.v2.ConversationEvent.Type.CONVERSATION_STARTED]: crate::model::conversation_event::r#type::CONVERSATION_STARTED
+    /// [google.cloud.dialogflow.v2.ConversationEvent.Type.CONVERSATION_STARTED]: crate::model::conversation_event::Type::ConversationStarted
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub topic: std::string::String,
 
@@ -12084,61 +13402,120 @@ pub mod notification_config {
     use super::*;
 
     /// Format of cloud pub/sub message.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MessageFormat {
+        /// If it is unspecified, PROTO will be used.
+        Unspecified,
+        /// Pub/Sub message will be serialized proto.
+        Proto,
+        /// Pub/Sub message will be json.
+        Json,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MessageFormat::value] or
+        /// [MessageFormat::name].
+        UnknownValue(message_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod message_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MessageFormat {
-        /// If it is unspecified, PROTO will be used.
-        pub const MESSAGE_FORMAT_UNSPECIFIED: MessageFormat = MessageFormat::new(0);
-
-        /// Pub/Sub message will be serialized proto.
-        pub const PROTO: MessageFormat = MessageFormat::new(1);
-
-        /// Pub/Sub message will be json.
-        pub const JSON: MessageFormat = MessageFormat::new(2);
-
-        /// Creates a new MessageFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Proto => std::option::Option::Some(1),
+                Self::Json => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MESSAGE_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROTO"),
-                2 => std::borrow::Cow::Borrowed("JSON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MESSAGE_FORMAT_UNSPECIFIED"),
+                Self::Proto => std::option::Option::Some("PROTO"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MESSAGE_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MESSAGE_FORMAT_UNSPECIFIED)
-                }
-                "PROTO" => std::option::Option::Some(Self::PROTO),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MessageFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MessageFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MessageFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Proto,
+                2 => Self::Json,
+                _ => Self::UnknownValue(message_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MessageFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MESSAGE_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "PROTO" => Self::Proto,
+                "JSON" => Self::Json,
+                _ => Self::UnknownValue(message_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MessageFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Proto => serializer.serialize_i32(1),
+                Self::Json => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MessageFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MessageFormat>::new(
+                ".google.cloud.dialogflow.v2.NotificationConfig.MessageFormat",
+            ))
         }
     }
 }
@@ -12155,7 +13532,7 @@ pub struct LoggingConfig {
     /// [ConversationEvent][google.cloud.dialogflow.v2.ConversationEvent] protos.
     ///
     /// [google.cloud.dialogflow.v2.ConversationEvent]: crate::model::ConversationEvent
-    /// [google.cloud.dialogflow.v2.ConversationEvent.Type.CONVERSATION_STARTED]: crate::model::conversation_event::r#type::CONVERSATION_STARTED
+    /// [google.cloud.dialogflow.v2.ConversationEvent.Type.CONVERSATION_STARTED]: crate::model::conversation_event::Type::ConversationStarted
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub enable_stackdriver_logging: bool,
 
@@ -12224,81 +13601,150 @@ pub mod suggestion_feature {
     use super::*;
 
     /// Defines the type of Human Agent Assistant feature.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified feature type.
+        Unspecified,
+        /// Run article suggestion model for chat.
+        ArticleSuggestion,
+        /// Run FAQ model for chat.
+        Faq,
+        /// Run smart reply model for chat.
+        SmartReply,
+        /// Run conversation summarization model for chat.
+        ConversationSummarization,
+        /// Run knowledge search with text input from agent or text generated query.
+        KnowledgeSearch,
+        /// Run knowledge assist with automatic query generation.
+        KnowledgeAssist,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified feature type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Run article suggestion model for chat.
-        pub const ARTICLE_SUGGESTION: Type = Type::new(1);
-
-        /// Run FAQ model for chat.
-        pub const FAQ: Type = Type::new(2);
-
-        /// Run smart reply model for chat.
-        pub const SMART_REPLY: Type = Type::new(3);
-
-        /// Run conversation summarization model for chat.
-        pub const CONVERSATION_SUMMARIZATION: Type = Type::new(8);
-
-        /// Run knowledge search with text input from agent or text generated query.
-        pub const KNOWLEDGE_SEARCH: Type = Type::new(14);
-
-        /// Run knowledge assist with automatic query generation.
-        pub const KNOWLEDGE_ASSIST: Type = Type::new(15);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ArticleSuggestion => std::option::Option::Some(1),
+                Self::Faq => std::option::Option::Some(2),
+                Self::SmartReply => std::option::Option::Some(3),
+                Self::ConversationSummarization => std::option::Option::Some(8),
+                Self::KnowledgeSearch => std::option::Option::Some(14),
+                Self::KnowledgeAssist => std::option::Option::Some(15),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ARTICLE_SUGGESTION"),
-                2 => std::borrow::Cow::Borrowed("FAQ"),
-                3 => std::borrow::Cow::Borrowed("SMART_REPLY"),
-                8 => std::borrow::Cow::Borrowed("CONVERSATION_SUMMARIZATION"),
-                14 => std::borrow::Cow::Borrowed("KNOWLEDGE_SEARCH"),
-                15 => std::borrow::Cow::Borrowed("KNOWLEDGE_ASSIST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "ARTICLE_SUGGESTION" => std::option::Option::Some(Self::ARTICLE_SUGGESTION),
-                "FAQ" => std::option::Option::Some(Self::FAQ),
-                "SMART_REPLY" => std::option::Option::Some(Self::SMART_REPLY),
-                "CONVERSATION_SUMMARIZATION" => {
-                    std::option::Option::Some(Self::CONVERSATION_SUMMARIZATION)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::ArticleSuggestion => std::option::Option::Some("ARTICLE_SUGGESTION"),
+                Self::Faq => std::option::Option::Some("FAQ"),
+                Self::SmartReply => std::option::Option::Some("SMART_REPLY"),
+                Self::ConversationSummarization => {
+                    std::option::Option::Some("CONVERSATION_SUMMARIZATION")
                 }
-                "KNOWLEDGE_SEARCH" => std::option::Option::Some(Self::KNOWLEDGE_SEARCH),
-                "KNOWLEDGE_ASSIST" => std::option::Option::Some(Self::KNOWLEDGE_ASSIST),
-                _ => std::option::Option::None,
+                Self::KnowledgeSearch => std::option::Option::Some("KNOWLEDGE_SEARCH"),
+                Self::KnowledgeAssist => std::option::Option::Some("KNOWLEDGE_ASSIST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ArticleSuggestion,
+                2 => Self::Faq,
+                3 => Self::SmartReply,
+                8 => Self::ConversationSummarization,
+                14 => Self::KnowledgeSearch,
+                15 => Self::KnowledgeAssist,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ARTICLE_SUGGESTION" => Self::ArticleSuggestion,
+                "FAQ" => Self::Faq,
+                "SMART_REPLY" => Self::SmartReply,
+                "CONVERSATION_SUMMARIZATION" => Self::ConversationSummarization,
+                "KNOWLEDGE_SEARCH" => Self::KnowledgeSearch,
+                "KNOWLEDGE_ASSIST" => Self::KnowledgeAssist,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ArticleSuggestion => serializer.serialize_i32(1),
+                Self::Faq => serializer.serialize_i32(2),
+                Self::SmartReply => serializer.serialize_i32(3),
+                Self::ConversationSummarization => serializer.serialize_i32(8),
+                Self::KnowledgeSearch => serializer.serialize_i32(14),
+                Self::KnowledgeAssist => serializer.serialize_i32(15),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dialogflow.v2.SuggestionFeature.Type",
+            ))
         }
     }
 }
@@ -12873,13 +14319,11 @@ pub mod document {
     }
 
     /// The knowledge type of document content.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KnowledgeType(i32);
-
-    impl KnowledgeType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KnowledgeType {
         /// The type is unspecified or arbitrary.
-        pub const KNOWLEDGE_TYPE_UNSPECIFIED: KnowledgeType = KnowledgeType::new(0);
-
+        Unspecified,
         /// The document content contains question and answer pairs as either HTML or
         /// CSV. Typical FAQ HTML formats are parsed accurately, but unusual formats
         /// may fail to be parsed.
@@ -12887,139 +14331,271 @@ pub mod document {
         /// CSV must have questions in the first column and answers in the second,
         /// with no header. Because of this explicit format, they are always parsed
         /// accurately.
-        pub const FAQ: KnowledgeType = KnowledgeType::new(1);
-
+        Faq,
         /// Documents for which unstructured text is extracted and used for
         /// question answering.
-        pub const EXTRACTIVE_QA: KnowledgeType = KnowledgeType::new(2);
-
+        ExtractiveQa,
         /// The entire document content as a whole can be used for query results.
         /// Only for Contact Center Solutions on Dialogflow.
-        pub const ARTICLE_SUGGESTION: KnowledgeType = KnowledgeType::new(3);
-
+        ArticleSuggestion,
         /// The document contains agent-facing Smart Reply entries.
-        pub const AGENT_FACING_SMART_REPLY: KnowledgeType = KnowledgeType::new(4);
+        AgentFacingSmartReply,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KnowledgeType::value] or
+        /// [KnowledgeType::name].
+        UnknownValue(knowledge_type::UnknownValue),
+    }
 
-        /// Creates a new KnowledgeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod knowledge_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KnowledgeType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Faq => std::option::Option::Some(1),
+                Self::ExtractiveQa => std::option::Option::Some(2),
+                Self::ArticleSuggestion => std::option::Option::Some(3),
+                Self::AgentFacingSmartReply => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KNOWLEDGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FAQ"),
-                2 => std::borrow::Cow::Borrowed("EXTRACTIVE_QA"),
-                3 => std::borrow::Cow::Borrowed("ARTICLE_SUGGESTION"),
-                4 => std::borrow::Cow::Borrowed("AGENT_FACING_SMART_REPLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KNOWLEDGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KNOWLEDGE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KNOWLEDGE_TYPE_UNSPECIFIED"),
+                Self::Faq => std::option::Option::Some("FAQ"),
+                Self::ExtractiveQa => std::option::Option::Some("EXTRACTIVE_QA"),
+                Self::ArticleSuggestion => std::option::Option::Some("ARTICLE_SUGGESTION"),
+                Self::AgentFacingSmartReply => {
+                    std::option::Option::Some("AGENT_FACING_SMART_REPLY")
                 }
-                "FAQ" => std::option::Option::Some(Self::FAQ),
-                "EXTRACTIVE_QA" => std::option::Option::Some(Self::EXTRACTIVE_QA),
-                "ARTICLE_SUGGESTION" => std::option::Option::Some(Self::ARTICLE_SUGGESTION),
-                "AGENT_FACING_SMART_REPLY" => {
-                    std::option::Option::Some(Self::AGENT_FACING_SMART_REPLY)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for KnowledgeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KnowledgeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KnowledgeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KnowledgeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Faq,
+                2 => Self::ExtractiveQa,
+                3 => Self::ArticleSuggestion,
+                4 => Self::AgentFacingSmartReply,
+                _ => Self::UnknownValue(knowledge_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KnowledgeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KNOWLEDGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FAQ" => Self::Faq,
+                "EXTRACTIVE_QA" => Self::ExtractiveQa,
+                "ARTICLE_SUGGESTION" => Self::ArticleSuggestion,
+                "AGENT_FACING_SMART_REPLY" => Self::AgentFacingSmartReply,
+                _ => Self::UnknownValue(knowledge_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KnowledgeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Faq => serializer.serialize_i32(1),
+                Self::ExtractiveQa => serializer.serialize_i32(2),
+                Self::ArticleSuggestion => serializer.serialize_i32(3),
+                Self::AgentFacingSmartReply => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KnowledgeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KnowledgeType>::new(
+                ".google.cloud.dialogflow.v2.Document.KnowledgeType",
+            ))
         }
     }
 
     /// Possible states of the document
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The document state is unspecified.
+        Unspecified,
+        /// The document creation is in progress.
+        Creating,
+        /// The document is active and ready to use.
+        Active,
+        /// The document updation is in progress.
+        Updating,
+        /// The document is reloading.
+        Reloading,
+        /// The document deletion is in progress.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The document state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The document creation is in progress.
-        pub const CREATING: State = State::new(1);
-
-        /// The document is active and ready to use.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The document updation is in progress.
-        pub const UPDATING: State = State::new(3);
-
-        /// The document is reloading.
-        pub const RELOADING: State = State::new(4);
-
-        /// The document deletion is in progress.
-        pub const DELETING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Reloading => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("RELOADING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Reloading => std::option::Option::Some("RELOADING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "RELOADING" => std::option::Option::Some(Self::RELOADING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Reloading,
+                5 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "RELOADING" => Self::Reloading,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Reloading => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.v2.Document.State",
+            ))
         }
     }
 
@@ -14022,64 +15598,127 @@ pub mod knowledge_operation_metadata {
     use super::*;
 
     /// States of the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State unspecified.
+        Unspecified,
+        /// The operation has been created.
+        Pending,
+        /// The operation is currently running.
+        Running,
+        /// The operation is done, either cancelled or completed.
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The operation has been created.
-        pub const PENDING: State = State::new(1);
-
-        /// The operation is currently running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The operation is done, either cancelled or completed.
-        pub const DONE: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.v2.KnowledgeOperationMetadata.State",
+            ))
         }
     }
 
@@ -14457,127 +16096,245 @@ pub mod entity_type {
     }
 
     /// Represents kinds of entities.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(i32);
-
-    impl Kind {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kind {
         /// Not specified. This value should be never used.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
-
+        Unspecified,
         /// Map entity types allow mapping of a group of synonyms to a reference
         /// value.
-        pub const KIND_MAP: Kind = Kind::new(1);
-
+        Map,
         /// List entity types contain a set of entries that do not map to reference
         /// values. However, list entity types can contain references to other entity
         /// types (with or without aliases).
-        pub const KIND_LIST: Kind = Kind::new(2);
-
+        List,
         /// Regexp entity types allow to specify regular expressions in entries
         /// values.
-        pub const KIND_REGEXP: Kind = Kind::new(3);
+        Regexp,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kind::value] or
+        /// [Kind::name].
+        UnknownValue(kind::UnknownValue),
+    }
 
-        /// Creates a new Kind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Kind {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Map => std::option::Option::Some(1),
+                Self::List => std::option::Option::Some(2),
+                Self::Regexp => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KIND_MAP"),
-                2 => std::borrow::Cow::Borrowed("KIND_LIST"),
-                3 => std::borrow::Cow::Borrowed("KIND_REGEXP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KIND_UNSPECIFIED"),
+                Self::Map => std::option::Option::Some("KIND_MAP"),
+                Self::List => std::option::Option::Some("KIND_LIST"),
+                Self::Regexp => std::option::Option::Some("KIND_REGEXP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
-                "KIND_MAP" => std::option::Option::Some(Self::KIND_MAP),
-                "KIND_LIST" => std::option::Option::Some(Self::KIND_LIST),
-                "KIND_REGEXP" => std::option::Option::Some(Self::KIND_REGEXP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Map,
+                2 => Self::List,
+                3 => Self::Regexp,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KIND_UNSPECIFIED" => Self::Unspecified,
+                "KIND_MAP" => Self::Map,
+                "KIND_LIST" => Self::List,
+                "KIND_REGEXP" => Self::Regexp,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Map => serializer.serialize_i32(1),
+                Self::List => serializer.serialize_i32(2),
+                Self::Regexp => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                ".google.cloud.dialogflow.v2.EntityType.Kind",
+            ))
         }
     }
 
     /// Represents different entity type expansion modes. Automated expansion
     /// allows an agent to recognize values that have not been explicitly listed in
     /// the entity (for example, new kinds of shopping list items).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutoExpansionMode(i32);
-
-    impl AutoExpansionMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AutoExpansionMode {
         /// Auto expansion disabled for the entity.
-        pub const AUTO_EXPANSION_MODE_UNSPECIFIED: AutoExpansionMode = AutoExpansionMode::new(0);
-
+        Unspecified,
         /// Allows an agent to recognize values that have not been explicitly
         /// listed in the entity.
-        pub const AUTO_EXPANSION_MODE_DEFAULT: AutoExpansionMode = AutoExpansionMode::new(1);
+        Default,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AutoExpansionMode::value] or
+        /// [AutoExpansionMode::name].
+        UnknownValue(auto_expansion_mode::UnknownValue),
+    }
 
-        /// Creates a new AutoExpansionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod auto_expansion_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AutoExpansionMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTO_EXPANSION_MODE_DEFAULT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTO_EXPANSION_MODE_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("AUTO_EXPANSION_MODE_DEFAULT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTO_EXPANSION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_UNSPECIFIED)
-                }
-                "AUTO_EXPANSION_MODE_DEFAULT" => {
-                    std::option::Option::Some(Self::AUTO_EXPANSION_MODE_DEFAULT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AutoExpansionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AutoExpansionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AutoExpansionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AutoExpansionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                _ => Self::UnknownValue(auto_expansion_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AutoExpansionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTO_EXPANSION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTO_EXPANSION_MODE_DEFAULT" => Self::Default,
+                _ => Self::UnknownValue(auto_expansion_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AutoExpansionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AutoExpansionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AutoExpansionMode>::new(
+                ".google.cloud.dialogflow.v2.EntityType.AutoExpansionMode",
+            ))
         }
     }
 }
@@ -15597,64 +17354,127 @@ pub mod environment {
     /// During that time, the environment keeps on serving the previous version of
     /// the agent. After the new agent version is done loading, the environment is
     /// set back to the `RUNNING` state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not specified. This value is not used.
+        Unspecified,
+        /// Stopped.
+        Stopped,
+        /// Loading.
+        Loading,
+        /// Running.
+        Running,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not specified. This value is not used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Stopped.
-        pub const STOPPED: State = State::new(1);
-
-        /// Loading.
-        pub const LOADING: State = State::new(2);
-
-        /// Running.
-        pub const RUNNING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Stopped => std::option::Option::Some(1),
+                Self::Loading => std::option::Option::Some(2),
+                Self::Running => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STOPPED"),
-                2 => std::borrow::Cow::Borrowed("LOADING"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Loading => std::option::Option::Some("LOADING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "LOADING" => std::option::Option::Some(Self::LOADING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Stopped,
+                2 => Self::Loading,
+                3 => Self::Running,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STOPPED" => Self::Stopped,
+                "LOADING" => Self::Loading,
+                "RUNNING" => Self::Running,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Stopped => serializer.serialize_i32(1),
+                Self::Loading => serializer.serialize_i32(2),
+                Self::Running => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.dialogflow.v2.Environment.State",
+            ))
         }
     }
 }
@@ -16563,54 +18383,116 @@ pub mod fulfillment {
         use super::*;
 
         /// The type of the feature.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Feature type not specified.
+            Unspecified,
+            /// Fulfillment is enabled for SmallTalk.
+            Smalltalk,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Feature type not specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// Fulfillment is enabled for SmallTalk.
-            pub const SMALLTALK: Type = Type::new(1);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Smalltalk => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SMALLTALK"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::Smalltalk => std::option::Option::Some("SMALLTALK"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "SMALLTALK" => std::option::Option::Some(Self::SMALLTALK),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Smalltalk,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SMALLTALK" => Self::Smalltalk,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Smalltalk => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.dialogflow.v2.Fulfillment.Feature.Type",
+                ))
             }
         }
     }
@@ -17162,65 +19044,128 @@ pub mod message_entry {
     use super::*;
 
     /// Enumeration of the roles a participant can play in a conversation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
-
-    impl Role {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
         /// Participant role not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
+        Unspecified,
         /// Participant is a human agent.
-        pub const HUMAN_AGENT: Role = Role::new(1);
-
+        HumanAgent,
         /// Participant is an automated agent, such as a Dialogflow agent.
-        pub const AUTOMATED_AGENT: Role = Role::new(2);
-
+        AutomatedAgent,
         /// Participant is an end user that has called or chatted with
         /// Dialogflow services.
-        pub const END_USER: Role = Role::new(3);
+        EndUser,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
 
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Role {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HumanAgent => std::option::Option::Some(1),
+                Self::AutomatedAgent => std::option::Option::Some(2),
+                Self::EndUser => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HUMAN_AGENT"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT"),
-                3 => std::borrow::Cow::Borrowed("END_USER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::HumanAgent => std::option::Option::Some("HUMAN_AGENT"),
+                Self::AutomatedAgent => std::option::Option::Some("AUTOMATED_AGENT"),
+                Self::EndUser => std::option::Option::Some("END_USER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "HUMAN_AGENT" => std::option::Option::Some(Self::HUMAN_AGENT),
-                "AUTOMATED_AGENT" => std::option::Option::Some(Self::AUTOMATED_AGENT),
-                "END_USER" => std::option::Option::Some(Self::END_USER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HumanAgent,
+                2 => Self::AutomatedAgent,
+                3 => Self::EndUser,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "HUMAN_AGENT" => Self::HumanAgent,
+                "AUTOMATED_AGENT" => Self::AutomatedAgent,
+                "END_USER" => Self::EndUser,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HumanAgent => serializer.serialize_i32(1),
+                Self::AutomatedAgent => serializer.serialize_i32(2),
+                Self::EndUser => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.dialogflow.v2.MessageEntry.Role",
+            ))
         }
     }
 }
@@ -17582,108 +19527,181 @@ pub mod summarization_section {
     use super::*;
 
     /// Type enum of the summarization sections.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Undefined section type, does not return anything.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// What the customer needs help with or has question about.
         /// Section name: "situation".
-        pub const SITUATION: Type = Type::new(1);
-
+        Situation,
         /// What the agent does to help the customer.
         /// Section name: "action".
-        pub const ACTION: Type = Type::new(2);
-
+        Action,
         /// Result of the customer service. A single word describing the result
         /// of the conversation.
         /// Section name: "resolution".
-        pub const RESOLUTION: Type = Type::new(3);
-
+        Resolution,
         /// Reason for cancellation if the customer requests for a cancellation.
         /// "N/A" otherwise.
         /// Section name: "reason_for_cancellation".
-        pub const REASON_FOR_CANCELLATION: Type = Type::new(4);
-
+        ReasonForCancellation,
         /// "Unsatisfied" or "Satisfied" depending on the customer's feelings at
         /// the end of the conversation.
         /// Section name: "customer_satisfaction".
-        pub const CUSTOMER_SATISFACTION: Type = Type::new(5);
-
+        CustomerSatisfaction,
         /// Key entities extracted from the conversation, such as ticket number,
         /// order number, dollar amount, etc.
         /// Section names are prefixed by "entities/".
-        pub const ENTITIES: Type = Type::new(6);
-
+        Entities,
         /// Customer defined sections.
-        pub const CUSTOMER_DEFINED: Type = Type::new(7);
-
+        CustomerDefined,
         /// Concise version of the situation section. This type is only available if
         /// type SITUATION is not selected.
-        pub const SITUATION_CONCISE: Type = Type::new(9);
-
+        SituationConcise,
         /// Concise version of the action section. This type is only available if
         /// type ACTION is not selected.
-        pub const ACTION_CONCISE: Type = Type::new(10);
+        ActionConcise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Situation => std::option::Option::Some(1),
+                Self::Action => std::option::Option::Some(2),
+                Self::Resolution => std::option::Option::Some(3),
+                Self::ReasonForCancellation => std::option::Option::Some(4),
+                Self::CustomerSatisfaction => std::option::Option::Some(5),
+                Self::Entities => std::option::Option::Some(6),
+                Self::CustomerDefined => std::option::Option::Some(7),
+                Self::SituationConcise => std::option::Option::Some(9),
+                Self::ActionConcise => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SITUATION"),
-                2 => std::borrow::Cow::Borrowed("ACTION"),
-                3 => std::borrow::Cow::Borrowed("RESOLUTION"),
-                4 => std::borrow::Cow::Borrowed("REASON_FOR_CANCELLATION"),
-                5 => std::borrow::Cow::Borrowed("CUSTOMER_SATISFACTION"),
-                6 => std::borrow::Cow::Borrowed("ENTITIES"),
-                7 => std::borrow::Cow::Borrowed("CUSTOMER_DEFINED"),
-                9 => std::borrow::Cow::Borrowed("SITUATION_CONCISE"),
-                10 => std::borrow::Cow::Borrowed("ACTION_CONCISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Situation => std::option::Option::Some("SITUATION"),
+                Self::Action => std::option::Option::Some("ACTION"),
+                Self::Resolution => std::option::Option::Some("RESOLUTION"),
+                Self::ReasonForCancellation => std::option::Option::Some("REASON_FOR_CANCELLATION"),
+                Self::CustomerSatisfaction => std::option::Option::Some("CUSTOMER_SATISFACTION"),
+                Self::Entities => std::option::Option::Some("ENTITIES"),
+                Self::CustomerDefined => std::option::Option::Some("CUSTOMER_DEFINED"),
+                Self::SituationConcise => std::option::Option::Some("SITUATION_CONCISE"),
+                Self::ActionConcise => std::option::Option::Some("ACTION_CONCISE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "SITUATION" => std::option::Option::Some(Self::SITUATION),
-                "ACTION" => std::option::Option::Some(Self::ACTION),
-                "RESOLUTION" => std::option::Option::Some(Self::RESOLUTION),
-                "REASON_FOR_CANCELLATION" => {
-                    std::option::Option::Some(Self::REASON_FOR_CANCELLATION)
-                }
-                "CUSTOMER_SATISFACTION" => std::option::Option::Some(Self::CUSTOMER_SATISFACTION),
-                "ENTITIES" => std::option::Option::Some(Self::ENTITIES),
-                "CUSTOMER_DEFINED" => std::option::Option::Some(Self::CUSTOMER_DEFINED),
-                "SITUATION_CONCISE" => std::option::Option::Some(Self::SITUATION_CONCISE),
-                "ACTION_CONCISE" => std::option::Option::Some(Self::ACTION_CONCISE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Situation,
+                2 => Self::Action,
+                3 => Self::Resolution,
+                4 => Self::ReasonForCancellation,
+                5 => Self::CustomerSatisfaction,
+                6 => Self::Entities,
+                7 => Self::CustomerDefined,
+                9 => Self::SituationConcise,
+                10 => Self::ActionConcise,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SITUATION" => Self::Situation,
+                "ACTION" => Self::Action,
+                "RESOLUTION" => Self::Resolution,
+                "REASON_FOR_CANCELLATION" => Self::ReasonForCancellation,
+                "CUSTOMER_SATISFACTION" => Self::CustomerSatisfaction,
+                "ENTITIES" => Self::Entities,
+                "CUSTOMER_DEFINED" => Self::CustomerDefined,
+                "SITUATION_CONCISE" => Self::SituationConcise,
+                "ACTION_CONCISE" => Self::ActionConcise,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Situation => serializer.serialize_i32(1),
+                Self::Action => serializer.serialize_i32(2),
+                Self::Resolution => serializer.serialize_i32(3),
+                Self::ReasonForCancellation => serializer.serialize_i32(4),
+                Self::CustomerSatisfaction => serializer.serialize_i32(5),
+                Self::Entities => serializer.serialize_i32(6),
+                Self::CustomerDefined => serializer.serialize_i32(7),
+                Self::SituationConcise => serializer.serialize_i32(9),
+                Self::ActionConcise => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.dialogflow.v2.SummarizationSection.Type",
+            ))
         }
     }
 }
@@ -18861,65 +20879,129 @@ pub mod intent {
         }
 
         /// Represents different types of training phrases.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
-
-        impl Type {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
             /// Not specified. This value should never be used.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+            Unspecified,
             /// Examples do not contain @-prefixed entity type names, but example parts
             /// can be annotated with entity types.
-            pub const EXAMPLE: Type = Type::new(1);
-
+            Example,
             /// Templates are not annotated with entity types, but they can contain
             /// @-prefixed entity type names as substrings.
             /// Template mode has been deprecated. Example mode is the only supported
             /// way to create new training phrases. If you have existing training
             /// phrases that you've created in template mode, those will continue to
             /// work.
-            pub const TEMPLATE: Type = Type::new(2);
+            Template,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
 
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Type {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Example => std::option::Option::Some(1),
+                    Self::Template => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EXAMPLE"),
-                    2 => std::borrow::Cow::Borrowed("TEMPLATE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::Example => std::option::Option::Some("EXAMPLE"),
+                    Self::Template => std::option::Option::Some("TEMPLATE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "EXAMPLE" => std::option::Option::Some(Self::EXAMPLE),
-                    "TEMPLATE" => std::option::Option::Some(Self::TEMPLATE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Example,
+                    2 => Self::Template,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "EXAMPLE" => Self::Example,
+                    "TEMPLATE" => Self::Template,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Example => serializer.serialize_i32(1),
+                    Self::Template => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.dialogflow.v2.Intent.TrainingPhrase.Type",
+                ))
             }
         }
     }
@@ -20769,57 +22851,117 @@ pub mod intent {
             }
 
             /// Format of response media type.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ResponseMediaType(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ResponseMediaType {
+                /// Unspecified.
+                Unspecified,
+                /// Response media type is audio.
+                Audio,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ResponseMediaType::value] or
+                /// [ResponseMediaType::name].
+                UnknownValue(response_media_type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod response_media_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl ResponseMediaType {
-                /// Unspecified.
-                pub const RESPONSE_MEDIA_TYPE_UNSPECIFIED: ResponseMediaType =
-                    ResponseMediaType::new(0);
-
-                /// Response media type is audio.
-                pub const AUDIO: ResponseMediaType = ResponseMediaType::new(1);
-
-                /// Creates a new ResponseMediaType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Audio => std::option::Option::Some(1),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("RESPONSE_MEDIA_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("AUDIO"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "RESPONSE_MEDIA_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::RESPONSE_MEDIA_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("RESPONSE_MEDIA_TYPE_UNSPECIFIED")
                         }
-                        "AUDIO" => std::option::Option::Some(Self::AUDIO),
-                        _ => std::option::Option::None,
+                        Self::Audio => std::option::Option::Some("AUDIO"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for ResponseMediaType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ResponseMediaType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ResponseMediaType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ResponseMediaType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Audio,
+                        _ => Self::UnknownValue(response_media_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ResponseMediaType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "RESPONSE_MEDIA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "AUDIO" => Self::Audio,
+                        _ => Self::UnknownValue(response_media_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ResponseMediaType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Audio => serializer.serialize_i32(1),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ResponseMediaType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseMediaType>::new(
+                        ".google.cloud.dialogflow.v2.Intent.Message.MediaContent.ResponseMediaType"))
                 }
             }
         }
@@ -21040,65 +23182,128 @@ pub mod intent {
                     use super::*;
 
                     /// Type of the URI.
-                    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                    pub struct UrlTypeHint(i32);
-
-                    impl UrlTypeHint {
+                    #[derive(Clone, Debug, PartialEq)]
+                    #[non_exhaustive]
+                    pub enum UrlTypeHint {
                         /// Unspecified
-                        pub const URL_TYPE_HINT_UNSPECIFIED: UrlTypeHint = UrlTypeHint::new(0);
-
+                        Unspecified,
                         /// Url would be an amp action
-                        pub const AMP_ACTION: UrlTypeHint = UrlTypeHint::new(1);
-
+                        AmpAction,
                         /// URL that points directly to AMP content, or to a canonical URL
                         /// which refers to AMP content via \<link rel="amphtml"\>.
-                        pub const AMP_CONTENT: UrlTypeHint = UrlTypeHint::new(2);
+                        AmpContent,
+                        /// If set, the enum was initialized with an unknown value.
+                        ///
+                        /// Applications can examine the value using [UrlTypeHint::value] or
+                        /// [UrlTypeHint::name].
+                        UnknownValue(url_type_hint::UnknownValue),
+                    }
 
-                        /// Creates a new UrlTypeHint instance.
-                        pub(crate) const fn new(value: i32) -> Self {
-                            Self(value)
-                        }
+                    #[doc(hidden)]
+                    pub mod url_type_hint {
+                        #[allow(unused_imports)]
+                        use super::*;
+                        #[derive(Clone, Debug, PartialEq)]
+                        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                    }
 
+                    impl UrlTypeHint {
                         /// Gets the enum value.
-                        pub fn value(&self) -> i32 {
-                            self.0
+                        ///
+                        /// Returns `None` if the enum contains an unknown value deserialized from
+                        /// the string representation of enums.
+                        pub fn value(&self) -> std::option::Option<i32> {
+                            match self {
+                                Self::Unspecified => std::option::Option::Some(0),
+                                Self::AmpAction => std::option::Option::Some(1),
+                                Self::AmpContent => std::option::Option::Some(2),
+                                Self::UnknownValue(u) => u.0.value(),
+                            }
                         }
 
                         /// Gets the enum value as a string.
-                        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                            match self.0 {
-                                0 => std::borrow::Cow::Borrowed("URL_TYPE_HINT_UNSPECIFIED"),
-                                1 => std::borrow::Cow::Borrowed("AMP_ACTION"),
-                                2 => std::borrow::Cow::Borrowed("AMP_CONTENT"),
-                                _ => std::borrow::Cow::Owned(std::format!(
-                                    "UNKNOWN-VALUE:{}",
-                                    self.0
-                                )),
-                            }
-                        }
-
-                        /// Creates an enum value from the value name.
-                        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                            match name {
-                                "URL_TYPE_HINT_UNSPECIFIED" => {
-                                    std::option::Option::Some(Self::URL_TYPE_HINT_UNSPECIFIED)
+                        ///
+                        /// Returns `None` if the enum contains an unknown value deserialized from
+                        /// the integer representation of enums.
+                        pub fn name(&self) -> std::option::Option<&str> {
+                            match self {
+                                Self::Unspecified => {
+                                    std::option::Option::Some("URL_TYPE_HINT_UNSPECIFIED")
                                 }
-                                "AMP_ACTION" => std::option::Option::Some(Self::AMP_ACTION),
-                                "AMP_CONTENT" => std::option::Option::Some(Self::AMP_CONTENT),
-                                _ => std::option::Option::None,
+                                Self::AmpAction => std::option::Option::Some("AMP_ACTION"),
+                                Self::AmpContent => std::option::Option::Some("AMP_CONTENT"),
+                                Self::UnknownValue(u) => u.0.name(),
                             }
-                        }
-                    }
-
-                    impl std::convert::From<i32> for UrlTypeHint {
-                        fn from(value: i32) -> Self {
-                            Self::new(value)
                         }
                     }
 
                     impl std::default::Default for UrlTypeHint {
                         fn default() -> Self {
-                            Self::new(0)
+                            use std::convert::From;
+                            Self::from(0)
+                        }
+                    }
+
+                    impl std::fmt::Display for UrlTypeHint {
+                        fn fmt(
+                            &self,
+                            f: &mut std::fmt::Formatter<'_>,
+                        ) -> std::result::Result<(), std::fmt::Error> {
+                            wkt::internal::display_enum(f, self.name(), self.value())
+                        }
+                    }
+
+                    impl std::convert::From<i32> for UrlTypeHint {
+                        fn from(value: i32) -> Self {
+                            match value {
+                                0 => Self::Unspecified,
+                                1 => Self::AmpAction,
+                                2 => Self::AmpContent,
+                                _ => Self::UnknownValue(url_type_hint::UnknownValue(
+                                    wkt::internal::UnknownEnumValue::Integer(value),
+                                )),
+                            }
+                        }
+                    }
+
+                    impl std::convert::From<&str> for UrlTypeHint {
+                        fn from(value: &str) -> Self {
+                            use std::string::ToString;
+                            match value {
+                                "URL_TYPE_HINT_UNSPECIFIED" => Self::Unspecified,
+                                "AMP_ACTION" => Self::AmpAction,
+                                "AMP_CONTENT" => Self::AmpContent,
+                                _ => Self::UnknownValue(url_type_hint::UnknownValue(
+                                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                                )),
+                            }
+                        }
+                    }
+
+                    impl serde::ser::Serialize for UrlTypeHint {
+                        fn serialize<S>(
+                            &self,
+                            serializer: S,
+                        ) -> std::result::Result<S::Ok, S::Error>
+                        where
+                            S: serde::Serializer,
+                        {
+                            match self {
+                                Self::Unspecified => serializer.serialize_i32(0),
+                                Self::AmpAction => serializer.serialize_i32(1),
+                                Self::AmpContent => serializer.serialize_i32(2),
+                                Self::UnknownValue(u) => u.0.serialize(serializer),
+                            }
+                        }
+                    }
+
+                    impl<'de> serde::de::Deserialize<'de> for UrlTypeHint {
+                        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                        where
+                            D: serde::Deserializer<'de>,
+                        {
+                            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UrlTypeHint>::new(
+                                ".google.cloud.dialogflow.v2.Intent.Message.BrowseCarouselCard.BrowseCarouselCardItem.OpenUrlAction.UrlTypeHint"))
                         }
                     }
                 }
@@ -21107,81 +23312,147 @@ pub mod intent {
             /// Image display options for Actions on Google. This should be used for
             /// when the image's aspect ratio does not match the image container's
             /// aspect ratio.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ImageDisplayOptions(i32);
-
-            impl ImageDisplayOptions {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ImageDisplayOptions {
                 /// Fill the gaps between the image and the image container with gray
                 /// bars.
-                pub const IMAGE_DISPLAY_OPTIONS_UNSPECIFIED: ImageDisplayOptions =
-                    ImageDisplayOptions::new(0);
-
+                Unspecified,
                 /// Fill the gaps between the image and the image container with gray
                 /// bars.
-                pub const GRAY: ImageDisplayOptions = ImageDisplayOptions::new(1);
-
+                Gray,
                 /// Fill the gaps between the image and the image container with white
                 /// bars.
-                pub const WHITE: ImageDisplayOptions = ImageDisplayOptions::new(2);
-
+                White,
                 /// Image is scaled such that the image width and height match or exceed
                 /// the container dimensions. This may crop the top and bottom of the
                 /// image if the scaled image height is greater than the container
                 /// height, or crop the left and right of the image if the scaled image
                 /// width is greater than the container width. This is similar to "Zoom
                 /// Mode" on a widescreen TV when playing a 4:3 video.
-                pub const CROPPED: ImageDisplayOptions = ImageDisplayOptions::new(3);
-
+                Cropped,
                 /// Pad the gaps between image and image frame with a blurred copy of the
                 /// same image.
-                pub const BLURRED_BACKGROUND: ImageDisplayOptions = ImageDisplayOptions::new(4);
+                BlurredBackground,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ImageDisplayOptions::value] or
+                /// [ImageDisplayOptions::name].
+                UnknownValue(image_display_options::UnknownValue),
+            }
 
-                /// Creates a new ImageDisplayOptions instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod image_display_options {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl ImageDisplayOptions {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Gray => std::option::Option::Some(1),
+                        Self::White => std::option::Option::Some(2),
+                        Self::Cropped => std::option::Option::Some(3),
+                        Self::BlurredBackground => std::option::Option::Some(4),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("IMAGE_DISPLAY_OPTIONS_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("GRAY"),
-                        2 => std::borrow::Cow::Borrowed("WHITE"),
-                        3 => std::borrow::Cow::Borrowed("CROPPED"),
-                        4 => std::borrow::Cow::Borrowed("BLURRED_BACKGROUND"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "IMAGE_DISPLAY_OPTIONS_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::IMAGE_DISPLAY_OPTIONS_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("IMAGE_DISPLAY_OPTIONS_UNSPECIFIED")
                         }
-                        "GRAY" => std::option::Option::Some(Self::GRAY),
-                        "WHITE" => std::option::Option::Some(Self::WHITE),
-                        "CROPPED" => std::option::Option::Some(Self::CROPPED),
-                        "BLURRED_BACKGROUND" => std::option::Option::Some(Self::BLURRED_BACKGROUND),
-                        _ => std::option::Option::None,
+                        Self::Gray => std::option::Option::Some("GRAY"),
+                        Self::White => std::option::Option::Some("WHITE"),
+                        Self::Cropped => std::option::Option::Some("CROPPED"),
+                        Self::BlurredBackground => std::option::Option::Some("BLURRED_BACKGROUND"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for ImageDisplayOptions {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ImageDisplayOptions {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ImageDisplayOptions {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ImageDisplayOptions {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Gray,
+                        2 => Self::White,
+                        3 => Self::Cropped,
+                        4 => Self::BlurredBackground,
+                        _ => Self::UnknownValue(image_display_options::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ImageDisplayOptions {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "IMAGE_DISPLAY_OPTIONS_UNSPECIFIED" => Self::Unspecified,
+                        "GRAY" => Self::Gray,
+                        "WHITE" => Self::White,
+                        "CROPPED" => Self::Cropped,
+                        "BLURRED_BACKGROUND" => Self::BlurredBackground,
+                        _ => Self::UnknownValue(image_display_options::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ImageDisplayOptions {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Gray => serializer.serialize_i32(1),
+                        Self::White => serializer.serialize_i32(2),
+                        Self::Cropped => serializer.serialize_i32(3),
+                        Self::BlurredBackground => serializer.serialize_i32(4),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ImageDisplayOptions {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImageDisplayOptions>::new(
+                        ".google.cloud.dialogflow.v2.Intent.Message.BrowseCarouselCard.ImageDisplayOptions"))
                 }
             }
         }
@@ -21349,67 +23620,131 @@ pub mod intent {
             use super::*;
 
             /// Text alignments within a cell.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct HorizontalAlignment(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum HorizontalAlignment {
+                /// Text is aligned to the leading edge of the column.
+                Unspecified,
+                /// Text is aligned to the leading edge of the column.
+                Leading,
+                /// Text is centered in the column.
+                Center,
+                /// Text is aligned to the trailing edge of the column.
+                Trailing,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [HorizontalAlignment::value] or
+                /// [HorizontalAlignment::name].
+                UnknownValue(horizontal_alignment::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod horizontal_alignment {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl HorizontalAlignment {
-                /// Text is aligned to the leading edge of the column.
-                pub const HORIZONTAL_ALIGNMENT_UNSPECIFIED: HorizontalAlignment =
-                    HorizontalAlignment::new(0);
-
-                /// Text is aligned to the leading edge of the column.
-                pub const LEADING: HorizontalAlignment = HorizontalAlignment::new(1);
-
-                /// Text is centered in the column.
-                pub const CENTER: HorizontalAlignment = HorizontalAlignment::new(2);
-
-                /// Text is aligned to the trailing edge of the column.
-                pub const TRAILING: HorizontalAlignment = HorizontalAlignment::new(3);
-
-                /// Creates a new HorizontalAlignment instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Leading => std::option::Option::Some(1),
+                        Self::Center => std::option::Option::Some(2),
+                        Self::Trailing => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("HORIZONTAL_ALIGNMENT_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("LEADING"),
-                        2 => std::borrow::Cow::Borrowed("CENTER"),
-                        3 => std::borrow::Cow::Borrowed("TRAILING"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "HORIZONTAL_ALIGNMENT_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::HORIZONTAL_ALIGNMENT_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("HORIZONTAL_ALIGNMENT_UNSPECIFIED")
                         }
-                        "LEADING" => std::option::Option::Some(Self::LEADING),
-                        "CENTER" => std::option::Option::Some(Self::CENTER),
-                        "TRAILING" => std::option::Option::Some(Self::TRAILING),
-                        _ => std::option::Option::None,
+                        Self::Leading => std::option::Option::Some("LEADING"),
+                        Self::Center => std::option::Option::Some("CENTER"),
+                        Self::Trailing => std::option::Option::Some("TRAILING"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for HorizontalAlignment {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for HorizontalAlignment {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for HorizontalAlignment {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for HorizontalAlignment {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Leading,
+                        2 => Self::Center,
+                        3 => Self::Trailing,
+                        _ => Self::UnknownValue(horizontal_alignment::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for HorizontalAlignment {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "HORIZONTAL_ALIGNMENT_UNSPECIFIED" => Self::Unspecified,
+                        "LEADING" => Self::Leading,
+                        "CENTER" => Self::Center,
+                        "TRAILING" => Self::Trailing,
+                        _ => Self::UnknownValue(horizontal_alignment::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for HorizontalAlignment {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Leading => serializer.serialize_i32(1),
+                        Self::Center => serializer.serialize_i32(2),
+                        Self::Trailing => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for HorizontalAlignment {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<HorizontalAlignment>::new(
+                        ".google.cloud.dialogflow.v2.Intent.Message.ColumnProperties.HorizontalAlignment"))
                 }
             }
         }
@@ -21500,96 +23835,174 @@ pub mod intent {
 
         /// The rich response message integration platform. See
         /// [Integrations](https://cloud.google.com/dialogflow/docs/integrations).
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Platform(i32);
-
-        impl Platform {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Platform {
             /// Default platform.
-            pub const PLATFORM_UNSPECIFIED: Platform = Platform::new(0);
-
+            Unspecified,
             /// Facebook.
-            pub const FACEBOOK: Platform = Platform::new(1);
-
+            Facebook,
             /// Slack.
-            pub const SLACK: Platform = Platform::new(2);
-
+            Slack,
             /// Telegram.
-            pub const TELEGRAM: Platform = Platform::new(3);
-
+            Telegram,
             /// Kik.
-            pub const KIK: Platform = Platform::new(4);
-
+            Kik,
             /// Skype.
-            pub const SKYPE: Platform = Platform::new(5);
-
+            Skype,
             /// Line.
-            pub const LINE: Platform = Platform::new(6);
-
+            Line,
             /// Viber.
-            pub const VIBER: Platform = Platform::new(7);
-
+            Viber,
             /// Google Assistant
             /// See [Dialogflow webhook
             /// format](https://developers.google.com/assistant/actions/build/json/dialogflow-webhook-json)
-            pub const ACTIONS_ON_GOOGLE: Platform = Platform::new(8);
-
+            ActionsOnGoogle,
             /// Google Hangouts.
-            pub const GOOGLE_HANGOUTS: Platform = Platform::new(11);
+            GoogleHangouts,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Platform::value] or
+            /// [Platform::name].
+            UnknownValue(platform::UnknownValue),
+        }
 
-            /// Creates a new Platform instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod platform {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Platform {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Facebook => std::option::Option::Some(1),
+                    Self::Slack => std::option::Option::Some(2),
+                    Self::Telegram => std::option::Option::Some(3),
+                    Self::Kik => std::option::Option::Some(4),
+                    Self::Skype => std::option::Option::Some(5),
+                    Self::Line => std::option::Option::Some(6),
+                    Self::Viber => std::option::Option::Some(7),
+                    Self::ActionsOnGoogle => std::option::Option::Some(8),
+                    Self::GoogleHangouts => std::option::Option::Some(11),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PLATFORM_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("FACEBOOK"),
-                    2 => std::borrow::Cow::Borrowed("SLACK"),
-                    3 => std::borrow::Cow::Borrowed("TELEGRAM"),
-                    4 => std::borrow::Cow::Borrowed("KIK"),
-                    5 => std::borrow::Cow::Borrowed("SKYPE"),
-                    6 => std::borrow::Cow::Borrowed("LINE"),
-                    7 => std::borrow::Cow::Borrowed("VIBER"),
-                    8 => std::borrow::Cow::Borrowed("ACTIONS_ON_GOOGLE"),
-                    11 => std::borrow::Cow::Borrowed("GOOGLE_HANGOUTS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PLATFORM_UNSPECIFIED"),
+                    Self::Facebook => std::option::Option::Some("FACEBOOK"),
+                    Self::Slack => std::option::Option::Some("SLACK"),
+                    Self::Telegram => std::option::Option::Some("TELEGRAM"),
+                    Self::Kik => std::option::Option::Some("KIK"),
+                    Self::Skype => std::option::Option::Some("SKYPE"),
+                    Self::Line => std::option::Option::Some("LINE"),
+                    Self::Viber => std::option::Option::Some("VIBER"),
+                    Self::ActionsOnGoogle => std::option::Option::Some("ACTIONS_ON_GOOGLE"),
+                    Self::GoogleHangouts => std::option::Option::Some("GOOGLE_HANGOUTS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PLATFORM_UNSPECIFIED" => std::option::Option::Some(Self::PLATFORM_UNSPECIFIED),
-                    "FACEBOOK" => std::option::Option::Some(Self::FACEBOOK),
-                    "SLACK" => std::option::Option::Some(Self::SLACK),
-                    "TELEGRAM" => std::option::Option::Some(Self::TELEGRAM),
-                    "KIK" => std::option::Option::Some(Self::KIK),
-                    "SKYPE" => std::option::Option::Some(Self::SKYPE),
-                    "LINE" => std::option::Option::Some(Self::LINE),
-                    "VIBER" => std::option::Option::Some(Self::VIBER),
-                    "ACTIONS_ON_GOOGLE" => std::option::Option::Some(Self::ACTIONS_ON_GOOGLE),
-                    "GOOGLE_HANGOUTS" => std::option::Option::Some(Self::GOOGLE_HANGOUTS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Platform {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Platform {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Platform {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Platform {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Facebook,
+                    2 => Self::Slack,
+                    3 => Self::Telegram,
+                    4 => Self::Kik,
+                    5 => Self::Skype,
+                    6 => Self::Line,
+                    7 => Self::Viber,
+                    8 => Self::ActionsOnGoogle,
+                    11 => Self::GoogleHangouts,
+                    _ => Self::UnknownValue(platform::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Platform {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PLATFORM_UNSPECIFIED" => Self::Unspecified,
+                    "FACEBOOK" => Self::Facebook,
+                    "SLACK" => Self::Slack,
+                    "TELEGRAM" => Self::Telegram,
+                    "KIK" => Self::Kik,
+                    "SKYPE" => Self::Skype,
+                    "LINE" => Self::Line,
+                    "VIBER" => Self::Viber,
+                    "ACTIONS_ON_GOOGLE" => Self::ActionsOnGoogle,
+                    "GOOGLE_HANGOUTS" => Self::GoogleHangouts,
+                    _ => Self::UnknownValue(platform::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Platform {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Facebook => serializer.serialize_i32(1),
+                    Self::Slack => serializer.serialize_i32(2),
+                    Self::Telegram => serializer.serialize_i32(3),
+                    Self::Kik => serializer.serialize_i32(4),
+                    Self::Skype => serializer.serialize_i32(5),
+                    Self::Line => serializer.serialize_i32(6),
+                    Self::Viber => serializer.serialize_i32(7),
+                    Self::ActionsOnGoogle => serializer.serialize_i32(8),
+                    Self::GoogleHangouts => serializer.serialize_i32(11),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Platform {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Platform>::new(
+                    ".google.cloud.dialogflow.v2.Intent.Message.Platform",
+                ))
             }
         }
 
@@ -21680,64 +24093,123 @@ pub mod intent {
     }
 
     /// Represents the different states that webhooks can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WebhookState(i32);
-
-    impl WebhookState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WebhookState {
         /// Webhook is disabled in the agent and in the intent.
-        pub const WEBHOOK_STATE_UNSPECIFIED: WebhookState = WebhookState::new(0);
-
+        Unspecified,
         /// Webhook is enabled in the agent and in the intent.
-        pub const WEBHOOK_STATE_ENABLED: WebhookState = WebhookState::new(1);
-
+        Enabled,
         /// Webhook is enabled in the agent and in the intent. Also, each slot
         /// filling prompt is forwarded to the webhook.
-        pub const WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING: WebhookState = WebhookState::new(2);
+        EnabledForSlotFilling,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WebhookState::value] or
+        /// [WebhookState::name].
+        UnknownValue(webhook_state::UnknownValue),
+    }
 
-        /// Creates a new WebhookState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod webhook_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl WebhookState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::EnabledForSlotFilling => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WEBHOOK_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WEBHOOK_STATE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WEBHOOK_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WEBHOOK_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WEBHOOK_STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("WEBHOOK_STATE_ENABLED"),
+                Self::EnabledForSlotFilling => {
+                    std::option::Option::Some("WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING")
                 }
-                "WEBHOOK_STATE_ENABLED" => std::option::Option::Some(Self::WEBHOOK_STATE_ENABLED),
-                "WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING" => {
-                    std::option::Option::Some(Self::WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for WebhookState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WebhookState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WebhookState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WebhookState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::EnabledForSlotFilling,
+                _ => Self::UnknownValue(webhook_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WebhookState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WEBHOOK_STATE_UNSPECIFIED" => Self::Unspecified,
+                "WEBHOOK_STATE_ENABLED" => Self::Enabled,
+                "WEBHOOK_STATE_ENABLED_FOR_SLOT_FILLING" => Self::EnabledForSlotFilling,
+                _ => Self::UnknownValue(webhook_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WebhookState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::EnabledForSlotFilling => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WebhookState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WebhookState>::new(
+                ".google.cloud.dialogflow.v2.Intent.WebhookState",
+            ))
         }
     }
 }
@@ -22923,7 +25395,7 @@ pub struct Participant {
     ///
     /// [google.cloud.dialogflow.v2.AnalyzeContentRequest.participant]: crate::model::AnalyzeContentRequest::participant
     /// [google.cloud.dialogflow.v2.CreateParticipantRequest.participant]: crate::model::CreateParticipantRequest::participant
-    /// [google.cloud.dialogflow.v2.Participant.Role.END_USER]: crate::model::participant::role::END_USER
+    /// [google.cloud.dialogflow.v2.Participant.Role.END_USER]: crate::model::participant::Role::EndUser
     /// [google.cloud.dialogflow.v2.Participant.obfuscated_external_user_id]: crate::model::Participant::obfuscated_external_user_id
     /// [google.cloud.dialogflow.v2.StreamingAnalyzeContentRequest.participant]: crate::model::StreamingAnalyzeContentRequest::participant
     /// [google.cloud.dialogflow.v2.UpdateParticipantRequest.participant]: crate::model::UpdateParticipantRequest::participant
@@ -23022,65 +25494,128 @@ pub mod participant {
     use super::*;
 
     /// Enumeration of the roles a participant can play in a conversation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
-
-    impl Role {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
         /// Participant role not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
+        Unspecified,
         /// Participant is a human agent.
-        pub const HUMAN_AGENT: Role = Role::new(1);
-
+        HumanAgent,
         /// Participant is an automated agent, such as a Dialogflow agent.
-        pub const AUTOMATED_AGENT: Role = Role::new(2);
-
+        AutomatedAgent,
         /// Participant is an end user that has called or chatted with
         /// Dialogflow services.
-        pub const END_USER: Role = Role::new(3);
+        EndUser,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
 
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Role {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HumanAgent => std::option::Option::Some(1),
+                Self::AutomatedAgent => std::option::Option::Some(2),
+                Self::EndUser => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HUMAN_AGENT"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT"),
-                3 => std::borrow::Cow::Borrowed("END_USER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::HumanAgent => std::option::Option::Some("HUMAN_AGENT"),
+                Self::AutomatedAgent => std::option::Option::Some("AUTOMATED_AGENT"),
+                Self::EndUser => std::option::Option::Some("END_USER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "HUMAN_AGENT" => std::option::Option::Some(Self::HUMAN_AGENT),
-                "AUTOMATED_AGENT" => std::option::Option::Some(Self::AUTOMATED_AGENT),
-                "END_USER" => std::option::Option::Some(Self::END_USER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HumanAgent,
+                2 => Self::AutomatedAgent,
+                3 => Self::EndUser,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "HUMAN_AGENT" => Self::HumanAgent,
+                "AUTOMATED_AGENT" => Self::AutomatedAgent,
+                "END_USER" => Self::EndUser,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HumanAgent => serializer.serialize_i32(1),
+                Self::AutomatedAgent => serializer.serialize_i32(2),
+                Self::EndUser => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.dialogflow.v2.Participant.Role",
+            ))
         }
     }
 }
@@ -24060,8 +26595,8 @@ pub struct StreamingAnalyzeContentRequest {
     /// You can find more details in
     /// <https://cloud.google.com/agent-assist/docs/extended-streaming>
     ///
-    /// [google.cloud.dialogflow.v2.AudioEncoding.AUDIO_ENCODING_LINEAR_16]: crate::model::audio_encoding::AUDIO_ENCODING_LINEAR_16
-    /// [google.cloud.dialogflow.v2.AudioEncoding.AUDIO_ENCODING_MULAW]: crate::model::audio_encoding::AUDIO_ENCODING_MULAW
+    /// [google.cloud.dialogflow.v2.AudioEncoding.AUDIO_ENCODING_LINEAR_16]: crate::model::AudioEncoding::Linear16
+    /// [google.cloud.dialogflow.v2.AudioEncoding.AUDIO_ENCODING_MULAW]: crate::model::AudioEncoding::Mulaw
     /// [google.cloud.dialogflow.v2.Conversations.CreateConversation]: crate::client::Conversations::create_conversation
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub enable_extended_streaming: bool,
@@ -25371,64 +27906,126 @@ pub mod automated_agent_reply {
     use super::*;
 
     /// Represents different automated agent reply types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutomatedAgentReplyType(i32);
-
-    impl AutomatedAgentReplyType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AutomatedAgentReplyType {
         /// Not specified. This should never happen.
-        pub const AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED: AutomatedAgentReplyType =
-            AutomatedAgentReplyType::new(0);
-
+        Unspecified,
         /// Partial reply. e.g. Aggregated responses in a `Fulfillment` that enables
         /// `return_partial_response` can be returned as partial reply.
         /// WARNING: partial reply is not eligible for barge-in.
-        pub const PARTIAL: AutomatedAgentReplyType = AutomatedAgentReplyType::new(1);
-
+        Partial,
         /// Final reply.
-        pub const FINAL: AutomatedAgentReplyType = AutomatedAgentReplyType::new(2);
+        Final,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AutomatedAgentReplyType::value] or
+        /// [AutomatedAgentReplyType::name].
+        UnknownValue(automated_agent_reply_type::UnknownValue),
+    }
 
-        /// Creates a new AutomatedAgentReplyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod automated_agent_reply_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AutomatedAgentReplyType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Partial => std::option::Option::Some(1),
+                Self::Final => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PARTIAL"),
-                2 => std::borrow::Cow::Borrowed("FINAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED")
                 }
-                "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
-                "FINAL" => std::option::Option::Some(Self::FINAL),
-                _ => std::option::Option::None,
+                Self::Partial => std::option::Option::Some("PARTIAL"),
+                Self::Final => std::option::Option::Some("FINAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for AutomatedAgentReplyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AutomatedAgentReplyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AutomatedAgentReplyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AutomatedAgentReplyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Partial,
+                2 => Self::Final,
+                _ => Self::UnknownValue(automated_agent_reply_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AutomatedAgentReplyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTOMATED_AGENT_REPLY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PARTIAL" => Self::Partial,
+                "FINAL" => Self::Final,
+                _ => Self::UnknownValue(automated_agent_reply_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AutomatedAgentReplyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Partial => serializer.serialize_i32(1),
+                Self::Final => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AutomatedAgentReplyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<AutomatedAgentReplyType>::new(
+                    ".google.cloud.dialogflow.v2.AutomatedAgentReply.AutomatedAgentReplyType",
+                ),
+            )
         }
     }
 }
@@ -28606,16 +31203,13 @@ pub mod streaming_recognition_result {
     use super::*;
 
     /// Type of the response message.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageType(i32);
-
-    impl MessageType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MessageType {
         /// Not specified. Should never be used.
-        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType = MessageType::new(0);
-
+        Unspecified,
         /// Message contains a (possibly partial) transcript.
-        pub const TRANSCRIPT: MessageType = MessageType::new(1);
-
+        Transcript,
         /// This event indicates that the server has detected the end of the user's
         /// speech utterance and expects no additional inputs.
         /// Therefore, the server will not process additional audio (although it may
@@ -28624,52 +31218,112 @@ pub mod streaming_recognition_result {
         /// additional results until the server closes the gRPC connection. This
         /// message is only sent if `single_utterance` was set to `true`, and is not
         /// used otherwise.
-        pub const END_OF_SINGLE_UTTERANCE: MessageType = MessageType::new(2);
+        EndOfSingleUtterance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MessageType::value] or
+        /// [MessageType::name].
+        UnknownValue(message_type::UnknownValue),
+    }
 
-        /// Creates a new MessageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod message_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MessageType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Transcript => std::option::Option::Some(1),
+                Self::EndOfSingleUtterance => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MESSAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRANSCRIPT"),
-                2 => std::borrow::Cow::Borrowed("END_OF_SINGLE_UTTERANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MESSAGE_TYPE_UNSPECIFIED"),
+                Self::Transcript => std::option::Option::Some("TRANSCRIPT"),
+                Self::EndOfSingleUtterance => std::option::Option::Some("END_OF_SINGLE_UTTERANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MESSAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MESSAGE_TYPE_UNSPECIFIED)
-                }
-                "TRANSCRIPT" => std::option::Option::Some(Self::TRANSCRIPT),
-                "END_OF_SINGLE_UTTERANCE" => {
-                    std::option::Option::Some(Self::END_OF_SINGLE_UTTERANCE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MessageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MessageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MessageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Transcript,
+                2 => Self::EndOfSingleUtterance,
+                _ => Self::UnknownValue(message_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MessageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MESSAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TRANSCRIPT" => Self::Transcript,
+                "END_OF_SINGLE_UTTERANCE" => Self::EndOfSingleUtterance,
+                _ => Self::UnknownValue(message_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MessageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Transcript => serializer.serialize_i32(1),
+                Self::EndOfSingleUtterance => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MessageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MessageType>::new(
+                ".google.cloud.dialogflow.v2.StreamingRecognitionResult.MessageType",
+            ))
         }
     }
 }
@@ -29024,17 +31678,14 @@ pub mod session_entity_type {
     use super::*;
 
     /// The types of modifications for a session entity type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EntityOverrideMode(i32);
-
-    impl EntityOverrideMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EntityOverrideMode {
         /// Not specified. This value should be never used.
-        pub const ENTITY_OVERRIDE_MODE_UNSPECIFIED: EntityOverrideMode = EntityOverrideMode::new(0);
-
+        Unspecified,
         /// The collection of session entities overrides the collection of entities
         /// in the corresponding custom entity type.
-        pub const ENTITY_OVERRIDE_MODE_OVERRIDE: EntityOverrideMode = EntityOverrideMode::new(1);
-
+        Override,
         /// The collection of session entities extends the collection of entities in
         /// the corresponding custom entity type.
         ///
@@ -29047,54 +31698,112 @@ pub mod session_entity_type {
         /// on the custom entity type and merge.
         ///
         /// [google.cloud.dialogflow.v2.EntityTypes.GetEntityType]: crate::client::EntityTypes::get_entity_type
-        pub const ENTITY_OVERRIDE_MODE_SUPPLEMENT: EntityOverrideMode = EntityOverrideMode::new(2);
+        Supplement,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EntityOverrideMode::value] or
+        /// [EntityOverrideMode::name].
+        UnknownValue(entity_override_mode::UnknownValue),
+    }
 
-        /// Creates a new EntityOverrideMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod entity_override_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EntityOverrideMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Override => std::option::Option::Some(1),
+                Self::Supplement => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_OVERRIDE"),
-                2 => std::borrow::Cow::Borrowed("ENTITY_OVERRIDE_MODE_SUPPLEMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENTITY_OVERRIDE_MODE_UNSPECIFIED"),
+                Self::Override => std::option::Option::Some("ENTITY_OVERRIDE_MODE_OVERRIDE"),
+                Self::Supplement => std::option::Option::Some("ENTITY_OVERRIDE_MODE_SUPPLEMENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENTITY_OVERRIDE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_UNSPECIFIED)
-                }
-                "ENTITY_OVERRIDE_MODE_OVERRIDE" => {
-                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_OVERRIDE)
-                }
-                "ENTITY_OVERRIDE_MODE_SUPPLEMENT" => {
-                    std::option::Option::Some(Self::ENTITY_OVERRIDE_MODE_SUPPLEMENT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EntityOverrideMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EntityOverrideMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EntityOverrideMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EntityOverrideMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Override,
+                2 => Self::Supplement,
+                _ => Self::UnknownValue(entity_override_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EntityOverrideMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENTITY_OVERRIDE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ENTITY_OVERRIDE_MODE_OVERRIDE" => Self::Override,
+                "ENTITY_OVERRIDE_MODE_SUPPLEMENT" => Self::Supplement,
+                _ => Self::UnknownValue(entity_override_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EntityOverrideMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Override => serializer.serialize_i32(1),
+                Self::Supplement => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EntityOverrideMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EntityOverrideMode>::new(
+                ".google.cloud.dialogflow.v2.SessionEntityType.EntityOverrideMode",
+            ))
         }
     }
 }
@@ -29494,69 +32203,134 @@ pub mod validation_error {
     use super::*;
 
     /// Represents a level of severity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Not specified. This value should never be used.
+        Unspecified,
+        /// The agent doesn't follow Dialogflow best practices.
+        Info,
+        /// The agent may not behave as expected.
+        Warning,
+        /// The agent may experience partial failures.
+        Error,
+        /// The agent may completely fail.
+        Critical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Not specified. This value should never be used.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// The agent doesn't follow Dialogflow best practices.
-        pub const INFO: Severity = Severity::new(1);
-
-        /// The agent may not behave as expected.
-        pub const WARNING: Severity = Severity::new(2);
-
-        /// The agent may experience partial failures.
-        pub const ERROR: Severity = Severity::new(3);
-
-        /// The agent may completely fail.
-        pub const CRITICAL: Severity = Severity::new(4);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Info => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::Critical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INFO"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                4 => std::borrow::Cow::Borrowed("CRITICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Info,
+                2 => Self::Warning,
+                3 => Self::Error,
+                4 => Self::Critical,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "INFO" => Self::Info,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                "CRITICAL" => Self::Critical,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Info => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::Critical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.dialogflow.v2.ValidationError.Severity",
+            ))
         }
     }
 }
@@ -29706,66 +32480,127 @@ pub mod version {
     use super::*;
 
     /// The status of a version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionStatus(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VersionStatus {
+        /// Not specified. This value is not used.
+        Unspecified,
+        /// Version is not ready to serve (e.g. training is in progress).
+        InProgress,
+        /// Version is ready to serve.
+        Ready,
+        /// Version training failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VersionStatus::value] or
+        /// [VersionStatus::name].
+        UnknownValue(version_status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod version_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VersionStatus {
-        /// Not specified. This value is not used.
-        pub const VERSION_STATUS_UNSPECIFIED: VersionStatus = VersionStatus::new(0);
-
-        /// Version is not ready to serve (e.g. training is in progress).
-        pub const IN_PROGRESS: VersionStatus = VersionStatus::new(1);
-
-        /// Version is ready to serve.
-        pub const READY: VersionStatus = VersionStatus::new(2);
-
-        /// Version training failed.
-        pub const FAILED: VersionStatus = VersionStatus::new(3);
-
-        /// Creates a new VersionStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VERSION_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VERSION_STATUS_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VERSION_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VERSION_STATUS_UNSPECIFIED)
-                }
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "READY" => std::option::Option::Some(Self::READY),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VersionStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VersionStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VersionStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Ready,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(version_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VersionStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VERSION_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "READY" => Self::Ready,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(version_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VersionStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VersionStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionStatus>::new(
+                ".google.cloud.dialogflow.v2.Version.VersionStatus",
+            ))
         }
     }
 }
@@ -30411,131 +33246,218 @@ impl wkt::message::Message for OriginalDetectIntentRequest {
 
 /// [DTMF](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling)
 /// digit in Telephony Gateway.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TelephonyDtmf(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TelephonyDtmf {
+    /// Not specified. This value may be used to indicate an absent digit.
+    Unspecified,
+    /// Number: '1'.
+    DtmfOne,
+    /// Number: '2'.
+    DtmfTwo,
+    /// Number: '3'.
+    DtmfThree,
+    /// Number: '4'.
+    DtmfFour,
+    /// Number: '5'.
+    DtmfFive,
+    /// Number: '6'.
+    DtmfSix,
+    /// Number: '7'.
+    DtmfSeven,
+    /// Number: '8'.
+    DtmfEight,
+    /// Number: '9'.
+    DtmfNine,
+    /// Number: '0'.
+    DtmfZero,
+    /// Letter: 'A'.
+    DtmfA,
+    /// Letter: 'B'.
+    DtmfB,
+    /// Letter: 'C'.
+    DtmfC,
+    /// Letter: 'D'.
+    DtmfD,
+    /// Asterisk/star: '*'.
+    DtmfStar,
+    /// Pound/diamond/hash/square/gate/octothorpe: '#'.
+    DtmfPound,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TelephonyDtmf::value] or
+    /// [TelephonyDtmf::name].
+    UnknownValue(telephony_dtmf::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod telephony_dtmf {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TelephonyDtmf {
-    /// Not specified. This value may be used to indicate an absent digit.
-    pub const TELEPHONY_DTMF_UNSPECIFIED: TelephonyDtmf = TelephonyDtmf::new(0);
-
-    /// Number: '1'.
-    pub const DTMF_ONE: TelephonyDtmf = TelephonyDtmf::new(1);
-
-    /// Number: '2'.
-    pub const DTMF_TWO: TelephonyDtmf = TelephonyDtmf::new(2);
-
-    /// Number: '3'.
-    pub const DTMF_THREE: TelephonyDtmf = TelephonyDtmf::new(3);
-
-    /// Number: '4'.
-    pub const DTMF_FOUR: TelephonyDtmf = TelephonyDtmf::new(4);
-
-    /// Number: '5'.
-    pub const DTMF_FIVE: TelephonyDtmf = TelephonyDtmf::new(5);
-
-    /// Number: '6'.
-    pub const DTMF_SIX: TelephonyDtmf = TelephonyDtmf::new(6);
-
-    /// Number: '7'.
-    pub const DTMF_SEVEN: TelephonyDtmf = TelephonyDtmf::new(7);
-
-    /// Number: '8'.
-    pub const DTMF_EIGHT: TelephonyDtmf = TelephonyDtmf::new(8);
-
-    /// Number: '9'.
-    pub const DTMF_NINE: TelephonyDtmf = TelephonyDtmf::new(9);
-
-    /// Number: '0'.
-    pub const DTMF_ZERO: TelephonyDtmf = TelephonyDtmf::new(10);
-
-    /// Letter: 'A'.
-    pub const DTMF_A: TelephonyDtmf = TelephonyDtmf::new(11);
-
-    /// Letter: 'B'.
-    pub const DTMF_B: TelephonyDtmf = TelephonyDtmf::new(12);
-
-    /// Letter: 'C'.
-    pub const DTMF_C: TelephonyDtmf = TelephonyDtmf::new(13);
-
-    /// Letter: 'D'.
-    pub const DTMF_D: TelephonyDtmf = TelephonyDtmf::new(14);
-
-    /// Asterisk/star: '*'.
-    pub const DTMF_STAR: TelephonyDtmf = TelephonyDtmf::new(15);
-
-    /// Pound/diamond/hash/square/gate/octothorpe: '#'.
-    pub const DTMF_POUND: TelephonyDtmf = TelephonyDtmf::new(16);
-
-    /// Creates a new TelephonyDtmf instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::DtmfOne => std::option::Option::Some(1),
+            Self::DtmfTwo => std::option::Option::Some(2),
+            Self::DtmfThree => std::option::Option::Some(3),
+            Self::DtmfFour => std::option::Option::Some(4),
+            Self::DtmfFive => std::option::Option::Some(5),
+            Self::DtmfSix => std::option::Option::Some(6),
+            Self::DtmfSeven => std::option::Option::Some(7),
+            Self::DtmfEight => std::option::Option::Some(8),
+            Self::DtmfNine => std::option::Option::Some(9),
+            Self::DtmfZero => std::option::Option::Some(10),
+            Self::DtmfA => std::option::Option::Some(11),
+            Self::DtmfB => std::option::Option::Some(12),
+            Self::DtmfC => std::option::Option::Some(13),
+            Self::DtmfD => std::option::Option::Some(14),
+            Self::DtmfStar => std::option::Option::Some(15),
+            Self::DtmfPound => std::option::Option::Some(16),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TELEPHONY_DTMF_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DTMF_ONE"),
-            2 => std::borrow::Cow::Borrowed("DTMF_TWO"),
-            3 => std::borrow::Cow::Borrowed("DTMF_THREE"),
-            4 => std::borrow::Cow::Borrowed("DTMF_FOUR"),
-            5 => std::borrow::Cow::Borrowed("DTMF_FIVE"),
-            6 => std::borrow::Cow::Borrowed("DTMF_SIX"),
-            7 => std::borrow::Cow::Borrowed("DTMF_SEVEN"),
-            8 => std::borrow::Cow::Borrowed("DTMF_EIGHT"),
-            9 => std::borrow::Cow::Borrowed("DTMF_NINE"),
-            10 => std::borrow::Cow::Borrowed("DTMF_ZERO"),
-            11 => std::borrow::Cow::Borrowed("DTMF_A"),
-            12 => std::borrow::Cow::Borrowed("DTMF_B"),
-            13 => std::borrow::Cow::Borrowed("DTMF_C"),
-            14 => std::borrow::Cow::Borrowed("DTMF_D"),
-            15 => std::borrow::Cow::Borrowed("DTMF_STAR"),
-            16 => std::borrow::Cow::Borrowed("DTMF_POUND"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TELEPHONY_DTMF_UNSPECIFIED"),
+            Self::DtmfOne => std::option::Option::Some("DTMF_ONE"),
+            Self::DtmfTwo => std::option::Option::Some("DTMF_TWO"),
+            Self::DtmfThree => std::option::Option::Some("DTMF_THREE"),
+            Self::DtmfFour => std::option::Option::Some("DTMF_FOUR"),
+            Self::DtmfFive => std::option::Option::Some("DTMF_FIVE"),
+            Self::DtmfSix => std::option::Option::Some("DTMF_SIX"),
+            Self::DtmfSeven => std::option::Option::Some("DTMF_SEVEN"),
+            Self::DtmfEight => std::option::Option::Some("DTMF_EIGHT"),
+            Self::DtmfNine => std::option::Option::Some("DTMF_NINE"),
+            Self::DtmfZero => std::option::Option::Some("DTMF_ZERO"),
+            Self::DtmfA => std::option::Option::Some("DTMF_A"),
+            Self::DtmfB => std::option::Option::Some("DTMF_B"),
+            Self::DtmfC => std::option::Option::Some("DTMF_C"),
+            Self::DtmfD => std::option::Option::Some("DTMF_D"),
+            Self::DtmfStar => std::option::Option::Some("DTMF_STAR"),
+            Self::DtmfPound => std::option::Option::Some("DTMF_POUND"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TELEPHONY_DTMF_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TELEPHONY_DTMF_UNSPECIFIED)
-            }
-            "DTMF_ONE" => std::option::Option::Some(Self::DTMF_ONE),
-            "DTMF_TWO" => std::option::Option::Some(Self::DTMF_TWO),
-            "DTMF_THREE" => std::option::Option::Some(Self::DTMF_THREE),
-            "DTMF_FOUR" => std::option::Option::Some(Self::DTMF_FOUR),
-            "DTMF_FIVE" => std::option::Option::Some(Self::DTMF_FIVE),
-            "DTMF_SIX" => std::option::Option::Some(Self::DTMF_SIX),
-            "DTMF_SEVEN" => std::option::Option::Some(Self::DTMF_SEVEN),
-            "DTMF_EIGHT" => std::option::Option::Some(Self::DTMF_EIGHT),
-            "DTMF_NINE" => std::option::Option::Some(Self::DTMF_NINE),
-            "DTMF_ZERO" => std::option::Option::Some(Self::DTMF_ZERO),
-            "DTMF_A" => std::option::Option::Some(Self::DTMF_A),
-            "DTMF_B" => std::option::Option::Some(Self::DTMF_B),
-            "DTMF_C" => std::option::Option::Some(Self::DTMF_C),
-            "DTMF_D" => std::option::Option::Some(Self::DTMF_D),
-            "DTMF_STAR" => std::option::Option::Some(Self::DTMF_STAR),
-            "DTMF_POUND" => std::option::Option::Some(Self::DTMF_POUND),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TelephonyDtmf {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TelephonyDtmf {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TelephonyDtmf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TelephonyDtmf {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::DtmfOne,
+            2 => Self::DtmfTwo,
+            3 => Self::DtmfThree,
+            4 => Self::DtmfFour,
+            5 => Self::DtmfFive,
+            6 => Self::DtmfSix,
+            7 => Self::DtmfSeven,
+            8 => Self::DtmfEight,
+            9 => Self::DtmfNine,
+            10 => Self::DtmfZero,
+            11 => Self::DtmfA,
+            12 => Self::DtmfB,
+            13 => Self::DtmfC,
+            14 => Self::DtmfD,
+            15 => Self::DtmfStar,
+            16 => Self::DtmfPound,
+            _ => Self::UnknownValue(telephony_dtmf::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TelephonyDtmf {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TELEPHONY_DTMF_UNSPECIFIED" => Self::Unspecified,
+            "DTMF_ONE" => Self::DtmfOne,
+            "DTMF_TWO" => Self::DtmfTwo,
+            "DTMF_THREE" => Self::DtmfThree,
+            "DTMF_FOUR" => Self::DtmfFour,
+            "DTMF_FIVE" => Self::DtmfFive,
+            "DTMF_SIX" => Self::DtmfSix,
+            "DTMF_SEVEN" => Self::DtmfSeven,
+            "DTMF_EIGHT" => Self::DtmfEight,
+            "DTMF_NINE" => Self::DtmfNine,
+            "DTMF_ZERO" => Self::DtmfZero,
+            "DTMF_A" => Self::DtmfA,
+            "DTMF_B" => Self::DtmfB,
+            "DTMF_C" => Self::DtmfC,
+            "DTMF_D" => Self::DtmfD,
+            "DTMF_STAR" => Self::DtmfStar,
+            "DTMF_POUND" => Self::DtmfPound,
+            _ => Self::UnknownValue(telephony_dtmf::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TelephonyDtmf {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::DtmfOne => serializer.serialize_i32(1),
+            Self::DtmfTwo => serializer.serialize_i32(2),
+            Self::DtmfThree => serializer.serialize_i32(3),
+            Self::DtmfFour => serializer.serialize_i32(4),
+            Self::DtmfFive => serializer.serialize_i32(5),
+            Self::DtmfSix => serializer.serialize_i32(6),
+            Self::DtmfSeven => serializer.serialize_i32(7),
+            Self::DtmfEight => serializer.serialize_i32(8),
+            Self::DtmfNine => serializer.serialize_i32(9),
+            Self::DtmfZero => serializer.serialize_i32(10),
+            Self::DtmfA => serializer.serialize_i32(11),
+            Self::DtmfB => serializer.serialize_i32(12),
+            Self::DtmfC => serializer.serialize_i32(13),
+            Self::DtmfD => serializer.serialize_i32(14),
+            Self::DtmfStar => serializer.serialize_i32(15),
+            Self::DtmfPound => serializer.serialize_i32(16),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TelephonyDtmf {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TelephonyDtmf>::new(
+            ".google.cloud.dialogflow.v2.TelephonyDtmf",
+        ))
     }
 }
 
@@ -30544,37 +33466,29 @@ impl std::default::Default for TelephonyDtmf {
 /// [Cloud Speech API
 /// documentation](https://cloud.google.com/speech-to-text/docs/basics) for more
 /// details.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AudioEncoding(i32);
-
-impl AudioEncoding {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AudioEncoding {
     /// Not specified.
-    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
-
+    Unspecified,
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
-    pub const AUDIO_ENCODING_LINEAR_16: AudioEncoding = AudioEncoding::new(1);
-
+    Linear16,
     /// [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
     /// Codec) is the recommended encoding because it is lossless (therefore
     /// recognition is not compromised) and requires only about half the
     /// bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
     /// 24-bit samples, however, not all fields in `STREAMINFO` are supported.
-    pub const AUDIO_ENCODING_FLAC: AudioEncoding = AudioEncoding::new(2);
-
+    Flac,
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const AUDIO_ENCODING_MULAW: AudioEncoding = AudioEncoding::new(3);
-
+    Mulaw,
     /// Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
-    pub const AUDIO_ENCODING_AMR: AudioEncoding = AudioEncoding::new(4);
-
+    Amr,
     /// Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_AMR_WB: AudioEncoding = AudioEncoding::new(5);
-
+    AmrWb,
     /// Opus encoded audio frames in Ogg container
     /// ([OggOpus](https://wiki.xiph.org/OggOpus)).
     /// `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_OGG_OPUS: AudioEncoding = AudioEncoding::new(6);
-
+    OggOpus,
     /// Although the use of lossy encodings is not recommended, if a very low
     /// bitrate encoding is required, `OGG_OPUS` is highly preferred over
     /// Speex encoding. The [Speex](https://speex.org/) encoding supported by
@@ -30588,67 +33502,146 @@ impl AudioEncoding {
     /// bytes (octets) as specified in RFC 5574. In other words, each RTP header
     /// is replaced with a single byte containing the block length. Only Speex
     /// wideband is supported. `sample_rate_hertz` must be 16000.
-    pub const AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE: AudioEncoding = AudioEncoding::new(7);
-
+    SpeexWithHeaderByte,
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const AUDIO_ENCODING_ALAW: AudioEncoding = AudioEncoding::new(8);
+    Alaw,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AudioEncoding::value] or
+    /// [AudioEncoding::name].
+    UnknownValue(audio_encoding::UnknownValue),
+}
 
-    /// Creates a new AudioEncoding instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod audio_encoding {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AudioEncoding {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linear16 => std::option::Option::Some(1),
+            Self::Flac => std::option::Option::Some(2),
+            Self::Mulaw => std::option::Option::Some(3),
+            Self::Amr => std::option::Option::Some(4),
+            Self::AmrWb => std::option::Option::Some(5),
+            Self::OggOpus => std::option::Option::Some(6),
+            Self::SpeexWithHeaderByte => std::option::Option::Some(7),
+            Self::Alaw => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_LINEAR_16"),
-            2 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_FLAC"),
-            3 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_MULAW"),
-            4 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR"),
-            5 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_AMR_WB"),
-            6 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_OGG_OPUS"),
-            7 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE"),
-            8 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_ALAW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUDIO_ENCODING_UNSPECIFIED" => {
-                std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AUDIO_ENCODING_UNSPECIFIED"),
+            Self::Linear16 => std::option::Option::Some("AUDIO_ENCODING_LINEAR_16"),
+            Self::Flac => std::option::Option::Some("AUDIO_ENCODING_FLAC"),
+            Self::Mulaw => std::option::Option::Some("AUDIO_ENCODING_MULAW"),
+            Self::Amr => std::option::Option::Some("AUDIO_ENCODING_AMR"),
+            Self::AmrWb => std::option::Option::Some("AUDIO_ENCODING_AMR_WB"),
+            Self::OggOpus => std::option::Option::Some("AUDIO_ENCODING_OGG_OPUS"),
+            Self::SpeexWithHeaderByte => {
+                std::option::Option::Some("AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE")
             }
-            "AUDIO_ENCODING_LINEAR_16" => std::option::Option::Some(Self::AUDIO_ENCODING_LINEAR_16),
-            "AUDIO_ENCODING_FLAC" => std::option::Option::Some(Self::AUDIO_ENCODING_FLAC),
-            "AUDIO_ENCODING_MULAW" => std::option::Option::Some(Self::AUDIO_ENCODING_MULAW),
-            "AUDIO_ENCODING_AMR" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR),
-            "AUDIO_ENCODING_AMR_WB" => std::option::Option::Some(Self::AUDIO_ENCODING_AMR_WB),
-            "AUDIO_ENCODING_OGG_OPUS" => std::option::Option::Some(Self::AUDIO_ENCODING_OGG_OPUS),
-            "AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE" => {
-                std::option::Option::Some(Self::AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE)
-            }
-            "AUDIO_ENCODING_ALAW" => std::option::Option::Some(Self::AUDIO_ENCODING_ALAW),
-            _ => std::option::Option::None,
+            Self::Alaw => std::option::Option::Some("AUDIO_ENCODING_ALAW"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for AudioEncoding {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AudioEncoding {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AudioEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AudioEncoding {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linear16,
+            2 => Self::Flac,
+            3 => Self::Mulaw,
+            4 => Self::Amr,
+            5 => Self::AmrWb,
+            6 => Self::OggOpus,
+            7 => Self::SpeexWithHeaderByte,
+            8 => Self::Alaw,
+            _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AudioEncoding {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUDIO_ENCODING_UNSPECIFIED" => Self::Unspecified,
+            "AUDIO_ENCODING_LINEAR_16" => Self::Linear16,
+            "AUDIO_ENCODING_FLAC" => Self::Flac,
+            "AUDIO_ENCODING_MULAW" => Self::Mulaw,
+            "AUDIO_ENCODING_AMR" => Self::Amr,
+            "AUDIO_ENCODING_AMR_WB" => Self::AmrWb,
+            "AUDIO_ENCODING_OGG_OPUS" => Self::OggOpus,
+            "AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE" => Self::SpeexWithHeaderByte,
+            "AUDIO_ENCODING_ALAW" => Self::Alaw,
+            _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AudioEncoding {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linear16 => serializer.serialize_i32(1),
+            Self::Flac => serializer.serialize_i32(2),
+            Self::Mulaw => serializer.serialize_i32(3),
+            Self::Amr => serializer.serialize_i32(4),
+            Self::AmrWb => serializer.serialize_i32(5),
+            Self::OggOpus => serializer.serialize_i32(6),
+            Self::SpeexWithHeaderByte => serializer.serialize_i32(7),
+            Self::Alaw => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AudioEncoding {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AudioEncoding>::new(
+            ".google.cloud.dialogflow.v2.AudioEncoding",
+        ))
     }
 }
 
@@ -30662,28 +33655,24 @@ impl std::default::Default for AudioEncoding {
 /// you will generally receive higher quality results than for a standard model.
 ///
 /// [google.cloud.dialogflow.v2.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SpeechModelVariant(i32);
-
-impl SpeechModelVariant {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SpeechModelVariant {
     /// No model variant specified. In this case Dialogflow defaults to
     /// USE_BEST_AVAILABLE.
-    pub const SPEECH_MODEL_VARIANT_UNSPECIFIED: SpeechModelVariant = SpeechModelVariant::new(0);
-
+    Unspecified,
     /// Use the best available variant of the [Speech model][model] that the caller
     /// is eligible for.
     ///
     /// Please see the [Dialogflow
     /// docs](https://cloud.google.com/dialogflow/docs/data-logging) for
     /// how to make your project eligible for enhanced models.
-    pub const USE_BEST_AVAILABLE: SpeechModelVariant = SpeechModelVariant::new(1);
-
+    UseBestAvailable,
     /// Use standard model variant even if an enhanced model is available.  See the
     /// [Cloud Speech
     /// documentation](https://cloud.google.com/speech-to-text/docs/enhanced-models)
     /// for details about enhanced models.
-    pub const USE_STANDARD: SpeechModelVariant = SpeechModelVariant::new(2);
-
+    UseStandard,
     /// Use an enhanced model variant:
     ///
     /// * If an enhanced variant does not exist for the given
@@ -30701,339 +33690,640 @@ impl SpeechModelVariant {
     ///
     ///
     /// [google.cloud.dialogflow.v2.InputAudioConfig.model]: crate::model::InputAudioConfig::model
-    pub const USE_ENHANCED: SpeechModelVariant = SpeechModelVariant::new(3);
+    UseEnhanced,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SpeechModelVariant::value] or
+    /// [SpeechModelVariant::name].
+    UnknownValue(speech_model_variant::UnknownValue),
+}
 
-    /// Creates a new SpeechModelVariant instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod speech_model_variant {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SpeechModelVariant {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::UseBestAvailable => std::option::Option::Some(1),
+            Self::UseStandard => std::option::Option::Some(2),
+            Self::UseEnhanced => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SPEECH_MODEL_VARIANT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("USE_BEST_AVAILABLE"),
-            2 => std::borrow::Cow::Borrowed("USE_STANDARD"),
-            3 => std::borrow::Cow::Borrowed("USE_ENHANCED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SPEECH_MODEL_VARIANT_UNSPECIFIED"),
+            Self::UseBestAvailable => std::option::Option::Some("USE_BEST_AVAILABLE"),
+            Self::UseStandard => std::option::Option::Some("USE_STANDARD"),
+            Self::UseEnhanced => std::option::Option::Some("USE_ENHANCED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SPEECH_MODEL_VARIANT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SPEECH_MODEL_VARIANT_UNSPECIFIED)
-            }
-            "USE_BEST_AVAILABLE" => std::option::Option::Some(Self::USE_BEST_AVAILABLE),
-            "USE_STANDARD" => std::option::Option::Some(Self::USE_STANDARD),
-            "USE_ENHANCED" => std::option::Option::Some(Self::USE_ENHANCED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SpeechModelVariant {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SpeechModelVariant {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SpeechModelVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SpeechModelVariant {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::UseBestAvailable,
+            2 => Self::UseStandard,
+            3 => Self::UseEnhanced,
+            _ => Self::UnknownValue(speech_model_variant::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SpeechModelVariant {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SPEECH_MODEL_VARIANT_UNSPECIFIED" => Self::Unspecified,
+            "USE_BEST_AVAILABLE" => Self::UseBestAvailable,
+            "USE_STANDARD" => Self::UseStandard,
+            "USE_ENHANCED" => Self::UseEnhanced,
+            _ => Self::UnknownValue(speech_model_variant::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SpeechModelVariant {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::UseBestAvailable => serializer.serialize_i32(1),
+            Self::UseStandard => serializer.serialize_i32(2),
+            Self::UseEnhanced => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SpeechModelVariant {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SpeechModelVariant>::new(
+            ".google.cloud.dialogflow.v2.SpeechModelVariant",
+        ))
     }
 }
 
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SsmlVoiceGender(i32);
-
-impl SsmlVoiceGender {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SsmlVoiceGender {
     /// An unspecified gender, which means that the client doesn't care which
     /// gender the selected voice will have.
-    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender = SsmlVoiceGender::new(0);
-
+    Unspecified,
     /// A male voice.
-    pub const SSML_VOICE_GENDER_MALE: SsmlVoiceGender = SsmlVoiceGender::new(1);
-
+    Male,
     /// A female voice.
-    pub const SSML_VOICE_GENDER_FEMALE: SsmlVoiceGender = SsmlVoiceGender::new(2);
-
+    Female,
     /// A gender-neutral voice.
-    pub const SSML_VOICE_GENDER_NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new(3);
+    Neutral,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SsmlVoiceGender::value] or
+    /// [SsmlVoiceGender::name].
+    UnknownValue(ssml_voice_gender::UnknownValue),
+}
 
-    /// Creates a new SsmlVoiceGender instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod ssml_voice_gender {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SsmlVoiceGender {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Male => std::option::Option::Some(1),
+            Self::Female => std::option::Option::Some(2),
+            Self::Neutral => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_MALE"),
-            2 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_FEMALE"),
-            3 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_NEUTRAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SSML_VOICE_GENDER_UNSPECIFIED"),
+            Self::Male => std::option::Option::Some("SSML_VOICE_GENDER_MALE"),
+            Self::Female => std::option::Option::Some("SSML_VOICE_GENDER_FEMALE"),
+            Self::Neutral => std::option::Option::Some("SSML_VOICE_GENDER_NEUTRAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SSML_VOICE_GENDER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SSML_VOICE_GENDER_UNSPECIFIED)
-            }
-            "SSML_VOICE_GENDER_MALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_MALE),
-            "SSML_VOICE_GENDER_FEMALE" => std::option::Option::Some(Self::SSML_VOICE_GENDER_FEMALE),
-            "SSML_VOICE_GENDER_NEUTRAL" => {
-                std::option::Option::Some(Self::SSML_VOICE_GENDER_NEUTRAL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SsmlVoiceGender {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SsmlVoiceGender {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SsmlVoiceGender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SsmlVoiceGender {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Male,
+            2 => Self::Female,
+            3 => Self::Neutral,
+            _ => Self::UnknownValue(ssml_voice_gender::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SsmlVoiceGender {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SSML_VOICE_GENDER_UNSPECIFIED" => Self::Unspecified,
+            "SSML_VOICE_GENDER_MALE" => Self::Male,
+            "SSML_VOICE_GENDER_FEMALE" => Self::Female,
+            "SSML_VOICE_GENDER_NEUTRAL" => Self::Neutral,
+            _ => Self::UnknownValue(ssml_voice_gender::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SsmlVoiceGender {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Male => serializer.serialize_i32(1),
+            Self::Female => serializer.serialize_i32(2),
+            Self::Neutral => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SsmlVoiceGender {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SsmlVoiceGender>::new(
+            ".google.cloud.dialogflow.v2.SsmlVoiceGender",
+        ))
     }
 }
 
 /// Audio encoding of the output audio format in Text-To-Speech.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OutputAudioEncoding(i32);
-
-impl OutputAudioEncoding {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OutputAudioEncoding {
     /// Not specified.
-    pub const OUTPUT_AUDIO_ENCODING_UNSPECIFIED: OutputAudioEncoding = OutputAudioEncoding::new(0);
-
+    Unspecified,
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Audio content returned as LINEAR16 also contains a WAV header.
-    pub const OUTPUT_AUDIO_ENCODING_LINEAR_16: OutputAudioEncoding = OutputAudioEncoding::new(1);
-
+    Linear16,
     /// MP3 audio at 32kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3: OutputAudioEncoding = OutputAudioEncoding::new(2);
-
+    Mp3,
     /// MP3 audio at 64kbps.
-    pub const OUTPUT_AUDIO_ENCODING_MP3_64_KBPS: OutputAudioEncoding = OutputAudioEncoding::new(4);
-
+    Mp364Kbps,
     /// Opus encoded audio wrapped in an ogg container. The result will be a
     /// file which can be played natively on Android, and in browsers (at least
     /// Chrome and Firefox). The quality of the encoding is considerably higher
     /// than MP3 while using approximately the same bitrate.
-    pub const OUTPUT_AUDIO_ENCODING_OGG_OPUS: OutputAudioEncoding = OutputAudioEncoding::new(3);
-
+    OggOpus,
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
-    pub const OUTPUT_AUDIO_ENCODING_MULAW: OutputAudioEncoding = OutputAudioEncoding::new(5);
-
+    Mulaw,
     /// 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
-    pub const OUTPUT_AUDIO_ENCODING_ALAW: OutputAudioEncoding = OutputAudioEncoding::new(6);
+    Alaw,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OutputAudioEncoding::value] or
+    /// [OutputAudioEncoding::name].
+    UnknownValue(output_audio_encoding::UnknownValue),
+}
 
-    /// Creates a new OutputAudioEncoding instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod output_audio_encoding {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl OutputAudioEncoding {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linear16 => std::option::Option::Some(1),
+            Self::Mp3 => std::option::Option::Some(2),
+            Self::Mp364Kbps => std::option::Option::Some(4),
+            Self::OggOpus => std::option::Option::Some(3),
+            Self::Mulaw => std::option::Option::Some(5),
+            Self::Alaw => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_LINEAR_16"),
-            2 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3"),
-            3 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_OGG_OPUS"),
-            4 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS"),
-            5 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_MULAW"),
-            6 => std::borrow::Cow::Borrowed("OUTPUT_AUDIO_ENCODING_ALAW"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_UNSPECIFIED"),
+            Self::Linear16 => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_LINEAR_16"),
+            Self::Mp3 => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_MP3"),
+            Self::Mp364Kbps => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_MP3_64_KBPS"),
+            Self::OggOpus => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_OGG_OPUS"),
+            Self::Mulaw => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_MULAW"),
+            Self::Alaw => std::option::Option::Some("OUTPUT_AUDIO_ENCODING_ALAW"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OUTPUT_AUDIO_ENCODING_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_UNSPECIFIED)
-            }
-            "OUTPUT_AUDIO_ENCODING_LINEAR_16" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_LINEAR_16)
-            }
-            "OUTPUT_AUDIO_ENCODING_MP3" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3)
-            }
-            "OUTPUT_AUDIO_ENCODING_MP3_64_KBPS" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MP3_64_KBPS)
-            }
-            "OUTPUT_AUDIO_ENCODING_OGG_OPUS" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_OGG_OPUS)
-            }
-            "OUTPUT_AUDIO_ENCODING_MULAW" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_MULAW)
-            }
-            "OUTPUT_AUDIO_ENCODING_ALAW" => {
-                std::option::Option::Some(Self::OUTPUT_AUDIO_ENCODING_ALAW)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OutputAudioEncoding {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OutputAudioEncoding {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OutputAudioEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OutputAudioEncoding {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linear16,
+            2 => Self::Mp3,
+            3 => Self::OggOpus,
+            4 => Self::Mp364Kbps,
+            5 => Self::Mulaw,
+            6 => Self::Alaw,
+            _ => Self::UnknownValue(output_audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OutputAudioEncoding {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OUTPUT_AUDIO_ENCODING_UNSPECIFIED" => Self::Unspecified,
+            "OUTPUT_AUDIO_ENCODING_LINEAR_16" => Self::Linear16,
+            "OUTPUT_AUDIO_ENCODING_MP3" => Self::Mp3,
+            "OUTPUT_AUDIO_ENCODING_MP3_64_KBPS" => Self::Mp364Kbps,
+            "OUTPUT_AUDIO_ENCODING_OGG_OPUS" => Self::OggOpus,
+            "OUTPUT_AUDIO_ENCODING_MULAW" => Self::Mulaw,
+            "OUTPUT_AUDIO_ENCODING_ALAW" => Self::Alaw,
+            _ => Self::UnknownValue(output_audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OutputAudioEncoding {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linear16 => serializer.serialize_i32(1),
+            Self::Mp3 => serializer.serialize_i32(2),
+            Self::Mp364Kbps => serializer.serialize_i32(4),
+            Self::OggOpus => serializer.serialize_i32(3),
+            Self::Mulaw => serializer.serialize_i32(5),
+            Self::Alaw => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OutputAudioEncoding {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OutputAudioEncoding>::new(
+            ".google.cloud.dialogflow.v2.OutputAudioEncoding",
+        ))
     }
 }
 
 /// The event that triggers the generator and LLM execution.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TriggerEvent(i32);
-
-impl TriggerEvent {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TriggerEvent {
     /// Default value for TriggerEvent.
-    pub const TRIGGER_EVENT_UNSPECIFIED: TriggerEvent = TriggerEvent::new(0);
-
+    Unspecified,
     /// Triggers when each chat message or voice utterance ends.
-    pub const END_OF_UTTERANCE: TriggerEvent = TriggerEvent::new(1);
-
+    EndOfUtterance,
     /// Triggers on the conversation manually by API calls, such as
     /// Conversations.GenerateStatelessSuggestion and
     /// Conversations.GenerateSuggestions.
-    pub const MANUAL_CALL: TriggerEvent = TriggerEvent::new(2);
-
+    ManualCall,
     /// Triggers after each customer message only.
-    pub const CUSTOMER_MESSAGE: TriggerEvent = TriggerEvent::new(3);
-
+    CustomerMessage,
     /// Triggers after each agent message only.
-    pub const AGENT_MESSAGE: TriggerEvent = TriggerEvent::new(4);
+    AgentMessage,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TriggerEvent::value] or
+    /// [TriggerEvent::name].
+    UnknownValue(trigger_event::UnknownValue),
+}
 
-    /// Creates a new TriggerEvent instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod trigger_event {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl TriggerEvent {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::EndOfUtterance => std::option::Option::Some(1),
+            Self::ManualCall => std::option::Option::Some(2),
+            Self::CustomerMessage => std::option::Option::Some(3),
+            Self::AgentMessage => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRIGGER_EVENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("END_OF_UTTERANCE"),
-            2 => std::borrow::Cow::Borrowed("MANUAL_CALL"),
-            3 => std::borrow::Cow::Borrowed("CUSTOMER_MESSAGE"),
-            4 => std::borrow::Cow::Borrowed("AGENT_MESSAGE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRIGGER_EVENT_UNSPECIFIED"),
+            Self::EndOfUtterance => std::option::Option::Some("END_OF_UTTERANCE"),
+            Self::ManualCall => std::option::Option::Some("MANUAL_CALL"),
+            Self::CustomerMessage => std::option::Option::Some("CUSTOMER_MESSAGE"),
+            Self::AgentMessage => std::option::Option::Some("AGENT_MESSAGE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRIGGER_EVENT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRIGGER_EVENT_UNSPECIFIED)
-            }
-            "END_OF_UTTERANCE" => std::option::Option::Some(Self::END_OF_UTTERANCE),
-            "MANUAL_CALL" => std::option::Option::Some(Self::MANUAL_CALL),
-            "CUSTOMER_MESSAGE" => std::option::Option::Some(Self::CUSTOMER_MESSAGE),
-            "AGENT_MESSAGE" => std::option::Option::Some(Self::AGENT_MESSAGE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TriggerEvent {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TriggerEvent {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TriggerEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TriggerEvent {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::EndOfUtterance,
+            2 => Self::ManualCall,
+            3 => Self::CustomerMessage,
+            4 => Self::AgentMessage,
+            _ => Self::UnknownValue(trigger_event::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TriggerEvent {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRIGGER_EVENT_UNSPECIFIED" => Self::Unspecified,
+            "END_OF_UTTERANCE" => Self::EndOfUtterance,
+            "MANUAL_CALL" => Self::ManualCall,
+            "CUSTOMER_MESSAGE" => Self::CustomerMessage,
+            "AGENT_MESSAGE" => Self::AgentMessage,
+            _ => Self::UnknownValue(trigger_event::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TriggerEvent {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::EndOfUtterance => serializer.serialize_i32(1),
+            Self::ManualCall => serializer.serialize_i32(2),
+            Self::CustomerMessage => serializer.serialize_i32(3),
+            Self::AgentMessage => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TriggerEvent {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TriggerEvent>::new(
+            ".google.cloud.dialogflow.v2.TriggerEvent",
+        ))
     }
 }
 
 /// Represents the options for views of an intent.
 /// An intent can be a sizable object. Therefore, we provide a resource view that
 /// does not return training phrases in the response by default.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IntentView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IntentView {
+    /// Training phrases field is not populated in the response.
+    Unspecified,
+    /// All fields are populated.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IntentView::value] or
+    /// [IntentView::name].
+    UnknownValue(intent_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod intent_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl IntentView {
-    /// Training phrases field is not populated in the response.
-    pub const INTENT_VIEW_UNSPECIFIED: IntentView = IntentView::new(0);
-
-    /// All fields are populated.
-    pub const INTENT_VIEW_FULL: IntentView = IntentView::new(1);
-
-    /// Creates a new IntentView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Full => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INTENT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INTENT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INTENT_VIEW_UNSPECIFIED"),
+            Self::Full => std::option::Option::Some("INTENT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INTENT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::INTENT_VIEW_UNSPECIFIED),
-            "INTENT_VIEW_FULL" => std::option::Option::Some(Self::INTENT_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IntentView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IntentView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IntentView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IntentView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Full,
+            _ => Self::UnknownValue(intent_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IntentView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INTENT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "INTENT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(intent_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IntentView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Full => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IntentView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IntentView>::new(
+            ".google.cloud.dialogflow.v2.IntentView",
+        ))
     }
 }

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -3679,7 +3679,7 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        let builder = builder.query(&[("intentView", &req.intent_view.value())]);
+        let builder = builder.query(&[("intentView", &req.intent_view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -3702,7 +3702,7 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        let builder = builder.query(&[("intentView", &req.intent_view.value())]);
+        let builder = builder.query(&[("intentView", &req.intent_view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -3723,7 +3723,7 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        let builder = builder.query(&[("intentView", &req.intent_view.value())]);
+        let builder = builder.query(&[("intentView", &req.intent_view)]);
         self.inner.execute(builder, Some(req.intent), options).await
     }
 
@@ -3757,7 +3757,7 @@ impl super::stub::Intents for Intents {
             .iter()
             .flat_map(|p| p.paths.iter())
             .fold(builder, |builder, v| builder.query(&[("updateMask", v)]));
-        let builder = builder.query(&[("intentView", &req.intent_view.value())]);
+        let builder = builder.query(&[("intentView", &req.intent_view)]);
         self.inner.execute(builder, Some(req.intent), options).await
     }
 

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -1515,64 +1515,130 @@ pub mod answer {
         }
 
         /// Enumeration of the state of the step.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// Unknown.
+            Unspecified,
+            /// Step is currently in progress.
+            InProgress,
+            /// Step currently failed.
+            Failed,
+            /// Step has succeeded.
+            Succeeded,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// Unknown.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// Step is currently in progress.
-            pub const IN_PROGRESS: State = State::new(1);
-
-            /// Step currently failed.
-            pub const FAILED: State = State::new(2);
-
-            /// Step has succeeded.
-            pub const SUCCEEDED: State = State::new(3);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::InProgress => std::option::Option::Some(1),
+                    Self::Failed => std::option::Option::Some(2),
+                    Self::Succeeded => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                    2 => std::borrow::Cow::Borrowed("FAILED"),
-                    3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::InProgress,
+                    2 => Self::Failed,
+                    3 => Self::Succeeded,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "IN_PROGRESS" => Self::InProgress,
+                    "FAILED" => Self::Failed,
+                    "SUCCEEDED" => Self::Succeeded,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::InProgress => serializer.serialize_i32(1),
+                    Self::Failed => serializer.serialize_i32(2),
+                    Self::Succeeded => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.discoveryengine.v1.Answer.Step.State",
+                ))
             }
         }
     }
@@ -1671,277 +1737,477 @@ pub mod answer {
             use super::*;
 
             /// Query classification types.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Type {
+                /// Unspecified query classification type.
+                Unspecified,
+                /// Adversarial query classification type.
+                AdversarialQuery,
+                /// Non-answer-seeking query classification type, for chit chat.
+                NonAnswerSeekingQuery,
+                /// Jail-breaking query classification type.
+                JailBreakingQuery,
+                /// Non-answer-seeking query classification type, for no clear intent.
+                NonAnswerSeekingQueryV2,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Type::value] or
+                /// [Type::name].
+                UnknownValue(r#type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod r#type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl Type {
-                /// Unspecified query classification type.
-                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-                /// Adversarial query classification type.
-                pub const ADVERSARIAL_QUERY: Type = Type::new(1);
-
-                /// Non-answer-seeking query classification type, for chit chat.
-                pub const NON_ANSWER_SEEKING_QUERY: Type = Type::new(2);
-
-                /// Jail-breaking query classification type.
-                pub const JAIL_BREAKING_QUERY: Type = Type::new(3);
-
-                /// Non-answer-seeking query classification type, for no clear intent.
-                pub const NON_ANSWER_SEEKING_QUERY_V2: Type = Type::new(4);
-
-                /// Creates a new Type instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::AdversarialQuery => std::option::Option::Some(1),
+                        Self::NonAnswerSeekingQuery => std::option::Option::Some(2),
+                        Self::JailBreakingQuery => std::option::Option::Some(3),
+                        Self::NonAnswerSeekingQueryV2 => std::option::Option::Some(4),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY"),
-                        2 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY"),
-                        3 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY"),
-                        4 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_V2"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                        Self::AdversarialQuery => std::option::Option::Some("ADVERSARIAL_QUERY"),
+                        Self::NonAnswerSeekingQuery => {
+                            std::option::Option::Some("NON_ANSWER_SEEKING_QUERY")
+                        }
+                        Self::JailBreakingQuery => std::option::Option::Some("JAIL_BREAKING_QUERY"),
+                        Self::NonAnswerSeekingQueryV2 => {
+                            std::option::Option::Some("NON_ANSWER_SEEKING_QUERY_V2")
+                        }
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                        "ADVERSARIAL_QUERY" => std::option::Option::Some(Self::ADVERSARIAL_QUERY),
-                        "NON_ANSWER_SEEKING_QUERY" => {
-                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY)
-                        }
-                        "JAIL_BREAKING_QUERY" => {
-                            std::option::Option::Some(Self::JAIL_BREAKING_QUERY)
-                        }
-                        "NON_ANSWER_SEEKING_QUERY_V2" => {
-                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_V2)
-                        }
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Type {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Type {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::AdversarialQuery,
+                        2 => Self::NonAnswerSeekingQuery,
+                        3 => Self::JailBreakingQuery,
+                        4 => Self::NonAnswerSeekingQueryV2,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Type {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "ADVERSARIAL_QUERY" => Self::AdversarialQuery,
+                        "NON_ANSWER_SEEKING_QUERY" => Self::NonAnswerSeekingQuery,
+                        "JAIL_BREAKING_QUERY" => Self::JailBreakingQuery,
+                        "NON_ANSWER_SEEKING_QUERY_V2" => Self::NonAnswerSeekingQueryV2,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Type {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::AdversarialQuery => serializer.serialize_i32(1),
+                        Self::NonAnswerSeekingQuery => serializer.serialize_i32(2),
+                        Self::JailBreakingQuery => serializer.serialize_i32(3),
+                        Self::NonAnswerSeekingQueryV2 => serializer.serialize_i32(4),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Type {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                        ".google.cloud.discoveryengine.v1.Answer.QueryUnderstandingInfo.QueryClassificationInfo.Type"))
                 }
             }
         }
     }
 
     /// Enumeration of the state of the answer generation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unknown.
+        Unspecified,
+        /// Answer generation is currently in progress.
+        InProgress,
+        /// Answer generation currently failed.
+        Failed,
+        /// Answer generation has succeeded.
+        Succeeded,
+        /// Answer generation is currently in progress.
+        Streaming,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Answer generation is currently in progress.
-        pub const IN_PROGRESS: State = State::new(1);
-
-        /// Answer generation currently failed.
-        pub const FAILED: State = State::new(2);
-
-        /// Answer generation has succeeded.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// Answer generation is currently in progress.
-        pub const STREAMING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Streaming => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("STREAMING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Streaming => std::option::Option::Some("STREAMING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "STREAMING" => std::option::Option::Some(Self::STREAMING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Failed,
+                3 => Self::Succeeded,
+                4 => Self::Streaming,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "FAILED" => Self::Failed,
+                "SUCCEEDED" => Self::Succeeded,
+                "STREAMING" => Self::Streaming,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Streaming => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.discoveryengine.v1.Answer.State",
+            ))
         }
     }
 
     /// An enum for answer skipped reasons.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnswerSkippedReason(i32);
-
-    impl AnswerSkippedReason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AnswerSkippedReason {
         /// Default value. The answer skipped reason is not specified.
-        pub const ANSWER_SKIPPED_REASON_UNSPECIFIED: AnswerSkippedReason =
-            AnswerSkippedReason::new(0);
-
+        Unspecified,
         /// The adversarial query ignored case.
-        pub const ADVERSARIAL_QUERY_IGNORED: AnswerSkippedReason = AnswerSkippedReason::new(1);
-
+        AdversarialQueryIgnored,
         /// The non-answer seeking query ignored case
         ///
         /// Google skips the answer if the query is chit chat.
-        pub const NON_ANSWER_SEEKING_QUERY_IGNORED: AnswerSkippedReason =
-            AnswerSkippedReason::new(2);
-
+        NonAnswerSeekingQueryIgnored,
         /// The out-of-domain query ignored case.
         ///
         /// Google skips the answer if there are no high-relevance search results.
-        pub const OUT_OF_DOMAIN_QUERY_IGNORED: AnswerSkippedReason = AnswerSkippedReason::new(3);
-
+        OutOfDomainQueryIgnored,
         /// The potential policy violation case.
         ///
         /// Google skips the answer if there is a potential policy violation
         /// detected. This includes content that may be violent or toxic.
-        pub const POTENTIAL_POLICY_VIOLATION: AnswerSkippedReason = AnswerSkippedReason::new(4);
-
+        PotentialPolicyViolation,
         /// The no relevant content case.
         ///
         /// Google skips the answer if there is no relevant content in the
         /// retrieved search results.
-        pub const NO_RELEVANT_CONTENT: AnswerSkippedReason = AnswerSkippedReason::new(5);
-
+        NoRelevantContent,
         /// The jail-breaking query ignored case.
         ///
         /// For example, "Reply in the tone of a competing company's CEO".
         /// Google skips the answer if the query is classified as a jail-breaking
         /// query.
-        pub const JAIL_BREAKING_QUERY_IGNORED: AnswerSkippedReason = AnswerSkippedReason::new(6);
-
+        JailBreakingQueryIgnored,
         /// The customer policy violation case.
         ///
         /// Google skips the summary if there is a customer policy violation
         /// detected. The policy is defined by the customer.
-        pub const CUSTOMER_POLICY_VIOLATION: AnswerSkippedReason = AnswerSkippedReason::new(7);
-
+        CustomerPolicyViolation,
         /// The non-answer seeking query ignored case.
         ///
         /// Google skips the answer if the query doesn't have clear intent.
-        pub const NON_ANSWER_SEEKING_QUERY_IGNORED_V2: AnswerSkippedReason =
-            AnswerSkippedReason::new(8);
-
+        NonAnswerSeekingQueryIgnoredV2,
         /// The low-grounded answer case.
         ///
         /// Google skips the answer if a well grounded answer was unable to be
         /// generated.
-        pub const LOW_GROUNDED_ANSWER: AnswerSkippedReason = AnswerSkippedReason::new(9);
+        LowGroundedAnswer,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AnswerSkippedReason::value] or
+        /// [AnswerSkippedReason::name].
+        UnknownValue(answer_skipped_reason::UnknownValue),
+    }
 
-        /// Creates a new AnswerSkippedReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod answer_skipped_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AnswerSkippedReason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AdversarialQueryIgnored => std::option::Option::Some(1),
+                Self::NonAnswerSeekingQueryIgnored => std::option::Option::Some(2),
+                Self::OutOfDomainQueryIgnored => std::option::Option::Some(3),
+                Self::PotentialPolicyViolation => std::option::Option::Some(4),
+                Self::NoRelevantContent => std::option::Option::Some(5),
+                Self::JailBreakingQueryIgnored => std::option::Option::Some(6),
+                Self::CustomerPolicyViolation => std::option::Option::Some(7),
+                Self::NonAnswerSeekingQueryIgnoredV2 => std::option::Option::Some(8),
+                Self::LowGroundedAnswer => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANSWER_SKIPPED_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY_IGNORED"),
-                2 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_IGNORED"),
-                3 => std::borrow::Cow::Borrowed("OUT_OF_DOMAIN_QUERY_IGNORED"),
-                4 => std::borrow::Cow::Borrowed("POTENTIAL_POLICY_VIOLATION"),
-                5 => std::borrow::Cow::Borrowed("NO_RELEVANT_CONTENT"),
-                6 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY_IGNORED"),
-                7 => std::borrow::Cow::Borrowed("CUSTOMER_POLICY_VIOLATION"),
-                8 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_IGNORED_V2"),
-                9 => std::borrow::Cow::Borrowed("LOW_GROUNDED_ANSWER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANSWER_SKIPPED_REASON_UNSPECIFIED"),
+                Self::AdversarialQueryIgnored => {
+                    std::option::Option::Some("ADVERSARIAL_QUERY_IGNORED")
+                }
+                Self::NonAnswerSeekingQueryIgnored => {
+                    std::option::Option::Some("NON_ANSWER_SEEKING_QUERY_IGNORED")
+                }
+                Self::OutOfDomainQueryIgnored => {
+                    std::option::Option::Some("OUT_OF_DOMAIN_QUERY_IGNORED")
+                }
+                Self::PotentialPolicyViolation => {
+                    std::option::Option::Some("POTENTIAL_POLICY_VIOLATION")
+                }
+                Self::NoRelevantContent => std::option::Option::Some("NO_RELEVANT_CONTENT"),
+                Self::JailBreakingQueryIgnored => {
+                    std::option::Option::Some("JAIL_BREAKING_QUERY_IGNORED")
+                }
+                Self::CustomerPolicyViolation => {
+                    std::option::Option::Some("CUSTOMER_POLICY_VIOLATION")
+                }
+                Self::NonAnswerSeekingQueryIgnoredV2 => {
+                    std::option::Option::Some("NON_ANSWER_SEEKING_QUERY_IGNORED_V2")
+                }
+                Self::LowGroundedAnswer => std::option::Option::Some("LOW_GROUNDED_ANSWER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANSWER_SKIPPED_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ANSWER_SKIPPED_REASON_UNSPECIFIED)
-                }
-                "ADVERSARIAL_QUERY_IGNORED" => {
-                    std::option::Option::Some(Self::ADVERSARIAL_QUERY_IGNORED)
-                }
-                "NON_ANSWER_SEEKING_QUERY_IGNORED" => {
-                    std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_IGNORED)
-                }
-                "OUT_OF_DOMAIN_QUERY_IGNORED" => {
-                    std::option::Option::Some(Self::OUT_OF_DOMAIN_QUERY_IGNORED)
-                }
-                "POTENTIAL_POLICY_VIOLATION" => {
-                    std::option::Option::Some(Self::POTENTIAL_POLICY_VIOLATION)
-                }
-                "NO_RELEVANT_CONTENT" => std::option::Option::Some(Self::NO_RELEVANT_CONTENT),
-                "JAIL_BREAKING_QUERY_IGNORED" => {
-                    std::option::Option::Some(Self::JAIL_BREAKING_QUERY_IGNORED)
-                }
-                "CUSTOMER_POLICY_VIOLATION" => {
-                    std::option::Option::Some(Self::CUSTOMER_POLICY_VIOLATION)
-                }
-                "NON_ANSWER_SEEKING_QUERY_IGNORED_V2" => {
-                    std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_IGNORED_V2)
-                }
-                "LOW_GROUNDED_ANSWER" => std::option::Option::Some(Self::LOW_GROUNDED_ANSWER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AnswerSkippedReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AnswerSkippedReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AnswerSkippedReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AnswerSkippedReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AdversarialQueryIgnored,
+                2 => Self::NonAnswerSeekingQueryIgnored,
+                3 => Self::OutOfDomainQueryIgnored,
+                4 => Self::PotentialPolicyViolation,
+                5 => Self::NoRelevantContent,
+                6 => Self::JailBreakingQueryIgnored,
+                7 => Self::CustomerPolicyViolation,
+                8 => Self::NonAnswerSeekingQueryIgnoredV2,
+                9 => Self::LowGroundedAnswer,
+                _ => Self::UnknownValue(answer_skipped_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AnswerSkippedReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANSWER_SKIPPED_REASON_UNSPECIFIED" => Self::Unspecified,
+                "ADVERSARIAL_QUERY_IGNORED" => Self::AdversarialQueryIgnored,
+                "NON_ANSWER_SEEKING_QUERY_IGNORED" => Self::NonAnswerSeekingQueryIgnored,
+                "OUT_OF_DOMAIN_QUERY_IGNORED" => Self::OutOfDomainQueryIgnored,
+                "POTENTIAL_POLICY_VIOLATION" => Self::PotentialPolicyViolation,
+                "NO_RELEVANT_CONTENT" => Self::NoRelevantContent,
+                "JAIL_BREAKING_QUERY_IGNORED" => Self::JailBreakingQueryIgnored,
+                "CUSTOMER_POLICY_VIOLATION" => Self::CustomerPolicyViolation,
+                "NON_ANSWER_SEEKING_QUERY_IGNORED_V2" => Self::NonAnswerSeekingQueryIgnoredV2,
+                "LOW_GROUNDED_ANSWER" => Self::LowGroundedAnswer,
+                _ => Self::UnknownValue(answer_skipped_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AnswerSkippedReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AdversarialQueryIgnored => serializer.serialize_i32(1),
+                Self::NonAnswerSeekingQueryIgnored => serializer.serialize_i32(2),
+                Self::OutOfDomainQueryIgnored => serializer.serialize_i32(3),
+                Self::PotentialPolicyViolation => serializer.serialize_i32(4),
+                Self::NoRelevantContent => serializer.serialize_i32(5),
+                Self::JailBreakingQueryIgnored => serializer.serialize_i32(6),
+                Self::CustomerPolicyViolation => serializer.serialize_i32(7),
+                Self::NonAnswerSeekingQueryIgnoredV2 => serializer.serialize_i32(8),
+                Self::LowGroundedAnswer => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AnswerSkippedReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AnswerSkippedReason>::new(
+                ".google.cloud.discoveryengine.v1.Answer.AnswerSkippedReason",
+            ))
         }
     }
 }
@@ -2771,61 +3037,120 @@ pub mod suggestion_deny_list_entry {
     use super::*;
 
     /// Operator for matching with the generated suggestions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MatchOperator(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MatchOperator {
+        /// Default value. Should not be used
+        Unspecified,
+        /// If the suggestion is an exact match to the block_phrase, then block it.
+        ExactMatch,
+        /// If the suggestion contains the block_phrase, then block it.
+        Contains,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MatchOperator::value] or
+        /// [MatchOperator::name].
+        UnknownValue(match_operator::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod match_operator {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MatchOperator {
-        /// Default value. Should not be used
-        pub const MATCH_OPERATOR_UNSPECIFIED: MatchOperator = MatchOperator::new(0);
-
-        /// If the suggestion is an exact match to the block_phrase, then block it.
-        pub const EXACT_MATCH: MatchOperator = MatchOperator::new(1);
-
-        /// If the suggestion contains the block_phrase, then block it.
-        pub const CONTAINS: MatchOperator = MatchOperator::new(2);
-
-        /// Creates a new MatchOperator instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ExactMatch => std::option::Option::Some(1),
+                Self::Contains => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MATCH_OPERATOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXACT_MATCH"),
-                2 => std::borrow::Cow::Borrowed("CONTAINS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MATCH_OPERATOR_UNSPECIFIED"),
+                Self::ExactMatch => std::option::Option::Some("EXACT_MATCH"),
+                Self::Contains => std::option::Option::Some("CONTAINS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MATCH_OPERATOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MATCH_OPERATOR_UNSPECIFIED)
-                }
-                "EXACT_MATCH" => std::option::Option::Some(Self::EXACT_MATCH),
-                "CONTAINS" => std::option::Option::Some(Self::CONTAINS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MatchOperator {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MatchOperator {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MatchOperator {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MatchOperator {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ExactMatch,
+                2 => Self::Contains,
+                _ => Self::UnknownValue(match_operator::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MatchOperator {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MATCH_OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                "EXACT_MATCH" => Self::ExactMatch,
+                "CONTAINS" => Self::Contains,
+                _ => Self::UnknownValue(match_operator::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MatchOperator {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ExactMatch => serializer.serialize_i32(1),
+                Self::Contains => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MatchOperator {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MatchOperator>::new(
+                ".google.cloud.discoveryengine.v1.SuggestionDenyListEntry.MatchOperator",
+            ))
         }
     }
 }
@@ -3451,7 +3776,7 @@ pub struct Control {
     /// Must be set when solution_type is
     /// [SolutionType.SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub use_cases: std::vec::Vec<crate::model::SearchUseCase>,
 
@@ -3991,126 +4316,249 @@ pub mod control {
 
             /// The attribute(or function) for which the custom ranking is to be
             /// applied.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct AttributeType(i32);
-
-            impl AttributeType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum AttributeType {
                 /// Unspecified AttributeType.
-                pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType = AttributeType::new(0);
-
+                Unspecified,
                 /// The value of the numerical field will be used to dynamically update
                 /// the boost amount. In this case, the attribute_value (the x value)
                 /// of the control point will be the actual value of the numerical
                 /// field for which the boost_amount is specified.
-                pub const NUMERICAL: AttributeType = AttributeType::new(1);
-
+                Numerical,
                 /// For the freshness use case the attribute value will be the duration
                 /// between the current time and the date in the datetime field
                 /// specified. The value must be formatted as an XSD `dayTimeDuration`
                 /// value (a restricted subset of an ISO 8601 duration value). The
                 /// pattern for this is: `[nD][T[nH][nM][nS]]`.
                 /// For example, `5D`, `3DT12H30M`, `T24H`.
-                pub const FRESHNESS: AttributeType = AttributeType::new(2);
+                Freshness,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [AttributeType::value] or
+                /// [AttributeType::name].
+                UnknownValue(attribute_type::UnknownValue),
+            }
 
-                /// Creates a new AttributeType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod attribute_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl AttributeType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Numerical => std::option::Option::Some(1),
+                        Self::Freshness => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("NUMERICAL"),
-                        2 => std::borrow::Cow::Borrowed("FRESHNESS"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "ATTRIBUTE_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("ATTRIBUTE_TYPE_UNSPECIFIED")
                         }
-                        "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
-                        "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
-                        _ => std::option::Option::None,
+                        Self::Numerical => std::option::Option::Some("NUMERICAL"),
+                        Self::Freshness => std::option::Option::Some("FRESHNESS"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for AttributeType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for AttributeType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for AttributeType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for AttributeType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Numerical,
+                        2 => Self::Freshness,
+                        _ => Self::UnknownValue(attribute_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for AttributeType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "ATTRIBUTE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "NUMERICAL" => Self::Numerical,
+                        "FRESHNESS" => Self::Freshness,
+                        _ => Self::UnknownValue(attribute_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for AttributeType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Numerical => serializer.serialize_i32(1),
+                        Self::Freshness => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for AttributeType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttributeType>::new(
+                        ".google.cloud.discoveryengine.v1.Control.BoostAction.InterpolationBoostSpec.AttributeType"))
                 }
             }
 
             /// The interpolation type to be applied. Default will be linear
             /// (Piecewise Linear).
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct InterpolationType(i32);
-
-            impl InterpolationType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum InterpolationType {
                 /// Interpolation type is unspecified. In this case, it defaults to
                 /// Linear.
-                pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                    InterpolationType::new(0);
-
+                Unspecified,
                 /// Piecewise linear interpolation will be applied.
-                pub const LINEAR: InterpolationType = InterpolationType::new(1);
+                Linear,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [InterpolationType::value] or
+                /// [InterpolationType::name].
+                UnknownValue(interpolation_type::UnknownValue),
+            }
 
-                /// Creates a new InterpolationType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod interpolation_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl InterpolationType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Linear => std::option::Option::Some(1),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("LINEAR"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "INTERPOLATION_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::INTERPOLATION_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("INTERPOLATION_TYPE_UNSPECIFIED")
                         }
-                        "LINEAR" => std::option::Option::Some(Self::LINEAR),
-                        _ => std::option::Option::None,
+                        Self::Linear => std::option::Option::Some("LINEAR"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for InterpolationType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for InterpolationType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for InterpolationType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for InterpolationType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Linear,
+                        _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for InterpolationType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "INTERPOLATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "LINEAR" => Self::Linear,
+                        _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for InterpolationType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Linear => serializer.serialize_i32(1),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for InterpolationType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterpolationType>::new(
+                        ".google.cloud.discoveryengine.v1.Control.BoostAction.InterpolationBoostSpec.InterpolationType"))
                 }
             }
         }
@@ -4762,59 +5210,120 @@ pub mod conversation {
     use super::*;
 
     /// Enumeration of the state of the conversation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unknown.
+        Unspecified,
+        /// Conversation is currently open.
+        InProgress,
+        /// Conversation has been completed.
+        Completed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Conversation is currently open.
-        pub const IN_PROGRESS: State = State::new(1);
-
-        /// Conversation has been completed.
-        pub const COMPLETED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Completed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("COMPLETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Completed => std::option::Option::Some("COMPLETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "COMPLETED" => std::option::Option::Some(Self::COMPLETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "COMPLETED" => Self::Completed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Completed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.discoveryengine.v1.Conversation.State",
+            ))
         }
     }
 }
@@ -6023,81 +6532,147 @@ pub mod answer_query_request {
             use super::*;
 
             /// Probability based thresholds levels for blocking.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct HarmBlockThreshold(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum HarmBlockThreshold {
+                /// Unspecified harm block threshold.
+                Unspecified,
+                /// Block low threshold and above (i.e. block more).
+                BlockLowAndAbove,
+                /// Block medium threshold and above.
+                BlockMediumAndAbove,
+                /// Block only high threshold (i.e. block less).
+                BlockOnlyHigh,
+                /// Block none.
+                BlockNone,
+                /// Turn off the safety filter.
+                Off,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [HarmBlockThreshold::value] or
+                /// [HarmBlockThreshold::name].
+                UnknownValue(harm_block_threshold::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod harm_block_threshold {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl HarmBlockThreshold {
-                /// Unspecified harm block threshold.
-                pub const HARM_BLOCK_THRESHOLD_UNSPECIFIED: HarmBlockThreshold =
-                    HarmBlockThreshold::new(0);
-
-                /// Block low threshold and above (i.e. block more).
-                pub const BLOCK_LOW_AND_ABOVE: HarmBlockThreshold = HarmBlockThreshold::new(1);
-
-                /// Block medium threshold and above.
-                pub const BLOCK_MEDIUM_AND_ABOVE: HarmBlockThreshold = HarmBlockThreshold::new(2);
-
-                /// Block only high threshold (i.e. block less).
-                pub const BLOCK_ONLY_HIGH: HarmBlockThreshold = HarmBlockThreshold::new(3);
-
-                /// Block none.
-                pub const BLOCK_NONE: HarmBlockThreshold = HarmBlockThreshold::new(4);
-
-                /// Turn off the safety filter.
-                pub const OFF: HarmBlockThreshold = HarmBlockThreshold::new(5);
-
-                /// Creates a new HarmBlockThreshold instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::BlockLowAndAbove => std::option::Option::Some(1),
+                        Self::BlockMediumAndAbove => std::option::Option::Some(2),
+                        Self::BlockOnlyHigh => std::option::Option::Some(3),
+                        Self::BlockNone => std::option::Option::Some(4),
+                        Self::Off => std::option::Option::Some(5),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("HARM_BLOCK_THRESHOLD_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("BLOCK_LOW_AND_ABOVE"),
-                        2 => std::borrow::Cow::Borrowed("BLOCK_MEDIUM_AND_ABOVE"),
-                        3 => std::borrow::Cow::Borrowed("BLOCK_ONLY_HIGH"),
-                        4 => std::borrow::Cow::Borrowed("BLOCK_NONE"),
-                        5 => std::borrow::Cow::Borrowed("OFF"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("HARM_BLOCK_THRESHOLD_UNSPECIFIED")
+                        }
+                        Self::BlockLowAndAbove => std::option::Option::Some("BLOCK_LOW_AND_ABOVE"),
+                        Self::BlockMediumAndAbove => {
+                            std::option::Option::Some("BLOCK_MEDIUM_AND_ABOVE")
+                        }
+                        Self::BlockOnlyHigh => std::option::Option::Some("BLOCK_ONLY_HIGH"),
+                        Self::BlockNone => std::option::Option::Some("BLOCK_NONE"),
+                        Self::Off => std::option::Option::Some("OFF"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "HARM_BLOCK_THRESHOLD_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::HARM_BLOCK_THRESHOLD_UNSPECIFIED)
-                        }
-                        "BLOCK_LOW_AND_ABOVE" => {
-                            std::option::Option::Some(Self::BLOCK_LOW_AND_ABOVE)
-                        }
-                        "BLOCK_MEDIUM_AND_ABOVE" => {
-                            std::option::Option::Some(Self::BLOCK_MEDIUM_AND_ABOVE)
-                        }
-                        "BLOCK_ONLY_HIGH" => std::option::Option::Some(Self::BLOCK_ONLY_HIGH),
-                        "BLOCK_NONE" => std::option::Option::Some(Self::BLOCK_NONE),
-                        "OFF" => std::option::Option::Some(Self::OFF),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for HarmBlockThreshold {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for HarmBlockThreshold {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for HarmBlockThreshold {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for HarmBlockThreshold {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::BlockLowAndAbove,
+                        2 => Self::BlockMediumAndAbove,
+                        3 => Self::BlockOnlyHigh,
+                        4 => Self::BlockNone,
+                        5 => Self::Off,
+                        _ => Self::UnknownValue(harm_block_threshold::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for HarmBlockThreshold {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "HARM_BLOCK_THRESHOLD_UNSPECIFIED" => Self::Unspecified,
+                        "BLOCK_LOW_AND_ABOVE" => Self::BlockLowAndAbove,
+                        "BLOCK_MEDIUM_AND_ABOVE" => Self::BlockMediumAndAbove,
+                        "BLOCK_ONLY_HIGH" => Self::BlockOnlyHigh,
+                        "BLOCK_NONE" => Self::BlockNone,
+                        "OFF" => Self::Off,
+                        _ => Self::UnknownValue(harm_block_threshold::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for HarmBlockThreshold {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::BlockLowAndAbove => serializer.serialize_i32(1),
+                        Self::BlockMediumAndAbove => serializer.serialize_i32(2),
+                        Self::BlockOnlyHigh => serializer.serialize_i32(3),
+                        Self::BlockNone => serializer.serialize_i32(4),
+                        Self::Off => serializer.serialize_i32(5),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for HarmBlockThreshold {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmBlockThreshold>::new(
+                        ".google.cloud.discoveryengine.v1.AnswerQueryRequest.SafetySpec.SafetySetting.HarmBlockThreshold"))
                 }
             }
         }
@@ -6192,61 +6767,122 @@ pub mod answer_query_request {
         use super::*;
 
         /// Level to filter based on answer grounding.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FilteringLevel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum FilteringLevel {
+            /// Default is no filter
+            Unspecified,
+            /// Filter answers based on a low threshold.
+            Low,
+            /// Filter answers based on a high threshold.
+            High,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [FilteringLevel::value] or
+            /// [FilteringLevel::name].
+            UnknownValue(filtering_level::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod filtering_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl FilteringLevel {
-            /// Default is no filter
-            pub const FILTERING_LEVEL_UNSPECIFIED: FilteringLevel = FilteringLevel::new(0);
-
-            /// Filter answers based on a low threshold.
-            pub const FILTERING_LEVEL_LOW: FilteringLevel = FilteringLevel::new(1);
-
-            /// Filter answers based on a high threshold.
-            pub const FILTERING_LEVEL_HIGH: FilteringLevel = FilteringLevel::new(2);
-
-            /// Creates a new FilteringLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Low => std::option::Option::Some(1),
+                    Self::High => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("FILTERING_LEVEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("FILTERING_LEVEL_LOW"),
-                    2 => std::borrow::Cow::Borrowed("FILTERING_LEVEL_HIGH"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("FILTERING_LEVEL_UNSPECIFIED"),
+                    Self::Low => std::option::Option::Some("FILTERING_LEVEL_LOW"),
+                    Self::High => std::option::Option::Some("FILTERING_LEVEL_HIGH"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "FILTERING_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::FILTERING_LEVEL_UNSPECIFIED)
-                    }
-                    "FILTERING_LEVEL_LOW" => std::option::Option::Some(Self::FILTERING_LEVEL_LOW),
-                    "FILTERING_LEVEL_HIGH" => std::option::Option::Some(Self::FILTERING_LEVEL_HIGH),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for FilteringLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for FilteringLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for FilteringLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for FilteringLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Low,
+                    2 => Self::High,
+                    _ => Self::UnknownValue(filtering_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for FilteringLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "FILTERING_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "FILTERING_LEVEL_LOW" => Self::Low,
+                    "FILTERING_LEVEL_HIGH" => Self::High,
+                    _ => Self::UnknownValue(filtering_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for FilteringLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Low => serializer.serialize_i32(1),
+                    Self::High => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for FilteringLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<FilteringLevel>::new(
+                    ".google.cloud.discoveryengine.v1.AnswerQueryRequest.GroundingSpec.FilteringLevel"))
             }
         }
     }
@@ -7415,75 +8051,140 @@ pub mod answer_query_request {
             use super::*;
 
             /// Query classification types.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Type {
+                /// Unspecified query classification type.
+                Unspecified,
+                /// Adversarial query classification type.
+                AdversarialQuery,
+                /// Non-answer-seeking query classification type, for chit chat.
+                NonAnswerSeekingQuery,
+                /// Jail-breaking query classification type.
+                JailBreakingQuery,
+                /// Non-answer-seeking query classification type, for no clear intent.
+                NonAnswerSeekingQueryV2,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Type::value] or
+                /// [Type::name].
+                UnknownValue(r#type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod r#type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl Type {
-                /// Unspecified query classification type.
-                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-                /// Adversarial query classification type.
-                pub const ADVERSARIAL_QUERY: Type = Type::new(1);
-
-                /// Non-answer-seeking query classification type, for chit chat.
-                pub const NON_ANSWER_SEEKING_QUERY: Type = Type::new(2);
-
-                /// Jail-breaking query classification type.
-                pub const JAIL_BREAKING_QUERY: Type = Type::new(3);
-
-                /// Non-answer-seeking query classification type, for no clear intent.
-                pub const NON_ANSWER_SEEKING_QUERY_V2: Type = Type::new(4);
-
-                /// Creates a new Type instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::AdversarialQuery => std::option::Option::Some(1),
+                        Self::NonAnswerSeekingQuery => std::option::Option::Some(2),
+                        Self::JailBreakingQuery => std::option::Option::Some(3),
+                        Self::NonAnswerSeekingQueryV2 => std::option::Option::Some(4),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY"),
-                        2 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY"),
-                        3 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY"),
-                        4 => std::borrow::Cow::Borrowed("NON_ANSWER_SEEKING_QUERY_V2"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                        Self::AdversarialQuery => std::option::Option::Some("ADVERSARIAL_QUERY"),
+                        Self::NonAnswerSeekingQuery => {
+                            std::option::Option::Some("NON_ANSWER_SEEKING_QUERY")
+                        }
+                        Self::JailBreakingQuery => std::option::Option::Some("JAIL_BREAKING_QUERY"),
+                        Self::NonAnswerSeekingQueryV2 => {
+                            std::option::Option::Some("NON_ANSWER_SEEKING_QUERY_V2")
+                        }
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                        "ADVERSARIAL_QUERY" => std::option::Option::Some(Self::ADVERSARIAL_QUERY),
-                        "NON_ANSWER_SEEKING_QUERY" => {
-                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY)
-                        }
-                        "JAIL_BREAKING_QUERY" => {
-                            std::option::Option::Some(Self::JAIL_BREAKING_QUERY)
-                        }
-                        "NON_ANSWER_SEEKING_QUERY_V2" => {
-                            std::option::Option::Some(Self::NON_ANSWER_SEEKING_QUERY_V2)
-                        }
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Type {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Type {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::AdversarialQuery,
+                        2 => Self::NonAnswerSeekingQuery,
+                        3 => Self::JailBreakingQuery,
+                        4 => Self::NonAnswerSeekingQueryV2,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Type {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "ADVERSARIAL_QUERY" => Self::AdversarialQuery,
+                        "NON_ANSWER_SEEKING_QUERY" => Self::NonAnswerSeekingQuery,
+                        "JAIL_BREAKING_QUERY" => Self::JailBreakingQuery,
+                        "NON_ANSWER_SEEKING_QUERY_V2" => Self::NonAnswerSeekingQueryV2,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Type {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::AdversarialQuery => serializer.serialize_i32(1),
+                        Self::NonAnswerSeekingQuery => serializer.serialize_i32(2),
+                        Self::JailBreakingQuery => serializer.serialize_i32(3),
+                        Self::NonAnswerSeekingQueryV2 => serializer.serialize_i32(4),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Type {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                        ".google.cloud.discoveryengine.v1.AnswerQueryRequest.QueryUnderstandingSpec.QueryClassificationSpec.Type"))
                 }
             }
         }
@@ -7589,61 +8290,124 @@ pub mod answer_query_request {
                 /// Query rephraser types. Currently only supports single-hop
                 /// (max_rephrase_steps = 1) model selections. For multi-hop
                 /// (max_rephrase_steps > 1), there is only one default model.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct ModelType(i32);
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum ModelType {
+                    /// Unspecified model type.
+                    Unspecified,
+                    /// Small query rephraser model. Gemini 1.0 XS model.
+                    Small,
+                    /// Large query rephraser model. Gemini 1.0 Pro model.
+                    Large,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [ModelType::value] or
+                    /// [ModelType::name].
+                    UnknownValue(model_type::UnknownValue),
+                }
+
+                #[doc(hidden)]
+                pub mod model_type {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
                 impl ModelType {
-                    /// Unspecified model type.
-                    pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
-
-                    /// Small query rephraser model. Gemini 1.0 XS model.
-                    pub const SMALL: ModelType = ModelType::new(1);
-
-                    /// Large query rephraser model. Gemini 1.0 Pro model.
-                    pub const LARGE: ModelType = ModelType::new(2);
-
-                    /// Creates a new ModelType instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
-
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::Small => std::option::Option::Some(1),
+                            Self::Large => std::option::Option::Some(2),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("SMALL"),
-                            2 => std::borrow::Cow::Borrowed("LARGE"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "MODEL_TYPE_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => {
+                                std::option::Option::Some("MODEL_TYPE_UNSPECIFIED")
                             }
-                            "SMALL" => std::option::Option::Some(Self::SMALL),
-                            "LARGE" => std::option::Option::Some(Self::LARGE),
-                            _ => std::option::Option::None,
+                            Self::Small => std::option::Option::Some("SMALL"),
+                            Self::Large => std::option::Option::Some("LARGE"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for ModelType {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for ModelType {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for ModelType {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for ModelType {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::Small,
+                            2 => Self::Large,
+                            _ => Self::UnknownValue(model_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for ModelType {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                            "SMALL" => Self::Small,
+                            "LARGE" => Self::Large,
+                            _ => Self::UnknownValue(model_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for ModelType {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::Small => serializer.serialize_i32(1),
+                            Self::Large => serializer.serialize_i32(2),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for ModelType {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelType>::new(
+                            ".google.cloud.discoveryengine.v1.AnswerQueryRequest.QueryUnderstandingSpec.QueryRephraserSpec.ModelSpec.ModelType"))
                     }
                 }
             }
@@ -8442,88 +9206,155 @@ pub mod custom_tuning_model {
     use super::*;
 
     /// The state of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelState {
+        /// Default value.
+        Unspecified,
+        /// The model is in a paused training state.
+        TrainingPaused,
+        /// The model is currently training.
+        Training,
+        /// The model has successfully completed training.
+        TrainingComplete,
+        /// The model is ready for serving.
+        ReadyForServing,
+        /// The model training failed.
+        TrainingFailed,
+        /// The model training finished successfully but metrics did not improve.
+        NoImprovement,
+        /// Input data validation failed. Model training didn't start.
+        InputValidationFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelState::value] or
+        /// [ModelState::name].
+        UnknownValue(model_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod model_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ModelState {
-        /// Default value.
-        pub const MODEL_STATE_UNSPECIFIED: ModelState = ModelState::new(0);
-
-        /// The model is in a paused training state.
-        pub const TRAINING_PAUSED: ModelState = ModelState::new(1);
-
-        /// The model is currently training.
-        pub const TRAINING: ModelState = ModelState::new(2);
-
-        /// The model has successfully completed training.
-        pub const TRAINING_COMPLETE: ModelState = ModelState::new(3);
-
-        /// The model is ready for serving.
-        pub const READY_FOR_SERVING: ModelState = ModelState::new(4);
-
-        /// The model training failed.
-        pub const TRAINING_FAILED: ModelState = ModelState::new(5);
-
-        /// The model training finished successfully but metrics did not improve.
-        pub const NO_IMPROVEMENT: ModelState = ModelState::new(6);
-
-        /// Input data validation failed. Model training didn't start.
-        pub const INPUT_VALIDATION_FAILED: ModelState = ModelState::new(7);
-
-        /// Creates a new ModelState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TrainingPaused => std::option::Option::Some(1),
+                Self::Training => std::option::Option::Some(2),
+                Self::TrainingComplete => std::option::Option::Some(3),
+                Self::ReadyForServing => std::option::Option::Some(4),
+                Self::TrainingFailed => std::option::Option::Some(5),
+                Self::NoImprovement => std::option::Option::Some(6),
+                Self::InputValidationFailed => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRAINING_PAUSED"),
-                2 => std::borrow::Cow::Borrowed("TRAINING"),
-                3 => std::borrow::Cow::Borrowed("TRAINING_COMPLETE"),
-                4 => std::borrow::Cow::Borrowed("READY_FOR_SERVING"),
-                5 => std::borrow::Cow::Borrowed("TRAINING_FAILED"),
-                6 => std::borrow::Cow::Borrowed("NO_IMPROVEMENT"),
-                7 => std::borrow::Cow::Borrowed("INPUT_VALIDATION_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_STATE_UNSPECIFIED"),
+                Self::TrainingPaused => std::option::Option::Some("TRAINING_PAUSED"),
+                Self::Training => std::option::Option::Some("TRAINING"),
+                Self::TrainingComplete => std::option::Option::Some("TRAINING_COMPLETE"),
+                Self::ReadyForServing => std::option::Option::Some("READY_FOR_SERVING"),
+                Self::TrainingFailed => std::option::Option::Some("TRAINING_FAILED"),
+                Self::NoImprovement => std::option::Option::Some("NO_IMPROVEMENT"),
+                Self::InputValidationFailed => std::option::Option::Some("INPUT_VALIDATION_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MODEL_STATE_UNSPECIFIED)
-                }
-                "TRAINING_PAUSED" => std::option::Option::Some(Self::TRAINING_PAUSED),
-                "TRAINING" => std::option::Option::Some(Self::TRAINING),
-                "TRAINING_COMPLETE" => std::option::Option::Some(Self::TRAINING_COMPLETE),
-                "READY_FOR_SERVING" => std::option::Option::Some(Self::READY_FOR_SERVING),
-                "TRAINING_FAILED" => std::option::Option::Some(Self::TRAINING_FAILED),
-                "NO_IMPROVEMENT" => std::option::Option::Some(Self::NO_IMPROVEMENT),
-                "INPUT_VALIDATION_FAILED" => {
-                    std::option::Option::Some(Self::INPUT_VALIDATION_FAILED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TrainingPaused,
+                2 => Self::Training,
+                3 => Self::TrainingComplete,
+                4 => Self::ReadyForServing,
+                5 => Self::TrainingFailed,
+                6 => Self::NoImprovement,
+                7 => Self::InputValidationFailed,
+                _ => Self::UnknownValue(model_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_STATE_UNSPECIFIED" => Self::Unspecified,
+                "TRAINING_PAUSED" => Self::TrainingPaused,
+                "TRAINING" => Self::Training,
+                "TRAINING_COMPLETE" => Self::TrainingComplete,
+                "READY_FOR_SERVING" => Self::ReadyForServing,
+                "TRAINING_FAILED" => Self::TrainingFailed,
+                "NO_IMPROVEMENT" => Self::NoImprovement,
+                "INPUT_VALIDATION_FAILED" => Self::InputValidationFailed,
+                _ => Self::UnknownValue(model_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TrainingPaused => serializer.serialize_i32(1),
+                Self::Training => serializer.serialize_i32(2),
+                Self::TrainingComplete => serializer.serialize_i32(3),
+                Self::ReadyForServing => serializer.serialize_i32(4),
+                Self::TrainingFailed => serializer.serialize_i32(5),
+                Self::NoImprovement => serializer.serialize_i32(6),
+                Self::InputValidationFailed => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelState>::new(
+                ".google.cloud.discoveryengine.v1.CustomTuningModel.ModelState",
+            ))
         }
     }
 }
@@ -8576,7 +9407,7 @@ pub struct DataStore {
     /// the server behavior defaults to
     /// [ContentConfig.NO_CONTENT][google.cloud.discoveryengine.v1.DataStore.ContentConfig.NO_CONTENT].
     ///
-    /// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.NO_CONTENT]: crate::model::data_store::content_config::NO_CONTENT
+    /// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.NO_CONTENT]: crate::model::data_store::ContentConfig::NoContent
     pub content_config: crate::model::data_store::ContentConfig,
 
     /// Output only. Timestamp the
@@ -8600,7 +9431,7 @@ pub struct DataStore {
     /// is set as
     /// [DataStore.ContentConfig.GOOGLE_WORKSPACE][google.cloud.discoveryengine.v1.DataStore.ContentConfig.GOOGLE_WORKSPACE].
     ///
-    /// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.GOOGLE_WORKSPACE]: crate::model::data_store::content_config::GOOGLE_WORKSPACE
+    /// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.GOOGLE_WORKSPACE]: crate::model::data_store::ContentConfig::GoogleWorkspace
     /// [google.cloud.discoveryengine.v1.DataStore.content_config]: crate::model::DataStore::content_config
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub workspace_config: std::option::Option<crate::model::WorkspaceConfig>,
@@ -8867,81 +9698,144 @@ pub mod data_store {
     }
 
     /// Content config of the data store.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContentConfig(i32);
-
-    impl ContentConfig {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ContentConfig {
         /// Default value.
-        pub const CONTENT_CONFIG_UNSPECIFIED: ContentConfig = ContentConfig::new(0);
-
+        Unspecified,
         /// Only contains documents without any
         /// [Document.content][google.cloud.discoveryengine.v1.Document.content].
         ///
         /// [google.cloud.discoveryengine.v1.Document.content]: crate::model::Document::content
-        pub const NO_CONTENT: ContentConfig = ContentConfig::new(1);
-
+        NoContent,
         /// Only contains documents with
         /// [Document.content][google.cloud.discoveryengine.v1.Document.content].
         ///
         /// [google.cloud.discoveryengine.v1.Document.content]: crate::model::Document::content
-        pub const CONTENT_REQUIRED: ContentConfig = ContentConfig::new(2);
-
+        ContentRequired,
         /// The data store is used for public website search.
-        pub const PUBLIC_WEBSITE: ContentConfig = ContentConfig::new(3);
-
+        PublicWebsite,
         /// The data store is used for workspace search. Details of workspace
         /// data store are specified in the
         /// [WorkspaceConfig][google.cloud.discoveryengine.v1.WorkspaceConfig].
         ///
         /// [google.cloud.discoveryengine.v1.WorkspaceConfig]: crate::model::WorkspaceConfig
-        pub const GOOGLE_WORKSPACE: ContentConfig = ContentConfig::new(4);
+        GoogleWorkspace,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ContentConfig::value] or
+        /// [ContentConfig::name].
+        UnknownValue(content_config::UnknownValue),
+    }
 
-        /// Creates a new ContentConfig instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod content_config {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ContentConfig {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoContent => std::option::Option::Some(1),
+                Self::ContentRequired => std::option::Option::Some(2),
+                Self::PublicWebsite => std::option::Option::Some(3),
+                Self::GoogleWorkspace => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONTENT_CONFIG_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_CONTENT"),
-                2 => std::borrow::Cow::Borrowed("CONTENT_REQUIRED"),
-                3 => std::borrow::Cow::Borrowed("PUBLIC_WEBSITE"),
-                4 => std::borrow::Cow::Borrowed("GOOGLE_WORKSPACE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONTENT_CONFIG_UNSPECIFIED"),
+                Self::NoContent => std::option::Option::Some("NO_CONTENT"),
+                Self::ContentRequired => std::option::Option::Some("CONTENT_REQUIRED"),
+                Self::PublicWebsite => std::option::Option::Some("PUBLIC_WEBSITE"),
+                Self::GoogleWorkspace => std::option::Option::Some("GOOGLE_WORKSPACE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONTENT_CONFIG_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONTENT_CONFIG_UNSPECIFIED)
-                }
-                "NO_CONTENT" => std::option::Option::Some(Self::NO_CONTENT),
-                "CONTENT_REQUIRED" => std::option::Option::Some(Self::CONTENT_REQUIRED),
-                "PUBLIC_WEBSITE" => std::option::Option::Some(Self::PUBLIC_WEBSITE),
-                "GOOGLE_WORKSPACE" => std::option::Option::Some(Self::GOOGLE_WORKSPACE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ContentConfig {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ContentConfig {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ContentConfig {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ContentConfig {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoContent,
+                2 => Self::ContentRequired,
+                3 => Self::PublicWebsite,
+                4 => Self::GoogleWorkspace,
+                _ => Self::UnknownValue(content_config::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ContentConfig {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONTENT_CONFIG_UNSPECIFIED" => Self::Unspecified,
+                "NO_CONTENT" => Self::NoContent,
+                "CONTENT_REQUIRED" => Self::ContentRequired,
+                "PUBLIC_WEBSITE" => Self::PublicWebsite,
+                "GOOGLE_WORKSPACE" => Self::GoogleWorkspace,
+                _ => Self::UnknownValue(content_config::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ContentConfig {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoContent => serializer.serialize_i32(1),
+                Self::ContentRequired => serializer.serialize_i32(2),
+                Self::PublicWebsite => serializer.serialize_i32(3),
+                Self::GoogleWorkspace => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ContentConfig {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentConfig>::new(
+                ".google.cloud.discoveryengine.v1.DataStore.ContentConfig",
+            ))
         }
     }
 }
@@ -9078,89 +9972,162 @@ pub mod workspace_config {
     use super::*;
 
     /// Specifies the type of Workspace App supported by this DataStore
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Defaults to an unspecified Workspace type.
+        Unspecified,
+        /// Workspace Data Store contains Drive data
+        GoogleDrive,
+        /// Workspace Data Store contains Mail data
+        GoogleMail,
+        /// Workspace Data Store contains Sites data
+        GoogleSites,
+        /// Workspace Data Store contains Calendar data
+        GoogleCalendar,
+        /// Workspace Data Store contains Chat data
+        GoogleChat,
+        /// Workspace Data Store contains Groups data
+        GoogleGroups,
+        /// Workspace Data Store contains Keep data
+        GoogleKeep,
+        /// Workspace Data Store contains People data
+        GooglePeople,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Defaults to an unspecified Workspace type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Workspace Data Store contains Drive data
-        pub const GOOGLE_DRIVE: Type = Type::new(1);
-
-        /// Workspace Data Store contains Mail data
-        pub const GOOGLE_MAIL: Type = Type::new(2);
-
-        /// Workspace Data Store contains Sites data
-        pub const GOOGLE_SITES: Type = Type::new(3);
-
-        /// Workspace Data Store contains Calendar data
-        pub const GOOGLE_CALENDAR: Type = Type::new(4);
-
-        /// Workspace Data Store contains Chat data
-        pub const GOOGLE_CHAT: Type = Type::new(5);
-
-        /// Workspace Data Store contains Groups data
-        pub const GOOGLE_GROUPS: Type = Type::new(6);
-
-        /// Workspace Data Store contains Keep data
-        pub const GOOGLE_KEEP: Type = Type::new(7);
-
-        /// Workspace Data Store contains People data
-        pub const GOOGLE_PEOPLE: Type = Type::new(8);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleDrive => std::option::Option::Some(1),
+                Self::GoogleMail => std::option::Option::Some(2),
+                Self::GoogleSites => std::option::Option::Some(3),
+                Self::GoogleCalendar => std::option::Option::Some(4),
+                Self::GoogleChat => std::option::Option::Some(5),
+                Self::GoogleGroups => std::option::Option::Some(6),
+                Self::GoogleKeep => std::option::Option::Some(7),
+                Self::GooglePeople => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_DRIVE"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_MAIL"),
-                3 => std::borrow::Cow::Borrowed("GOOGLE_SITES"),
-                4 => std::borrow::Cow::Borrowed("GOOGLE_CALENDAR"),
-                5 => std::borrow::Cow::Borrowed("GOOGLE_CHAT"),
-                6 => std::borrow::Cow::Borrowed("GOOGLE_GROUPS"),
-                7 => std::borrow::Cow::Borrowed("GOOGLE_KEEP"),
-                8 => std::borrow::Cow::Borrowed("GOOGLE_PEOPLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::GoogleDrive => std::option::Option::Some("GOOGLE_DRIVE"),
+                Self::GoogleMail => std::option::Option::Some("GOOGLE_MAIL"),
+                Self::GoogleSites => std::option::Option::Some("GOOGLE_SITES"),
+                Self::GoogleCalendar => std::option::Option::Some("GOOGLE_CALENDAR"),
+                Self::GoogleChat => std::option::Option::Some("GOOGLE_CHAT"),
+                Self::GoogleGroups => std::option::Option::Some("GOOGLE_GROUPS"),
+                Self::GoogleKeep => std::option::Option::Some("GOOGLE_KEEP"),
+                Self::GooglePeople => std::option::Option::Some("GOOGLE_PEOPLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "GOOGLE_DRIVE" => std::option::Option::Some(Self::GOOGLE_DRIVE),
-                "GOOGLE_MAIL" => std::option::Option::Some(Self::GOOGLE_MAIL),
-                "GOOGLE_SITES" => std::option::Option::Some(Self::GOOGLE_SITES),
-                "GOOGLE_CALENDAR" => std::option::Option::Some(Self::GOOGLE_CALENDAR),
-                "GOOGLE_CHAT" => std::option::Option::Some(Self::GOOGLE_CHAT),
-                "GOOGLE_GROUPS" => std::option::Option::Some(Self::GOOGLE_GROUPS),
-                "GOOGLE_KEEP" => std::option::Option::Some(Self::GOOGLE_KEEP),
-                "GOOGLE_PEOPLE" => std::option::Option::Some(Self::GOOGLE_PEOPLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleDrive,
+                2 => Self::GoogleMail,
+                3 => Self::GoogleSites,
+                4 => Self::GoogleCalendar,
+                5 => Self::GoogleChat,
+                6 => Self::GoogleGroups,
+                7 => Self::GoogleKeep,
+                8 => Self::GooglePeople,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_DRIVE" => Self::GoogleDrive,
+                "GOOGLE_MAIL" => Self::GoogleMail,
+                "GOOGLE_SITES" => Self::GoogleSites,
+                "GOOGLE_CALENDAR" => Self::GoogleCalendar,
+                "GOOGLE_CHAT" => Self::GoogleChat,
+                "GOOGLE_GROUPS" => Self::GoogleGroups,
+                "GOOGLE_KEEP" => Self::GoogleKeep,
+                "GOOGLE_PEOPLE" => Self::GooglePeople,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleDrive => serializer.serialize_i32(1),
+                Self::GoogleMail => serializer.serialize_i32(2),
+                Self::GoogleSites => serializer.serialize_i32(3),
+                Self::GoogleCalendar => serializer.serialize_i32(4),
+                Self::GoogleChat => serializer.serialize_i32(5),
+                Self::GoogleGroups => serializer.serialize_i32(6),
+                Self::GoogleKeep => serializer.serialize_i32(7),
+                Self::GooglePeople => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.discoveryengine.v1.WorkspaceConfig.Type",
+            ))
         }
     }
 }
@@ -10151,7 +11118,7 @@ pub mod document {
 /// the default parser will default to digital parser.
 ///
 /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-/// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.CONTENT_REQUIRED]: crate::model::data_store::content_config::CONTENT_REQUIRED
+/// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.CONTENT_REQUIRED]: crate::model::data_store::ContentConfig::ContentRequired
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -11644,73 +12611,136 @@ pub mod batch_get_documents_metadata_response {
     /// The state of the [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Should never be set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The [Document][google.cloud.discoveryengine.v1.Document] is indexed.
         ///
         /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-        pub const INDEXED: State = State::new(1);
-
+        Indexed,
         /// The [Document][google.cloud.discoveryengine.v1.Document] is not indexed
         /// because its URI is not in the
         /// [TargetSite][google.cloud.discoveryengine.v1.TargetSite].
         ///
         /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
         /// [google.cloud.discoveryengine.v1.TargetSite]: crate::model::TargetSite
-        pub const NOT_IN_TARGET_SITE: State = State::new(2);
-
+        NotInTargetSite,
         /// The [Document][google.cloud.discoveryengine.v1.Document] is not indexed.
         ///
         /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
-        pub const NOT_IN_INDEX: State = State::new(3);
+        NotInIndex,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Indexed => std::option::Option::Some(1),
+                Self::NotInTargetSite => std::option::Option::Some(2),
+                Self::NotInIndex => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INDEXED"),
-                2 => std::borrow::Cow::Borrowed("NOT_IN_TARGET_SITE"),
-                3 => std::borrow::Cow::Borrowed("NOT_IN_INDEX"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Indexed => std::option::Option::Some("INDEXED"),
+                Self::NotInTargetSite => std::option::Option::Some("NOT_IN_TARGET_SITE"),
+                Self::NotInIndex => std::option::Option::Some("NOT_IN_INDEX"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INDEXED" => std::option::Option::Some(Self::INDEXED),
-                "NOT_IN_TARGET_SITE" => std::option::Option::Some(Self::NOT_IN_TARGET_SITE),
-                "NOT_IN_INDEX" => std::option::Option::Some(Self::NOT_IN_INDEX),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Indexed,
+                2 => Self::NotInTargetSite,
+                3 => Self::NotInIndex,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INDEXED" => Self::Indexed,
+                "NOT_IN_TARGET_SITE" => Self::NotInTargetSite,
+                "NOT_IN_INDEX" => Self::NotInIndex,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Indexed => serializer.serialize_i32(1),
+                Self::NotInTargetSite => serializer.serialize_i32(2),
+                Self::NotInIndex => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.discoveryengine.v1.BatchGetDocumentsMetadataResponse.State",
+            ))
         }
     }
 }
@@ -11771,9 +12801,9 @@ pub struct Engine {
     /// [google.cloud.discoveryengine.v1.CreateEngineRequest]: crate::model::CreateEngineRequest
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
     /// [google.cloud.discoveryengine.v1.Engine.solution_type]: crate::model::Engine::solution_type
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::solution_type::SOLUTION_TYPE_CHAT
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::solution_type::SOLUTION_TYPE_RECOMMENDATION
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::SolutionType::Chat
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::SolutionType::Recommendation
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub data_store_ids: std::vec::Vec<std::string::String>,
 
@@ -12039,7 +13069,7 @@ pub mod engine {
         /// [SearchTier.SEARCH_TIER_STANDARD][google.cloud.discoveryengine.v1.SearchTier.SEARCH_TIER_STANDARD]
         /// if not specified.
         ///
-        /// [google.cloud.discoveryengine.v1.SearchTier.SEARCH_TIER_STANDARD]: crate::model::search_tier::SEARCH_TIER_STANDARD
+        /// [google.cloud.discoveryengine.v1.SearchTier.SEARCH_TIER_STANDARD]: crate::model::SearchTier::Standard
         pub search_tier: crate::model::SearchTier,
 
         /// The add-on that this search engine enables.
@@ -12376,14 +13406,14 @@ pub mod engine {
         /// [SOLUTION_TYPE_CHAT][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT].
         ///
         /// [google.cloud.discoveryengine.v1.Engine.solution_type]: crate::model::Engine::solution_type
-        /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::solution_type::SOLUTION_TYPE_CHAT
+        /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::SolutionType::Chat
         ChatEngineConfig(std::boxed::Box<crate::model::engine::ChatEngineConfig>),
         /// Configurations for the Search Engine. Only applicable if
         /// [solution_type][google.cloud.discoveryengine.v1.Engine.solution_type] is
         /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
         ///
         /// [google.cloud.discoveryengine.v1.Engine.solution_type]: crate::model::Engine::solution_type
-        /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+        /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
         SearchEngineConfig(std::boxed::Box<crate::model::engine::SearchEngineConfig>),
     }
 
@@ -12398,7 +13428,7 @@ pub mod engine {
         /// [SOLUTION_TYPE_CHAT][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT].
         ///
         /// [google.cloud.discoveryengine.v1.Engine.solution_type]: crate::model::Engine::solution_type
-        /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::solution_type::SOLUTION_TYPE_CHAT
+        /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::SolutionType::Chat
         ChatEngineMetadata(std::boxed::Box<crate::model::engine::ChatEngineMetadata>),
     }
 }
@@ -13374,56 +14404,115 @@ pub mod generate_grounded_content_request {
             use super::*;
 
             /// The version of the predictor to be used in dynamic retrieval.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Version(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Version {
+                /// Automatically choose the best version of the retrieval predictor.
+                Unspecified,
+                /// The V1 model which is evaluating each source independently.
+                V1Independent,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Version::value] or
+                /// [Version::name].
+                UnknownValue(version::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod version {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl Version {
-                /// Automatically choose the best version of the retrieval predictor.
-                pub const VERSION_UNSPECIFIED: Version = Version::new(0);
-
-                /// The V1 model which is evaluating each source independently.
-                pub const V1_INDEPENDENT: Version = Version::new(1);
-
-                /// Creates a new Version instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::V1Independent => std::option::Option::Some(1),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("VERSION_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("V1_INDEPENDENT"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("VERSION_UNSPECIFIED"),
+                        Self::V1Independent => std::option::Option::Some("V1_INDEPENDENT"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "VERSION_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::VERSION_UNSPECIFIED)
-                        }
-                        "V1_INDEPENDENT" => std::option::Option::Some(Self::V1_INDEPENDENT),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Version {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Version {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Version {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Version {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::V1Independent,
+                        _ => Self::UnknownValue(version::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Version {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "VERSION_UNSPECIFIED" => Self::Unspecified,
+                        "V1_INDEPENDENT" => Self::V1Independent,
+                        _ => Self::UnknownValue(version::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Version {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::V1Independent => serializer.serialize_i32(1),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Version {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Version>::new(
+                        ".google.cloud.discoveryengine.v1.GenerateGroundedContentRequest.DynamicRetrievalConfiguration.DynamicRetrievalPredictor.Version"))
                 }
             }
         }
@@ -14121,71 +15210,136 @@ pub mod generate_grounded_content_response {
                 use super::*;
 
                 /// Describes the source to which the metadata is associated to.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Source(i32);
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum Source {
+                    /// Unspecified source.
+                    Unspecified,
+                    /// Vertex AI search.
+                    VertexAiSearch,
+                    /// Google Search.
+                    GoogleSearch,
+                    /// User inline provided content.
+                    InlineContent,
+                    /// Google Maps.
+                    GoogleMaps,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [Source::value] or
+                    /// [Source::name].
+                    UnknownValue(source::UnknownValue),
+                }
+
+                #[doc(hidden)]
+                pub mod source {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
                 impl Source {
-                    /// Unspecified source.
-                    pub const SOURCE_UNSPECIFIED: Source = Source::new(0);
-
-                    /// Vertex AI search.
-                    pub const VERTEX_AI_SEARCH: Source = Source::new(1);
-
-                    /// Google Search.
-                    pub const GOOGLE_SEARCH: Source = Source::new(3);
-
-                    /// User inline provided content.
-                    pub const INLINE_CONTENT: Source = Source::new(2);
-
-                    /// Google Maps.
-                    pub const GOOGLE_MAPS: Source = Source::new(4);
-
-                    /// Creates a new Source instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
-
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::VertexAiSearch => std::option::Option::Some(1),
+                            Self::GoogleSearch => std::option::Option::Some(3),
+                            Self::InlineContent => std::option::Option::Some(2),
+                            Self::GoogleMaps => std::option::Option::Some(4),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("SOURCE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("VERTEX_AI_SEARCH"),
-                            2 => std::borrow::Cow::Borrowed("INLINE_CONTENT"),
-                            3 => std::borrow::Cow::Borrowed("GOOGLE_SEARCH"),
-                            4 => std::borrow::Cow::Borrowed("GOOGLE_MAPS"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some("SOURCE_UNSPECIFIED"),
+                            Self::VertexAiSearch => std::option::Option::Some("VERTEX_AI_SEARCH"),
+                            Self::GoogleSearch => std::option::Option::Some("GOOGLE_SEARCH"),
+                            Self::InlineContent => std::option::Option::Some("INLINE_CONTENT"),
+                            Self::GoogleMaps => std::option::Option::Some("GOOGLE_MAPS"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "SOURCE_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::SOURCE_UNSPECIFIED)
-                            }
-                            "VERTEX_AI_SEARCH" => std::option::Option::Some(Self::VERTEX_AI_SEARCH),
-                            "GOOGLE_SEARCH" => std::option::Option::Some(Self::GOOGLE_SEARCH),
-                            "INLINE_CONTENT" => std::option::Option::Some(Self::INLINE_CONTENT),
-                            "GOOGLE_MAPS" => std::option::Option::Some(Self::GOOGLE_MAPS),
-                            _ => std::option::Option::None,
-                        }
-                    }
-                }
-
-                impl std::convert::From<i32> for Source {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Source {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for Source {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for Source {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::VertexAiSearch,
+                            2 => Self::InlineContent,
+                            3 => Self::GoogleSearch,
+                            4 => Self::GoogleMaps,
+                            _ => Self::UnknownValue(source::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for Source {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "SOURCE_UNSPECIFIED" => Self::Unspecified,
+                            "VERTEX_AI_SEARCH" => Self::VertexAiSearch,
+                            "GOOGLE_SEARCH" => Self::GoogleSearch,
+                            "INLINE_CONTENT" => Self::InlineContent,
+                            "GOOGLE_MAPS" => Self::GoogleMaps,
+                            _ => Self::UnknownValue(source::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for Source {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::VertexAiSearch => serializer.serialize_i32(1),
+                            Self::GoogleSearch => serializer.serialize_i32(3),
+                            Self::InlineContent => serializer.serialize_i32(2),
+                            Self::GoogleMaps => serializer.serialize_i32(4),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for Source {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Source>::new(
+                            ".google.cloud.discoveryengine.v1.GenerateGroundedContentResponse.Candidate.GroundingMetadata.RetrievalMetadata.Source"))
                     }
                 }
             }
@@ -14278,56 +15432,115 @@ pub mod generate_grounded_content_response {
                 use super::*;
 
                 /// The version of the predictor which was used in dynamic retrieval.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Version(i32);
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum Version {
+                    /// Unspecified version, should never be used.
+                    Unspecified,
+                    /// The V1 model which is evaluating each source independently.
+                    V1Independent,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [Version::value] or
+                    /// [Version::name].
+                    UnknownValue(version::UnknownValue),
+                }
+
+                #[doc(hidden)]
+                pub mod version {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
                 impl Version {
-                    /// Unspecified version, should never be used.
-                    pub const VERSION_UNSPECIFIED: Version = Version::new(0);
-
-                    /// The V1 model which is evaluating each source independently.
-                    pub const V1_INDEPENDENT: Version = Version::new(1);
-
-                    /// Creates a new Version instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
-
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::V1Independent => std::option::Option::Some(1),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("VERSION_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("V1_INDEPENDENT"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some("VERSION_UNSPECIFIED"),
+                            Self::V1Independent => std::option::Option::Some("V1_INDEPENDENT"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "VERSION_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::VERSION_UNSPECIFIED)
-                            }
-                            "V1_INDEPENDENT" => std::option::Option::Some(Self::V1_INDEPENDENT),
-                            _ => std::option::Option::None,
-                        }
-                    }
-                }
-
-                impl std::convert::From<i32> for Version {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Version {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for Version {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for Version {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::V1Independent,
+                            _ => Self::UnknownValue(version::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for Version {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "VERSION_UNSPECIFIED" => Self::Unspecified,
+                            "V1_INDEPENDENT" => Self::V1Independent,
+                            _ => Self::UnknownValue(version::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for Version {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::V1Independent => serializer.serialize_i32(1),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for Version {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Version>::new(
+                            ".google.cloud.discoveryengine.v1.GenerateGroundedContentResponse.Candidate.GroundingMetadata.DynamicRetrievalPredictorMetadata.Version"))
                     }
                 }
             }
@@ -15684,141 +16897,273 @@ pub mod bigtable_options {
     /// [HBase
     /// Bytes.toBytes](https://hbase.apache.org/1.4/apidocs/org/apache/hadoop/hbase/util/Bytes.html)
     /// function when the encoding value is set to `BINARY`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// The type is unspecified.
+        Unspecified,
+        /// String type.
+        String,
+        /// Numerical type.
+        Number,
+        /// Integer type.
+        Integer,
+        /// Variable length integer type.
+        VarInteger,
+        /// BigDecimal type.
+        BigNumeric,
+        /// Boolean type.
+        Boolean,
+        /// JSON type.
+        Json,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// The type is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// String type.
-        pub const STRING: Type = Type::new(1);
-
-        /// Numerical type.
-        pub const NUMBER: Type = Type::new(2);
-
-        /// Integer type.
-        pub const INTEGER: Type = Type::new(3);
-
-        /// Variable length integer type.
-        pub const VAR_INTEGER: Type = Type::new(4);
-
-        /// BigDecimal type.
-        pub const BIG_NUMERIC: Type = Type::new(5);
-
-        /// Boolean type.
-        pub const BOOLEAN: Type = Type::new(6);
-
-        /// JSON type.
-        pub const JSON: Type = Type::new(7);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::String => std::option::Option::Some(1),
+                Self::Number => std::option::Option::Some(2),
+                Self::Integer => std::option::Option::Some(3),
+                Self::VarInteger => std::option::Option::Some(4),
+                Self::BigNumeric => std::option::Option::Some(5),
+                Self::Boolean => std::option::Option::Some(6),
+                Self::Json => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STRING"),
-                2 => std::borrow::Cow::Borrowed("NUMBER"),
-                3 => std::borrow::Cow::Borrowed("INTEGER"),
-                4 => std::borrow::Cow::Borrowed("VAR_INTEGER"),
-                5 => std::borrow::Cow::Borrowed("BIG_NUMERIC"),
-                6 => std::borrow::Cow::Borrowed("BOOLEAN"),
-                7 => std::borrow::Cow::Borrowed("JSON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Number => std::option::Option::Some("NUMBER"),
+                Self::Integer => std::option::Option::Some("INTEGER"),
+                Self::VarInteger => std::option::Option::Some("VAR_INTEGER"),
+                Self::BigNumeric => std::option::Option::Some("BIG_NUMERIC"),
+                Self::Boolean => std::option::Option::Some("BOOLEAN"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "NUMBER" => std::option::Option::Some(Self::NUMBER),
-                "INTEGER" => std::option::Option::Some(Self::INTEGER),
-                "VAR_INTEGER" => std::option::Option::Some(Self::VAR_INTEGER),
-                "BIG_NUMERIC" => std::option::Option::Some(Self::BIG_NUMERIC),
-                "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::String,
+                2 => Self::Number,
+                3 => Self::Integer,
+                4 => Self::VarInteger,
+                5 => Self::BigNumeric,
+                6 => Self::Boolean,
+                7 => Self::Json,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STRING" => Self::String,
+                "NUMBER" => Self::Number,
+                "INTEGER" => Self::Integer,
+                "VAR_INTEGER" => Self::VarInteger,
+                "BIG_NUMERIC" => Self::BigNumeric,
+                "BOOLEAN" => Self::Boolean,
+                "JSON" => Self::Json,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::String => serializer.serialize_i32(1),
+                Self::Number => serializer.serialize_i32(2),
+                Self::Integer => serializer.serialize_i32(3),
+                Self::VarInteger => serializer.serialize_i32(4),
+                Self::BigNumeric => serializer.serialize_i32(5),
+                Self::Boolean => serializer.serialize_i32(6),
+                Self::Json => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.discoveryengine.v1.BigtableOptions.Type",
+            ))
         }
     }
 
     /// The encoding mode of a Bigtable column or column family.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Encoding(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Encoding {
+        /// The encoding is unspecified.
+        Unspecified,
+        /// Text encoding.
+        Text,
+        /// Binary encoding.
+        Binary,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Encoding::value] or
+        /// [Encoding::name].
+        UnknownValue(encoding::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod encoding {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Encoding {
-        /// The encoding is unspecified.
-        pub const ENCODING_UNSPECIFIED: Encoding = Encoding::new(0);
-
-        /// Text encoding.
-        pub const TEXT: Encoding = Encoding::new(1);
-
-        /// Binary encoding.
-        pub const BINARY: Encoding = Encoding::new(2);
-
-        /// Creates a new Encoding instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Text => std::option::Option::Some(1),
+                Self::Binary => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENCODING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TEXT"),
-                2 => std::borrow::Cow::Borrowed("BINARY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENCODING_UNSPECIFIED"),
+                Self::Text => std::option::Option::Some("TEXT"),
+                Self::Binary => std::option::Option::Some("BINARY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENCODING_UNSPECIFIED" => std::option::Option::Some(Self::ENCODING_UNSPECIFIED),
-                "TEXT" => std::option::Option::Some(Self::TEXT),
-                "BINARY" => std::option::Option::Some(Self::BINARY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Encoding {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Encoding {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Encoding {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Encoding {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Text,
+                2 => Self::Binary,
+                _ => Self::UnknownValue(encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Encoding {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENCODING_UNSPECIFIED" => Self::Unspecified,
+                "TEXT" => Self::Text,
+                "BINARY" => Self::Binary,
+                _ => Self::UnknownValue(encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Encoding {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Text => serializer.serialize_i32(1),
+                Self::Binary => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Encoding {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Encoding>::new(
+                ".google.cloud.discoveryengine.v1.BigtableOptions.Encoding",
+            ))
         }
     }
 }
@@ -16788,7 +18133,7 @@ pub struct ImportDocumentsRequest {
     /// be imported. Defaults to
     /// [ReconciliationMode.INCREMENTAL][google.cloud.discoveryengine.v1.ImportDocumentsRequest.ReconciliationMode.INCREMENTAL].
     ///
-    /// [google.cloud.discoveryengine.v1.ImportDocumentsRequest.ReconciliationMode.INCREMENTAL]: crate::model::import_documents_request::reconciliation_mode::INCREMENTAL
+    /// [google.cloud.discoveryengine.v1.ImportDocumentsRequest.ReconciliationMode.INCREMENTAL]: crate::model::import_documents_request::ReconciliationMode::Incremental
     pub reconciliation_mode: crate::model::import_documents_request::ReconciliationMode,
 
     /// Indicates which fields in the provided imported documents to update. If
@@ -16830,7 +18175,7 @@ pub struct ImportDocumentsRequest {
     /// [google.cloud.discoveryengine.v1.FirestoreSource]: crate::model::FirestoreSource
     /// [google.cloud.discoveryengine.v1.GcsSource]: crate::model::GcsSource
     /// [google.cloud.discoveryengine.v1.GcsSource.data_schema]: crate::model::GcsSource::data_schema
-    /// [google.cloud.discoveryengine.v1.ImportDocumentsRequest.ReconciliationMode.FULL]: crate::model::import_documents_request::reconciliation_mode::FULL
+    /// [google.cloud.discoveryengine.v1.ImportDocumentsRequest.ReconciliationMode.FULL]: crate::model::import_documents_request::ReconciliationMode::Full
     /// [google.cloud.discoveryengine.v1.ImportDocumentsRequest.id_field]: crate::model::ImportDocumentsRequest::id_field
     /// [google.cloud.discoveryengine.v1.SpannerSource]: crate::model::SpannerSource
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -17314,62 +18659,121 @@ pub mod import_documents_request {
 
     /// Indicates how imported documents are reconciled with the existing documents
     /// created or imported before.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReconciliationMode(i32);
-
-    impl ReconciliationMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReconciliationMode {
         /// Defaults to `INCREMENTAL`.
-        pub const RECONCILIATION_MODE_UNSPECIFIED: ReconciliationMode = ReconciliationMode::new(0);
-
+        Unspecified,
         /// Inserts new documents or updates existing documents.
-        pub const INCREMENTAL: ReconciliationMode = ReconciliationMode::new(1);
-
+        Incremental,
         /// Calculates diff and replaces the entire document dataset. Existing
         /// documents may be deleted if they are not present in the source location.
-        pub const FULL: ReconciliationMode = ReconciliationMode::new(2);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReconciliationMode::value] or
+        /// [ReconciliationMode::name].
+        UnknownValue(reconciliation_mode::UnknownValue),
+    }
 
-        /// Creates a new ReconciliationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reconciliation_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ReconciliationMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incremental => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RECONCILIATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCREMENTAL"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RECONCILIATION_MODE_UNSPECIFIED"),
+                Self::Incremental => std::option::Option::Some("INCREMENTAL"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RECONCILIATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RECONCILIATION_MODE_UNSPECIFIED)
-                }
-                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReconciliationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReconciliationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReconciliationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReconciliationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Incremental,
+                2 => Self::Full,
+                _ => Self::UnknownValue(reconciliation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReconciliationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RECONCILIATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "INCREMENTAL" => Self::Incremental,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(reconciliation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReconciliationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incremental => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReconciliationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReconciliationMode>::new(
+                ".google.cloud.discoveryengine.v1.ImportDocumentsRequest.ReconciliationMode",
+            ))
         }
     }
 
@@ -18321,64 +19725,130 @@ pub mod project {
         use super::*;
 
         /// The agreement states this terms of service.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// The default value of the enum. This value is not actually used.
+            Unspecified,
+            /// The project has given consent to the terms of service.
+            TermsAccepted,
+            /// The project is pending to review and accept the terms of service.
+            TermsPending,
+            /// The project has declined or revoked the agreement to terms of service.
+            TermsDeclined,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// The default value of the enum. This value is not actually used.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// The project has given consent to the terms of service.
-            pub const TERMS_ACCEPTED: State = State::new(1);
-
-            /// The project is pending to review and accept the terms of service.
-            pub const TERMS_PENDING: State = State::new(2);
-
-            /// The project has declined or revoked the agreement to terms of service.
-            pub const TERMS_DECLINED: State = State::new(3);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::TermsAccepted => std::option::Option::Some(1),
+                    Self::TermsPending => std::option::Option::Some(2),
+                    Self::TermsDeclined => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TERMS_ACCEPTED"),
-                    2 => std::borrow::Cow::Borrowed("TERMS_PENDING"),
-                    3 => std::borrow::Cow::Borrowed("TERMS_DECLINED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::TermsAccepted => std::option::Option::Some("TERMS_ACCEPTED"),
+                    Self::TermsPending => std::option::Option::Some("TERMS_PENDING"),
+                    Self::TermsDeclined => std::option::Option::Some("TERMS_DECLINED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "TERMS_ACCEPTED" => std::option::Option::Some(Self::TERMS_ACCEPTED),
-                    "TERMS_PENDING" => std::option::Option::Some(Self::TERMS_PENDING),
-                    "TERMS_DECLINED" => std::option::Option::Some(Self::TERMS_DECLINED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::TermsAccepted,
+                    2 => Self::TermsPending,
+                    3 => Self::TermsDeclined,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "TERMS_ACCEPTED" => Self::TermsAccepted,
+                    "TERMS_PENDING" => Self::TermsPending,
+                    "TERMS_DECLINED" => Self::TermsDeclined,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::TermsAccepted => serializer.serialize_i32(1),
+                    Self::TermsPending => serializer.serialize_i32(2),
+                    Self::TermsDeclined => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.discoveryengine.v1.Project.ServiceTerms.State",
+                ))
             }
         }
     }
@@ -20124,142 +21594,266 @@ pub mod safety_rating {
     use super::*;
 
     /// Harm probability levels in the content.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmProbability(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HarmProbability {
+        /// Harm probability unspecified.
+        Unspecified,
+        /// Negligible level of harm.
+        Negligible,
+        /// Low level of harm.
+        Low,
+        /// Medium level of harm.
+        Medium,
+        /// High level of harm.
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HarmProbability::value] or
+        /// [HarmProbability::name].
+        UnknownValue(harm_probability::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod harm_probability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HarmProbability {
-        /// Harm probability unspecified.
-        pub const HARM_PROBABILITY_UNSPECIFIED: HarmProbability = HarmProbability::new(0);
-
-        /// Negligible level of harm.
-        pub const NEGLIGIBLE: HarmProbability = HarmProbability::new(1);
-
-        /// Low level of harm.
-        pub const LOW: HarmProbability = HarmProbability::new(2);
-
-        /// Medium level of harm.
-        pub const MEDIUM: HarmProbability = HarmProbability::new(3);
-
-        /// High level of harm.
-        pub const HIGH: HarmProbability = HarmProbability::new(4);
-
-        /// Creates a new HarmProbability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Negligible => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HARM_PROBABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEGLIGIBLE"),
-                2 => std::borrow::Cow::Borrowed("LOW"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HARM_PROBABILITY_UNSPECIFIED"),
+                Self::Negligible => std::option::Option::Some("NEGLIGIBLE"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HARM_PROBABILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HARM_PROBABILITY_UNSPECIFIED)
-                }
-                "NEGLIGIBLE" => std::option::Option::Some(Self::NEGLIGIBLE),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HarmProbability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HarmProbability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HarmProbability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HarmProbability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Negligible,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                _ => Self::UnknownValue(harm_probability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HarmProbability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HARM_PROBABILITY_UNSPECIFIED" => Self::Unspecified,
+                "NEGLIGIBLE" => Self::Negligible,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                _ => Self::UnknownValue(harm_probability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HarmProbability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Negligible => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HarmProbability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmProbability>::new(
+                ".google.cloud.discoveryengine.v1.SafetyRating.HarmProbability",
+            ))
         }
     }
 
     /// Harm severity levels.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HarmSeverity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HarmSeverity {
+        /// Harm severity unspecified.
+        Unspecified,
+        /// Negligible level of harm severity.
+        Negligible,
+        /// Low level of harm severity.
+        Low,
+        /// Medium level of harm severity.
+        Medium,
+        /// High level of harm severity.
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HarmSeverity::value] or
+        /// [HarmSeverity::name].
+        UnknownValue(harm_severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod harm_severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HarmSeverity {
-        /// Harm severity unspecified.
-        pub const HARM_SEVERITY_UNSPECIFIED: HarmSeverity = HarmSeverity::new(0);
-
-        /// Negligible level of harm severity.
-        pub const HARM_SEVERITY_NEGLIGIBLE: HarmSeverity = HarmSeverity::new(1);
-
-        /// Low level of harm severity.
-        pub const HARM_SEVERITY_LOW: HarmSeverity = HarmSeverity::new(2);
-
-        /// Medium level of harm severity.
-        pub const HARM_SEVERITY_MEDIUM: HarmSeverity = HarmSeverity::new(3);
-
-        /// High level of harm severity.
-        pub const HARM_SEVERITY_HIGH: HarmSeverity = HarmSeverity::new(4);
-
-        /// Creates a new HarmSeverity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Negligible => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HARM_SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HARM_SEVERITY_NEGLIGIBLE"),
-                2 => std::borrow::Cow::Borrowed("HARM_SEVERITY_LOW"),
-                3 => std::borrow::Cow::Borrowed("HARM_SEVERITY_MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HARM_SEVERITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HARM_SEVERITY_UNSPECIFIED"),
+                Self::Negligible => std::option::Option::Some("HARM_SEVERITY_NEGLIGIBLE"),
+                Self::Low => std::option::Option::Some("HARM_SEVERITY_LOW"),
+                Self::Medium => std::option::Option::Some("HARM_SEVERITY_MEDIUM"),
+                Self::High => std::option::Option::Some("HARM_SEVERITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HARM_SEVERITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HARM_SEVERITY_UNSPECIFIED)
-                }
-                "HARM_SEVERITY_NEGLIGIBLE" => {
-                    std::option::Option::Some(Self::HARM_SEVERITY_NEGLIGIBLE)
-                }
-                "HARM_SEVERITY_LOW" => std::option::Option::Some(Self::HARM_SEVERITY_LOW),
-                "HARM_SEVERITY_MEDIUM" => std::option::Option::Some(Self::HARM_SEVERITY_MEDIUM),
-                "HARM_SEVERITY_HIGH" => std::option::Option::Some(Self::HARM_SEVERITY_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HarmSeverity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HarmSeverity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HarmSeverity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HarmSeverity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Negligible,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                _ => Self::UnknownValue(harm_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HarmSeverity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HARM_SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "HARM_SEVERITY_NEGLIGIBLE" => Self::Negligible,
+                "HARM_SEVERITY_LOW" => Self::Low,
+                "HARM_SEVERITY_MEDIUM" => Self::Medium,
+                "HARM_SEVERITY_HIGH" => Self::High,
+                _ => Self::UnknownValue(harm_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HarmSeverity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Negligible => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HarmSeverity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmSeverity>::new(
+                ".google.cloud.discoveryengine.v1.SafetyRating.HarmSeverity",
+            ))
         }
     }
 }
@@ -21145,7 +22739,7 @@ pub struct SearchRequest {
     /// [IndustryVertical.MEDIA][google.cloud.discoveryengine.v1.IndustryVertical.MEDIA]
     /// vertical.
     ///
-    /// [google.cloud.discoveryengine.v1.IndustryVertical.MEDIA]: crate::model::industry_vertical::MEDIA
+    /// [google.cloud.discoveryengine.v1.IndustryVertical.MEDIA]: crate::model::IndustryVertical::Media
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub search_as_you_type_spec:
         std::option::Option<crate::model::search_request::SearchAsYouTypeSpec>,
@@ -22205,126 +23799,249 @@ pub mod search_request {
 
                 /// The attribute(or function) for which the custom ranking is to be
                 /// applied.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct AttributeType(i32);
-
-                impl AttributeType {
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum AttributeType {
                     /// Unspecified AttributeType.
-                    pub const ATTRIBUTE_TYPE_UNSPECIFIED: AttributeType = AttributeType::new(0);
-
+                    Unspecified,
                     /// The value of the numerical field will be used to dynamically update
                     /// the boost amount. In this case, the attribute_value (the x value)
                     /// of the control point will be the actual value of the numerical
                     /// field for which the boost_amount is specified.
-                    pub const NUMERICAL: AttributeType = AttributeType::new(1);
-
+                    Numerical,
                     /// For the freshness use case the attribute value will be the duration
                     /// between the current time and the date in the datetime field
                     /// specified. The value must be formatted as an XSD `dayTimeDuration`
                     /// value (a restricted subset of an ISO 8601 duration value). The
                     /// pattern for this is: `[nD][T[nH][nM][nS]]`.
                     /// For example, `5D`, `3DT12H30M`, `T24H`.
-                    pub const FRESHNESS: AttributeType = AttributeType::new(2);
+                    Freshness,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [AttributeType::value] or
+                    /// [AttributeType::name].
+                    UnknownValue(attribute_type::UnknownValue),
+                }
 
-                    /// Creates a new AttributeType instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
+                #[doc(hidden)]
+                pub mod attribute_type {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
+                impl AttributeType {
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::Numerical => std::option::Option::Some(1),
+                            Self::Freshness => std::option::Option::Some(2),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("ATTRIBUTE_TYPE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("NUMERICAL"),
-                            2 => std::borrow::Cow::Borrowed("FRESHNESS"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "ATTRIBUTE_TYPE_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::ATTRIBUTE_TYPE_UNSPECIFIED)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => {
+                                std::option::Option::Some("ATTRIBUTE_TYPE_UNSPECIFIED")
                             }
-                            "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
-                            "FRESHNESS" => std::option::Option::Some(Self::FRESHNESS),
-                            _ => std::option::Option::None,
+                            Self::Numerical => std::option::Option::Some("NUMERICAL"),
+                            Self::Freshness => std::option::Option::Some("FRESHNESS"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for AttributeType {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for AttributeType {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for AttributeType {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for AttributeType {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::Numerical,
+                            2 => Self::Freshness,
+                            _ => Self::UnknownValue(attribute_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for AttributeType {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "ATTRIBUTE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                            "NUMERICAL" => Self::Numerical,
+                            "FRESHNESS" => Self::Freshness,
+                            _ => Self::UnknownValue(attribute_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for AttributeType {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::Numerical => serializer.serialize_i32(1),
+                            Self::Freshness => serializer.serialize_i32(2),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for AttributeType {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttributeType>::new(
+                            ".google.cloud.discoveryengine.v1.SearchRequest.BoostSpec.ConditionBoostSpec.BoostControlSpec.AttributeType"))
                     }
                 }
 
                 /// The interpolation type to be applied. Default will be linear
                 /// (Piecewise Linear).
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct InterpolationType(i32);
-
-                impl InterpolationType {
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum InterpolationType {
                     /// Interpolation type is unspecified. In this case, it defaults to
                     /// Linear.
-                    pub const INTERPOLATION_TYPE_UNSPECIFIED: InterpolationType =
-                        InterpolationType::new(0);
-
+                    Unspecified,
                     /// Piecewise linear interpolation will be applied.
-                    pub const LINEAR: InterpolationType = InterpolationType::new(1);
+                    Linear,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [InterpolationType::value] or
+                    /// [InterpolationType::name].
+                    UnknownValue(interpolation_type::UnknownValue),
+                }
 
-                    /// Creates a new InterpolationType instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
+                #[doc(hidden)]
+                pub mod interpolation_type {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
+                impl InterpolationType {
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::Linear => std::option::Option::Some(1),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("INTERPOLATION_TYPE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("LINEAR"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "INTERPOLATION_TYPE_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::INTERPOLATION_TYPE_UNSPECIFIED)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => {
+                                std::option::Option::Some("INTERPOLATION_TYPE_UNSPECIFIED")
                             }
-                            "LINEAR" => std::option::Option::Some(Self::LINEAR),
-                            _ => std::option::Option::None,
+                            Self::Linear => std::option::Option::Some("LINEAR"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for InterpolationType {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for InterpolationType {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for InterpolationType {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for InterpolationType {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::Linear,
+                            _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for InterpolationType {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "INTERPOLATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                            "LINEAR" => Self::Linear,
+                            _ => Self::UnknownValue(interpolation_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for InterpolationType {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::Linear => serializer.serialize_i32(1),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for InterpolationType {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterpolationType>::new(
+                            ".google.cloud.discoveryengine.v1.SearchRequest.BoostSpec.ConditionBoostSpec.BoostControlSpec.InterpolationType"))
                     }
                 }
             }
@@ -22341,7 +24058,7 @@ pub mod search_request {
         /// The condition under which query expansion should occur. Default to
         /// [Condition.DISABLED][google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED].
         ///
-        /// [google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::condition::DISABLED
+        /// [google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::Condition::Disabled
         pub condition: crate::model::search_request::query_expansion_spec::Condition,
 
         /// Whether to pin unexpanded results. If this field is set to true,
@@ -22389,69 +24106,131 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition query expansion should occur.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Condition(i32);
-
-        impl Condition {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Condition {
             /// Unspecified query expansion condition. In this case, server behavior
             /// defaults to
             /// [Condition.DISABLED][google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED].
             ///
-            /// [google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::condition::DISABLED
-            pub const CONDITION_UNSPECIFIED: Condition = Condition::new(0);
-
+            /// [google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::Condition::Disabled
+            Unspecified,
             /// Disabled query expansion. Only the exact search query is used, even if
             /// [SearchResponse.total_size][google.cloud.discoveryengine.v1.SearchResponse.total_size]
             /// is zero.
             ///
             /// [google.cloud.discoveryengine.v1.SearchResponse.total_size]: crate::model::SearchResponse::total_size
-            pub const DISABLED: Condition = Condition::new(1);
-
+            Disabled,
             /// Automatic query expansion built by the Search API.
-            pub const AUTO: Condition = Condition::new(2);
+            Auto,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Condition::value] or
+            /// [Condition::name].
+            UnknownValue(condition::UnknownValue),
+        }
 
-            /// Creates a new Condition instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod condition {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Condition {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Disabled => std::option::Option::Some(1),
+                    Self::Auto => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONDITION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DISABLED"),
-                    2 => std::borrow::Cow::Borrowed("AUTO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CONDITION_UNSPECIFIED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONDITION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONDITION_UNSPECIFIED)
-                    }
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Condition {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Condition {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Condition {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Condition {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Disabled,
+                    2 => Self::Auto,
+                    _ => Self::UnknownValue(condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Condition {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONDITION_UNSPECIFIED" => Self::Unspecified,
+                    "DISABLED" => Self::Disabled,
+                    "AUTO" => Self::Auto,
+                    _ => Self::UnknownValue(condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Condition {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Disabled => serializer.serialize_i32(1),
+                    Self::Auto => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Condition {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Condition>::new(
+                    ".google.cloud.discoveryengine.v1.SearchRequest.QueryExpansionSpec.Condition",
+                ))
             }
         }
     }
@@ -22466,7 +24245,7 @@ pub mod search_request {
         /// replaces the original search query. Defaults to
         /// [Mode.AUTO][google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO].
         ///
-        /// [google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::mode::AUTO
+        /// [google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::Mode::Auto
         pub mode: crate::model::search_request::spell_correction_spec::Mode,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22502,69 +24281,133 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which mode spell correction should occur.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(i32);
-
-        impl Mode {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Mode {
             /// Unspecified spell correction mode. In this case, server behavior
             /// defaults to
             /// [Mode.AUTO][google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO].
             ///
-            /// [google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::mode::AUTO
-            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+            /// [google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::Mode::Auto
+            Unspecified,
             /// Search API tries to find a spelling suggestion. If a suggestion is
             /// found, it is put in the
             /// [SearchResponse.corrected_query][google.cloud.discoveryengine.v1.SearchResponse.corrected_query].
             /// The spelling suggestion won't be used as the search query.
             ///
             /// [google.cloud.discoveryengine.v1.SearchResponse.corrected_query]: crate::model::SearchResponse::corrected_query
-            pub const SUGGESTION_ONLY: Mode = Mode::new(1);
-
+            SuggestionOnly,
             /// Automatic spell correction built by the Search API. Search will
             /// be based on the corrected query if found.
-            pub const AUTO: Mode = Mode::new(2);
+            Auto,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Mode::value] or
+            /// [Mode::name].
+            UnknownValue(mode::UnknownValue),
+        }
 
-            /// Creates a new Mode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Mode {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SuggestionOnly => std::option::Option::Some(1),
+                    Self::Auto => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SUGGESTION_ONLY"),
-                    2 => std::borrow::Cow::Borrowed("AUTO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                    Self::SuggestionOnly => std::option::Option::Some("SUGGESTION_ONLY"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                    "SUGGESTION_ONLY" => std::option::Option::Some(Self::SUGGESTION_ONLY),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Mode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Mode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SuggestionOnly,
+                    2 => Self::Auto,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Mode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODE_UNSPECIFIED" => Self::Unspecified,
+                    "SUGGESTION_ONLY" => Self::SuggestionOnly,
+                    "AUTO" => Self::Auto,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Mode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SuggestionOnly => serializer.serialize_i32(1),
+                    Self::Auto => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Mode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                    ".google.cloud.discoveryengine.v1.SearchRequest.SpellCorrectionSpec.Mode",
+                ))
             }
         }
     }
@@ -22604,7 +24447,7 @@ pub mod search_request {
         /// is set to
         /// [CHUNKS][google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]
         ///
-        /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::search_result_mode::CHUNKS
+        /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::SearchResultMode::Chunks
         /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.search_result_mode]: crate::model::search_request::ContentSearchSpec::search_result_mode
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
         pub chunk_spec:
@@ -22776,7 +24619,7 @@ pub mod search_request {
             /// is set to
             /// [CHUNKS][google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS].
             ///
-            /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::search_result_mode::CHUNKS
+            /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::SearchResultMode::Chunks
             /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.search_result_mode]: crate::model::search_request::ContentSearchSpec::search_result_mode
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
             pub summary_result_count: i32,
@@ -23103,9 +24946,9 @@ pub mod search_request {
             /// return the `max_extractive_segment_count`.
             ///
             /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-            /// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.CONTENT_REQUIRED]: crate::model::data_store::content_config::CONTENT_REQUIRED
+            /// [google.cloud.discoveryengine.v1.DataStore.ContentConfig.CONTENT_REQUIRED]: crate::model::data_store::ContentConfig::ContentRequired
             /// [google.cloud.discoveryengine.v1.DataStore.solution_types]: crate::model::DataStore::solution_types
-            /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::solution_type::SOLUTION_TYPE_CHAT
+            /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_CHAT]: crate::model::SolutionType::Chat
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
             pub max_extractive_segment_count: i32,
 
@@ -23189,7 +25032,7 @@ pub mod search_request {
         /// is set to
         /// [CHUNKS][google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]
         ///
-        /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::search_result_mode::CHUNKS
+        /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::SearchResultMode::Chunks
         /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.search_result_mode]: crate::model::search_request::ContentSearchSpec::search_result_mode
         #[serde_with::serde_as]
         #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -23238,65 +25081,128 @@ pub mod search_request {
 
         /// Specifies the search result mode. If unspecified, the
         /// search result mode defaults to `DOCUMENTS`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SearchResultMode(i32);
-
-        impl SearchResultMode {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SearchResultMode {
             /// Default value.
-            pub const SEARCH_RESULT_MODE_UNSPECIFIED: SearchResultMode = SearchResultMode::new(0);
-
+            Unspecified,
             /// Returns documents in the search result.
-            pub const DOCUMENTS: SearchResultMode = SearchResultMode::new(1);
-
+            Documents,
             /// Returns chunks in the search result. Only available if the
             /// [DocumentProcessingConfig.chunking_config][google.cloud.discoveryengine.v1.DocumentProcessingConfig.chunking_config]
             /// is specified.
             ///
             /// [google.cloud.discoveryengine.v1.DocumentProcessingConfig.chunking_config]: crate::model::DocumentProcessingConfig::chunking_config
-            pub const CHUNKS: SearchResultMode = SearchResultMode::new(2);
+            Chunks,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SearchResultMode::value] or
+            /// [SearchResultMode::name].
+            UnknownValue(search_result_mode::UnknownValue),
+        }
 
-            /// Creates a new SearchResultMode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod search_result_mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SearchResultMode {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Documents => std::option::Option::Some(1),
+                    Self::Chunks => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SEARCH_RESULT_MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DOCUMENTS"),
-                    2 => std::borrow::Cow::Borrowed("CHUNKS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SEARCH_RESULT_MODE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SEARCH_RESULT_MODE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SEARCH_RESULT_MODE_UNSPECIFIED")
                     }
-                    "DOCUMENTS" => std::option::Option::Some(Self::DOCUMENTS),
-                    "CHUNKS" => std::option::Option::Some(Self::CHUNKS),
-                    _ => std::option::Option::None,
+                    Self::Documents => std::option::Option::Some("DOCUMENTS"),
+                    Self::Chunks => std::option::Option::Some("CHUNKS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for SearchResultMode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SearchResultMode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SearchResultMode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SearchResultMode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Documents,
+                    2 => Self::Chunks,
+                    _ => Self::UnknownValue(search_result_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SearchResultMode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SEARCH_RESULT_MODE_UNSPECIFIED" => Self::Unspecified,
+                    "DOCUMENTS" => Self::Documents,
+                    "CHUNKS" => Self::Chunks,
+                    _ => Self::UnknownValue(search_result_mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SearchResultMode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Documents => serializer.serialize_i32(1),
+                    Self::Chunks => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SearchResultMode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchResultMode>::new(
+                    ".google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode"))
             }
         }
     }
@@ -23311,7 +25217,7 @@ pub mod search_request {
         /// Default to
         /// [Condition.DISABLED][google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED].
         ///
-        /// [google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED]: crate::model::search_request::search_as_you_type_spec::condition::DISABLED
+        /// [google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED]: crate::model::search_request::search_as_you_type_spec::Condition::Disabled
         pub condition: crate::model::search_request::search_as_you_type_spec::Condition,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -23347,70 +25253,134 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition search as you type should occur.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Condition(i32);
-
-        impl Condition {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Condition {
             /// Server behavior defaults to
             /// [Condition.DISABLED][google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED].
             ///
-            /// [google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED]: crate::model::search_request::search_as_you_type_spec::condition::DISABLED
-            pub const CONDITION_UNSPECIFIED: Condition = Condition::new(0);
-
+            /// [google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition.DISABLED]: crate::model::search_request::search_as_you_type_spec::Condition::Disabled
+            Unspecified,
             /// Disables Search As You Type.
-            pub const DISABLED: Condition = Condition::new(1);
-
+            Disabled,
             /// Enables Search As You Type.
-            pub const ENABLED: Condition = Condition::new(2);
-
+            Enabled,
             /// Automatic switching between search-as-you-type and standard search
             /// modes, ideal for single-API implementations (e.g., debouncing).
-            pub const AUTO: Condition = Condition::new(3);
+            Auto,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Condition::value] or
+            /// [Condition::name].
+            UnknownValue(condition::UnknownValue),
+        }
 
-            /// Creates a new Condition instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod condition {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Condition {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Disabled => std::option::Option::Some(1),
+                    Self::Enabled => std::option::Option::Some(2),
+                    Self::Auto => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONDITION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DISABLED"),
-                    2 => std::borrow::Cow::Borrowed("ENABLED"),
-                    3 => std::borrow::Cow::Borrowed("AUTO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CONDITION_UNSPECIFIED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::Enabled => std::option::Option::Some("ENABLED"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONDITION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONDITION_UNSPECIFIED)
-                    }
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Condition {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Condition {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Condition {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Condition {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Disabled,
+                    2 => Self::Enabled,
+                    3 => Self::Auto,
+                    _ => Self::UnknownValue(condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Condition {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONDITION_UNSPECIFIED" => Self::Unspecified,
+                    "DISABLED" => Self::Disabled,
+                    "ENABLED" => Self::Enabled,
+                    "AUTO" => Self::Auto,
+                    _ => Self::UnknownValue(condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Condition {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Disabled => serializer.serialize_i32(1),
+                    Self::Enabled => serializer.serialize_i32(2),
+                    Self::Auto => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Condition {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Condition>::new(
+                    ".google.cloud.discoveryengine.v1.SearchRequest.SearchAsYouTypeSpec.Condition",
+                ))
             }
         }
     }
@@ -23460,68 +25430,128 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition match highlighting should occur.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MatchHighlightingCondition(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MatchHighlightingCondition {
+            /// Server behavior is the same as `MATCH_HIGHLIGHTING_DISABLED`.
+            Unspecified,
+            /// Disables match highlighting on all documents.
+            MatchHighlightingDisabled,
+            /// Enables match highlighting on all documents.
+            MatchHighlightingEnabled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MatchHighlightingCondition::value] or
+            /// [MatchHighlightingCondition::name].
+            UnknownValue(match_highlighting_condition::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod match_highlighting_condition {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl MatchHighlightingCondition {
-            /// Server behavior is the same as `MATCH_HIGHLIGHTING_DISABLED`.
-            pub const MATCH_HIGHLIGHTING_CONDITION_UNSPECIFIED: MatchHighlightingCondition =
-                MatchHighlightingCondition::new(0);
-
-            /// Disables match highlighting on all documents.
-            pub const MATCH_HIGHLIGHTING_DISABLED: MatchHighlightingCondition =
-                MatchHighlightingCondition::new(1);
-
-            /// Enables match highlighting on all documents.
-            pub const MATCH_HIGHLIGHTING_ENABLED: MatchHighlightingCondition =
-                MatchHighlightingCondition::new(2);
-
-            /// Creates a new MatchHighlightingCondition instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::MatchHighlightingDisabled => std::option::Option::Some(1),
+                    Self::MatchHighlightingEnabled => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MATCH_HIGHLIGHTING_CONDITION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MATCH_HIGHLIGHTING_DISABLED"),
-                    2 => std::borrow::Cow::Borrowed("MATCH_HIGHLIGHTING_ENABLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("MATCH_HIGHLIGHTING_CONDITION_UNSPECIFIED")
+                    }
+                    Self::MatchHighlightingDisabled => {
+                        std::option::Option::Some("MATCH_HIGHLIGHTING_DISABLED")
+                    }
+                    Self::MatchHighlightingEnabled => {
+                        std::option::Option::Some("MATCH_HIGHLIGHTING_ENABLED")
+                    }
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MATCH_HIGHLIGHTING_CONDITION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::MATCH_HIGHLIGHTING_CONDITION_UNSPECIFIED)
-                    }
-                    "MATCH_HIGHLIGHTING_DISABLED" => {
-                        std::option::Option::Some(Self::MATCH_HIGHLIGHTING_DISABLED)
-                    }
-                    "MATCH_HIGHLIGHTING_ENABLED" => {
-                        std::option::Option::Some(Self::MATCH_HIGHLIGHTING_ENABLED)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MatchHighlightingCondition {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MatchHighlightingCondition {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MatchHighlightingCondition {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MatchHighlightingCondition {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::MatchHighlightingDisabled,
+                    2 => Self::MatchHighlightingEnabled,
+                    _ => Self::UnknownValue(match_highlighting_condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MatchHighlightingCondition {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MATCH_HIGHLIGHTING_CONDITION_UNSPECIFIED" => Self::Unspecified,
+                    "MATCH_HIGHLIGHTING_DISABLED" => Self::MatchHighlightingDisabled,
+                    "MATCH_HIGHLIGHTING_ENABLED" => Self::MatchHighlightingEnabled,
+                    _ => Self::UnknownValue(match_highlighting_condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MatchHighlightingCondition {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::MatchHighlightingDisabled => serializer.serialize_i32(1),
+                    Self::MatchHighlightingEnabled => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MatchHighlightingCondition {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MatchHighlightingCondition>::new(
+                    ".google.cloud.discoveryengine.v1.SearchRequest.DisplaySpec.MatchHighlightingCondition"))
             }
         }
     }
@@ -23645,72 +25675,135 @@ pub mod search_request {
     /// The relevance threshold of the search results. The higher relevance
     /// threshold is, the higher relevant results are shown and the less number of
     /// results are returned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RelevanceThreshold(i32);
-
-    impl RelevanceThreshold {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RelevanceThreshold {
         /// Default value. In this case, server behavior defaults to Google defined
         /// threshold.
-        pub const RELEVANCE_THRESHOLD_UNSPECIFIED: RelevanceThreshold = RelevanceThreshold::new(0);
-
+        Unspecified,
         /// Lowest relevance threshold.
-        pub const LOWEST: RelevanceThreshold = RelevanceThreshold::new(1);
-
+        Lowest,
         /// Low relevance threshold.
-        pub const LOW: RelevanceThreshold = RelevanceThreshold::new(2);
-
+        Low,
         /// Medium relevance threshold.
-        pub const MEDIUM: RelevanceThreshold = RelevanceThreshold::new(3);
-
+        Medium,
         /// High relevance threshold.
-        pub const HIGH: RelevanceThreshold = RelevanceThreshold::new(4);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RelevanceThreshold::value] or
+        /// [RelevanceThreshold::name].
+        UnknownValue(relevance_threshold::UnknownValue),
+    }
 
-        /// Creates a new RelevanceThreshold instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod relevance_threshold {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RelevanceThreshold {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Lowest => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RELEVANCE_THRESHOLD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOWEST"),
-                2 => std::borrow::Cow::Borrowed("LOW"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RELEVANCE_THRESHOLD_UNSPECIFIED"),
+                Self::Lowest => std::option::Option::Some("LOWEST"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RELEVANCE_THRESHOLD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RELEVANCE_THRESHOLD_UNSPECIFIED)
-                }
-                "LOWEST" => std::option::Option::Some(Self::LOWEST),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RelevanceThreshold {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RelevanceThreshold {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RelevanceThreshold {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RelevanceThreshold {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Lowest,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                _ => Self::UnknownValue(relevance_threshold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RelevanceThreshold {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RELEVANCE_THRESHOLD_UNSPECIFIED" => Self::Unspecified,
+                "LOWEST" => Self::Lowest,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                _ => Self::UnknownValue(relevance_threshold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RelevanceThreshold {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Lowest => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RelevanceThreshold {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RelevanceThreshold>::new(
+                ".google.cloud.discoveryengine.v1.SearchRequest.RelevanceThreshold",
+            ))
         }
     }
 }
@@ -23967,7 +26060,7 @@ pub mod search_response {
         /// is set to
         /// [CHUNKS][google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS].
         ///
-        /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::search_result_mode::CHUNKS
+        /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SearchResultMode.CHUNKS]: crate::model::search_request::content_search_spec::SearchResultMode::Chunks
         /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.search_result_mode]: crate::model::search_request::ContentSearchSpec::search_result_mode
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
         pub chunk: std::option::Option<crate::model::Chunk>,
@@ -24709,14 +26802,11 @@ pub mod search_response {
         }
 
         /// An Enum for summary-skipped reasons.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SummarySkippedReason(i32);
-
-        impl SummarySkippedReason {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SummarySkippedReason {
             /// Default value. The summary skipped reason is not specified.
-            pub const SUMMARY_SKIPPED_REASON_UNSPECIFIED: SummarySkippedReason =
-                SummarySkippedReason::new(0);
-
+            Unspecified,
             /// The adversarial query ignored case.
             ///
             /// Only used when
@@ -24724,9 +26814,7 @@ pub mod search_response {
             /// is set to `true`.
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SummarySpec.ignore_adversarial_query]: crate::model::search_request::content_search_spec::SummarySpec::ignore_adversarial_query
-            pub const ADVERSARIAL_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new(1);
-
+            AdversarialQueryIgnored,
             /// The non-summary seeking query ignored case.
             ///
             /// Google skips the summary if the query is chit chat.
@@ -24735,139 +26823,213 @@ pub mod search_response {
             /// is set to `true`.
             ///
             /// [google.cloud.discoveryengine.v1.SearchRequest.ContentSearchSpec.SummarySpec.ignore_non_summary_seeking_query]: crate::model::search_request::content_search_spec::SummarySpec::ignore_non_summary_seeking_query
-            pub const NON_SUMMARY_SEEKING_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new(2);
-
+            NonSummarySeekingQueryIgnored,
             /// The out-of-domain query ignored case.
             ///
             /// Google skips the summary if there are no high-relevance search results.
             /// For example, the data store contains facts about company A but the
             /// user query is asking questions about company B.
-            pub const OUT_OF_DOMAIN_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new(3);
-
+            OutOfDomainQueryIgnored,
             /// The potential policy violation case.
             ///
             /// Google skips the summary if there is a potential policy violation
             /// detected. This includes content that may be violent or toxic.
-            pub const POTENTIAL_POLICY_VIOLATION: SummarySkippedReason =
-                SummarySkippedReason::new(4);
-
+            PotentialPolicyViolation,
             /// The LLM addon not enabled case.
             ///
             /// Google skips the summary if the LLM addon is not enabled.
-            pub const LLM_ADDON_NOT_ENABLED: SummarySkippedReason = SummarySkippedReason::new(5);
-
+            LlmAddonNotEnabled,
             /// The no relevant content case.
             ///
             /// Google skips the summary if there is no relevant content in the
             /// retrieved search results.
-            pub const NO_RELEVANT_CONTENT: SummarySkippedReason = SummarySkippedReason::new(6);
-
+            NoRelevantContent,
             /// The jail-breaking query ignored case.
             ///
             /// For example, "Reply in the tone of a competing company's CEO".
             /// Only used when
             /// [SearchRequest.ContentSearchSpec.SummarySpec.ignore_jail_breaking_query]
             /// is set to `true`.
-            pub const JAIL_BREAKING_QUERY_IGNORED: SummarySkippedReason =
-                SummarySkippedReason::new(7);
-
+            JailBreakingQueryIgnored,
             /// The customer policy violation case.
             ///
             /// Google skips the summary if there is a customer policy violation
             /// detected. The policy is defined by the customer.
-            pub const CUSTOMER_POLICY_VIOLATION: SummarySkippedReason =
-                SummarySkippedReason::new(8);
-
+            CustomerPolicyViolation,
             /// The non-answer seeking query ignored case.
             ///
             /// Google skips the summary if the query doesn't have clear intent.
             /// Only used when
             /// [SearchRequest.ContentSearchSpec.SummarySpec.ignore_non_answer_seeking_query]
             /// is set to `true`.
-            pub const NON_SUMMARY_SEEKING_QUERY_IGNORED_V2: SummarySkippedReason =
-                SummarySkippedReason::new(9);
-
+            NonSummarySeekingQueryIgnoredV2,
             /// The time out case.
             ///
             /// Google skips the summary if the time out.
-            pub const TIME_OUT: SummarySkippedReason = SummarySkippedReason::new(10);
+            TimeOut,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SummarySkippedReason::value] or
+            /// [SummarySkippedReason::name].
+            UnknownValue(summary_skipped_reason::UnknownValue),
+        }
 
-            /// Creates a new SummarySkippedReason instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod summary_skipped_reason {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SummarySkippedReason {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::AdversarialQueryIgnored => std::option::Option::Some(1),
+                    Self::NonSummarySeekingQueryIgnored => std::option::Option::Some(2),
+                    Self::OutOfDomainQueryIgnored => std::option::Option::Some(3),
+                    Self::PotentialPolicyViolation => std::option::Option::Some(4),
+                    Self::LlmAddonNotEnabled => std::option::Option::Some(5),
+                    Self::NoRelevantContent => std::option::Option::Some(6),
+                    Self::JailBreakingQueryIgnored => std::option::Option::Some(7),
+                    Self::CustomerPolicyViolation => std::option::Option::Some(8),
+                    Self::NonSummarySeekingQueryIgnoredV2 => std::option::Option::Some(9),
+                    Self::TimeOut => std::option::Option::Some(10),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SUMMARY_SKIPPED_REASON_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ADVERSARIAL_QUERY_IGNORED"),
-                    2 => std::borrow::Cow::Borrowed("NON_SUMMARY_SEEKING_QUERY_IGNORED"),
-                    3 => std::borrow::Cow::Borrowed("OUT_OF_DOMAIN_QUERY_IGNORED"),
-                    4 => std::borrow::Cow::Borrowed("POTENTIAL_POLICY_VIOLATION"),
-                    5 => std::borrow::Cow::Borrowed("LLM_ADDON_NOT_ENABLED"),
-                    6 => std::borrow::Cow::Borrowed("NO_RELEVANT_CONTENT"),
-                    7 => std::borrow::Cow::Borrowed("JAIL_BREAKING_QUERY_IGNORED"),
-                    8 => std::borrow::Cow::Borrowed("CUSTOMER_POLICY_VIOLATION"),
-                    9 => std::borrow::Cow::Borrowed("NON_SUMMARY_SEEKING_QUERY_IGNORED_V2"),
-                    10 => std::borrow::Cow::Borrowed("TIME_OUT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SUMMARY_SKIPPED_REASON_UNSPECIFIED")
+                    }
+                    Self::AdversarialQueryIgnored => {
+                        std::option::Option::Some("ADVERSARIAL_QUERY_IGNORED")
+                    }
+                    Self::NonSummarySeekingQueryIgnored => {
+                        std::option::Option::Some("NON_SUMMARY_SEEKING_QUERY_IGNORED")
+                    }
+                    Self::OutOfDomainQueryIgnored => {
+                        std::option::Option::Some("OUT_OF_DOMAIN_QUERY_IGNORED")
+                    }
+                    Self::PotentialPolicyViolation => {
+                        std::option::Option::Some("POTENTIAL_POLICY_VIOLATION")
+                    }
+                    Self::LlmAddonNotEnabled => std::option::Option::Some("LLM_ADDON_NOT_ENABLED"),
+                    Self::NoRelevantContent => std::option::Option::Some("NO_RELEVANT_CONTENT"),
+                    Self::JailBreakingQueryIgnored => {
+                        std::option::Option::Some("JAIL_BREAKING_QUERY_IGNORED")
+                    }
+                    Self::CustomerPolicyViolation => {
+                        std::option::Option::Some("CUSTOMER_POLICY_VIOLATION")
+                    }
+                    Self::NonSummarySeekingQueryIgnoredV2 => {
+                        std::option::Option::Some("NON_SUMMARY_SEEKING_QUERY_IGNORED_V2")
+                    }
+                    Self::TimeOut => std::option::Option::Some("TIME_OUT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SUMMARY_SKIPPED_REASON_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SUMMARY_SKIPPED_REASON_UNSPECIFIED)
-                    }
-                    "ADVERSARIAL_QUERY_IGNORED" => {
-                        std::option::Option::Some(Self::ADVERSARIAL_QUERY_IGNORED)
-                    }
-                    "NON_SUMMARY_SEEKING_QUERY_IGNORED" => {
-                        std::option::Option::Some(Self::NON_SUMMARY_SEEKING_QUERY_IGNORED)
-                    }
-                    "OUT_OF_DOMAIN_QUERY_IGNORED" => {
-                        std::option::Option::Some(Self::OUT_OF_DOMAIN_QUERY_IGNORED)
-                    }
-                    "POTENTIAL_POLICY_VIOLATION" => {
-                        std::option::Option::Some(Self::POTENTIAL_POLICY_VIOLATION)
-                    }
-                    "LLM_ADDON_NOT_ENABLED" => {
-                        std::option::Option::Some(Self::LLM_ADDON_NOT_ENABLED)
-                    }
-                    "NO_RELEVANT_CONTENT" => std::option::Option::Some(Self::NO_RELEVANT_CONTENT),
-                    "JAIL_BREAKING_QUERY_IGNORED" => {
-                        std::option::Option::Some(Self::JAIL_BREAKING_QUERY_IGNORED)
-                    }
-                    "CUSTOMER_POLICY_VIOLATION" => {
-                        std::option::Option::Some(Self::CUSTOMER_POLICY_VIOLATION)
-                    }
-                    "NON_SUMMARY_SEEKING_QUERY_IGNORED_V2" => {
-                        std::option::Option::Some(Self::NON_SUMMARY_SEEKING_QUERY_IGNORED_V2)
-                    }
-                    "TIME_OUT" => std::option::Option::Some(Self::TIME_OUT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SummarySkippedReason {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SummarySkippedReason {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SummarySkippedReason {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SummarySkippedReason {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::AdversarialQueryIgnored,
+                    2 => Self::NonSummarySeekingQueryIgnored,
+                    3 => Self::OutOfDomainQueryIgnored,
+                    4 => Self::PotentialPolicyViolation,
+                    5 => Self::LlmAddonNotEnabled,
+                    6 => Self::NoRelevantContent,
+                    7 => Self::JailBreakingQueryIgnored,
+                    8 => Self::CustomerPolicyViolation,
+                    9 => Self::NonSummarySeekingQueryIgnoredV2,
+                    10 => Self::TimeOut,
+                    _ => Self::UnknownValue(summary_skipped_reason::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SummarySkippedReason {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SUMMARY_SKIPPED_REASON_UNSPECIFIED" => Self::Unspecified,
+                    "ADVERSARIAL_QUERY_IGNORED" => Self::AdversarialQueryIgnored,
+                    "NON_SUMMARY_SEEKING_QUERY_IGNORED" => Self::NonSummarySeekingQueryIgnored,
+                    "OUT_OF_DOMAIN_QUERY_IGNORED" => Self::OutOfDomainQueryIgnored,
+                    "POTENTIAL_POLICY_VIOLATION" => Self::PotentialPolicyViolation,
+                    "LLM_ADDON_NOT_ENABLED" => Self::LlmAddonNotEnabled,
+                    "NO_RELEVANT_CONTENT" => Self::NoRelevantContent,
+                    "JAIL_BREAKING_QUERY_IGNORED" => Self::JailBreakingQueryIgnored,
+                    "CUSTOMER_POLICY_VIOLATION" => Self::CustomerPolicyViolation,
+                    "NON_SUMMARY_SEEKING_QUERY_IGNORED_V2" => Self::NonSummarySeekingQueryIgnoredV2,
+                    "TIME_OUT" => Self::TimeOut,
+                    _ => Self::UnknownValue(summary_skipped_reason::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SummarySkippedReason {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::AdversarialQueryIgnored => serializer.serialize_i32(1),
+                    Self::NonSummarySeekingQueryIgnored => serializer.serialize_i32(2),
+                    Self::OutOfDomainQueryIgnored => serializer.serialize_i32(3),
+                    Self::PotentialPolicyViolation => serializer.serialize_i32(4),
+                    Self::LlmAddonNotEnabled => serializer.serialize_i32(5),
+                    Self::NoRelevantContent => serializer.serialize_i32(6),
+                    Self::JailBreakingQueryIgnored => serializer.serialize_i32(7),
+                    Self::CustomerPolicyViolation => serializer.serialize_i32(8),
+                    Self::NonSummarySeekingQueryIgnoredV2 => serializer.serialize_i32(9),
+                    Self::TimeOut => serializer.serialize_i32(10),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SummarySkippedReason {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SummarySkippedReason>::new(
+                    ".google.cloud.discoveryengine.v1.SearchResponse.Summary.SummarySkippedReason"))
             }
         }
     }
@@ -25485,7 +27647,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_RECOMMENDATION][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::solution_type::SOLUTION_TYPE_RECOMMENDATION
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::SolutionType::Recommendation
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub model_id: std::string::String,
 
@@ -25506,7 +27668,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_RECOMMENDATION][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::solution_type::SOLUTION_TYPE_RECOMMENDATION
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::SolutionType::Recommendation
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub diversity_level: std::string::String,
 
@@ -25573,7 +27735,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub redirect_control_ids: std::vec::Vec<std::string::String>,
 
@@ -25586,7 +27748,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub synonyms_control_ids: std::vec::Vec<std::string::String>,
 
@@ -25599,7 +27761,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub oneway_synonyms_control_ids: std::vec::Vec<std::string::String>,
 
@@ -25614,7 +27776,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub dissociate_control_ids: std::vec::Vec<std::string::String>,
 
@@ -25628,7 +27790,7 @@ pub struct ServingConfig {
     /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub replacement_control_ids: std::vec::Vec<std::string::String>,
 
@@ -25925,7 +28087,7 @@ pub mod serving_config {
     ///   [SOLUTION_TYPE_RECOMMENDATION][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION].
     ///
     /// [google.cloud.discoveryengine.v1.SolutionType]: crate::model::SolutionType
-    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::solution_type::SOLUTION_TYPE_RECOMMENDATION
+    /// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_RECOMMENDATION]: crate::model::SolutionType::Recommendation
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
@@ -26409,54 +28571,113 @@ pub mod session {
     }
 
     /// Enumeration of the state of the session.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified.
+        Unspecified,
+        /// The session is currently open.
+        InProgress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The session is currently open.
-        pub const IN_PROGRESS: State = State::new(1);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.discoveryengine.v1.Session.State",
+            ))
         }
     }
 }
@@ -26867,136 +29088,260 @@ pub mod target_site {
     }
 
     /// Possible target site types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// This value is unused. In this case, server behavior defaults to
         /// [Type.INCLUDE][google.cloud.discoveryengine.v1.TargetSite.Type.INCLUDE].
         ///
-        /// [google.cloud.discoveryengine.v1.TargetSite.Type.INCLUDE]: crate::model::target_site::r#type::INCLUDE
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        /// [google.cloud.discoveryengine.v1.TargetSite.Type.INCLUDE]: crate::model::target_site::Type::Include
+        Unspecified,
         /// Include the target site.
-        pub const INCLUDE: Type = Type::new(1);
-
+        Include,
         /// Exclude the target site.
-        pub const EXCLUDE: Type = Type::new(2);
+        Exclude,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Include => std::option::Option::Some(1),
+                Self::Exclude => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCLUDE"),
-                2 => std::borrow::Cow::Borrowed("EXCLUDE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Include => std::option::Option::Some("INCLUDE"),
+                Self::Exclude => std::option::Option::Some("EXCLUDE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "INCLUDE" => std::option::Option::Some(Self::INCLUDE),
-                "EXCLUDE" => std::option::Option::Some(Self::EXCLUDE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Include,
+                2 => Self::Exclude,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INCLUDE" => Self::Include,
+                "EXCLUDE" => Self::Exclude,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Include => serializer.serialize_i32(1),
+                Self::Exclude => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.discoveryengine.v1.TargetSite.Type",
+            ))
         }
     }
 
     /// Target site indexing status enumeration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexingStatus(i32);
-
-    impl IndexingStatus {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IndexingStatus {
         /// Defaults to SUCCEEDED.
-        pub const INDEXING_STATUS_UNSPECIFIED: IndexingStatus = IndexingStatus::new(0);
-
+        Unspecified,
         /// The target site is in the update queue and will be picked up by indexing
         /// pipeline.
-        pub const PENDING: IndexingStatus = IndexingStatus::new(1);
-
+        Pending,
         /// The target site fails to be indexed.
-        pub const FAILED: IndexingStatus = IndexingStatus::new(2);
-
+        Failed,
         /// The target site has been indexed.
-        pub const SUCCEEDED: IndexingStatus = IndexingStatus::new(3);
-
+        Succeeded,
         /// The previously indexed target site has been marked to be deleted. This is
         /// a transitioning state which will resulted in either:
         ///
         /// . target site deleted if unindexing is successful;
         /// . state reverts to SUCCEEDED if the unindexing fails.
-        pub const DELETING: IndexingStatus = IndexingStatus::new(4);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IndexingStatus::value] or
+        /// [IndexingStatus::name].
+        UnknownValue(indexing_status::UnknownValue),
+    }
 
-        /// Creates a new IndexingStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod indexing_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl IndexingStatus {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INDEXING_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INDEXING_STATUS_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INDEXING_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INDEXING_STATUS_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IndexingStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexingStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IndexingStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IndexingStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Failed,
+                3 => Self::Succeeded,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(indexing_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IndexingStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INDEXING_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "FAILED" => Self::Failed,
+                "SUCCEEDED" => Self::Succeeded,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(indexing_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IndexingStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IndexingStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndexingStatus>::new(
+                ".google.cloud.discoveryengine.v1.TargetSite.IndexingStatus",
+            ))
         }
     }
 }
@@ -27056,67 +29401,129 @@ pub mod site_verification_info {
     use super::*;
 
     /// Site verification state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SiteVerificationState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SiteVerificationState {
+        /// Defaults to VERIFIED.
+        Unspecified,
+        /// Site ownership verified.
+        Verified,
+        /// Site ownership pending verification or verification failed.
+        Unverified,
+        /// Site exempt from verification, e.g., a public website that opens to all.
+        Exempted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SiteVerificationState::value] or
+        /// [SiteVerificationState::name].
+        UnknownValue(site_verification_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod site_verification_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SiteVerificationState {
-        /// Defaults to VERIFIED.
-        pub const SITE_VERIFICATION_STATE_UNSPECIFIED: SiteVerificationState =
-            SiteVerificationState::new(0);
-
-        /// Site ownership verified.
-        pub const VERIFIED: SiteVerificationState = SiteVerificationState::new(1);
-
-        /// Site ownership pending verification or verification failed.
-        pub const UNVERIFIED: SiteVerificationState = SiteVerificationState::new(2);
-
-        /// Site exempt from verification, e.g., a public website that opens to all.
-        pub const EXEMPTED: SiteVerificationState = SiteVerificationState::new(3);
-
-        /// Creates a new SiteVerificationState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Verified => std::option::Option::Some(1),
+                Self::Unverified => std::option::Option::Some(2),
+                Self::Exempted => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SITE_VERIFICATION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VERIFIED"),
-                2 => std::borrow::Cow::Borrowed("UNVERIFIED"),
-                3 => std::borrow::Cow::Borrowed("EXEMPTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SITE_VERIFICATION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SITE_VERIFICATION_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("SITE_VERIFICATION_STATE_UNSPECIFIED")
                 }
-                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
-                "UNVERIFIED" => std::option::Option::Some(Self::UNVERIFIED),
-                "EXEMPTED" => std::option::Option::Some(Self::EXEMPTED),
-                _ => std::option::Option::None,
+                Self::Verified => std::option::Option::Some("VERIFIED"),
+                Self::Unverified => std::option::Option::Some("UNVERIFIED"),
+                Self::Exempted => std::option::Option::Some("EXEMPTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SiteVerificationState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SiteVerificationState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SiteVerificationState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SiteVerificationState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Verified,
+                2 => Self::Unverified,
+                3 => Self::Exempted,
+                _ => Self::UnknownValue(site_verification_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SiteVerificationState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SITE_VERIFICATION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "VERIFIED" => Self::Verified,
+                "UNVERIFIED" => Self::Unverified,
+                "EXEMPTED" => Self::Exempted,
+                _ => Self::UnknownValue(site_verification_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SiteVerificationState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Verified => serializer.serialize_i32(1),
+                Self::Unverified => serializer.serialize_i32(2),
+                Self::Exempted => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SiteVerificationState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SiteVerificationState>::new(
+                ".google.cloud.discoveryengine.v1.SiteVerificationInfo.SiteVerificationState",
+            ))
         }
     }
 }
@@ -28916,61 +31323,122 @@ pub mod recrawl_uris_response {
             use super::*;
 
             /// CorpusType for the failed crawling operation.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct CorpusType(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum CorpusType {
+                /// Default value.
+                Unspecified,
+                /// Denotes a crawling attempt for the desktop version of a page.
+                Desktop,
+                /// Denotes a crawling attempt for the mobile version of a page.
+                Mobile,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [CorpusType::value] or
+                /// [CorpusType::name].
+                UnknownValue(corpus_type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod corpus_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl CorpusType {
-                /// Default value.
-                pub const CORPUS_TYPE_UNSPECIFIED: CorpusType = CorpusType::new(0);
-
-                /// Denotes a crawling attempt for the desktop version of a page.
-                pub const DESKTOP: CorpusType = CorpusType::new(1);
-
-                /// Denotes a crawling attempt for the mobile version of a page.
-                pub const MOBILE: CorpusType = CorpusType::new(2);
-
-                /// Creates a new CorpusType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Desktop => std::option::Option::Some(1),
+                        Self::Mobile => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("CORPUS_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("DESKTOP"),
-                        2 => std::borrow::Cow::Borrowed("MOBILE"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("CORPUS_TYPE_UNSPECIFIED"),
+                        Self::Desktop => std::option::Option::Some("DESKTOP"),
+                        Self::Mobile => std::option::Option::Some("MOBILE"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "CORPUS_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::CORPUS_TYPE_UNSPECIFIED)
-                        }
-                        "DESKTOP" => std::option::Option::Some(Self::DESKTOP),
-                        "MOBILE" => std::option::Option::Some(Self::MOBILE),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for CorpusType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for CorpusType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for CorpusType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for CorpusType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Desktop,
+                        2 => Self::Mobile,
+                        _ => Self::UnknownValue(corpus_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for CorpusType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "CORPUS_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "DESKTOP" => Self::Desktop,
+                        "MOBILE" => Self::Mobile,
+                        _ => Self::UnknownValue(corpus_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for CorpusType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Desktop => serializer.serialize_i32(1),
+                        Self::Mobile => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for CorpusType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<CorpusType>::new(
+                        ".google.cloud.discoveryengine.v1.RecrawlUrisResponse.FailureInfo.FailureReason.CorpusType"))
                 }
             }
         }
@@ -30834,142 +33302,262 @@ impl wkt::message::Message for CollectUserEventRequest {
 /// [DataStore][google.cloud.discoveryengine.v1.DataStore].
 ///
 /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IndustryVertical(i32);
-
-impl IndustryVertical {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IndustryVertical {
     /// Value used when unset.
-    pub const INDUSTRY_VERTICAL_UNSPECIFIED: IndustryVertical = IndustryVertical::new(0);
-
+    Unspecified,
     /// The generic vertical for documents that are not specific to any industry
     /// vertical.
-    pub const GENERIC: IndustryVertical = IndustryVertical::new(1);
-
+    Generic,
     /// The media industry vertical.
-    pub const MEDIA: IndustryVertical = IndustryVertical::new(2);
-
+    Media,
     /// The healthcare FHIR vertical.
-    pub const HEALTHCARE_FHIR: IndustryVertical = IndustryVertical::new(7);
+    HealthcareFhir,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IndustryVertical::value] or
+    /// [IndustryVertical::name].
+    UnknownValue(industry_vertical::UnknownValue),
+}
 
-    /// Creates a new IndustryVertical instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod industry_vertical {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl IndustryVertical {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Generic => std::option::Option::Some(1),
+            Self::Media => std::option::Option::Some(2),
+            Self::HealthcareFhir => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INDUSTRY_VERTICAL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GENERIC"),
-            2 => std::borrow::Cow::Borrowed("MEDIA"),
-            7 => std::borrow::Cow::Borrowed("HEALTHCARE_FHIR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INDUSTRY_VERTICAL_UNSPECIFIED"),
+            Self::Generic => std::option::Option::Some("GENERIC"),
+            Self::Media => std::option::Option::Some("MEDIA"),
+            Self::HealthcareFhir => std::option::Option::Some("HEALTHCARE_FHIR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INDUSTRY_VERTICAL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INDUSTRY_VERTICAL_UNSPECIFIED)
-            }
-            "GENERIC" => std::option::Option::Some(Self::GENERIC),
-            "MEDIA" => std::option::Option::Some(Self::MEDIA),
-            "HEALTHCARE_FHIR" => std::option::Option::Some(Self::HEALTHCARE_FHIR),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IndustryVertical {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IndustryVertical {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IndustryVertical {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IndustryVertical {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Generic,
+            2 => Self::Media,
+            7 => Self::HealthcareFhir,
+            _ => Self::UnknownValue(industry_vertical::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IndustryVertical {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INDUSTRY_VERTICAL_UNSPECIFIED" => Self::Unspecified,
+            "GENERIC" => Self::Generic,
+            "MEDIA" => Self::Media,
+            "HEALTHCARE_FHIR" => Self::HealthcareFhir,
+            _ => Self::UnknownValue(industry_vertical::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IndustryVertical {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Generic => serializer.serialize_i32(1),
+            Self::Media => serializer.serialize_i32(2),
+            Self::HealthcareFhir => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IndustryVertical {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndustryVertical>::new(
+            ".google.cloud.discoveryengine.v1.IndustryVertical",
+        ))
     }
 }
 
 /// The type of solution.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SolutionType(i32);
-
-impl SolutionType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SolutionType {
     /// Default value.
-    pub const SOLUTION_TYPE_UNSPECIFIED: SolutionType = SolutionType::new(0);
-
+    Unspecified,
     /// Used for Recommendations AI.
-    pub const SOLUTION_TYPE_RECOMMENDATION: SolutionType = SolutionType::new(1);
-
+    Recommendation,
     /// Used for Discovery Search.
-    pub const SOLUTION_TYPE_SEARCH: SolutionType = SolutionType::new(2);
-
+    Search,
     /// Used for use cases related to the Generative AI agent.
-    pub const SOLUTION_TYPE_CHAT: SolutionType = SolutionType::new(3);
-
+    Chat,
     /// Used for use cases related to the Generative Chat agent.
     /// It's used for Generative chat engine only, the associated data stores
     /// must enrolled with `SOLUTION_TYPE_CHAT` solution.
-    pub const SOLUTION_TYPE_GENERATIVE_CHAT: SolutionType = SolutionType::new(4);
+    GenerativeChat,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SolutionType::value] or
+    /// [SolutionType::name].
+    UnknownValue(solution_type::UnknownValue),
+}
 
-    /// Creates a new SolutionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod solution_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SolutionType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Recommendation => std::option::Option::Some(1),
+            Self::Search => std::option::Option::Some(2),
+            Self::Chat => std::option::Option::Some(3),
+            Self::GenerativeChat => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_RECOMMENDATION"),
-            2 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_SEARCH"),
-            3 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_CHAT"),
-            4 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_GENERATIVE_CHAT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SOLUTION_TYPE_UNSPECIFIED"),
+            Self::Recommendation => std::option::Option::Some("SOLUTION_TYPE_RECOMMENDATION"),
+            Self::Search => std::option::Option::Some("SOLUTION_TYPE_SEARCH"),
+            Self::Chat => std::option::Option::Some("SOLUTION_TYPE_CHAT"),
+            Self::GenerativeChat => std::option::Option::Some("SOLUTION_TYPE_GENERATIVE_CHAT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SOLUTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SOLUTION_TYPE_UNSPECIFIED)
-            }
-            "SOLUTION_TYPE_RECOMMENDATION" => {
-                std::option::Option::Some(Self::SOLUTION_TYPE_RECOMMENDATION)
-            }
-            "SOLUTION_TYPE_SEARCH" => std::option::Option::Some(Self::SOLUTION_TYPE_SEARCH),
-            "SOLUTION_TYPE_CHAT" => std::option::Option::Some(Self::SOLUTION_TYPE_CHAT),
-            "SOLUTION_TYPE_GENERATIVE_CHAT" => {
-                std::option::Option::Some(Self::SOLUTION_TYPE_GENERATIVE_CHAT)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SolutionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SolutionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SolutionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SolutionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Recommendation,
+            2 => Self::Search,
+            3 => Self::Chat,
+            4 => Self::GenerativeChat,
+            _ => Self::UnknownValue(solution_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SolutionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SOLUTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SOLUTION_TYPE_RECOMMENDATION" => Self::Recommendation,
+            "SOLUTION_TYPE_SEARCH" => Self::Search,
+            "SOLUTION_TYPE_CHAT" => Self::Chat,
+            "SOLUTION_TYPE_GENERATIVE_CHAT" => Self::GenerativeChat,
+            _ => Self::UnknownValue(solution_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SolutionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Recommendation => serializer.serialize_i32(1),
+            Self::Search => serializer.serialize_i32(2),
+            Self::Chat => serializer.serialize_i32(3),
+            Self::GenerativeChat => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SolutionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SolutionType>::new(
+            ".google.cloud.discoveryengine.v1.SolutionType",
+        ))
     }
 }
 
@@ -30977,261 +33565,495 @@ impl std::default::Default for SolutionType {
 /// Specifically applies to
 /// [SOLUTION_TYPE_SEARCH][google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH].
 ///
-/// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchUseCase(i32);
-
-impl SearchUseCase {
+/// [google.cloud.discoveryengine.v1.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SearchUseCase {
     /// Value used when unset. Will not occur in CSS.
-    pub const SEARCH_USE_CASE_UNSPECIFIED: SearchUseCase = SearchUseCase::new(0);
-
+    Unspecified,
     /// Search use case. Expects the traffic has a non-empty
     /// [query][google.cloud.discoveryengine.v1.SearchRequest.query].
     ///
     /// [google.cloud.discoveryengine.v1.SearchRequest.query]: crate::model::SearchRequest::query
-    pub const SEARCH_USE_CASE_SEARCH: SearchUseCase = SearchUseCase::new(1);
-
+    Search,
     /// Browse use case. Expects the traffic has an empty
     /// [query][google.cloud.discoveryengine.v1.SearchRequest.query].
     ///
     /// [google.cloud.discoveryengine.v1.SearchRequest.query]: crate::model::SearchRequest::query
-    pub const SEARCH_USE_CASE_BROWSE: SearchUseCase = SearchUseCase::new(2);
+    Browse,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SearchUseCase::value] or
+    /// [SearchUseCase::name].
+    UnknownValue(search_use_case::UnknownValue),
+}
 
-    /// Creates a new SearchUseCase instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod search_use_case {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SearchUseCase {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Search => std::option::Option::Some(1),
+            Self::Browse => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEARCH_USE_CASE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SEARCH_USE_CASE_SEARCH"),
-            2 => std::borrow::Cow::Borrowed("SEARCH_USE_CASE_BROWSE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEARCH_USE_CASE_UNSPECIFIED"),
+            Self::Search => std::option::Option::Some("SEARCH_USE_CASE_SEARCH"),
+            Self::Browse => std::option::Option::Some("SEARCH_USE_CASE_BROWSE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEARCH_USE_CASE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SEARCH_USE_CASE_UNSPECIFIED)
-            }
-            "SEARCH_USE_CASE_SEARCH" => std::option::Option::Some(Self::SEARCH_USE_CASE_SEARCH),
-            "SEARCH_USE_CASE_BROWSE" => std::option::Option::Some(Self::SEARCH_USE_CASE_BROWSE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SearchUseCase {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchUseCase {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SearchUseCase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SearchUseCase {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Search,
+            2 => Self::Browse,
+            _ => Self::UnknownValue(search_use_case::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SearchUseCase {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEARCH_USE_CASE_UNSPECIFIED" => Self::Unspecified,
+            "SEARCH_USE_CASE_SEARCH" => Self::Search,
+            "SEARCH_USE_CASE_BROWSE" => Self::Browse,
+            _ => Self::UnknownValue(search_use_case::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SearchUseCase {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Search => serializer.serialize_i32(1),
+            Self::Browse => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SearchUseCase {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchUseCase>::new(
+            ".google.cloud.discoveryengine.v1.SearchUseCase",
+        ))
     }
 }
 
 /// Tiers of search features. Different tiers might have different
 /// pricing. To learn more, check the pricing documentation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchTier(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SearchTier {
+    /// Default value when the enum is unspecified. This is invalid to use.
+    Unspecified,
+    /// Standard tier.
+    Standard,
+    /// Enterprise tier.
+    Enterprise,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SearchTier::value] or
+    /// [SearchTier::name].
+    UnknownValue(search_tier::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod search_tier {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SearchTier {
-    /// Default value when the enum is unspecified. This is invalid to use.
-    pub const SEARCH_TIER_UNSPECIFIED: SearchTier = SearchTier::new(0);
-
-    /// Standard tier.
-    pub const SEARCH_TIER_STANDARD: SearchTier = SearchTier::new(1);
-
-    /// Enterprise tier.
-    pub const SEARCH_TIER_ENTERPRISE: SearchTier = SearchTier::new(2);
-
-    /// Creates a new SearchTier instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Standard => std::option::Option::Some(1),
+            Self::Enterprise => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEARCH_TIER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SEARCH_TIER_STANDARD"),
-            2 => std::borrow::Cow::Borrowed("SEARCH_TIER_ENTERPRISE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEARCH_TIER_UNSPECIFIED"),
+            Self::Standard => std::option::Option::Some("SEARCH_TIER_STANDARD"),
+            Self::Enterprise => std::option::Option::Some("SEARCH_TIER_ENTERPRISE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEARCH_TIER_UNSPECIFIED" => std::option::Option::Some(Self::SEARCH_TIER_UNSPECIFIED),
-            "SEARCH_TIER_STANDARD" => std::option::Option::Some(Self::SEARCH_TIER_STANDARD),
-            "SEARCH_TIER_ENTERPRISE" => std::option::Option::Some(Self::SEARCH_TIER_ENTERPRISE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SearchTier {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchTier {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SearchTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SearchTier {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Standard,
+            2 => Self::Enterprise,
+            _ => Self::UnknownValue(search_tier::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SearchTier {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEARCH_TIER_UNSPECIFIED" => Self::Unspecified,
+            "SEARCH_TIER_STANDARD" => Self::Standard,
+            "SEARCH_TIER_ENTERPRISE" => Self::Enterprise,
+            _ => Self::UnknownValue(search_tier::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SearchTier {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Standard => serializer.serialize_i32(1),
+            Self::Enterprise => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SearchTier {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchTier>::new(
+            ".google.cloud.discoveryengine.v1.SearchTier",
+        ))
     }
 }
 
 /// Add-on that provides additional functionality for search.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchAddOn(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SearchAddOn {
+    /// Default value when the enum is unspecified. This is invalid to use.
+    Unspecified,
+    /// Large language model add-on.
+    Llm,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SearchAddOn::value] or
+    /// [SearchAddOn::name].
+    UnknownValue(search_add_on::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod search_add_on {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SearchAddOn {
-    /// Default value when the enum is unspecified. This is invalid to use.
-    pub const SEARCH_ADD_ON_UNSPECIFIED: SearchAddOn = SearchAddOn::new(0);
-
-    /// Large language model add-on.
-    pub const SEARCH_ADD_ON_LLM: SearchAddOn = SearchAddOn::new(1);
-
-    /// Creates a new SearchAddOn instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Llm => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEARCH_ADD_ON_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SEARCH_ADD_ON_LLM"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEARCH_ADD_ON_UNSPECIFIED"),
+            Self::Llm => std::option::Option::Some("SEARCH_ADD_ON_LLM"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEARCH_ADD_ON_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SEARCH_ADD_ON_UNSPECIFIED)
-            }
-            "SEARCH_ADD_ON_LLM" => std::option::Option::Some(Self::SEARCH_ADD_ON_LLM),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SearchAddOn {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchAddOn {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SearchAddOn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SearchAddOn {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Llm,
+            _ => Self::UnknownValue(search_add_on::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SearchAddOn {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEARCH_ADD_ON_UNSPECIFIED" => Self::Unspecified,
+            "SEARCH_ADD_ON_LLM" => Self::Llm,
+            _ => Self::UnknownValue(search_add_on::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SearchAddOn {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Llm => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SearchAddOn {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchAddOn>::new(
+            ".google.cloud.discoveryengine.v1.SearchAddOn",
+        ))
     }
 }
 
 /// Harm categories that will block the content.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HarmCategory(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HarmCategory {
+    /// The harm category is unspecified.
+    Unspecified,
+    /// The harm category is hate speech.
+    HateSpeech,
+    /// The harm category is dangerous content.
+    DangerousContent,
+    /// The harm category is harassment.
+    Harassment,
+    /// The harm category is sexually explicit content.
+    SexuallyExplicit,
+    /// The harm category is civic integrity.
+    CivicIntegrity,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HarmCategory::value] or
+    /// [HarmCategory::name].
+    UnknownValue(harm_category::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod harm_category {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl HarmCategory {
-    /// The harm category is unspecified.
-    pub const HARM_CATEGORY_UNSPECIFIED: HarmCategory = HarmCategory::new(0);
-
-    /// The harm category is hate speech.
-    pub const HARM_CATEGORY_HATE_SPEECH: HarmCategory = HarmCategory::new(1);
-
-    /// The harm category is dangerous content.
-    pub const HARM_CATEGORY_DANGEROUS_CONTENT: HarmCategory = HarmCategory::new(2);
-
-    /// The harm category is harassment.
-    pub const HARM_CATEGORY_HARASSMENT: HarmCategory = HarmCategory::new(3);
-
-    /// The harm category is sexually explicit content.
-    pub const HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmCategory = HarmCategory::new(4);
-
-    /// The harm category is civic integrity.
-    pub const HARM_CATEGORY_CIVIC_INTEGRITY: HarmCategory = HarmCategory::new(5);
-
-    /// Creates a new HarmCategory instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::HateSpeech => std::option::Option::Some(1),
+            Self::DangerousContent => std::option::Option::Some(2),
+            Self::Harassment => std::option::Option::Some(3),
+            Self::SexuallyExplicit => std::option::Option::Some(4),
+            Self::CivicIntegrity => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HARM_CATEGORY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HARM_CATEGORY_HATE_SPEECH"),
-            2 => std::borrow::Cow::Borrowed("HARM_CATEGORY_DANGEROUS_CONTENT"),
-            3 => std::borrow::Cow::Borrowed("HARM_CATEGORY_HARASSMENT"),
-            4 => std::borrow::Cow::Borrowed("HARM_CATEGORY_SEXUALLY_EXPLICIT"),
-            5 => std::borrow::Cow::Borrowed("HARM_CATEGORY_CIVIC_INTEGRITY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HARM_CATEGORY_UNSPECIFIED"),
+            Self::HateSpeech => std::option::Option::Some("HARM_CATEGORY_HATE_SPEECH"),
+            Self::DangerousContent => std::option::Option::Some("HARM_CATEGORY_DANGEROUS_CONTENT"),
+            Self::Harassment => std::option::Option::Some("HARM_CATEGORY_HARASSMENT"),
+            Self::SexuallyExplicit => std::option::Option::Some("HARM_CATEGORY_SEXUALLY_EXPLICIT"),
+            Self::CivicIntegrity => std::option::Option::Some("HARM_CATEGORY_CIVIC_INTEGRITY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HARM_CATEGORY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_UNSPECIFIED)
-            }
-            "HARM_CATEGORY_HATE_SPEECH" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_HATE_SPEECH)
-            }
-            "HARM_CATEGORY_DANGEROUS_CONTENT" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_DANGEROUS_CONTENT)
-            }
-            "HARM_CATEGORY_HARASSMENT" => std::option::Option::Some(Self::HARM_CATEGORY_HARASSMENT),
-            "HARM_CATEGORY_SEXUALLY_EXPLICIT" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_SEXUALLY_EXPLICIT)
-            }
-            "HARM_CATEGORY_CIVIC_INTEGRITY" => {
-                std::option::Option::Some(Self::HARM_CATEGORY_CIVIC_INTEGRITY)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HarmCategory {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HarmCategory {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HarmCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HarmCategory {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::HateSpeech,
+            2 => Self::DangerousContent,
+            3 => Self::Harassment,
+            4 => Self::SexuallyExplicit,
+            5 => Self::CivicIntegrity,
+            _ => Self::UnknownValue(harm_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HarmCategory {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HARM_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+            "HARM_CATEGORY_HATE_SPEECH" => Self::HateSpeech,
+            "HARM_CATEGORY_DANGEROUS_CONTENT" => Self::DangerousContent,
+            "HARM_CATEGORY_HARASSMENT" => Self::Harassment,
+            "HARM_CATEGORY_SEXUALLY_EXPLICIT" => Self::SexuallyExplicit,
+            "HARM_CATEGORY_CIVIC_INTEGRITY" => Self::CivicIntegrity,
+            _ => Self::UnknownValue(harm_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HarmCategory {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::HateSpeech => serializer.serialize_i32(1),
+            Self::DangerousContent => serializer.serialize_i32(2),
+            Self::Harassment => serializer.serialize_i32(3),
+            Self::SexuallyExplicit => serializer.serialize_i32(4),
+            Self::CivicIntegrity => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HarmCategory {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HarmCategory>::new(
+            ".google.cloud.discoveryengine.v1.HarmCategory",
+        ))
     }
 }

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -1235,74 +1235,140 @@ pub mod document {
             use super::*;
 
             /// Detected human reading orientation.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Orientation(i32);
-
-            impl Orientation {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Orientation {
                 /// Unspecified orientation.
-                pub const ORIENTATION_UNSPECIFIED: Orientation = Orientation::new(0);
-
+                Unspecified,
                 /// Orientation is aligned with page up.
-                pub const PAGE_UP: Orientation = Orientation::new(1);
-
+                PageUp,
                 /// Orientation is aligned with page right.
                 /// Turn the head 90 degrees clockwise from upright to read.
-                pub const PAGE_RIGHT: Orientation = Orientation::new(2);
-
+                PageRight,
                 /// Orientation is aligned with page down.
                 /// Turn the head 180 degrees from upright to read.
-                pub const PAGE_DOWN: Orientation = Orientation::new(3);
-
+                PageDown,
                 /// Orientation is aligned with page left.
                 /// Turn the head 90 degrees counterclockwise from upright to read.
-                pub const PAGE_LEFT: Orientation = Orientation::new(4);
+                PageLeft,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Orientation::value] or
+                /// [Orientation::name].
+                UnknownValue(orientation::UnknownValue),
+            }
 
-                /// Creates a new Orientation instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod orientation {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl Orientation {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::PageUp => std::option::Option::Some(1),
+                        Self::PageRight => std::option::Option::Some(2),
+                        Self::PageDown => std::option::Option::Some(3),
+                        Self::PageLeft => std::option::Option::Some(4),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("ORIENTATION_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("PAGE_UP"),
-                        2 => std::borrow::Cow::Borrowed("PAGE_RIGHT"),
-                        3 => std::borrow::Cow::Borrowed("PAGE_DOWN"),
-                        4 => std::borrow::Cow::Borrowed("PAGE_LEFT"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("ORIENTATION_UNSPECIFIED"),
+                        Self::PageUp => std::option::Option::Some("PAGE_UP"),
+                        Self::PageRight => std::option::Option::Some("PAGE_RIGHT"),
+                        Self::PageDown => std::option::Option::Some("PAGE_DOWN"),
+                        Self::PageLeft => std::option::Option::Some("PAGE_LEFT"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "ORIENTATION_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::ORIENTATION_UNSPECIFIED)
-                        }
-                        "PAGE_UP" => std::option::Option::Some(Self::PAGE_UP),
-                        "PAGE_RIGHT" => std::option::Option::Some(Self::PAGE_RIGHT),
-                        "PAGE_DOWN" => std::option::Option::Some(Self::PAGE_DOWN),
-                        "PAGE_LEFT" => std::option::Option::Some(Self::PAGE_LEFT),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Orientation {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Orientation {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Orientation {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Orientation {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::PageUp,
+                        2 => Self::PageRight,
+                        3 => Self::PageDown,
+                        4 => Self::PageLeft,
+                        _ => Self::UnknownValue(orientation::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Orientation {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "ORIENTATION_UNSPECIFIED" => Self::Unspecified,
+                        "PAGE_UP" => Self::PageUp,
+                        "PAGE_RIGHT" => Self::PageRight,
+                        "PAGE_DOWN" => Self::PageDown,
+                        "PAGE_LEFT" => Self::PageLeft,
+                        _ => Self::UnknownValue(orientation::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Orientation {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::PageUp => serializer.serialize_i32(1),
+                        Self::PageRight => serializer.serialize_i32(2),
+                        Self::PageDown => serializer.serialize_i32(3),
+                        Self::PageLeft => serializer.serialize_i32(4),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Orientation {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Orientation>::new(
+                        ".google.cloud.documentai.v1.Document.Page.Layout.Orientation",
+                    ))
                 }
             }
         }
@@ -1682,64 +1748,130 @@ pub mod document {
                 use super::*;
 
                 /// Enum to denote the type of break found.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Type(i32);
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum Type {
+                    /// Unspecified break type.
+                    Unspecified,
+                    /// A single whitespace.
+                    Space,
+                    /// A wider whitespace.
+                    WideSpace,
+                    /// A hyphen that indicates that a token has been split across lines.
+                    Hyphen,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [Type::value] or
+                    /// [Type::name].
+                    UnknownValue(r#type::UnknownValue),
+                }
+
+                #[doc(hidden)]
+                pub mod r#type {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
                 impl Type {
-                    /// Unspecified break type.
-                    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-                    /// A single whitespace.
-                    pub const SPACE: Type = Type::new(1);
-
-                    /// A wider whitespace.
-                    pub const WIDE_SPACE: Type = Type::new(2);
-
-                    /// A hyphen that indicates that a token has been split across lines.
-                    pub const HYPHEN: Type = Type::new(3);
-
-                    /// Creates a new Type instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
-
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::Space => std::option::Option::Some(1),
+                            Self::WideSpace => std::option::Option::Some(2),
+                            Self::Hyphen => std::option::Option::Some(3),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("SPACE"),
-                            2 => std::borrow::Cow::Borrowed("WIDE_SPACE"),
-                            3 => std::borrow::Cow::Borrowed("HYPHEN"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                            Self::Space => std::option::Option::Some("SPACE"),
+                            Self::WideSpace => std::option::Option::Some("WIDE_SPACE"),
+                            Self::Hyphen => std::option::Option::Some("HYPHEN"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                            "SPACE" => std::option::Option::Some(Self::SPACE),
-                            "WIDE_SPACE" => std::option::Option::Some(Self::WIDE_SPACE),
-                            "HYPHEN" => std::option::Option::Some(Self::HYPHEN),
-                            _ => std::option::Option::None,
-                        }
-                    }
-                }
-
-                impl std::convert::From<i32> for Type {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Type {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for Type {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for Type {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::Space,
+                            2 => Self::WideSpace,
+                            3 => Self::Hyphen,
+                            _ => Self::UnknownValue(r#type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for Type {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "TYPE_UNSPECIFIED" => Self::Unspecified,
+                            "SPACE" => Self::Space,
+                            "WIDE_SPACE" => Self::WideSpace,
+                            "HYPHEN" => Self::Hyphen,
+                            _ => Self::UnknownValue(r#type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for Type {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::Space => serializer.serialize_i32(1),
+                            Self::WideSpace => serializer.serialize_i32(2),
+                            Self::Hyphen => serializer.serialize_i32(3),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for Type {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                            ".google.cloud.documentai.v1.Document.Page.Token.DetectedBreak.Type",
+                        ))
                     }
                 }
             }
@@ -3476,113 +3608,185 @@ pub mod document {
             use super::*;
 
             /// The type of layout that is being referenced.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct LayoutType(i32);
-
-            impl LayoutType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum LayoutType {
                 /// Layout Unspecified.
-                pub const LAYOUT_TYPE_UNSPECIFIED: LayoutType = LayoutType::new(0);
-
+                Unspecified,
                 /// References a
                 /// [Page.blocks][google.cloud.documentai.v1.Document.Page.blocks]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.blocks]: crate::model::document::Page::blocks
-                pub const BLOCK: LayoutType = LayoutType::new(1);
-
+                Block,
                 /// References a
                 /// [Page.paragraphs][google.cloud.documentai.v1.Document.Page.paragraphs]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.paragraphs]: crate::model::document::Page::paragraphs
-                pub const PARAGRAPH: LayoutType = LayoutType::new(2);
-
+                Paragraph,
                 /// References a
                 /// [Page.lines][google.cloud.documentai.v1.Document.Page.lines] element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.lines]: crate::model::document::Page::lines
-                pub const LINE: LayoutType = LayoutType::new(3);
-
+                Line,
                 /// References a
                 /// [Page.tokens][google.cloud.documentai.v1.Document.Page.tokens]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.tokens]: crate::model::document::Page::tokens
-                pub const TOKEN: LayoutType = LayoutType::new(4);
-
+                Token,
                 /// References a
                 /// [Page.visual_elements][google.cloud.documentai.v1.Document.Page.visual_elements]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.visual_elements]: crate::model::document::Page::visual_elements
-                pub const VISUAL_ELEMENT: LayoutType = LayoutType::new(5);
-
+                VisualElement,
                 /// Refrrences a
                 /// [Page.tables][google.cloud.documentai.v1.Document.Page.tables]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.tables]: crate::model::document::Page::tables
-                pub const TABLE: LayoutType = LayoutType::new(6);
-
+                Table,
                 /// References a
                 /// [Page.form_fields][google.cloud.documentai.v1.Document.Page.form_fields]
                 /// element.
                 ///
                 /// [google.cloud.documentai.v1.Document.Page.form_fields]: crate::model::document::Page::form_fields
-                pub const FORM_FIELD: LayoutType = LayoutType::new(7);
+                FormField,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [LayoutType::value] or
+                /// [LayoutType::name].
+                UnknownValue(layout_type::UnknownValue),
+            }
 
-                /// Creates a new LayoutType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod layout_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl LayoutType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Block => std::option::Option::Some(1),
+                        Self::Paragraph => std::option::Option::Some(2),
+                        Self::Line => std::option::Option::Some(3),
+                        Self::Token => std::option::Option::Some(4),
+                        Self::VisualElement => std::option::Option::Some(5),
+                        Self::Table => std::option::Option::Some(6),
+                        Self::FormField => std::option::Option::Some(7),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("LAYOUT_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("BLOCK"),
-                        2 => std::borrow::Cow::Borrowed("PARAGRAPH"),
-                        3 => std::borrow::Cow::Borrowed("LINE"),
-                        4 => std::borrow::Cow::Borrowed("TOKEN"),
-                        5 => std::borrow::Cow::Borrowed("VISUAL_ELEMENT"),
-                        6 => std::borrow::Cow::Borrowed("TABLE"),
-                        7 => std::borrow::Cow::Borrowed("FORM_FIELD"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("LAYOUT_TYPE_UNSPECIFIED"),
+                        Self::Block => std::option::Option::Some("BLOCK"),
+                        Self::Paragraph => std::option::Option::Some("PARAGRAPH"),
+                        Self::Line => std::option::Option::Some("LINE"),
+                        Self::Token => std::option::Option::Some("TOKEN"),
+                        Self::VisualElement => std::option::Option::Some("VISUAL_ELEMENT"),
+                        Self::Table => std::option::Option::Some("TABLE"),
+                        Self::FormField => std::option::Option::Some("FORM_FIELD"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "LAYOUT_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::LAYOUT_TYPE_UNSPECIFIED)
-                        }
-                        "BLOCK" => std::option::Option::Some(Self::BLOCK),
-                        "PARAGRAPH" => std::option::Option::Some(Self::PARAGRAPH),
-                        "LINE" => std::option::Option::Some(Self::LINE),
-                        "TOKEN" => std::option::Option::Some(Self::TOKEN),
-                        "VISUAL_ELEMENT" => std::option::Option::Some(Self::VISUAL_ELEMENT),
-                        "TABLE" => std::option::Option::Some(Self::TABLE),
-                        "FORM_FIELD" => std::option::Option::Some(Self::FORM_FIELD),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for LayoutType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for LayoutType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for LayoutType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for LayoutType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Block,
+                        2 => Self::Paragraph,
+                        3 => Self::Line,
+                        4 => Self::Token,
+                        5 => Self::VisualElement,
+                        6 => Self::Table,
+                        7 => Self::FormField,
+                        _ => Self::UnknownValue(layout_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for LayoutType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "LAYOUT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "BLOCK" => Self::Block,
+                        "PARAGRAPH" => Self::Paragraph,
+                        "LINE" => Self::Line,
+                        "TOKEN" => Self::Token,
+                        "VISUAL_ELEMENT" => Self::VisualElement,
+                        "TABLE" => Self::Table,
+                        "FORM_FIELD" => Self::FormField,
+                        _ => Self::UnknownValue(layout_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for LayoutType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Block => serializer.serialize_i32(1),
+                        Self::Paragraph => serializer.serialize_i32(2),
+                        Self::Line => serializer.serialize_i32(3),
+                        Self::Token => serializer.serialize_i32(4),
+                        Self::VisualElement => serializer.serialize_i32(5),
+                        Self::Table => serializer.serialize_i32(6),
+                        Self::FormField => serializer.serialize_i32(7),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for LayoutType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<LayoutType>::new(
+                        ".google.cloud.documentai.v1.Document.PageAnchor.PageRef.LayoutType",
+                    ))
                 }
             }
         }
@@ -3722,92 +3926,164 @@ pub mod document {
         }
 
         /// If a processor or agent does an explicit operation on existing elements.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct OperationType(i32);
-
-        impl OperationType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum OperationType {
             /// Operation type unspecified. If no operation is specified a provenance
             /// entry is simply used to match against a `parent`.
-            pub const OPERATION_TYPE_UNSPECIFIED: OperationType = OperationType::new(0);
-
+            Unspecified,
             /// Add an element.
-            pub const ADD: OperationType = OperationType::new(1);
-
+            Add,
             /// Remove an element identified by `parent`.
-            pub const REMOVE: OperationType = OperationType::new(2);
-
+            Remove,
             /// Updates any fields within the given provenance scope of the message. It
             /// overwrites the fields rather than replacing them.  Use this when you
             /// want to update a field value of an entity without also updating all the
             /// child properties.
-            pub const UPDATE: OperationType = OperationType::new(7);
-
+            Update,
             /// Currently unused. Replace an element identified by `parent`.
-            pub const REPLACE: OperationType = OperationType::new(3);
-
+            Replace,
             /// Deprecated. Request human review for the element identified by
             /// `parent`.
-            pub const EVAL_REQUESTED: OperationType = OperationType::new(4);
-
+            EvalRequested,
             /// Deprecated. Element is reviewed and approved at human review,
             /// confidence will be set to 1.0.
-            pub const EVAL_APPROVED: OperationType = OperationType::new(5);
-
+            EvalApproved,
             /// Deprecated. Element is skipped in the validation process.
-            pub const EVAL_SKIPPED: OperationType = OperationType::new(6);
+            EvalSkipped,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [OperationType::value] or
+            /// [OperationType::name].
+            UnknownValue(operation_type::UnknownValue),
+        }
 
-            /// Creates a new OperationType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod operation_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl OperationType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Add => std::option::Option::Some(1),
+                    Self::Remove => std::option::Option::Some(2),
+                    Self::Update => std::option::Option::Some(7),
+                    Self::Replace => std::option::Option::Some(3),
+                    Self::EvalRequested => std::option::Option::Some(4),
+                    Self::EvalApproved => std::option::Option::Some(5),
+                    Self::EvalSkipped => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATION_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ADD"),
-                    2 => std::borrow::Cow::Borrowed("REMOVE"),
-                    3 => std::borrow::Cow::Borrowed("REPLACE"),
-                    4 => std::borrow::Cow::Borrowed("EVAL_REQUESTED"),
-                    5 => std::borrow::Cow::Borrowed("EVAL_APPROVED"),
-                    6 => std::borrow::Cow::Borrowed("EVAL_SKIPPED"),
-                    7 => std::borrow::Cow::Borrowed("UPDATE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATION_TYPE_UNSPECIFIED"),
+                    Self::Add => std::option::Option::Some("ADD"),
+                    Self::Remove => std::option::Option::Some("REMOVE"),
+                    Self::Update => std::option::Option::Some("UPDATE"),
+                    Self::Replace => std::option::Option::Some("REPLACE"),
+                    Self::EvalRequested => std::option::Option::Some("EVAL_REQUESTED"),
+                    Self::EvalApproved => std::option::Option::Some("EVAL_APPROVED"),
+                    Self::EvalSkipped => std::option::Option::Some("EVAL_SKIPPED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATION_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::OPERATION_TYPE_UNSPECIFIED)
-                    }
-                    "ADD" => std::option::Option::Some(Self::ADD),
-                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                    "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                    "REPLACE" => std::option::Option::Some(Self::REPLACE),
-                    "EVAL_REQUESTED" => std::option::Option::Some(Self::EVAL_REQUESTED),
-                    "EVAL_APPROVED" => std::option::Option::Some(Self::EVAL_APPROVED),
-                    "EVAL_SKIPPED" => std::option::Option::Some(Self::EVAL_SKIPPED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for OperationType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for OperationType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for OperationType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for OperationType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Add,
+                    2 => Self::Remove,
+                    3 => Self::Replace,
+                    4 => Self::EvalRequested,
+                    5 => Self::EvalApproved,
+                    6 => Self::EvalSkipped,
+                    7 => Self::Update,
+                    _ => Self::UnknownValue(operation_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for OperationType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "ADD" => Self::Add,
+                    "REMOVE" => Self::Remove,
+                    "UPDATE" => Self::Update,
+                    "REPLACE" => Self::Replace,
+                    "EVAL_REQUESTED" => Self::EvalRequested,
+                    "EVAL_APPROVED" => Self::EvalApproved,
+                    "EVAL_SKIPPED" => Self::EvalSkipped,
+                    _ => Self::UnknownValue(operation_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for OperationType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Add => serializer.serialize_i32(1),
+                    Self::Remove => serializer.serialize_i32(2),
+                    Self::Update => serializer.serialize_i32(7),
+                    Self::Replace => serializer.serialize_i32(3),
+                    Self::EvalRequested => serializer.serialize_i32(4),
+                    Self::EvalApproved => serializer.serialize_i32(5),
+                    Self::EvalSkipped => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for OperationType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationType>::new(
+                    ".google.cloud.documentai.v1.Document.Provenance.OperationType",
+                ))
             }
         }
     }
@@ -6461,75 +6737,140 @@ pub mod human_review_status {
     use super::*;
 
     /// The final state of human review on a processed document.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Human review state is unspecified. Most likely due to an internal error.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Human review is skipped for the document. This can happen because human
         /// review isn't enabled on the processor or the processing request has
         /// been set to skip this document.
-        pub const SKIPPED: State = State::new(1);
-
+        Skipped,
         /// Human review validation is triggered and passed, so no review is needed.
-        pub const VALIDATION_PASSED: State = State::new(2);
-
+        ValidationPassed,
         /// Human review validation is triggered and the document is under review.
-        pub const IN_PROGRESS: State = State::new(3);
-
+        InProgress,
         /// Some error happened during triggering human review, see the
         /// [state_message][google.cloud.documentai.v1.HumanReviewStatus.state_message]
         /// for details.
         ///
         /// [google.cloud.documentai.v1.HumanReviewStatus.state_message]: crate::model::HumanReviewStatus::state_message
-        pub const ERROR: State = State::new(4);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skipped => std::option::Option::Some(1),
+                Self::ValidationPassed => std::option::Option::Some(2),
+                Self::InProgress => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SKIPPED"),
-                2 => std::borrow::Cow::Borrowed("VALIDATION_PASSED"),
-                3 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Skipped => std::option::Option::Some("SKIPPED"),
+                Self::ValidationPassed => std::option::Option::Some("VALIDATION_PASSED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                "VALIDATION_PASSED" => std::option::Option::Some(Self::VALIDATION_PASSED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skipped,
+                2 => Self::ValidationPassed,
+                3 => Self::InProgress,
+                4 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "SKIPPED" => Self::Skipped,
+                "VALIDATION_PASSED" => Self::ValidationPassed,
+                "IN_PROGRESS" => Self::InProgress,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skipped => serializer.serialize_i32(1),
+                Self::ValidationPassed => serializer.serialize_i32(2),
+                Self::InProgress => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.documentai.v1.HumanReviewStatus.State",
+            ))
         }
     }
 }
@@ -6922,79 +7263,148 @@ pub mod batch_process_metadata {
     }
 
     /// Possible states of the batch processing operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// Request operation is waiting for scheduling.
+        Waiting,
+        /// Request is being processed.
+        Running,
+        /// The batch processing completed successfully.
+        Succeeded,
+        /// The batch processing was being cancelled.
+        Cancelling,
+        /// The batch processing was cancelled.
+        Cancelled,
+        /// The batch processing has failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Request operation is waiting for scheduling.
-        pub const WAITING: State = State::new(1);
-
-        /// Request is being processed.
-        pub const RUNNING: State = State::new(2);
-
-        /// The batch processing completed successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// The batch processing was being cancelled.
-        pub const CANCELLING: State = State::new(4);
-
-        /// The batch processing was cancelled.
-        pub const CANCELLED: State = State::new(5);
-
-        /// The batch processing has failed.
-        pub const FAILED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Waiting => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WAITING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Waiting => std::option::Option::Some("WAITING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "WAITING" => std::option::Option::Some(Self::WAITING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Waiting,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "WAITING" => Self::Waiting,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Waiting => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.documentai.v1.BatchProcessMetadata.State",
+            ))
         }
     }
 }
@@ -8610,58 +9020,119 @@ pub mod train_processor_version_request {
 
         /// Training Method for CDE. `TRAINING_METHOD_UNSPECIFIED` will fall back to
         /// `MODEL_BASED`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct TrainingMethod(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum TrainingMethod {
+            Unspecified,
+            ModelBased,
+            TemplateBased,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [TrainingMethod::value] or
+            /// [TrainingMethod::name].
+            UnknownValue(training_method::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod training_method {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl TrainingMethod {
-            pub const TRAINING_METHOD_UNSPECIFIED: TrainingMethod = TrainingMethod::new(0);
-
-            pub const MODEL_BASED: TrainingMethod = TrainingMethod::new(1);
-
-            pub const TEMPLATE_BASED: TrainingMethod = TrainingMethod::new(2);
-
-            /// Creates a new TrainingMethod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ModelBased => std::option::Option::Some(1),
+                    Self::TemplateBased => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TRAINING_METHOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MODEL_BASED"),
-                    2 => std::borrow::Cow::Borrowed("TEMPLATE_BASED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TRAINING_METHOD_UNSPECIFIED"),
+                    Self::ModelBased => std::option::Option::Some("MODEL_BASED"),
+                    Self::TemplateBased => std::option::Option::Some("TEMPLATE_BASED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TRAINING_METHOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::TRAINING_METHOD_UNSPECIFIED)
-                    }
-                    "MODEL_BASED" => std::option::Option::Some(Self::MODEL_BASED),
-                    "TEMPLATE_BASED" => std::option::Option::Some(Self::TEMPLATE_BASED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for TrainingMethod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for TrainingMethod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for TrainingMethod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for TrainingMethod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ModelBased,
+                    2 => Self::TemplateBased,
+                    _ => Self::UnknownValue(training_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for TrainingMethod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TRAINING_METHOD_UNSPECIFIED" => Self::Unspecified,
+                    "MODEL_BASED" => Self::ModelBased,
+                    "TEMPLATE_BASED" => Self::TemplateBased,
+                    _ => Self::UnknownValue(training_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for TrainingMethod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ModelBased => serializer.serialize_i32(1),
+                    Self::TemplateBased => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for TrainingMethod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<TrainingMethod>::new(
+                    ".google.cloud.documentai.v1.TrainProcessorVersionRequest.CustomDocumentExtractionOptions.TrainingMethod"))
             }
         }
     }
@@ -9058,55 +9529,114 @@ pub mod review_document_request {
     use super::*;
 
     /// The priority level of the human review task.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(i32);
-
-    impl Priority {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Priority {
         /// The default priority level.
-        pub const DEFAULT: Priority = Priority::new(0);
-
+        Default,
         /// The urgent priority level. The labeling manager should allocate labeler
         /// resource to the urgent task queue to respect this priority level.
-        pub const URGENT: Priority = Priority::new(1);
+        Urgent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Priority::value] or
+        /// [Priority::name].
+        UnknownValue(priority::UnknownValue),
+    }
 
-        /// Creates a new Priority instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod priority {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Priority {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Default => std::option::Option::Some(0),
+                Self::Urgent => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEFAULT"),
-                1 => std::borrow::Cow::Borrowed("URGENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Urgent => std::option::Option::Some("URGENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "URGENT" => std::option::Option::Some(Self::URGENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Priority {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Priority {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Default,
+                1 => Self::Urgent,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Priority {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEFAULT" => Self::Default,
+                "URGENT" => Self::Urgent,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Priority {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Default => serializer.serialize_i32(0),
+                Self::Urgent => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Priority {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Priority>::new(
+                ".google.cloud.documentai.v1.ReviewDocumentRequest.Priority",
+            ))
         }
     }
 
@@ -9188,59 +9718,120 @@ pub mod review_document_response {
     use super::*;
 
     /// Possible states of the review operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The review operation is rejected by the reviewer.
+        Rejected,
+        /// The review operation is succeeded.
+        Succeeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The review operation is rejected by the reviewer.
-        pub const REJECTED: State = State::new(1);
-
-        /// The review operation is succeeded.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Rejected => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REJECTED"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Rejected => std::option::Option::Some("REJECTED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "REJECTED" => std::option::Option::Some(Self::REJECTED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Rejected,
+                2 => Self::Succeeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "REJECTED" => Self::Rejected,
+                "SUCCEEDED" => Self::Succeeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Rejected => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.documentai.v1.ReviewDocumentResponse.State",
+            ))
         }
     }
 }
@@ -9951,73 +10542,140 @@ pub mod document_schema {
             /// expect a bank statement to contain the status of multiple different
             /// accounts for the customers, the occurrence type is set to
             /// `REQUIRED_MULTIPLE`.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct OccurrenceType(i32);
-
-            impl OccurrenceType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum OccurrenceType {
                 /// Unspecified occurrence type.
-                pub const OCCURRENCE_TYPE_UNSPECIFIED: OccurrenceType = OccurrenceType::new(0);
-
+                Unspecified,
                 /// There will be zero or one instance of this entity type.  The same
                 /// entity instance may be mentioned multiple times.
-                pub const OPTIONAL_ONCE: OccurrenceType = OccurrenceType::new(1);
-
+                OptionalOnce,
                 /// The entity type will appear zero or multiple times.
-                pub const OPTIONAL_MULTIPLE: OccurrenceType = OccurrenceType::new(2);
-
+                OptionalMultiple,
                 /// The entity type will only appear exactly once.  The same
                 /// entity instance may be mentioned multiple times.
-                pub const REQUIRED_ONCE: OccurrenceType = OccurrenceType::new(3);
-
+                RequiredOnce,
                 /// The entity type will appear once or more times.
-                pub const REQUIRED_MULTIPLE: OccurrenceType = OccurrenceType::new(4);
+                RequiredMultiple,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [OccurrenceType::value] or
+                /// [OccurrenceType::name].
+                UnknownValue(occurrence_type::UnknownValue),
+            }
 
-                /// Creates a new OccurrenceType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod occurrence_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl OccurrenceType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::OptionalOnce => std::option::Option::Some(1),
+                        Self::OptionalMultiple => std::option::Option::Some(2),
+                        Self::RequiredOnce => std::option::Option::Some(3),
+                        Self::RequiredMultiple => std::option::Option::Some(4),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("OCCURRENCE_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("OPTIONAL_ONCE"),
-                        2 => std::borrow::Cow::Borrowed("OPTIONAL_MULTIPLE"),
-                        3 => std::borrow::Cow::Borrowed("REQUIRED_ONCE"),
-                        4 => std::borrow::Cow::Borrowed("REQUIRED_MULTIPLE"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "OCCURRENCE_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::OCCURRENCE_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("OCCURRENCE_TYPE_UNSPECIFIED")
                         }
-                        "OPTIONAL_ONCE" => std::option::Option::Some(Self::OPTIONAL_ONCE),
-                        "OPTIONAL_MULTIPLE" => std::option::Option::Some(Self::OPTIONAL_MULTIPLE),
-                        "REQUIRED_ONCE" => std::option::Option::Some(Self::REQUIRED_ONCE),
-                        "REQUIRED_MULTIPLE" => std::option::Option::Some(Self::REQUIRED_MULTIPLE),
-                        _ => std::option::Option::None,
+                        Self::OptionalOnce => std::option::Option::Some("OPTIONAL_ONCE"),
+                        Self::OptionalMultiple => std::option::Option::Some("OPTIONAL_MULTIPLE"),
+                        Self::RequiredOnce => std::option::Option::Some("REQUIRED_ONCE"),
+                        Self::RequiredMultiple => std::option::Option::Some("REQUIRED_MULTIPLE"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for OccurrenceType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for OccurrenceType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for OccurrenceType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for OccurrenceType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::OptionalOnce,
+                        2 => Self::OptionalMultiple,
+                        3 => Self::RequiredOnce,
+                        4 => Self::RequiredMultiple,
+                        _ => Self::UnknownValue(occurrence_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for OccurrenceType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "OCCURRENCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "OPTIONAL_ONCE" => Self::OptionalOnce,
+                        "OPTIONAL_MULTIPLE" => Self::OptionalMultiple,
+                        "REQUIRED_ONCE" => Self::RequiredOnce,
+                        "REQUIRED_MULTIPLE" => Self::RequiredMultiple,
+                        _ => Self::UnknownValue(occurrence_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for OccurrenceType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::OptionalOnce => serializer.serialize_i32(1),
+                        Self::OptionalMultiple => serializer.serialize_i32(2),
+                        Self::RequiredOnce => serializer.serialize_i32(3),
+                        Self::RequiredMultiple => serializer.serialize_i32(4),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for OccurrenceType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<OccurrenceType>::new(
+                        ".google.cloud.documentai.v1.DocumentSchema.EntityType.Property.OccurrenceType"))
                 }
             }
         }
@@ -10672,62 +11330,122 @@ pub mod evaluation {
         use super::*;
 
         /// A type that determines how metrics should be interpreted.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MetricsType(i32);
-
-        impl MetricsType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MetricsType {
             /// The metrics type is unspecified. By default, metrics without a
             /// particular specification are for leaf entity types (i.e., top-level
             /// entity types without child types, or child types which are not
             /// parent types themselves).
-            pub const METRICS_TYPE_UNSPECIFIED: MetricsType = MetricsType::new(0);
-
+            Unspecified,
             /// Indicates whether metrics for this particular label type represent an
             /// aggregate of metrics for other types instead of being based on actual
             /// TP/FP/FN values for the label type. Metrics for parent (i.e., non-leaf)
             /// entity types are an aggregate of metrics for their children.
-            pub const AGGREGATE: MetricsType = MetricsType::new(1);
+            Aggregate,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MetricsType::value] or
+            /// [MetricsType::name].
+            UnknownValue(metrics_type::UnknownValue),
+        }
 
-            /// Creates a new MetricsType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod metrics_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl MetricsType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Aggregate => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("METRICS_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AGGREGATE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("METRICS_TYPE_UNSPECIFIED"),
+                    Self::Aggregate => std::option::Option::Some("AGGREGATE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "METRICS_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::METRICS_TYPE_UNSPECIFIED)
-                    }
-                    "AGGREGATE" => std::option::Option::Some(Self::AGGREGATE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MetricsType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MetricsType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MetricsType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MetricsType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Aggregate,
+                    _ => Self::UnknownValue(metrics_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MetricsType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "METRICS_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "AGGREGATE" => Self::Aggregate,
+                    _ => Self::UnknownValue(metrics_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MetricsType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Aggregate => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MetricsType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetricsType>::new(
+                    ".google.cloud.documentai.v1.Evaluation.MultiConfidenceMetrics.MetricsType",
+                ))
             }
         }
     }
@@ -10958,74 +11676,141 @@ pub mod common_operation_metadata {
     use super::*;
 
     /// State of the longrunning operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// Operation is still running.
+        Running,
+        /// Operation is being cancelled.
+        Cancelling,
+        /// Operation succeeded.
+        Succeeded,
+        /// Operation failed.
+        Failed,
+        /// Operation is cancelled.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Operation is still running.
-        pub const RUNNING: State = State::new(1);
-
-        /// Operation is being cancelled.
-        pub const CANCELLING: State = State::new(2);
-
-        /// Operation succeeded.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// Operation failed.
-        pub const FAILED: State = State::new(4);
-
-        /// Operation is cancelled.
-        pub const CANCELLED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Cancelling => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("CANCELLING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Cancelling,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "CANCELLING" => Self::Cancelling,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Cancelling => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.documentai.v1.CommonOperationMetadata.State",
+            ))
         }
     }
 }
@@ -11502,63 +12287,126 @@ pub mod processor_version {
             use super::*;
 
             /// The type of custom model created by the user.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct CustomModelType(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum CustomModelType {
+                /// The model type is unspecified.
+                Unspecified,
+                /// The model is a versioned foundation model.
+                VersionedFoundation,
+                /// The model is a finetuned foundation model.
+                FineTuned,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [CustomModelType::value] or
+                /// [CustomModelType::name].
+                UnknownValue(custom_model_type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod custom_model_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl CustomModelType {
-                /// The model type is unspecified.
-                pub const CUSTOM_MODEL_TYPE_UNSPECIFIED: CustomModelType = CustomModelType::new(0);
-
-                /// The model is a versioned foundation model.
-                pub const VERSIONED_FOUNDATION: CustomModelType = CustomModelType::new(1);
-
-                /// The model is a finetuned foundation model.
-                pub const FINE_TUNED: CustomModelType = CustomModelType::new(2);
-
-                /// Creates a new CustomModelType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::VersionedFoundation => std::option::Option::Some(1),
+                        Self::FineTuned => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("CUSTOM_MODEL_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("VERSIONED_FOUNDATION"),
-                        2 => std::borrow::Cow::Borrowed("FINE_TUNED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "CUSTOM_MODEL_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::CUSTOM_MODEL_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("CUSTOM_MODEL_TYPE_UNSPECIFIED")
                         }
-                        "VERSIONED_FOUNDATION" => {
-                            std::option::Option::Some(Self::VERSIONED_FOUNDATION)
+                        Self::VersionedFoundation => {
+                            std::option::Option::Some("VERSIONED_FOUNDATION")
                         }
-                        "FINE_TUNED" => std::option::Option::Some(Self::FINE_TUNED),
-                        _ => std::option::Option::None,
+                        Self::FineTuned => std::option::Option::Some("FINE_TUNED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for CustomModelType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for CustomModelType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for CustomModelType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for CustomModelType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::VersionedFoundation,
+                        2 => Self::FineTuned,
+                        _ => Self::UnknownValue(custom_model_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for CustomModelType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "CUSTOM_MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "VERSIONED_FOUNDATION" => Self::VersionedFoundation,
+                        "FINE_TUNED" => Self::FineTuned,
+                        _ => Self::UnknownValue(custom_model_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for CustomModelType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::VersionedFoundation => serializer.serialize_i32(1),
+                        Self::FineTuned => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for CustomModelType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<CustomModelType>::new(
+                        ".google.cloud.documentai.v1.ProcessorVersion.GenAiModelInfo.CustomGenAiModelInfo.CustomModelType"))
                 }
             }
         }
@@ -11585,146 +12433,280 @@ pub mod processor_version {
     }
 
     /// The possible states of the processor version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The processor version is in an unspecified state.
+        Unspecified,
+        /// The processor version is deployed and can be used for processing.
+        Deployed,
+        /// The processor version is being deployed.
+        Deploying,
+        /// The processor version is not deployed and cannot be used for processing.
+        Undeployed,
+        /// The processor version is being undeployed.
+        Undeploying,
+        /// The processor version is being created.
+        Creating,
+        /// The processor version is being deleted.
+        Deleting,
+        /// The processor version failed and is in an indeterminate state.
+        Failed,
+        /// The processor version is being imported.
+        Importing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The processor version is in an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The processor version is deployed and can be used for processing.
-        pub const DEPLOYED: State = State::new(1);
-
-        /// The processor version is being deployed.
-        pub const DEPLOYING: State = State::new(2);
-
-        /// The processor version is not deployed and cannot be used for processing.
-        pub const UNDEPLOYED: State = State::new(3);
-
-        /// The processor version is being undeployed.
-        pub const UNDEPLOYING: State = State::new(4);
-
-        /// The processor version is being created.
-        pub const CREATING: State = State::new(5);
-
-        /// The processor version is being deleted.
-        pub const DELETING: State = State::new(6);
-
-        /// The processor version failed and is in an indeterminate state.
-        pub const FAILED: State = State::new(7);
-
-        /// The processor version is being imported.
-        pub const IMPORTING: State = State::new(8);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Deployed => std::option::Option::Some(1),
+                Self::Deploying => std::option::Option::Some(2),
+                Self::Undeployed => std::option::Option::Some(3),
+                Self::Undeploying => std::option::Option::Some(4),
+                Self::Creating => std::option::Option::Some(5),
+                Self::Deleting => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::Importing => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEPLOYED"),
-                2 => std::borrow::Cow::Borrowed("DEPLOYING"),
-                3 => std::borrow::Cow::Borrowed("UNDEPLOYED"),
-                4 => std::borrow::Cow::Borrowed("UNDEPLOYING"),
-                5 => std::borrow::Cow::Borrowed("CREATING"),
-                6 => std::borrow::Cow::Borrowed("DELETING"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                8 => std::borrow::Cow::Borrowed("IMPORTING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Deployed => std::option::Option::Some("DEPLOYED"),
+                Self::Deploying => std::option::Option::Some("DEPLOYING"),
+                Self::Undeployed => std::option::Option::Some("UNDEPLOYED"),
+                Self::Undeploying => std::option::Option::Some("UNDEPLOYING"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Importing => std::option::Option::Some("IMPORTING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DEPLOYED" => std::option::Option::Some(Self::DEPLOYED),
-                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
-                "UNDEPLOYED" => std::option::Option::Some(Self::UNDEPLOYED),
-                "UNDEPLOYING" => std::option::Option::Some(Self::UNDEPLOYING),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "IMPORTING" => std::option::Option::Some(Self::IMPORTING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Deployed,
+                2 => Self::Deploying,
+                3 => Self::Undeployed,
+                4 => Self::Undeploying,
+                5 => Self::Creating,
+                6 => Self::Deleting,
+                7 => Self::Failed,
+                8 => Self::Importing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DEPLOYED" => Self::Deployed,
+                "DEPLOYING" => Self::Deploying,
+                "UNDEPLOYED" => Self::Undeployed,
+                "UNDEPLOYING" => Self::Undeploying,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "IMPORTING" => Self::Importing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Deployed => serializer.serialize_i32(1),
+                Self::Deploying => serializer.serialize_i32(2),
+                Self::Undeployed => serializer.serialize_i32(3),
+                Self::Undeploying => serializer.serialize_i32(4),
+                Self::Creating => serializer.serialize_i32(5),
+                Self::Deleting => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::Importing => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.documentai.v1.ProcessorVersion.State",
+            ))
         }
     }
 
     /// The possible model types of the processor version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelType {
+        /// The processor version has unspecified model type.
+        Unspecified,
+        /// The processor version has generative model type.
+        Generative,
+        /// The processor version has custom model type.
+        Custom,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelType::value] or
+        /// [ModelType::name].
+        UnknownValue(model_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod model_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ModelType {
-        /// The processor version has unspecified model type.
-        pub const MODEL_TYPE_UNSPECIFIED: ModelType = ModelType::new(0);
-
-        /// The processor version has generative model type.
-        pub const MODEL_TYPE_GENERATIVE: ModelType = ModelType::new(1);
-
-        /// The processor version has custom model type.
-        pub const MODEL_TYPE_CUSTOM: ModelType = ModelType::new(2);
-
-        /// Creates a new ModelType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Generative => std::option::Option::Some(1),
+                Self::Custom => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODEL_TYPE_GENERATIVE"),
-                2 => std::borrow::Cow::Borrowed("MODEL_TYPE_CUSTOM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_TYPE_UNSPECIFIED"),
+                Self::Generative => std::option::Option::Some("MODEL_TYPE_GENERATIVE"),
+                Self::Custom => std::option::Option::Some("MODEL_TYPE_CUSTOM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MODEL_TYPE_UNSPECIFIED),
-                "MODEL_TYPE_GENERATIVE" => std::option::Option::Some(Self::MODEL_TYPE_GENERATIVE),
-                "MODEL_TYPE_CUSTOM" => std::option::Option::Some(Self::MODEL_TYPE_CUSTOM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Generative,
+                2 => Self::Custom,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MODEL_TYPE_GENERATIVE" => Self::Generative,
+                "MODEL_TYPE_CUSTOM" => Self::Custom,
+                _ => Self::UnknownValue(model_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Generative => serializer.serialize_i32(1),
+                Self::Custom => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelType>::new(
+                ".google.cloud.documentai.v1.ProcessorVersion.ModelType",
+            ))
         }
     }
 }
@@ -11937,92 +12919,163 @@ pub mod processor {
     use super::*;
 
     /// The possible states of the processor.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The processor is in an unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The processor is enabled, i.e., has an enabled version which can
         /// currently serve processing requests and all the feature dependencies have
         /// been successfully initialized.
-        pub const ENABLED: State = State::new(1);
-
+        Enabled,
         /// The processor is disabled.
-        pub const DISABLED: State = State::new(2);
-
+        Disabled,
         /// The processor is being enabled, will become `ENABLED` if successful.
-        pub const ENABLING: State = State::new(3);
-
+        Enabling,
         /// The processor is being disabled, will become `DISABLED` if successful.
-        pub const DISABLING: State = State::new(4);
-
+        Disabling,
         /// The processor is being created, will become either `ENABLED` (for
         /// successful creation) or `FAILED` (for failed ones).
         /// Once a processor is in this state, it can then be used for document
         /// processing, but the feature dependencies of the processor might not be
         /// fully created yet.
-        pub const CREATING: State = State::new(5);
-
+        Creating,
         /// The processor failed during creation or initialization of feature
         /// dependencies. The user should delete the processor and recreate one as
         /// all the functionalities of the processor are disabled.
-        pub const FAILED: State = State::new(6);
-
+        Failed,
         /// The processor is being deleted, will be removed if successful.
-        pub const DELETING: State = State::new(7);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Enabling => std::option::Option::Some(3),
+                Self::Disabling => std::option::Option::Some(4),
+                Self::Creating => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Deleting => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("ENABLING"),
-                4 => std::borrow::Cow::Borrowed("DISABLING"),
-                5 => std::borrow::Cow::Borrowed("CREATING"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Enabling => std::option::Option::Some("ENABLING"),
+                Self::Disabling => std::option::Option::Some("DISABLING"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ENABLING" => std::option::Option::Some(Self::ENABLING),
-                "DISABLING" => std::option::Option::Some(Self::DISABLING),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Enabling,
+                4 => Self::Disabling,
+                5 => Self::Creating,
+                6 => Self::Failed,
+                7 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "ENABLING" => Self::Enabling,
+                "DISABLING" => Self::Disabling,
+                "CREATING" => Self::Creating,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Enabling => serializer.serialize_i32(3),
+                Self::Disabling => serializer.serialize_i32(4),
+                Self::Creating => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Deleting => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.documentai.v1.Processor.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -255,107 +255,175 @@ pub mod registration {
     use super::*;
 
     /// Possible states of a `Registration`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is undefined.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The domain is being registered.
-        pub const REGISTRATION_PENDING: State = State::new(1);
-
+        RegistrationPending,
         /// The domain registration failed. You can delete resources in this state
         /// to allow registration to be retried.
-        pub const REGISTRATION_FAILED: State = State::new(2);
-
+        RegistrationFailed,
         /// The domain is being transferred from another registrar to Cloud Domains.
-        pub const TRANSFER_PENDING: State = State::new(3);
-
+        TransferPending,
         /// The attempt to transfer the domain from another registrar to
         /// Cloud Domains failed. You can delete resources in this state and retry
         /// the transfer.
-        pub const TRANSFER_FAILED: State = State::new(4);
-
+        TransferFailed,
         /// The domain is registered and operational. The domain renews automatically
         /// as long as it remains in this state.
-        pub const ACTIVE: State = State::new(6);
-
+        Active,
         /// The domain is suspended and inoperative. For more details, see the
         /// `issues` field.
-        pub const SUSPENDED: State = State::new(7);
-
+        Suspended,
         /// The domain is no longer managed with Cloud Domains. It may have been
         /// transferred to another registrar or exported for management in
         /// [Google Domains](https://domains.google/). You can no longer update it
         /// with this API, and information shown about it may be stale. Domains in
         /// this state are not automatically renewed by Cloud Domains.
-        pub const EXPORTED: State = State::new(8);
+        Exported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RegistrationPending => std::option::Option::Some(1),
+                Self::RegistrationFailed => std::option::Option::Some(2),
+                Self::TransferPending => std::option::Option::Some(3),
+                Self::TransferFailed => std::option::Option::Some(4),
+                Self::Active => std::option::Option::Some(6),
+                Self::Suspended => std::option::Option::Some(7),
+                Self::Exported => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGISTRATION_PENDING"),
-                2 => std::borrow::Cow::Borrowed("REGISTRATION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("TRANSFER_PENDING"),
-                4 => std::borrow::Cow::Borrowed("TRANSFER_FAILED"),
-                6 => std::borrow::Cow::Borrowed("ACTIVE"),
-                7 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                8 => std::borrow::Cow::Borrowed("EXPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::RegistrationPending => std::option::Option::Some("REGISTRATION_PENDING"),
+                Self::RegistrationFailed => std::option::Option::Some("REGISTRATION_FAILED"),
+                Self::TransferPending => std::option::Option::Some("TRANSFER_PENDING"),
+                Self::TransferFailed => std::option::Option::Some("TRANSFER_FAILED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Exported => std::option::Option::Some("EXPORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "REGISTRATION_PENDING" => std::option::Option::Some(Self::REGISTRATION_PENDING),
-                "REGISTRATION_FAILED" => std::option::Option::Some(Self::REGISTRATION_FAILED),
-                "TRANSFER_PENDING" => std::option::Option::Some(Self::TRANSFER_PENDING),
-                "TRANSFER_FAILED" => std::option::Option::Some(Self::TRANSFER_FAILED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "EXPORTED" => std::option::Option::Some(Self::EXPORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RegistrationPending,
+                2 => Self::RegistrationFailed,
+                3 => Self::TransferPending,
+                4 => Self::TransferFailed,
+                6 => Self::Active,
+                7 => Self::Suspended,
+                8 => Self::Exported,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "REGISTRATION_PENDING" => Self::RegistrationPending,
+                "REGISTRATION_FAILED" => Self::RegistrationFailed,
+                "TRANSFER_PENDING" => Self::TransferPending,
+                "TRANSFER_FAILED" => Self::TransferFailed,
+                "ACTIVE" => Self::Active,
+                "SUSPENDED" => Self::Suspended,
+                "EXPORTED" => Self::Exported,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RegistrationPending => serializer.serialize_i32(1),
+                Self::RegistrationFailed => serializer.serialize_i32(2),
+                Self::TransferPending => serializer.serialize_i32(3),
+                Self::TransferFailed => serializer.serialize_i32(4),
+                Self::Active => serializer.serialize_i32(6),
+                Self::Suspended => serializer.serialize_i32(7),
+                Self::Exported => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.domains.v1.Registration.State",
+            ))
         }
     }
 
     /// Possible issues with a `Registration` that require attention.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Issue(i32);
-
-    impl Issue {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Issue {
         /// The issue is undefined.
-        pub const ISSUE_UNSPECIFIED: Issue = Issue::new(0);
-
+        Unspecified,
         /// Contact the Cloud Support team to resolve a problem with this domain.
-        pub const CONTACT_SUPPORT: Issue = Issue::new(1);
-
+        ContactSupport,
         /// [ICANN](https://icann.org/) requires verification of the email address
         /// in the `Registration`'s `contact_settings.registrant_contact` field. To
         /// verify the email address, follow the
@@ -364,48 +432,112 @@ pub mod registration {
         /// 15 days of registration, the domain is suspended. To resend the
         /// verification email, call ConfigureContactSettings and provide the current
         /// `registrant_contact.email`.
-        pub const UNVERIFIED_EMAIL: Issue = Issue::new(2);
+        UnverifiedEmail,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Issue::value] or
+        /// [Issue::name].
+        UnknownValue(issue::UnknownValue),
+    }
 
-        /// Creates a new Issue instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod issue {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Issue {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ContactSupport => std::option::Option::Some(1),
+                Self::UnverifiedEmail => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ISSUE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONTACT_SUPPORT"),
-                2 => std::borrow::Cow::Borrowed("UNVERIFIED_EMAIL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ISSUE_UNSPECIFIED"),
+                Self::ContactSupport => std::option::Option::Some("CONTACT_SUPPORT"),
+                Self::UnverifiedEmail => std::option::Option::Some("UNVERIFIED_EMAIL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ISSUE_UNSPECIFIED" => std::option::Option::Some(Self::ISSUE_UNSPECIFIED),
-                "CONTACT_SUPPORT" => std::option::Option::Some(Self::CONTACT_SUPPORT),
-                "UNVERIFIED_EMAIL" => std::option::Option::Some(Self::UNVERIFIED_EMAIL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Issue {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Issue {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Issue {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Issue {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ContactSupport,
+                2 => Self::UnverifiedEmail,
+                _ => Self::UnknownValue(issue::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Issue {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ISSUE_UNSPECIFIED" => Self::Unspecified,
+                "CONTACT_SUPPORT" => Self::ContactSupport,
+                "UNVERIFIED_EMAIL" => Self::UnverifiedEmail,
+                _ => Self::UnknownValue(issue::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Issue {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ContactSupport => serializer.serialize_i32(1),
+                Self::UnverifiedEmail => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Issue {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Issue>::new(
+                ".google.cloud.domains.v1.Registration.Issue",
+            ))
         }
     }
 }
@@ -464,69 +596,128 @@ pub mod management_settings {
     use super::*;
 
     /// Defines how the `Registration` is renewed.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RenewalMethod(i32);
-
-    impl RenewalMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RenewalMethod {
         /// The renewal method is undefined.
-        pub const RENEWAL_METHOD_UNSPECIFIED: RenewalMethod = RenewalMethod::new(0);
-
+        Unspecified,
         /// The domain is automatically renewed each year .
         ///
         /// To disable automatic renewals, delete the resource by calling
         /// `DeleteRegistration` or export it by calling `ExportRegistration`.
-        pub const AUTOMATIC_RENEWAL: RenewalMethod = RenewalMethod::new(1);
-
+        AutomaticRenewal,
         /// The domain must be explicitly renewed each year before its
         /// `expire_time`. This option is only available when the `Registration`
         /// is in state `EXPORTED`.
         ///
         /// To manage the domain's current billing and
         /// renewal settings, go to [Google Domains](https://domains.google/).
-        pub const MANUAL_RENEWAL: RenewalMethod = RenewalMethod::new(2);
+        ManualRenewal,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RenewalMethod::value] or
+        /// [RenewalMethod::name].
+        UnknownValue(renewal_method::UnknownValue),
+    }
 
-        /// Creates a new RenewalMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod renewal_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RenewalMethod {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AutomaticRenewal => std::option::Option::Some(1),
+                Self::ManualRenewal => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RENEWAL_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC_RENEWAL"),
-                2 => std::borrow::Cow::Borrowed("MANUAL_RENEWAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RENEWAL_METHOD_UNSPECIFIED"),
+                Self::AutomaticRenewal => std::option::Option::Some("AUTOMATIC_RENEWAL"),
+                Self::ManualRenewal => std::option::Option::Some("MANUAL_RENEWAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RENEWAL_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RENEWAL_METHOD_UNSPECIFIED)
-                }
-                "AUTOMATIC_RENEWAL" => std::option::Option::Some(Self::AUTOMATIC_RENEWAL),
-                "MANUAL_RENEWAL" => std::option::Option::Some(Self::MANUAL_RENEWAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RenewalMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RenewalMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RenewalMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RenewalMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AutomaticRenewal,
+                2 => Self::ManualRenewal,
+                _ => Self::UnknownValue(renewal_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RenewalMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RENEWAL_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC_RENEWAL" => Self::AutomaticRenewal,
+                "MANUAL_RENEWAL" => Self::ManualRenewal,
+                _ => Self::UnknownValue(renewal_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RenewalMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AutomaticRenewal => serializer.serialize_i32(1),
+                Self::ManualRenewal => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RenewalMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RenewalMethod>::new(
+                ".google.cloud.domains.v1.ManagementSettings.RenewalMethod",
+            ))
         }
     }
 }
@@ -861,206 +1052,364 @@ pub mod dns_settings {
 
         /// List of algorithms used to create a DNSKEY. Certain
         /// algorithms are not supported for particular domains.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Algorithm(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Algorithm {
+            /// The algorithm is unspecified.
+            Unspecified,
+            /// RSA/MD5. Cannot be used for new deployments.
+            Rsamd5,
+            /// Diffie-Hellman. Cannot be used for new deployments.
+            Dh,
+            /// DSA/SHA1. Not recommended for new deployments.
+            Dsa,
+            /// ECC. Not recommended for new deployments.
+            Ecc,
+            /// RSA/SHA-1. Not recommended for new deployments.
+            Rsasha1,
+            /// DSA-NSEC3-SHA1. Not recommended for new deployments.
+            Dsansec3Sha1,
+            /// RSA/SHA1-NSEC3-SHA1. Not recommended for new deployments.
+            Rsasha1Nsec3Sha1,
+            /// RSA/SHA-256.
+            Rsasha256,
+            /// RSA/SHA-512.
+            Rsasha512,
+            /// GOST R 34.10-2001.
+            Eccgost,
+            /// ECDSA Curve P-256 with SHA-256.
+            Ecdsap256Sha256,
+            /// ECDSA Curve P-384 with SHA-384.
+            Ecdsap384Sha384,
+            /// Ed25519.
+            Ed25519,
+            /// Ed448.
+            Ed448,
+            /// Reserved for Indirect Keys. Cannot be used for new deployments.
+            Indirect,
+            /// Private algorithm. Cannot be used for new deployments.
+            Privatedns,
+            /// Private algorithm OID. Cannot be used for new deployments.
+            Privateoid,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Algorithm::value] or
+            /// [Algorithm::name].
+            UnknownValue(algorithm::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod algorithm {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Algorithm {
-            /// The algorithm is unspecified.
-            pub const ALGORITHM_UNSPECIFIED: Algorithm = Algorithm::new(0);
-
-            /// RSA/MD5. Cannot be used for new deployments.
-            pub const RSAMD5: Algorithm = Algorithm::new(1);
-
-            /// Diffie-Hellman. Cannot be used for new deployments.
-            pub const DH: Algorithm = Algorithm::new(2);
-
-            /// DSA/SHA1. Not recommended for new deployments.
-            pub const DSA: Algorithm = Algorithm::new(3);
-
-            /// ECC. Not recommended for new deployments.
-            pub const ECC: Algorithm = Algorithm::new(4);
-
-            /// RSA/SHA-1. Not recommended for new deployments.
-            pub const RSASHA1: Algorithm = Algorithm::new(5);
-
-            /// DSA-NSEC3-SHA1. Not recommended for new deployments.
-            pub const DSANSEC3SHA1: Algorithm = Algorithm::new(6);
-
-            /// RSA/SHA1-NSEC3-SHA1. Not recommended for new deployments.
-            pub const RSASHA1NSEC3SHA1: Algorithm = Algorithm::new(7);
-
-            /// RSA/SHA-256.
-            pub const RSASHA256: Algorithm = Algorithm::new(8);
-
-            /// RSA/SHA-512.
-            pub const RSASHA512: Algorithm = Algorithm::new(10);
-
-            /// GOST R 34.10-2001.
-            pub const ECCGOST: Algorithm = Algorithm::new(12);
-
-            /// ECDSA Curve P-256 with SHA-256.
-            pub const ECDSAP256SHA256: Algorithm = Algorithm::new(13);
-
-            /// ECDSA Curve P-384 with SHA-384.
-            pub const ECDSAP384SHA384: Algorithm = Algorithm::new(14);
-
-            /// Ed25519.
-            pub const ED25519: Algorithm = Algorithm::new(15);
-
-            /// Ed448.
-            pub const ED448: Algorithm = Algorithm::new(16);
-
-            /// Reserved for Indirect Keys. Cannot be used for new deployments.
-            pub const INDIRECT: Algorithm = Algorithm::new(252);
-
-            /// Private algorithm. Cannot be used for new deployments.
-            pub const PRIVATEDNS: Algorithm = Algorithm::new(253);
-
-            /// Private algorithm OID. Cannot be used for new deployments.
-            pub const PRIVATEOID: Algorithm = Algorithm::new(254);
-
-            /// Creates a new Algorithm instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Rsamd5 => std::option::Option::Some(1),
+                    Self::Dh => std::option::Option::Some(2),
+                    Self::Dsa => std::option::Option::Some(3),
+                    Self::Ecc => std::option::Option::Some(4),
+                    Self::Rsasha1 => std::option::Option::Some(5),
+                    Self::Dsansec3Sha1 => std::option::Option::Some(6),
+                    Self::Rsasha1Nsec3Sha1 => std::option::Option::Some(7),
+                    Self::Rsasha256 => std::option::Option::Some(8),
+                    Self::Rsasha512 => std::option::Option::Some(10),
+                    Self::Eccgost => std::option::Option::Some(12),
+                    Self::Ecdsap256Sha256 => std::option::Option::Some(13),
+                    Self::Ecdsap384Sha384 => std::option::Option::Some(14),
+                    Self::Ed25519 => std::option::Option::Some(15),
+                    Self::Ed448 => std::option::Option::Some(16),
+                    Self::Indirect => std::option::Option::Some(252),
+                    Self::Privatedns => std::option::Option::Some(253),
+                    Self::Privateoid => std::option::Option::Some(254),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ALGORITHM_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RSAMD5"),
-                    2 => std::borrow::Cow::Borrowed("DH"),
-                    3 => std::borrow::Cow::Borrowed("DSA"),
-                    4 => std::borrow::Cow::Borrowed("ECC"),
-                    5 => std::borrow::Cow::Borrowed("RSASHA1"),
-                    6 => std::borrow::Cow::Borrowed("DSANSEC3SHA1"),
-                    7 => std::borrow::Cow::Borrowed("RSASHA1NSEC3SHA1"),
-                    8 => std::borrow::Cow::Borrowed("RSASHA256"),
-                    10 => std::borrow::Cow::Borrowed("RSASHA512"),
-                    12 => std::borrow::Cow::Borrowed("ECCGOST"),
-                    13 => std::borrow::Cow::Borrowed("ECDSAP256SHA256"),
-                    14 => std::borrow::Cow::Borrowed("ECDSAP384SHA384"),
-                    15 => std::borrow::Cow::Borrowed("ED25519"),
-                    16 => std::borrow::Cow::Borrowed("ED448"),
-                    252 => std::borrow::Cow::Borrowed("INDIRECT"),
-                    253 => std::borrow::Cow::Borrowed("PRIVATEDNS"),
-                    254 => std::borrow::Cow::Borrowed("PRIVATEOID"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ALGORITHM_UNSPECIFIED"),
+                    Self::Rsamd5 => std::option::Option::Some("RSAMD5"),
+                    Self::Dh => std::option::Option::Some("DH"),
+                    Self::Dsa => std::option::Option::Some("DSA"),
+                    Self::Ecc => std::option::Option::Some("ECC"),
+                    Self::Rsasha1 => std::option::Option::Some("RSASHA1"),
+                    Self::Dsansec3Sha1 => std::option::Option::Some("DSANSEC3SHA1"),
+                    Self::Rsasha1Nsec3Sha1 => std::option::Option::Some("RSASHA1NSEC3SHA1"),
+                    Self::Rsasha256 => std::option::Option::Some("RSASHA256"),
+                    Self::Rsasha512 => std::option::Option::Some("RSASHA512"),
+                    Self::Eccgost => std::option::Option::Some("ECCGOST"),
+                    Self::Ecdsap256Sha256 => std::option::Option::Some("ECDSAP256SHA256"),
+                    Self::Ecdsap384Sha384 => std::option::Option::Some("ECDSAP384SHA384"),
+                    Self::Ed25519 => std::option::Option::Some("ED25519"),
+                    Self::Ed448 => std::option::Option::Some("ED448"),
+                    Self::Indirect => std::option::Option::Some("INDIRECT"),
+                    Self::Privatedns => std::option::Option::Some("PRIVATEDNS"),
+                    Self::Privateoid => std::option::Option::Some("PRIVATEOID"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ALGORITHM_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ALGORITHM_UNSPECIFIED)
-                    }
-                    "RSAMD5" => std::option::Option::Some(Self::RSAMD5),
-                    "DH" => std::option::Option::Some(Self::DH),
-                    "DSA" => std::option::Option::Some(Self::DSA),
-                    "ECC" => std::option::Option::Some(Self::ECC),
-                    "RSASHA1" => std::option::Option::Some(Self::RSASHA1),
-                    "DSANSEC3SHA1" => std::option::Option::Some(Self::DSANSEC3SHA1),
-                    "RSASHA1NSEC3SHA1" => std::option::Option::Some(Self::RSASHA1NSEC3SHA1),
-                    "RSASHA256" => std::option::Option::Some(Self::RSASHA256),
-                    "RSASHA512" => std::option::Option::Some(Self::RSASHA512),
-                    "ECCGOST" => std::option::Option::Some(Self::ECCGOST),
-                    "ECDSAP256SHA256" => std::option::Option::Some(Self::ECDSAP256SHA256),
-                    "ECDSAP384SHA384" => std::option::Option::Some(Self::ECDSAP384SHA384),
-                    "ED25519" => std::option::Option::Some(Self::ED25519),
-                    "ED448" => std::option::Option::Some(Self::ED448),
-                    "INDIRECT" => std::option::Option::Some(Self::INDIRECT),
-                    "PRIVATEDNS" => std::option::Option::Some(Self::PRIVATEDNS),
-                    "PRIVATEOID" => std::option::Option::Some(Self::PRIVATEOID),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Algorithm {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Algorithm {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Algorithm {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Algorithm {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Rsamd5,
+                    2 => Self::Dh,
+                    3 => Self::Dsa,
+                    4 => Self::Ecc,
+                    5 => Self::Rsasha1,
+                    6 => Self::Dsansec3Sha1,
+                    7 => Self::Rsasha1Nsec3Sha1,
+                    8 => Self::Rsasha256,
+                    10 => Self::Rsasha512,
+                    12 => Self::Eccgost,
+                    13 => Self::Ecdsap256Sha256,
+                    14 => Self::Ecdsap384Sha384,
+                    15 => Self::Ed25519,
+                    16 => Self::Ed448,
+                    252 => Self::Indirect,
+                    253 => Self::Privatedns,
+                    254 => Self::Privateoid,
+                    _ => Self::UnknownValue(algorithm::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Algorithm {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                    "RSAMD5" => Self::Rsamd5,
+                    "DH" => Self::Dh,
+                    "DSA" => Self::Dsa,
+                    "ECC" => Self::Ecc,
+                    "RSASHA1" => Self::Rsasha1,
+                    "DSANSEC3SHA1" => Self::Dsansec3Sha1,
+                    "RSASHA1NSEC3SHA1" => Self::Rsasha1Nsec3Sha1,
+                    "RSASHA256" => Self::Rsasha256,
+                    "RSASHA512" => Self::Rsasha512,
+                    "ECCGOST" => Self::Eccgost,
+                    "ECDSAP256SHA256" => Self::Ecdsap256Sha256,
+                    "ECDSAP384SHA384" => Self::Ecdsap384Sha384,
+                    "ED25519" => Self::Ed25519,
+                    "ED448" => Self::Ed448,
+                    "INDIRECT" => Self::Indirect,
+                    "PRIVATEDNS" => Self::Privatedns,
+                    "PRIVATEOID" => Self::Privateoid,
+                    _ => Self::UnknownValue(algorithm::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Algorithm {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Rsamd5 => serializer.serialize_i32(1),
+                    Self::Dh => serializer.serialize_i32(2),
+                    Self::Dsa => serializer.serialize_i32(3),
+                    Self::Ecc => serializer.serialize_i32(4),
+                    Self::Rsasha1 => serializer.serialize_i32(5),
+                    Self::Dsansec3Sha1 => serializer.serialize_i32(6),
+                    Self::Rsasha1Nsec3Sha1 => serializer.serialize_i32(7),
+                    Self::Rsasha256 => serializer.serialize_i32(8),
+                    Self::Rsasha512 => serializer.serialize_i32(10),
+                    Self::Eccgost => serializer.serialize_i32(12),
+                    Self::Ecdsap256Sha256 => serializer.serialize_i32(13),
+                    Self::Ecdsap384Sha384 => serializer.serialize_i32(14),
+                    Self::Ed25519 => serializer.serialize_i32(15),
+                    Self::Ed448 => serializer.serialize_i32(16),
+                    Self::Indirect => serializer.serialize_i32(252),
+                    Self::Privatedns => serializer.serialize_i32(253),
+                    Self::Privateoid => serializer.serialize_i32(254),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Algorithm {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Algorithm>::new(
+                    ".google.cloud.domains.v1.DnsSettings.DsRecord.Algorithm",
+                ))
             }
         }
 
         /// List of hash functions that may have been used to generate a digest of a
         /// DNSKEY.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DigestType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DigestType {
+            /// The DigestType is unspecified.
+            Unspecified,
+            /// SHA-1. Not recommended for new deployments.
+            Sha1,
+            /// SHA-256.
+            Sha256,
+            /// GOST R 34.11-94.
+            Gost3411,
+            /// SHA-384.
+            Sha384,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DigestType::value] or
+            /// [DigestType::name].
+            UnknownValue(digest_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod digest_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl DigestType {
-            /// The DigestType is unspecified.
-            pub const DIGEST_TYPE_UNSPECIFIED: DigestType = DigestType::new(0);
-
-            /// SHA-1. Not recommended for new deployments.
-            pub const SHA1: DigestType = DigestType::new(1);
-
-            /// SHA-256.
-            pub const SHA256: DigestType = DigestType::new(2);
-
-            /// GOST R 34.11-94.
-            pub const GOST3411: DigestType = DigestType::new(3);
-
-            /// SHA-384.
-            pub const SHA384: DigestType = DigestType::new(4);
-
-            /// Creates a new DigestType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Sha1 => std::option::Option::Some(1),
+                    Self::Sha256 => std::option::Option::Some(2),
+                    Self::Gost3411 => std::option::Option::Some(3),
+                    Self::Sha384 => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DIGEST_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SHA1"),
-                    2 => std::borrow::Cow::Borrowed("SHA256"),
-                    3 => std::borrow::Cow::Borrowed("GOST3411"),
-                    4 => std::borrow::Cow::Borrowed("SHA384"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("DIGEST_TYPE_UNSPECIFIED"),
+                    Self::Sha1 => std::option::Option::Some("SHA1"),
+                    Self::Sha256 => std::option::Option::Some("SHA256"),
+                    Self::Gost3411 => std::option::Option::Some("GOST3411"),
+                    Self::Sha384 => std::option::Option::Some("SHA384"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DIGEST_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DIGEST_TYPE_UNSPECIFIED)
-                    }
-                    "SHA1" => std::option::Option::Some(Self::SHA1),
-                    "SHA256" => std::option::Option::Some(Self::SHA256),
-                    "GOST3411" => std::option::Option::Some(Self::GOST3411),
-                    "SHA384" => std::option::Option::Some(Self::SHA384),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for DigestType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for DigestType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for DigestType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for DigestType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Sha1,
+                    2 => Self::Sha256,
+                    3 => Self::Gost3411,
+                    4 => Self::Sha384,
+                    _ => Self::UnknownValue(digest_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for DigestType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DIGEST_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SHA1" => Self::Sha1,
+                    "SHA256" => Self::Sha256,
+                    "GOST3411" => Self::Gost3411,
+                    "SHA384" => Self::Sha384,
+                    _ => Self::UnknownValue(digest_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for DigestType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Sha1 => serializer.serialize_i32(1),
+                    Self::Sha256 => serializer.serialize_i32(2),
+                    Self::Gost3411 => serializer.serialize_i32(3),
+                    Self::Sha384 => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for DigestType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DigestType>::new(
+                    ".google.cloud.domains.v1.DnsSettings.DsRecord.DigestType",
+                ))
             }
         }
     }
@@ -1137,63 +1486,124 @@ pub mod dns_settings {
     }
 
     /// The publication state of DS records for a `Registration`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DsState(i32);
-
-    impl DsState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DsState {
         /// DS state is unspecified.
-        pub const DS_STATE_UNSPECIFIED: DsState = DsState::new(0);
-
+        Unspecified,
         /// DNSSEC is disabled for this domain. No DS records for this domain are
         /// published in the parent DNS zone.
-        pub const DS_RECORDS_UNPUBLISHED: DsState = DsState::new(1);
-
+        DsRecordsUnpublished,
         /// DNSSEC is enabled for this domain. Appropriate DS records for this domain
         /// are published in the parent DNS zone. This option is valid only if the
         /// DNS zone referenced in the `Registration`'s `dns_provider` field is
         /// already DNSSEC-signed.
-        pub const DS_RECORDS_PUBLISHED: DsState = DsState::new(2);
+        DsRecordsPublished,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DsState::value] or
+        /// [DsState::name].
+        UnknownValue(ds_state::UnknownValue),
+    }
 
-        /// Creates a new DsState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod ds_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DsState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DsRecordsUnpublished => std::option::Option::Some(1),
+                Self::DsRecordsPublished => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DS_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DS_RECORDS_UNPUBLISHED"),
-                2 => std::borrow::Cow::Borrowed("DS_RECORDS_PUBLISHED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DS_STATE_UNSPECIFIED"),
+                Self::DsRecordsUnpublished => std::option::Option::Some("DS_RECORDS_UNPUBLISHED"),
+                Self::DsRecordsPublished => std::option::Option::Some("DS_RECORDS_PUBLISHED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DS_STATE_UNSPECIFIED" => std::option::Option::Some(Self::DS_STATE_UNSPECIFIED),
-                "DS_RECORDS_UNPUBLISHED" => std::option::Option::Some(Self::DS_RECORDS_UNPUBLISHED),
-                "DS_RECORDS_PUBLISHED" => std::option::Option::Some(Self::DS_RECORDS_PUBLISHED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DsState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DsState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DsState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DsState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DsRecordsUnpublished,
+                2 => Self::DsRecordsPublished,
+                _ => Self::UnknownValue(ds_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DsState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DS_STATE_UNSPECIFIED" => Self::Unspecified,
+                "DS_RECORDS_UNPUBLISHED" => Self::DsRecordsUnpublished,
+                "DS_RECORDS_PUBLISHED" => Self::DsRecordsPublished,
+                _ => Self::UnknownValue(ds_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DsState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DsRecordsUnpublished => serializer.serialize_i32(1),
+                Self::DsRecordsPublished => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DsState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DsState>::new(
+                ".google.cloud.domains.v1.DnsSettings.DsState",
+            ))
         }
     }
 
@@ -2521,74 +2931,137 @@ pub mod register_parameters {
     use super::*;
 
     /// Possible availability states of a domain name.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Availability(i32);
-
-    impl Availability {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Availability {
         /// The availability is unspecified.
-        pub const AVAILABILITY_UNSPECIFIED: Availability = Availability::new(0);
-
+        Unspecified,
         /// The domain is available for registration.
-        pub const AVAILABLE: Availability = Availability::new(1);
-
+        Available,
         /// The domain is not available for registration. Generally this means it is
         /// already registered to another party.
-        pub const UNAVAILABLE: Availability = Availability::new(2);
-
+        Unavailable,
         /// The domain is not currently supported by Cloud Domains, but may
         /// be available elsewhere.
-        pub const UNSUPPORTED: Availability = Availability::new(3);
-
+        Unsupported,
         /// Cloud Domains is unable to determine domain availability, generally
         /// due to system maintenance at the domain name registry.
-        pub const UNKNOWN: Availability = Availability::new(4);
+        Unknown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Availability::value] or
+        /// [Availability::name].
+        UnknownValue(availability::UnknownValue),
+    }
 
-        /// Creates a new Availability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod availability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Availability {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Available => std::option::Option::Some(1),
+                Self::Unavailable => std::option::Option::Some(2),
+                Self::Unsupported => std::option::Option::Some(3),
+                Self::Unknown => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AVAILABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
-                4 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AVAILABILITY_UNSPECIFIED"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+                Self::Unsupported => std::option::Option::Some("UNSUPPORTED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AVAILABILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AVAILABILITY_UNSPECIFIED)
-                }
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Availability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Availability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Availability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Availability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Available,
+                2 => Self::Unavailable,
+                3 => Self::Unsupported,
+                4 => Self::Unknown,
+                _ => Self::UnknownValue(availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Availability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AVAILABILITY_UNSPECIFIED" => Self::Unspecified,
+                "AVAILABLE" => Self::Available,
+                "UNAVAILABLE" => Self::Unavailable,
+                "UNSUPPORTED" => Self::Unsupported,
+                "UNKNOWN" => Self::Unknown,
+                _ => Self::UnknownValue(availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Availability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Available => serializer.serialize_i32(1),
+                Self::Unavailable => serializer.serialize_i32(2),
+                Self::Unsupported => serializer.serialize_i32(3),
+                Self::Unknown => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Availability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Availability>::new(
+                ".google.cloud.domains.v1.RegisterParameters.Availability",
+            ))
         }
     }
 }
@@ -2822,248 +3295,482 @@ impl wkt::message::Message for OperationMetadata {
 /// accessible mapping from domain name to contact information, and requires that
 /// each domain name have an entry. Choose from these options to control how much
 /// information in your `ContactSettings` is published.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContactPrivacy(i32);
-
-impl ContactPrivacy {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ContactPrivacy {
     /// The contact privacy settings are undefined.
-    pub const CONTACT_PRIVACY_UNSPECIFIED: ContactPrivacy = ContactPrivacy::new(0);
-
+    Unspecified,
     /// All the data from `ContactSettings` is publicly available. When setting
     /// this option, you must also provide a
     /// `PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT` in the `contact_notices` field of the
     /// request.
-    pub const PUBLIC_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new(1);
-
+    PublicContactData,
     /// None of the data from `ContactSettings` is publicly available. Instead,
     /// proxy contact data is published for your domain. Email sent to the proxy
     /// email address is forwarded to the registrant's email address. Cloud Domains
     /// provides this privacy proxy service at no additional cost.
-    pub const PRIVATE_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new(2);
-
+    PrivateContactData,
     /// Some data from `ContactSettings` is publicly available. The actual
     /// information redacted depends on the domain. For details, see [the
     /// registration privacy
     /// article](https://support.google.com/domains/answer/3251242).
-    pub const REDACTED_CONTACT_DATA: ContactPrivacy = ContactPrivacy::new(3);
+    RedactedContactData,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ContactPrivacy::value] or
+    /// [ContactPrivacy::name].
+    UnknownValue(contact_privacy::UnknownValue),
+}
 
-    /// Creates a new ContactPrivacy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod contact_privacy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ContactPrivacy {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PublicContactData => std::option::Option::Some(1),
+            Self::PrivateContactData => std::option::Option::Some(2),
+            Self::RedactedContactData => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONTACT_PRIVACY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PUBLIC_CONTACT_DATA"),
-            2 => std::borrow::Cow::Borrowed("PRIVATE_CONTACT_DATA"),
-            3 => std::borrow::Cow::Borrowed("REDACTED_CONTACT_DATA"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONTACT_PRIVACY_UNSPECIFIED"),
+            Self::PublicContactData => std::option::Option::Some("PUBLIC_CONTACT_DATA"),
+            Self::PrivateContactData => std::option::Option::Some("PRIVATE_CONTACT_DATA"),
+            Self::RedactedContactData => std::option::Option::Some("REDACTED_CONTACT_DATA"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONTACT_PRIVACY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONTACT_PRIVACY_UNSPECIFIED)
-            }
-            "PUBLIC_CONTACT_DATA" => std::option::Option::Some(Self::PUBLIC_CONTACT_DATA),
-            "PRIVATE_CONTACT_DATA" => std::option::Option::Some(Self::PRIVATE_CONTACT_DATA),
-            "REDACTED_CONTACT_DATA" => std::option::Option::Some(Self::REDACTED_CONTACT_DATA),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ContactPrivacy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ContactPrivacy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ContactPrivacy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ContactPrivacy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PublicContactData,
+            2 => Self::PrivateContactData,
+            3 => Self::RedactedContactData,
+            _ => Self::UnknownValue(contact_privacy::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ContactPrivacy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONTACT_PRIVACY_UNSPECIFIED" => Self::Unspecified,
+            "PUBLIC_CONTACT_DATA" => Self::PublicContactData,
+            "PRIVATE_CONTACT_DATA" => Self::PrivateContactData,
+            "REDACTED_CONTACT_DATA" => Self::RedactedContactData,
+            _ => Self::UnknownValue(contact_privacy::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ContactPrivacy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PublicContactData => serializer.serialize_i32(1),
+            Self::PrivateContactData => serializer.serialize_i32(2),
+            Self::RedactedContactData => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ContactPrivacy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContactPrivacy>::new(
+            ".google.cloud.domains.v1.ContactPrivacy",
+        ))
     }
 }
 
 /// Notices about special properties of certain domains.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DomainNotice(i32);
-
-impl DomainNotice {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DomainNotice {
     /// The notice is undefined.
-    pub const DOMAIN_NOTICE_UNSPECIFIED: DomainNotice = DomainNotice::new(0);
-
+    Unspecified,
     /// Indicates that the domain is preloaded on the HTTP Strict Transport
     /// Security list in browsers. Serving a website on such domain requires
     /// an SSL certificate. For details, see
     /// [how to get an SSL
     /// certificate](https://support.google.com/domains/answer/7638036).
-    pub const HSTS_PRELOADED: DomainNotice = DomainNotice::new(1);
+    HstsPreloaded,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DomainNotice::value] or
+    /// [DomainNotice::name].
+    UnknownValue(domain_notice::UnknownValue),
+}
 
-    /// Creates a new DomainNotice instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod domain_notice {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DomainNotice {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::HstsPreloaded => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DOMAIN_NOTICE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HSTS_PRELOADED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DOMAIN_NOTICE_UNSPECIFIED"),
+            Self::HstsPreloaded => std::option::Option::Some("HSTS_PRELOADED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DOMAIN_NOTICE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DOMAIN_NOTICE_UNSPECIFIED)
-            }
-            "HSTS_PRELOADED" => std::option::Option::Some(Self::HSTS_PRELOADED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DomainNotice {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DomainNotice {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DomainNotice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DomainNotice {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::HstsPreloaded,
+            _ => Self::UnknownValue(domain_notice::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DomainNotice {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DOMAIN_NOTICE_UNSPECIFIED" => Self::Unspecified,
+            "HSTS_PRELOADED" => Self::HstsPreloaded,
+            _ => Self::UnknownValue(domain_notice::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DomainNotice {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::HstsPreloaded => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DomainNotice {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DomainNotice>::new(
+            ".google.cloud.domains.v1.DomainNotice",
+        ))
     }
 }
 
 /// Notices related to contact information.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContactNotice(i32);
-
-impl ContactNotice {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ContactNotice {
     /// The notice is undefined.
-    pub const CONTACT_NOTICE_UNSPECIFIED: ContactNotice = ContactNotice::new(0);
-
+    Unspecified,
     /// Required when setting the `privacy` field of `ContactSettings` to
     /// `PUBLIC_CONTACT_DATA`, which exposes contact data publicly.
-    pub const PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT: ContactNotice = ContactNotice::new(1);
+    PublicContactDataAcknowledgement,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ContactNotice::value] or
+    /// [ContactNotice::name].
+    UnknownValue(contact_notice::UnknownValue),
+}
 
-    /// Creates a new ContactNotice instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod contact_notice {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ContactNotice {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PublicContactDataAcknowledgement => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONTACT_NOTICE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONTACT_NOTICE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONTACT_NOTICE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONTACT_NOTICE_UNSPECIFIED"),
+            Self::PublicContactDataAcknowledgement => {
+                std::option::Option::Some("PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT")
             }
-            "PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT" => {
-                std::option::Option::Some(Self::PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ContactNotice {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ContactNotice {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ContactNotice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ContactNotice {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PublicContactDataAcknowledgement,
+            _ => Self::UnknownValue(contact_notice::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ContactNotice {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONTACT_NOTICE_UNSPECIFIED" => Self::Unspecified,
+            "PUBLIC_CONTACT_DATA_ACKNOWLEDGEMENT" => Self::PublicContactDataAcknowledgement,
+            _ => Self::UnknownValue(contact_notice::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ContactNotice {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PublicContactDataAcknowledgement => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ContactNotice {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContactNotice>::new(
+            ".google.cloud.domains.v1.ContactNotice",
+        ))
     }
 }
 
 /// Possible states of a `Registration`'s transfer lock.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferLockState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransferLockState {
+    /// The state is unspecified.
+    Unspecified,
+    /// The domain is unlocked and can be transferred to another registrar.
+    Unlocked,
+    /// The domain is locked and cannot be transferred to another registrar.
+    Locked,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransferLockState::value] or
+    /// [TransferLockState::name].
+    UnknownValue(transfer_lock_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod transfer_lock_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TransferLockState {
-    /// The state is unspecified.
-    pub const TRANSFER_LOCK_STATE_UNSPECIFIED: TransferLockState = TransferLockState::new(0);
-
-    /// The domain is unlocked and can be transferred to another registrar.
-    pub const UNLOCKED: TransferLockState = TransferLockState::new(1);
-
-    /// The domain is locked and cannot be transferred to another registrar.
-    pub const LOCKED: TransferLockState = TransferLockState::new(2);
-
-    /// Creates a new TransferLockState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Unlocked => std::option::Option::Some(1),
+            Self::Locked => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFER_LOCK_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("UNLOCKED"),
-            2 => std::borrow::Cow::Borrowed("LOCKED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFER_LOCK_STATE_UNSPECIFIED"),
+            Self::Unlocked => std::option::Option::Some("UNLOCKED"),
+            Self::Locked => std::option::Option::Some("LOCKED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFER_LOCK_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFER_LOCK_STATE_UNSPECIFIED)
-            }
-            "UNLOCKED" => std::option::Option::Some(Self::UNLOCKED),
-            "LOCKED" => std::option::Option::Some(Self::LOCKED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransferLockState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferLockState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransferLockState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransferLockState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Unlocked,
+            2 => Self::Locked,
+            _ => Self::UnknownValue(transfer_lock_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransferLockState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFER_LOCK_STATE_UNSPECIFIED" => Self::Unspecified,
+            "UNLOCKED" => Self::Unlocked,
+            "LOCKED" => Self::Locked,
+            _ => Self::UnknownValue(transfer_lock_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransferLockState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Unlocked => serializer.serialize_i32(1),
+            Self::Locked => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransferLockState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransferLockState>::new(
+            ".google.cloud.domains.v1.TransferLockState",
+        ))
     }
 }

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -637,64 +637,126 @@ pub mod cluster {
 
         /// Represents the policy configuration about how user applications are
         /// deployed.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SharedDeploymentPolicy(i32);
-
-        impl SharedDeploymentPolicy {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SharedDeploymentPolicy {
             /// Unspecified.
-            pub const SHARED_DEPLOYMENT_POLICY_UNSPECIFIED: SharedDeploymentPolicy =
-                SharedDeploymentPolicy::new(0);
-
+            Unspecified,
             /// User applications can be deployed both on control plane and worker
             /// nodes.
-            pub const ALLOWED: SharedDeploymentPolicy = SharedDeploymentPolicy::new(1);
-
+            Allowed,
             /// User applications can not be deployed on control plane nodes and can
             /// only be deployed on worker nodes.
-            pub const DISALLOWED: SharedDeploymentPolicy = SharedDeploymentPolicy::new(2);
+            Disallowed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SharedDeploymentPolicy::value] or
+            /// [SharedDeploymentPolicy::name].
+            UnknownValue(shared_deployment_policy::UnknownValue),
+        }
 
-            /// Creates a new SharedDeploymentPolicy instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod shared_deployment_policy {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl SharedDeploymentPolicy {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Allowed => std::option::Option::Some(1),
+                    Self::Disallowed => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SHARED_DEPLOYMENT_POLICY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ALLOWED"),
-                    2 => std::borrow::Cow::Borrowed("DISALLOWED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SHARED_DEPLOYMENT_POLICY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SHARED_DEPLOYMENT_POLICY_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SHARED_DEPLOYMENT_POLICY_UNSPECIFIED")
                     }
-                    "ALLOWED" => std::option::Option::Some(Self::ALLOWED),
-                    "DISALLOWED" => std::option::Option::Some(Self::DISALLOWED),
-                    _ => std::option::Option::None,
+                    Self::Allowed => std::option::Option::Some("ALLOWED"),
+                    Self::Disallowed => std::option::Option::Some("DISALLOWED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for SharedDeploymentPolicy {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SharedDeploymentPolicy {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SharedDeploymentPolicy {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SharedDeploymentPolicy {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Allowed,
+                    2 => Self::Disallowed,
+                    _ => Self::UnknownValue(shared_deployment_policy::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SharedDeploymentPolicy {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SHARED_DEPLOYMENT_POLICY_UNSPECIFIED" => Self::Unspecified,
+                    "ALLOWED" => Self::Allowed,
+                    "DISALLOWED" => Self::Disallowed,
+                    _ => Self::UnknownValue(shared_deployment_policy::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SharedDeploymentPolicy {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Allowed => serializer.serialize_i32(1),
+                    Self::Disallowed => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SharedDeploymentPolicy {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SharedDeploymentPolicy>::new(
+                    ".google.cloud.edgecontainer.v1.Cluster.ControlPlane.SharedDeploymentPolicy"))
             }
         }
 
@@ -1111,177 +1173,367 @@ pub mod cluster {
         use super::*;
 
         /// Indicates the maintenance event type.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Unspecified.
+            Unspecified,
+            /// Upgrade initiated by users.
+            UserInitiatedUpgrade,
+            /// Upgrade driven by Google.
+            GoogleDrivenUpgrade,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Unspecified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// Upgrade initiated by users.
-            pub const USER_INITIATED_UPGRADE: Type = Type::new(1);
-
-            /// Upgrade driven by Google.
-            pub const GOOGLE_DRIVEN_UPGRADE: Type = Type::new(2);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::UserInitiatedUpgrade => std::option::Option::Some(1),
+                    Self::GoogleDrivenUpgrade => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("USER_INITIATED_UPGRADE"),
-                    2 => std::borrow::Cow::Borrowed("GOOGLE_DRIVEN_UPGRADE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "USER_INITIATED_UPGRADE" => {
-                        std::option::Option::Some(Self::USER_INITIATED_UPGRADE)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::UserInitiatedUpgrade => {
+                        std::option::Option::Some("USER_INITIATED_UPGRADE")
                     }
-                    "GOOGLE_DRIVEN_UPGRADE" => {
-                        std::option::Option::Some(Self::GOOGLE_DRIVEN_UPGRADE)
-                    }
-                    _ => std::option::Option::None,
+                    Self::GoogleDrivenUpgrade => std::option::Option::Some("GOOGLE_DRIVEN_UPGRADE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::UserInitiatedUpgrade,
+                    2 => Self::GoogleDrivenUpgrade,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "USER_INITIATED_UPGRADE" => Self::UserInitiatedUpgrade,
+                    "GOOGLE_DRIVEN_UPGRADE" => Self::GoogleDrivenUpgrade,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::UserInitiatedUpgrade => serializer.serialize_i32(1),
+                    Self::GoogleDrivenUpgrade => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.edgecontainer.v1.Cluster.MaintenanceEvent.Type",
+                ))
             }
         }
 
         /// Indicates when the maintenance event should be performed.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Schedule(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Schedule {
+            /// Unspecified.
+            Unspecified,
+            /// Immediately after receiving the request.
+            Immediately,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Schedule::value] or
+            /// [Schedule::name].
+            UnknownValue(schedule::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod schedule {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Schedule {
-            /// Unspecified.
-            pub const SCHEDULE_UNSPECIFIED: Schedule = Schedule::new(0);
-
-            /// Immediately after receiving the request.
-            pub const IMMEDIATELY: Schedule = Schedule::new(1);
-
-            /// Creates a new Schedule instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Immediately => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SCHEDULE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IMMEDIATELY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SCHEDULE_UNSPECIFIED"),
+                    Self::Immediately => std::option::Option::Some("IMMEDIATELY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SCHEDULE_UNSPECIFIED" => std::option::Option::Some(Self::SCHEDULE_UNSPECIFIED),
-                    "IMMEDIATELY" => std::option::Option::Some(Self::IMMEDIATELY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Schedule {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Schedule {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Schedule {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Schedule {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Immediately,
+                    _ => Self::UnknownValue(schedule::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Schedule {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SCHEDULE_UNSPECIFIED" => Self::Unspecified,
+                    "IMMEDIATELY" => Self::Immediately,
+                    _ => Self::UnknownValue(schedule::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Schedule {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Immediately => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Schedule {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Schedule>::new(
+                    ".google.cloud.edgecontainer.v1.Cluster.MaintenanceEvent.Schedule",
+                ))
             }
         }
 
         /// Indicates the maintenance event state.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// Unspecified.
+            Unspecified,
+            /// The maintenance event is ongoing. The cluster might be unusable.
+            Reconciling,
+            /// The maintenance event succeeded.
+            Succeeded,
+            /// The maintenance event failed.
+            Failed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// Unspecified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// The maintenance event is ongoing. The cluster might be unusable.
-            pub const RECONCILING: State = State::new(1);
-
-            /// The maintenance event succeeded.
-            pub const SUCCEEDED: State = State::new(2);
-
-            /// The maintenance event failed.
-            pub const FAILED: State = State::new(3);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Reconciling => std::option::Option::Some(1),
+                    Self::Succeeded => std::option::Option::Some(2),
+                    Self::Failed => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RECONCILING"),
-                    2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                    3 => std::borrow::Cow::Borrowed("FAILED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                    Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                    "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Reconciling,
+                    2 => Self::Succeeded,
+                    3 => Self::Failed,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "RECONCILING" => Self::Reconciling,
+                    "SUCCEEDED" => Self::Succeeded,
+                    "FAILED" => Self::Failed,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Reconciling => serializer.serialize_i32(1),
+                    Self::Succeeded => serializer.serialize_i32(2),
+                    Self::Failed => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.edgecontainer.v1.Cluster.MaintenanceEvent.State",
+                ))
             }
         }
     }
@@ -1378,200 +1630,390 @@ pub mod cluster {
         use super::*;
 
         /// The connection state.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// Unknown connection state.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// This cluster is currently disconnected from Google.
-            pub const DISCONNECTED: State = State::new(1);
-
+            Disconnected,
             /// This cluster is currently connected to Google.
-            pub const CONNECTED: State = State::new(2);
-
+            Connected,
             /// This cluster is currently connected to Google, but may have recently
             /// reconnected after a disconnection. It is still syncing back.
-            pub const CONNECTED_AND_SYNCING: State = State::new(3);
+            ConnectedAndSyncing,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Disconnected => std::option::Option::Some(1),
+                    Self::Connected => std::option::Option::Some(2),
+                    Self::ConnectedAndSyncing => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DISCONNECTED"),
-                    2 => std::borrow::Cow::Borrowed("CONNECTED"),
-                    3 => std::borrow::Cow::Borrowed("CONNECTED_AND_SYNCING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Disconnected => std::option::Option::Some("DISCONNECTED"),
+                    Self::Connected => std::option::Option::Some("CONNECTED"),
+                    Self::ConnectedAndSyncing => std::option::Option::Some("CONNECTED_AND_SYNCING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "DISCONNECTED" => std::option::Option::Some(Self::DISCONNECTED),
-                    "CONNECTED" => std::option::Option::Some(Self::CONNECTED),
-                    "CONNECTED_AND_SYNCING" => {
-                        std::option::Option::Some(Self::CONNECTED_AND_SYNCING)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Disconnected,
+                    2 => Self::Connected,
+                    3 => Self::ConnectedAndSyncing,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "DISCONNECTED" => Self::Disconnected,
+                    "CONNECTED" => Self::Connected,
+                    "CONNECTED_AND_SYNCING" => Self::ConnectedAndSyncing,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Disconnected => serializer.serialize_i32(1),
+                    Self::Connected => serializer.serialize_i32(2),
+                    Self::ConnectedAndSyncing => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.edgecontainer.v1.Cluster.ConnectionState.State",
+                ))
             }
         }
     }
 
     /// Indicates the status of the cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// Status unknown.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+        Unspecified,
         /// The cluster is being created.
-        pub const PROVISIONING: Status = Status::new(1);
-
+        Provisioning,
         /// The cluster is created and fully usable.
-        pub const RUNNING: Status = Status::new(2);
-
+        Running,
         /// The cluster is being deleted.
-        pub const DELETING: Status = Status::new(3);
-
+        Deleting,
         /// The status indicates that some errors occurred while reconciling/deleting
         /// the cluster.
-        pub const ERROR: Status = Status::new(4);
-
+        Error,
         /// The cluster is undergoing some work such as version upgrades, etc.
-        pub const RECONCILING: Status = Status::new(5);
+        Reconciling,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::Reconciling => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                5 => std::borrow::Cow::Borrowed("RECONCILING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                5 => Self::Reconciling,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "RECONCILING" => Self::Reconciling,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::Reconciling => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.cloud.edgecontainer.v1.Cluster.Status",
+            ))
         }
     }
 
     /// The release channel a cluster is subscribed to.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReleaseChannel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReleaseChannel {
+        /// Unspecified release channel. This will default to the REGULAR channel.
+        Unspecified,
+        /// No release channel.
+        None,
+        /// Regular release channel.
+        Regular,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReleaseChannel::value] or
+        /// [ReleaseChannel::name].
+        UnknownValue(release_channel::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod release_channel {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ReleaseChannel {
-        /// Unspecified release channel. This will default to the REGULAR channel.
-        pub const RELEASE_CHANNEL_UNSPECIFIED: ReleaseChannel = ReleaseChannel::new(0);
-
-        /// No release channel.
-        pub const NONE: ReleaseChannel = ReleaseChannel::new(1);
-
-        /// Regular release channel.
-        pub const REGULAR: ReleaseChannel = ReleaseChannel::new(2);
-
-        /// Creates a new ReleaseChannel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Regular => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RELEASE_CHANNEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("REGULAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RELEASE_CHANNEL_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Regular => std::option::Option::Some("REGULAR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RELEASE_CHANNEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RELEASE_CHANNEL_UNSPECIFIED)
-                }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "REGULAR" => std::option::Option::Some(Self::REGULAR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReleaseChannel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReleaseChannel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReleaseChannel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReleaseChannel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Regular,
+                _ => Self::UnknownValue(release_channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReleaseChannel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RELEASE_CHANNEL_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "REGULAR" => Self::Regular,
+                _ => Self::UnknownValue(release_channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReleaseChannel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Regular => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReleaseChannel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReleaseChannel>::new(
+                ".google.cloud.edgecontainer.v1.Cluster.ReleaseChannel",
+            ))
         }
     }
 }
@@ -2552,124 +2994,249 @@ pub mod vpn_connection {
         }
 
         /// The current connection state.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// Unknown.
+            Unspecified,
+            /// Connected.
+            Connected,
+            /// Still connecting.
+            Connecting,
+            /// Error occurred.
+            Error,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// Unknown.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// Connected.
-            pub const STATE_CONNECTED: State = State::new(1);
-
-            /// Still connecting.
-            pub const STATE_CONNECTING: State = State::new(2);
-
-            /// Error occurred.
-            pub const STATE_ERROR: State = State::new(3);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Connected => std::option::Option::Some(1),
+                    Self::Connecting => std::option::Option::Some(2),
+                    Self::Error => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("STATE_CONNECTED"),
-                    2 => std::borrow::Cow::Borrowed("STATE_CONNECTING"),
-                    3 => std::borrow::Cow::Borrowed("STATE_ERROR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Connected => std::option::Option::Some("STATE_CONNECTED"),
+                    Self::Connecting => std::option::Option::Some("STATE_CONNECTING"),
+                    Self::Error => std::option::Option::Some("STATE_ERROR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "STATE_CONNECTED" => std::option::Option::Some(Self::STATE_CONNECTED),
-                    "STATE_CONNECTING" => std::option::Option::Some(Self::STATE_CONNECTING),
-                    "STATE_ERROR" => std::option::Option::Some(Self::STATE_ERROR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Connected,
+                    2 => Self::Connecting,
+                    3 => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "STATE_CONNECTED" => Self::Connected,
+                    "STATE_CONNECTING" => Self::Connecting,
+                    "STATE_ERROR" => Self::Error,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Connected => serializer.serialize_i32(1),
+                    Self::Connecting => serializer.serialize_i32(2),
+                    Self::Error => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.edgecontainer.v1.VpnConnection.Details.State",
+                ))
             }
         }
     }
 
     /// Routing mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BgpRoutingMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BgpRoutingMode {
+        /// Unknown.
+        Unspecified,
+        /// Regional mode.
+        Regional,
+        /// Global mode.
+        Global,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BgpRoutingMode::value] or
+        /// [BgpRoutingMode::name].
+        UnknownValue(bgp_routing_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod bgp_routing_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BgpRoutingMode {
-        /// Unknown.
-        pub const BGP_ROUTING_MODE_UNSPECIFIED: BgpRoutingMode = BgpRoutingMode::new(0);
-
-        /// Regional mode.
-        pub const REGIONAL: BgpRoutingMode = BgpRoutingMode::new(1);
-
-        /// Global mode.
-        pub const GLOBAL: BgpRoutingMode = BgpRoutingMode::new(2);
-
-        /// Creates a new BgpRoutingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Regional => std::option::Option::Some(1),
+                Self::Global => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BGP_ROUTING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGIONAL"),
-                2 => std::borrow::Cow::Borrowed("GLOBAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BGP_ROUTING_MODE_UNSPECIFIED"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::Global => std::option::Option::Some("GLOBAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BGP_ROUTING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BGP_ROUTING_MODE_UNSPECIFIED)
-                }
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BgpRoutingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BgpRoutingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BgpRoutingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BgpRoutingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Regional,
+                2 => Self::Global,
+                _ => Self::UnknownValue(bgp_routing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BgpRoutingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BGP_ROUTING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "REGIONAL" => Self::Regional,
+                "GLOBAL" => Self::Global,
+                _ => Self::UnknownValue(bgp_routing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BgpRoutingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Regional => serializer.serialize_i32(1),
+                Self::Global => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BgpRoutingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BgpRoutingMode>::new(
+                ".google.cloud.edgecontainer.v1.VpnConnection.BgpRoutingMode",
+            ))
         }
     }
 }
@@ -2789,61 +3356,122 @@ pub mod zone_metadata {
     use super::*;
 
     /// Type of the rack.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RackType(i32);
-
-    impl RackType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RackType {
         /// Unspecified rack type, single rack also belongs to this type.
-        pub const RACK_TYPE_UNSPECIFIED: RackType = RackType::new(0);
-
+        Unspecified,
         /// Base rack type, a pair of two modified Config-1 racks containing
         /// Aggregation switches.
-        pub const BASE: RackType = RackType::new(1);
-
+        Base,
         /// Expansion rack type, also known as standalone racks,
         /// added by customers on demand.
-        pub const EXPANSION: RackType = RackType::new(2);
+        Expansion,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RackType::value] or
+        /// [RackType::name].
+        UnknownValue(rack_type::UnknownValue),
+    }
 
-        /// Creates a new RackType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod rack_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RackType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Base => std::option::Option::Some(1),
+                Self::Expansion => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RACK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASE"),
-                2 => std::borrow::Cow::Borrowed("EXPANSION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RACK_TYPE_UNSPECIFIED"),
+                Self::Base => std::option::Option::Some("BASE"),
+                Self::Expansion => std::option::Option::Some("EXPANSION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RACK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RACK_TYPE_UNSPECIFIED),
-                "BASE" => std::option::Option::Some(Self::BASE),
-                "EXPANSION" => std::option::Option::Some(Self::EXPANSION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RackType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RackType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RackType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RackType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Base,
+                2 => Self::Expansion,
+                _ => Self::UnknownValue(rack_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RackType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RACK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BASE" => Self::Base,
+                "EXPANSION" => Self::Expansion,
+                _ => Self::UnknownValue(rack_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RackType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Base => serializer.serialize_i32(1),
+                Self::Expansion => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RackType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RackType>::new(
+                ".google.cloud.edgecontainer.v1.ZoneMetadata.RackType",
+            ))
         }
     }
 }
@@ -3451,56 +4079,113 @@ pub mod operation_metadata {
     use super::*;
 
     /// Indicates the reason for the status of the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StatusReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StatusReason {
+        /// Reason unknown.
+        Unspecified,
+        /// The cluster upgrade is currently paused.
+        UpgradePaused,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StatusReason::value] or
+        /// [StatusReason::name].
+        UnknownValue(status_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod status_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StatusReason {
-        /// Reason unknown.
-        pub const STATUS_REASON_UNSPECIFIED: StatusReason = StatusReason::new(0);
-
-        /// The cluster upgrade is currently paused.
-        pub const UPGRADE_PAUSED: StatusReason = StatusReason::new(1);
-
-        /// Creates a new StatusReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UpgradePaused => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UPGRADE_PAUSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_REASON_UNSPECIFIED"),
+                Self::UpgradePaused => std::option::Option::Some("UPGRADE_PAUSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STATUS_REASON_UNSPECIFIED)
-                }
-                "UPGRADE_PAUSED" => std::option::Option::Some(Self::UPGRADE_PAUSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StatusReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StatusReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StatusReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StatusReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UpgradePaused,
+                _ => Self::UnknownValue(status_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StatusReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_REASON_UNSPECIFIED" => Self::Unspecified,
+                "UPGRADE_PAUSED" => Self::UpgradePaused,
+                _ => Self::UnknownValue(status_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StatusReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UpgradePaused => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StatusReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StatusReason>::new(
+                ".google.cloud.edgecontainer.v1.OperationMetadata.StatusReason",
+            ))
         }
     }
 }
@@ -3889,56 +4574,115 @@ pub mod upgrade_cluster_request {
     use super::*;
 
     /// Represents the schedule about when the cluster is going to be upgraded.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Schedule(i32);
-
-    impl Schedule {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Schedule {
         /// Unspecified. The default is to upgrade the cluster immediately which is
         /// the only option today.
-        pub const SCHEDULE_UNSPECIFIED: Schedule = Schedule::new(0);
-
+        Unspecified,
         /// The cluster is going to be upgraded immediately after receiving the
         /// request.
-        pub const IMMEDIATELY: Schedule = Schedule::new(1);
+        Immediately,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Schedule::value] or
+        /// [Schedule::name].
+        UnknownValue(schedule::UnknownValue),
+    }
 
-        /// Creates a new Schedule instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod schedule {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Schedule {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Immediately => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCHEDULE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMMEDIATELY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCHEDULE_UNSPECIFIED"),
+                Self::Immediately => std::option::Option::Some("IMMEDIATELY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCHEDULE_UNSPECIFIED" => std::option::Option::Some(Self::SCHEDULE_UNSPECIFIED),
-                "IMMEDIATELY" => std::option::Option::Some(Self::IMMEDIATELY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Schedule {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Schedule {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Schedule {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Schedule {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Immediately,
+                _ => Self::UnknownValue(schedule::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Schedule {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCHEDULE_UNSPECIFIED" => Self::Unspecified,
+                "IMMEDIATELY" => Self::Immediately,
+                _ => Self::UnknownValue(schedule::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Schedule {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Immediately => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Schedule {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Schedule>::new(
+                ".google.cloud.edgecontainer.v1.UpgradeClusterRequest.Schedule",
+            ))
         }
     }
 }
@@ -5031,126 +5775,238 @@ impl wkt::message::Message for GetServerConfigRequest {
 
 /// Represents the accessibility state of a customer-managed KMS key used for
 /// CMEK integration.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct KmsKeyState(i32);
-
-impl KmsKeyState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum KmsKeyState {
     /// Unspecified.
-    pub const KMS_KEY_STATE_UNSPECIFIED: KmsKeyState = KmsKeyState::new(0);
-
+    Unspecified,
     /// The key is available for use, and dependent resources should be accessible.
-    pub const KMS_KEY_STATE_KEY_AVAILABLE: KmsKeyState = KmsKeyState::new(1);
-
+    KeyAvailable,
     /// The key is unavailable for an unspecified reason. Dependent resources may
     /// be inaccessible.
-    pub const KMS_KEY_STATE_KEY_UNAVAILABLE: KmsKeyState = KmsKeyState::new(2);
+    KeyUnavailable,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [KmsKeyState::value] or
+    /// [KmsKeyState::name].
+    UnknownValue(kms_key_state::UnknownValue),
+}
 
-    /// Creates a new KmsKeyState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod kms_key_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl KmsKeyState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::KeyAvailable => std::option::Option::Some(1),
+            Self::KeyUnavailable => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_KEY_AVAILABLE"),
-            2 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_KEY_UNAVAILABLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("KMS_KEY_STATE_UNSPECIFIED"),
+            Self::KeyAvailable => std::option::Option::Some("KMS_KEY_STATE_KEY_AVAILABLE"),
+            Self::KeyUnavailable => std::option::Option::Some("KMS_KEY_STATE_KEY_UNAVAILABLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "KMS_KEY_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::KMS_KEY_STATE_UNSPECIFIED)
-            }
-            "KMS_KEY_STATE_KEY_AVAILABLE" => {
-                std::option::Option::Some(Self::KMS_KEY_STATE_KEY_AVAILABLE)
-            }
-            "KMS_KEY_STATE_KEY_UNAVAILABLE" => {
-                std::option::Option::Some(Self::KMS_KEY_STATE_KEY_UNAVAILABLE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for KmsKeyState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for KmsKeyState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for KmsKeyState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for KmsKeyState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::KeyAvailable,
+            2 => Self::KeyUnavailable,
+            _ => Self::UnknownValue(kms_key_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for KmsKeyState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "KMS_KEY_STATE_UNSPECIFIED" => Self::Unspecified,
+            "KMS_KEY_STATE_KEY_AVAILABLE" => Self::KeyAvailable,
+            "KMS_KEY_STATE_KEY_UNAVAILABLE" => Self::KeyUnavailable,
+            _ => Self::UnknownValue(kms_key_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for KmsKeyState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::KeyAvailable => serializer.serialize_i32(1),
+            Self::KeyUnavailable => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for KmsKeyState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<KmsKeyState>::new(
+            ".google.cloud.edgecontainer.v1.KmsKeyState",
+        ))
     }
 }
 
 /// Represents if the resource is in lock down state or pending.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ResourceState {
+    /// Default value.
+    Unspecified,
+    /// The resource is in LOCK DOWN state.
+    LockDown,
+    /// The resource is pending lock down.
+    LockDownPending,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ResourceState::value] or
+    /// [ResourceState::name].
+    UnknownValue(resource_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod resource_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ResourceState {
-    /// Default value.
-    pub const RESOURCE_STATE_UNSPECIFIED: ResourceState = ResourceState::new(0);
-
-    /// The resource is in LOCK DOWN state.
-    pub const RESOURCE_STATE_LOCK_DOWN: ResourceState = ResourceState::new(1);
-
-    /// The resource is pending lock down.
-    pub const RESOURCE_STATE_LOCK_DOWN_PENDING: ResourceState = ResourceState::new(2);
-
-    /// Creates a new ResourceState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::LockDown => std::option::Option::Some(1),
+            Self::LockDownPending => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESOURCE_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RESOURCE_STATE_LOCK_DOWN"),
-            2 => std::borrow::Cow::Borrowed("RESOURCE_STATE_LOCK_DOWN_PENDING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RESOURCE_STATE_UNSPECIFIED"),
+            Self::LockDown => std::option::Option::Some("RESOURCE_STATE_LOCK_DOWN"),
+            Self::LockDownPending => std::option::Option::Some("RESOURCE_STATE_LOCK_DOWN_PENDING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESOURCE_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESOURCE_STATE_UNSPECIFIED)
-            }
-            "RESOURCE_STATE_LOCK_DOWN" => std::option::Option::Some(Self::RESOURCE_STATE_LOCK_DOWN),
-            "RESOURCE_STATE_LOCK_DOWN_PENDING" => {
-                std::option::Option::Some(Self::RESOURCE_STATE_LOCK_DOWN_PENDING)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ResourceState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ResourceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ResourceState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::LockDown,
+            2 => Self::LockDownPending,
+            _ => Self::UnknownValue(resource_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ResourceState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESOURCE_STATE_UNSPECIFIED" => Self::Unspecified,
+            "RESOURCE_STATE_LOCK_DOWN" => Self::LockDown,
+            "RESOURCE_STATE_LOCK_DOWN_PENDING" => Self::LockDownPending,
+            _ => Self::UnknownValue(resource_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ResourceState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::LockDown => serializer.serialize_i32(1),
+            Self::LockDownPending => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ResourceState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceState>::new(
+            ".google.cloud.edgecontainer.v1.ResourceState",
+        ))
     }
 }

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -383,65 +383,124 @@ pub mod subnet {
     use super::*;
 
     /// Bonding type in the subnet.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BondingType(i32);
-
-    impl BondingType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BondingType {
         /// Unspecified
         /// Bonding type will be unspecified by default and if the user chooses to
         /// not specify a bonding type at time of creating the VLAN. This will be
         /// treated as mixed bonding where the VLAN will have both bonded and
         /// non-bonded connectivity to machines.
-        pub const BONDING_TYPE_UNSPECIFIED: BondingType = BondingType::new(0);
-
+        Unspecified,
         /// Multi homed.
-        pub const BONDED: BondingType = BondingType::new(1);
-
+        Bonded,
         /// Single homed.
-        pub const NON_BONDED: BondingType = BondingType::new(2);
+        NonBonded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BondingType::value] or
+        /// [BondingType::name].
+        UnknownValue(bonding_type::UnknownValue),
+    }
 
-        /// Creates a new BondingType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod bonding_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl BondingType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bonded => std::option::Option::Some(1),
+                Self::NonBonded => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BONDING_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BONDED"),
-                2 => std::borrow::Cow::Borrowed("NON_BONDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BONDING_TYPE_UNSPECIFIED"),
+                Self::Bonded => std::option::Option::Some("BONDED"),
+                Self::NonBonded => std::option::Option::Some("NON_BONDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BONDING_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BONDING_TYPE_UNSPECIFIED)
-                }
-                "BONDED" => std::option::Option::Some(Self::BONDED),
-                "NON_BONDED" => std::option::Option::Some(Self::NON_BONDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BondingType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BondingType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BondingType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BondingType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bonded,
+                2 => Self::NonBonded,
+                _ => Self::UnknownValue(bonding_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BondingType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BONDING_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BONDED" => Self::Bonded,
+                "NON_BONDED" => Self::NonBonded,
+                _ => Self::UnknownValue(bonding_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BondingType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bonded => serializer.serialize_i32(1),
+                Self::NonBonded => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BondingType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BondingType>::new(
+                ".google.cloud.edgenetwork.v1.Subnet.BondingType",
+            ))
         }
     }
 }
@@ -591,56 +650,113 @@ pub mod interconnect {
     use super::*;
 
     /// Type of interconnect.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InterconnectType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InterconnectType {
+        /// Unspecified.
+        Unspecified,
+        /// Dedicated Interconnect.
+        Dedicated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InterconnectType::value] or
+        /// [InterconnectType::name].
+        UnknownValue(interconnect_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod interconnect_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl InterconnectType {
-        /// Unspecified.
-        pub const INTERCONNECT_TYPE_UNSPECIFIED: InterconnectType = InterconnectType::new(0);
-
-        /// Dedicated Interconnect.
-        pub const DEDICATED: InterconnectType = InterconnectType::new(1);
-
-        /// Creates a new InterconnectType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dedicated => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INTERCONNECT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEDICATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INTERCONNECT_TYPE_UNSPECIFIED"),
+                Self::Dedicated => std::option::Option::Some("DEDICATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INTERCONNECT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INTERCONNECT_TYPE_UNSPECIFIED)
-                }
-                "DEDICATED" => std::option::Option::Some(Self::DEDICATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InterconnectType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InterconnectType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InterconnectType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InterconnectType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dedicated,
+                _ => Self::UnknownValue(interconnect_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InterconnectType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INTERCONNECT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DEDICATED" => Self::Dedicated,
+                _ => Self::UnknownValue(interconnect_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InterconnectType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dedicated => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InterconnectType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterconnectType>::new(
+                ".google.cloud.edgenetwork.v1.Interconnect.InterconnectType",
+            ))
         }
     }
 }
@@ -1660,60 +1776,124 @@ pub mod interconnect_diagnostics {
         use super::*;
 
         /// State enum for LACP link.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// The default state indicating state is in unknown state.
-            pub const UNKNOWN: State = State::new(0);
-
+            Unknown,
             /// The link is configured and active within the bundle.
-            pub const ACTIVE: State = State::new(1);
-
+            Active,
             /// The link is not configured within the bundle, this means the rest of
             /// the object should be empty.
-            pub const DETACHED: State = State::new(2);
+            Detached,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unknown => std::option::Option::Some(0),
+                    Self::Active => std::option::Option::Some(1),
+                    Self::Detached => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                    1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                    2 => std::borrow::Cow::Borrowed("DETACHED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                    Self::Active => std::option::Option::Some("ACTIVE"),
+                    Self::Detached => std::option::Option::Some("DETACHED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                    "DETACHED" => std::option::Option::Some(Self::DETACHED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unknown,
+                    1 => Self::Active,
+                    2 => Self::Detached,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNKNOWN" => Self::Unknown,
+                    "ACTIVE" => Self::Active,
+                    "DETACHED" => Self::Detached,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unknown => serializer.serialize_i32(0),
+                    Self::Active => serializer.serialize_i32(1),
+                    Self::Detached => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.edgenetwork.v1.InterconnectDiagnostics.LinkLACPStatus.State",
+                ))
             }
         }
     }
@@ -1998,59 +2178,123 @@ pub mod router_status {
         use super::*;
 
         /// Status of the BGP peer: {UP, DOWN}
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BgpStatus(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum BgpStatus {
+            /// The default status indicating BGP session is in unknown state.
+            Unknown,
+            /// The UP status indicating BGP session is established.
+            Up,
+            /// The DOWN state indicating BGP session is not established yet.
+            Down,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [BgpStatus::value] or
+            /// [BgpStatus::name].
+            UnknownValue(bgp_status::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod bgp_status {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl BgpStatus {
-            /// The default status indicating BGP session is in unknown state.
-            pub const UNKNOWN: BgpStatus = BgpStatus::new(0);
-
-            /// The UP status indicating BGP session is established.
-            pub const UP: BgpStatus = BgpStatus::new(1);
-
-            /// The DOWN state indicating BGP session is not established yet.
-            pub const DOWN: BgpStatus = BgpStatus::new(2);
-
-            /// Creates a new BgpStatus instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unknown => std::option::Option::Some(0),
+                    Self::Up => std::option::Option::Some(1),
+                    Self::Down => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                    1 => std::borrow::Cow::Borrowed("UP"),
-                    2 => std::borrow::Cow::Borrowed("DOWN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                    Self::Up => std::option::Option::Some("UP"),
+                    Self::Down => std::option::Option::Some("DOWN"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                    "UP" => std::option::Option::Some(Self::UP),
-                    "DOWN" => std::option::Option::Some(Self::DOWN),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for BgpStatus {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for BgpStatus {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for BgpStatus {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for BgpStatus {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unknown,
+                    1 => Self::Up,
+                    2 => Self::Down,
+                    _ => Self::UnknownValue(bgp_status::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for BgpStatus {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNKNOWN" => Self::Unknown,
+                    "UP" => Self::Up,
+                    "DOWN" => Self::Down,
+                    _ => Self::UnknownValue(bgp_status::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for BgpStatus {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unknown => serializer.serialize_i32(0),
+                    Self::Up => serializer.serialize_i32(1),
+                    Self::Down => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for BgpStatus {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<BgpStatus>::new(
+                    ".google.cloud.edgenetwork.v1.RouterStatus.BgpPeerStatus.BgpStatus",
+                ))
             }
         }
     }
@@ -4172,61 +4416,122 @@ pub mod diagnose_network_response {
         use super::*;
 
         /// Denotes the status of MACsec sessions for the links of a zone.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MacsecStatus(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MacsecStatus {
+            /// MACsec status not specified, likely due to missing metrics.
+            Unspecified,
+            /// All relevant links have at least one MACsec session up.
+            Secure,
+            /// At least one relevant link does not have any MACsec sessions up.
+            Unsecure,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MacsecStatus::value] or
+            /// [MacsecStatus::name].
+            UnknownValue(macsec_status::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod macsec_status {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl MacsecStatus {
-            /// MACsec status not specified, likely due to missing metrics.
-            pub const MACSEC_STATUS_UNSPECIFIED: MacsecStatus = MacsecStatus::new(0);
-
-            /// All relevant links have at least one MACsec session up.
-            pub const SECURE: MacsecStatus = MacsecStatus::new(1);
-
-            /// At least one relevant link does not have any MACsec sessions up.
-            pub const UNSECURE: MacsecStatus = MacsecStatus::new(2);
-
-            /// Creates a new MacsecStatus instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Secure => std::option::Option::Some(1),
+                    Self::Unsecure => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MACSEC_STATUS_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SECURE"),
-                    2 => std::borrow::Cow::Borrowed("UNSECURE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MACSEC_STATUS_UNSPECIFIED"),
+                    Self::Secure => std::option::Option::Some("SECURE"),
+                    Self::Unsecure => std::option::Option::Some("UNSECURE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MACSEC_STATUS_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::MACSEC_STATUS_UNSPECIFIED)
-                    }
-                    "SECURE" => std::option::Option::Some(Self::SECURE),
-                    "UNSECURE" => std::option::Option::Some(Self::UNSECURE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MacsecStatus {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MacsecStatus {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MacsecStatus {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MacsecStatus {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Secure,
+                    2 => Self::Unsecure,
+                    _ => Self::UnknownValue(macsec_status::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MacsecStatus {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MACSEC_STATUS_UNSPECIFIED" => Self::Unspecified,
+                    "SECURE" => Self::Secure,
+                    "UNSECURE" => Self::Unsecure,
+                    _ => Self::UnknownValue(macsec_status::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MacsecStatus {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Secure => serializer.serialize_i32(1),
+                    Self::Unsecure => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MacsecStatus {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MacsecStatus>::new(
+                    ".google.cloud.edgenetwork.v1.DiagnoseNetworkResponse.NetworkStatus.MacsecStatus"))
             }
         }
     }
@@ -4455,73 +4760,140 @@ impl wkt::message::Message for InitializeZoneResponse {
 /// PROVISIONING -> RUNNING. A normal lifecycle of an existing resource being
 /// deleted would be: RUNNING -> DELETING. Any failures during processing will
 /// result the resource to be in a SUSPENDED state.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ResourceState {
+    /// Unspecified state.
+    StateUnknown,
+    /// The resource is being prepared to be applied to the rack.
+    StatePending,
+    /// The resource has started being applied to the rack.
+    StateProvisioning,
+    /// The resource has been pushed to the rack.
+    StateRunning,
+    /// The resource failed to push to the rack.
+    StateSuspended,
+    /// The resource is under deletion.
+    StateDeleting,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ResourceState::value] or
+    /// [ResourceState::name].
+    UnknownValue(resource_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod resource_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ResourceState {
-    /// Unspecified state.
-    pub const STATE_UNKNOWN: ResourceState = ResourceState::new(0);
-
-    /// The resource is being prepared to be applied to the rack.
-    pub const STATE_PENDING: ResourceState = ResourceState::new(1);
-
-    /// The resource has started being applied to the rack.
-    pub const STATE_PROVISIONING: ResourceState = ResourceState::new(2);
-
-    /// The resource has been pushed to the rack.
-    pub const STATE_RUNNING: ResourceState = ResourceState::new(3);
-
-    /// The resource failed to push to the rack.
-    pub const STATE_SUSPENDED: ResourceState = ResourceState::new(4);
-
-    /// The resource is under deletion.
-    pub const STATE_DELETING: ResourceState = ResourceState::new(5);
-
-    /// Creates a new ResourceState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::StateUnknown => std::option::Option::Some(0),
+            Self::StatePending => std::option::Option::Some(1),
+            Self::StateProvisioning => std::option::Option::Some(2),
+            Self::StateRunning => std::option::Option::Some(3),
+            Self::StateSuspended => std::option::Option::Some(4),
+            Self::StateDeleting => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_UNKNOWN"),
-            1 => std::borrow::Cow::Borrowed("STATE_PENDING"),
-            2 => std::borrow::Cow::Borrowed("STATE_PROVISIONING"),
-            3 => std::borrow::Cow::Borrowed("STATE_RUNNING"),
-            4 => std::borrow::Cow::Borrowed("STATE_SUSPENDED"),
-            5 => std::borrow::Cow::Borrowed("STATE_DELETING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::StateUnknown => std::option::Option::Some("STATE_UNKNOWN"),
+            Self::StatePending => std::option::Option::Some("STATE_PENDING"),
+            Self::StateProvisioning => std::option::Option::Some("STATE_PROVISIONING"),
+            Self::StateRunning => std::option::Option::Some("STATE_RUNNING"),
+            Self::StateSuspended => std::option::Option::Some("STATE_SUSPENDED"),
+            Self::StateDeleting => std::option::Option::Some("STATE_DELETING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_UNKNOWN" => std::option::Option::Some(Self::STATE_UNKNOWN),
-            "STATE_PENDING" => std::option::Option::Some(Self::STATE_PENDING),
-            "STATE_PROVISIONING" => std::option::Option::Some(Self::STATE_PROVISIONING),
-            "STATE_RUNNING" => std::option::Option::Some(Self::STATE_RUNNING),
-            "STATE_SUSPENDED" => std::option::Option::Some(Self::STATE_SUSPENDED),
-            "STATE_DELETING" => std::option::Option::Some(Self::STATE_DELETING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ResourceState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ResourceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ResourceState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::StateUnknown,
+            1 => Self::StatePending,
+            2 => Self::StateProvisioning,
+            3 => Self::StateRunning,
+            4 => Self::StateSuspended,
+            5 => Self::StateDeleting,
+            _ => Self::UnknownValue(resource_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ResourceState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_UNKNOWN" => Self::StateUnknown,
+            "STATE_PENDING" => Self::StatePending,
+            "STATE_PROVISIONING" => Self::StateProvisioning,
+            "STATE_RUNNING" => Self::StateRunning,
+            "STATE_SUSPENDED" => Self::StateSuspended,
+            "STATE_DELETING" => Self::StateDeleting,
+            _ => Self::UnknownValue(resource_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ResourceState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::StateUnknown => serializer.serialize_i32(0),
+            Self::StatePending => serializer.serialize_i32(1),
+            Self::StateProvisioning => serializer.serialize_i32(2),
+            Self::StateRunning => serializer.serialize_i32(3),
+            Self::StateSuspended => serializer.serialize_i32(4),
+            Self::StateDeleting => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ResourceState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceState>::new(
+            ".google.cloud.edgenetwork.v1.ResourceState",
+        ))
     }
 }

--- a/src/generated/cloud/essentialcontacts/v1/src/model.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/model.rs
@@ -638,160 +638,289 @@ impl wkt::message::Message for SendTestMessageRequest {
 /// Each notification will be categorized by the sender into one of the following
 /// categories. All contacts that are subscribed to that category will receive
 /// the notification.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NotificationCategory(i32);
-
-impl NotificationCategory {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NotificationCategory {
     /// Notification category is unrecognized or unspecified.
-    pub const NOTIFICATION_CATEGORY_UNSPECIFIED: NotificationCategory =
-        NotificationCategory::new(0);
-
+    Unspecified,
     /// All notifications related to the resource, including notifications
     /// pertaining to categories added in the future.
-    pub const ALL: NotificationCategory = NotificationCategory::new(2);
-
+    All,
     /// Notifications related to imminent account suspension.
-    pub const SUSPENSION: NotificationCategory = NotificationCategory::new(3);
-
+    Suspension,
     /// Notifications related to security/privacy incidents, notifications, and
     /// vulnerabilities.
-    pub const SECURITY: NotificationCategory = NotificationCategory::new(5);
-
+    Security,
     /// Notifications related to technical events and issues such as outages,
     /// errors, or bugs.
-    pub const TECHNICAL: NotificationCategory = NotificationCategory::new(6);
-
+    Technical,
     /// Notifications related to billing and payments notifications, price updates,
     /// errors, or credits.
-    pub const BILLING: NotificationCategory = NotificationCategory::new(7);
-
+    Billing,
     /// Notifications related to enforcement actions, regulatory compliance, or
     /// government notices.
-    pub const LEGAL: NotificationCategory = NotificationCategory::new(8);
-
+    Legal,
     /// Notifications related to new versions, product terms updates, or
     /// deprecations.
-    pub const PRODUCT_UPDATES: NotificationCategory = NotificationCategory::new(9);
-
+    ProductUpdates,
     /// Child category of TECHNICAL. If assigned, technical incident notifications
     /// will go to these contacts instead of TECHNICAL.
-    pub const TECHNICAL_INCIDENTS: NotificationCategory = NotificationCategory::new(10);
+    TechnicalIncidents,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NotificationCategory::value] or
+    /// [NotificationCategory::name].
+    UnknownValue(notification_category::UnknownValue),
+}
 
-    /// Creates a new NotificationCategory instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod notification_category {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl NotificationCategory {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::All => std::option::Option::Some(2),
+            Self::Suspension => std::option::Option::Some(3),
+            Self::Security => std::option::Option::Some(5),
+            Self::Technical => std::option::Option::Some(6),
+            Self::Billing => std::option::Option::Some(7),
+            Self::Legal => std::option::Option::Some(8),
+            Self::ProductUpdates => std::option::Option::Some(9),
+            Self::TechnicalIncidents => std::option::Option::Some(10),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NOTIFICATION_CATEGORY_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("ALL"),
-            3 => std::borrow::Cow::Borrowed("SUSPENSION"),
-            5 => std::borrow::Cow::Borrowed("SECURITY"),
-            6 => std::borrow::Cow::Borrowed("TECHNICAL"),
-            7 => std::borrow::Cow::Borrowed("BILLING"),
-            8 => std::borrow::Cow::Borrowed("LEGAL"),
-            9 => std::borrow::Cow::Borrowed("PRODUCT_UPDATES"),
-            10 => std::borrow::Cow::Borrowed("TECHNICAL_INCIDENTS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NOTIFICATION_CATEGORY_UNSPECIFIED"),
+            Self::All => std::option::Option::Some("ALL"),
+            Self::Suspension => std::option::Option::Some("SUSPENSION"),
+            Self::Security => std::option::Option::Some("SECURITY"),
+            Self::Technical => std::option::Option::Some("TECHNICAL"),
+            Self::Billing => std::option::Option::Some("BILLING"),
+            Self::Legal => std::option::Option::Some("LEGAL"),
+            Self::ProductUpdates => std::option::Option::Some("PRODUCT_UPDATES"),
+            Self::TechnicalIncidents => std::option::Option::Some("TECHNICAL_INCIDENTS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NOTIFICATION_CATEGORY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NOTIFICATION_CATEGORY_UNSPECIFIED)
-            }
-            "ALL" => std::option::Option::Some(Self::ALL),
-            "SUSPENSION" => std::option::Option::Some(Self::SUSPENSION),
-            "SECURITY" => std::option::Option::Some(Self::SECURITY),
-            "TECHNICAL" => std::option::Option::Some(Self::TECHNICAL),
-            "BILLING" => std::option::Option::Some(Self::BILLING),
-            "LEGAL" => std::option::Option::Some(Self::LEGAL),
-            "PRODUCT_UPDATES" => std::option::Option::Some(Self::PRODUCT_UPDATES),
-            "TECHNICAL_INCIDENTS" => std::option::Option::Some(Self::TECHNICAL_INCIDENTS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NotificationCategory {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NotificationCategory {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NotificationCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NotificationCategory {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::All,
+            3 => Self::Suspension,
+            5 => Self::Security,
+            6 => Self::Technical,
+            7 => Self::Billing,
+            8 => Self::Legal,
+            9 => Self::ProductUpdates,
+            10 => Self::TechnicalIncidents,
+            _ => Self::UnknownValue(notification_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NotificationCategory {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NOTIFICATION_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+            "ALL" => Self::All,
+            "SUSPENSION" => Self::Suspension,
+            "SECURITY" => Self::Security,
+            "TECHNICAL" => Self::Technical,
+            "BILLING" => Self::Billing,
+            "LEGAL" => Self::Legal,
+            "PRODUCT_UPDATES" => Self::ProductUpdates,
+            "TECHNICAL_INCIDENTS" => Self::TechnicalIncidents,
+            _ => Self::UnknownValue(notification_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NotificationCategory {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::All => serializer.serialize_i32(2),
+            Self::Suspension => serializer.serialize_i32(3),
+            Self::Security => serializer.serialize_i32(5),
+            Self::Technical => serializer.serialize_i32(6),
+            Self::Billing => serializer.serialize_i32(7),
+            Self::Legal => serializer.serialize_i32(8),
+            Self::ProductUpdates => serializer.serialize_i32(9),
+            Self::TechnicalIncidents => serializer.serialize_i32(10),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NotificationCategory {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NotificationCategory>::new(
+            ".google.cloud.essentialcontacts.v1.NotificationCategory",
+        ))
     }
 }
 
 /// A contact's validation state indicates whether or not it is the correct
 /// contact to be receiving notifications for a particular resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ValidationState(i32);
-
-impl ValidationState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ValidationState {
     /// The validation state is unknown or unspecified.
-    pub const VALIDATION_STATE_UNSPECIFIED: ValidationState = ValidationState::new(0);
-
+    Unspecified,
     /// The contact is marked as valid. This is usually done manually by the
     /// contact admin. All new contacts begin in the valid state.
-    pub const VALID: ValidationState = ValidationState::new(1);
-
+    Valid,
     /// The contact is considered invalid. This may become the state if the
     /// contact's email is found to be unreachable.
-    pub const INVALID: ValidationState = ValidationState::new(2);
+    Invalid,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ValidationState::value] or
+    /// [ValidationState::name].
+    UnknownValue(validation_state::UnknownValue),
+}
 
-    /// Creates a new ValidationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod validation_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ValidationState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Valid => std::option::Option::Some(1),
+            Self::Invalid => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VALIDATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VALID"),
-            2 => std::borrow::Cow::Borrowed("INVALID"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VALIDATION_STATE_UNSPECIFIED"),
+            Self::Valid => std::option::Option::Some("VALID"),
+            Self::Invalid => std::option::Option::Some("INVALID"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VALIDATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::VALIDATION_STATE_UNSPECIFIED)
-            }
-            "VALID" => std::option::Option::Some(Self::VALID),
-            "INVALID" => std::option::Option::Some(Self::INVALID),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ValidationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ValidationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ValidationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ValidationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Valid,
+            2 => Self::Invalid,
+            _ => Self::UnknownValue(validation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ValidationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VALIDATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "VALID" => Self::Valid,
+            "INVALID" => Self::Invalid,
+            _ => Self::UnknownValue(validation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ValidationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Valid => serializer.serialize_i32(1),
+            Self::Invalid => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ValidationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ValidationState>::new(
+            ".google.cloud.essentialcontacts.v1.ValidationState",
+        ))
     }
 }

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -180,7 +180,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
             .notification_categories
             .iter()
             .fold(builder, |builder, p| {
-                builder.query(&[("notificationCategories", p.value())])
+                builder.query(&[("notificationCategories", p)])
             });
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -216,24 +216,20 @@ pub mod channel {
     use super::*;
 
     /// State lists all the possible states of a Channel
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PENDING state indicates that a Channel has been created successfully
         /// and there is a new activation token available for the subscriber to use
         /// to convey the Channel to the provider in order to create a Connection.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The ACTIVE state indicates that a Channel has been successfully
         /// connected with the event provider.
         /// An ACTIVE Channel is ready to receive and route events from the
         /// event provider.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The INACTIVE state indicates that the Channel cannot receive events
         /// permanently. There are two possible cases this state can happen:
         ///
@@ -243,50 +239,117 @@ pub mod channel {
         ///
         /// To re-establish a Connection with a provider, the subscriber
         /// should create a new Channel and give it to the provider.
-        pub const INACTIVE: State = State::new(3);
+        Inactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Inactive => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Active,
+                3 => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "ACTIVE" => Self::Active,
+                "INACTIVE" => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Inactive => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.eventarc.v1.Channel.State",
+            ))
         }
     }
 
@@ -4133,100 +4196,173 @@ pub mod logging_config {
     /// resources.
     /// This enum is an exhaustive list of log severities and is FROZEN. Do not
     /// expect new values to be added.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSeverity(i32);
-
-    impl LogSeverity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogSeverity {
         /// Log severity is not specified. This value is treated the same as NONE,
         /// but is used to distinguish between no update and update to NONE in
         /// update_masks.
-        pub const LOG_SEVERITY_UNSPECIFIED: LogSeverity = LogSeverity::new(0);
-
+        Unspecified,
         /// Default value at resource creation, presence of this value must be
         /// treated as no logging/disable logging.
-        pub const NONE: LogSeverity = LogSeverity::new(1);
-
+        None,
         /// Debug or trace level logging.
-        pub const DEBUG: LogSeverity = LogSeverity::new(2);
-
+        Debug,
         /// Routine information, such as ongoing status or performance.
-        pub const INFO: LogSeverity = LogSeverity::new(3);
-
+        Info,
         /// Normal but significant events, such as start up, shut down, or a
         /// configuration change.
-        pub const NOTICE: LogSeverity = LogSeverity::new(4);
-
+        Notice,
         /// Warning events might cause problems.
-        pub const WARNING: LogSeverity = LogSeverity::new(5);
-
+        Warning,
         /// Error events are likely to cause problems.
-        pub const ERROR: LogSeverity = LogSeverity::new(6);
-
+        Error,
         /// Critical events cause more severe problems or outages.
-        pub const CRITICAL: LogSeverity = LogSeverity::new(7);
-
+        Critical,
         /// A person must take action immediately.
-        pub const ALERT: LogSeverity = LogSeverity::new(8);
-
+        Alert,
         /// One or more systems are unusable.
-        pub const EMERGENCY: LogSeverity = LogSeverity::new(9);
+        Emergency,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogSeverity::value] or
+        /// [LogSeverity::name].
+        UnknownValue(log_severity::UnknownValue),
+    }
 
-        /// Creates a new LogSeverity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod log_severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LogSeverity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Debug => std::option::Option::Some(2),
+                Self::Info => std::option::Option::Some(3),
+                Self::Notice => std::option::Option::Some(4),
+                Self::Warning => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::Critical => std::option::Option::Some(7),
+                Self::Alert => std::option::Option::Some(8),
+                Self::Emergency => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("DEBUG"),
-                3 => std::borrow::Cow::Borrowed("INFO"),
-                4 => std::borrow::Cow::Borrowed("NOTICE"),
-                5 => std::borrow::Cow::Borrowed("WARNING"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("CRITICAL"),
-                8 => std::borrow::Cow::Borrowed("ALERT"),
-                9 => std::borrow::Cow::Borrowed("EMERGENCY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_SEVERITY_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Debug => std::option::Option::Some("DEBUG"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Notice => std::option::Option::Some("NOTICE"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::Alert => std::option::Option::Some("ALERT"),
+                Self::Emergency => std::option::Option::Some("EMERGENCY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_SEVERITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOG_SEVERITY_UNSPECIFIED)
-                }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "DEBUG" => std::option::Option::Some(Self::DEBUG),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "NOTICE" => std::option::Option::Some(Self::NOTICE),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                "ALERT" => std::option::Option::Some(Self::ALERT),
-                "EMERGENCY" => std::option::Option::Some(Self::EMERGENCY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LogSeverity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSeverity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LogSeverity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LogSeverity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Debug,
+                3 => Self::Info,
+                4 => Self::Notice,
+                5 => Self::Warning,
+                6 => Self::Error,
+                7 => Self::Critical,
+                8 => Self::Alert,
+                9 => Self::Emergency,
+                _ => Self::UnknownValue(log_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LogSeverity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "DEBUG" => Self::Debug,
+                "INFO" => Self::Info,
+                "NOTICE" => Self::Notice,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                "CRITICAL" => Self::Critical,
+                "ALERT" => Self::Alert,
+                "EMERGENCY" => Self::Emergency,
+                _ => Self::UnknownValue(log_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LogSeverity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Debug => serializer.serialize_i32(2),
+                Self::Info => serializer.serialize_i32(3),
+                Self::Notice => serializer.serialize_i32(4),
+                Self::Warning => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::Critical => serializer.serialize_i32(7),
+                Self::Alert => serializer.serialize_i32(8),
+                Self::Emergency => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LogSeverity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogSeverity>::new(
+                ".google.cloud.eventarc.v1.LoggingConfig.LogSeverity",
+            ))
         }
     }
 }

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -151,117 +151,233 @@ pub mod network_config {
     use super::*;
 
     /// Internet protocol versions supported by Filestore.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AddressMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AddressMode {
+        /// Internet protocol not set.
+        Unspecified,
+        /// Use the IPv4 internet protocol.
+        ModeIpv4,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AddressMode::value] or
+        /// [AddressMode::name].
+        UnknownValue(address_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod address_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AddressMode {
-        /// Internet protocol not set.
-        pub const ADDRESS_MODE_UNSPECIFIED: AddressMode = AddressMode::new(0);
-
-        /// Use the IPv4 internet protocol.
-        pub const MODE_IPV4: AddressMode = AddressMode::new(1);
-
-        /// Creates a new AddressMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ModeIpv4 => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ADDRESS_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODE_IPV4"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ADDRESS_MODE_UNSPECIFIED"),
+                Self::ModeIpv4 => std::option::Option::Some("MODE_IPV4"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ADDRESS_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ADDRESS_MODE_UNSPECIFIED)
-                }
-                "MODE_IPV4" => std::option::Option::Some(Self::MODE_IPV4),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AddressMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AddressMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AddressMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AddressMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ModeIpv4,
+                _ => Self::UnknownValue(address_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AddressMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ADDRESS_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MODE_IPV4" => Self::ModeIpv4,
+                _ => Self::UnknownValue(address_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AddressMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ModeIpv4 => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AddressMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AddressMode>::new(
+                ".google.cloud.filestore.v1.NetworkConfig.AddressMode",
+            ))
         }
     }
 
     /// Available connection modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectMode(i32);
-
-    impl ConnectMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConnectMode {
         /// Not set.
-        pub const CONNECT_MODE_UNSPECIFIED: ConnectMode = ConnectMode::new(0);
-
+        Unspecified,
         /// Connect via direct peering to the Filestore service.
-        pub const DIRECT_PEERING: ConnectMode = ConnectMode::new(1);
-
+        DirectPeering,
         /// Connect to your Filestore instance using Private Service
         /// Access. Private services access provides an IP address range for multiple
         /// Google Cloud services, including Filestore.
-        pub const PRIVATE_SERVICE_ACCESS: ConnectMode = ConnectMode::new(2);
+        PrivateServiceAccess,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConnectMode::value] or
+        /// [ConnectMode::name].
+        UnknownValue(connect_mode::UnknownValue),
+    }
 
-        /// Creates a new ConnectMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod connect_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConnectMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DirectPeering => std::option::Option::Some(1),
+                Self::PrivateServiceAccess => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONNECT_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIRECT_PEERING"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONNECT_MODE_UNSPECIFIED"),
+                Self::DirectPeering => std::option::Option::Some("DIRECT_PEERING"),
+                Self::PrivateServiceAccess => std::option::Option::Some("PRIVATE_SERVICE_ACCESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONNECT_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONNECT_MODE_UNSPECIFIED)
-                }
-                "DIRECT_PEERING" => std::option::Option::Some(Self::DIRECT_PEERING),
-                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConnectMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConnectMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConnectMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DirectPeering,
+                2 => Self::PrivateServiceAccess,
+                _ => Self::UnknownValue(connect_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConnectMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONNECT_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DIRECT_PEERING" => Self::DirectPeering,
+                "PRIVATE_SERVICE_ACCESS" => Self::PrivateServiceAccess,
+                _ => Self::UnknownValue(connect_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConnectMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DirectPeering => serializer.serialize_i32(1),
+                Self::PrivateServiceAccess => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConnectMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectMode>::new(
+                ".google.cloud.filestore.v1.NetworkConfig.ConnectMode",
+            ))
         }
     }
 }
@@ -497,120 +613,238 @@ pub mod nfs_export_options {
     use super::*;
 
     /// The access mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AccessMode {
+        /// AccessMode not set.
+        Unspecified,
+        /// The client can only read the file share.
+        ReadOnly,
+        /// The client can read and write the file share (default).
+        ReadWrite,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AccessMode::value] or
+        /// [AccessMode::name].
+        UnknownValue(access_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod access_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AccessMode {
-        /// AccessMode not set.
-        pub const ACCESS_MODE_UNSPECIFIED: AccessMode = AccessMode::new(0);
-
-        /// The client can only read the file share.
-        pub const READ_ONLY: AccessMode = AccessMode::new(1);
-
-        /// The client can read and write the file share (default).
-        pub const READ_WRITE: AccessMode = AccessMode::new(2);
-
-        /// Creates a new AccessMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReadOnly => std::option::Option::Some(1),
+                Self::ReadWrite => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCESS_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                2 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCESS_MODE_UNSPECIFIED"),
+                Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCESS_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCESS_MODE_UNSPECIFIED)
-                }
-                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AccessMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AccessMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AccessMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReadOnly,
+                2 => Self::ReadWrite,
+                _ => Self::UnknownValue(access_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AccessMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCESS_MODE_UNSPECIFIED" => Self::Unspecified,
+                "READ_ONLY" => Self::ReadOnly,
+                "READ_WRITE" => Self::ReadWrite,
+                _ => Self::UnknownValue(access_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AccessMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReadOnly => serializer.serialize_i32(1),
+                Self::ReadWrite => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AccessMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessMode>::new(
+                ".google.cloud.filestore.v1.NfsExportOptions.AccessMode",
+            ))
         }
     }
 
     /// The squash mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SquashMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SquashMode {
+        /// SquashMode not set.
+        Unspecified,
+        /// The Root user has root access to the file share (default).
+        NoRootSquash,
+        /// The Root user has squashed access to the anonymous uid/gid.
+        RootSquash,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SquashMode::value] or
+        /// [SquashMode::name].
+        UnknownValue(squash_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod squash_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SquashMode {
-        /// SquashMode not set.
-        pub const SQUASH_MODE_UNSPECIFIED: SquashMode = SquashMode::new(0);
-
-        /// The Root user has root access to the file share (default).
-        pub const NO_ROOT_SQUASH: SquashMode = SquashMode::new(1);
-
-        /// The Root user has squashed access to the anonymous uid/gid.
-        pub const ROOT_SQUASH: SquashMode = SquashMode::new(2);
-
-        /// Creates a new SquashMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoRootSquash => std::option::Option::Some(1),
+                Self::RootSquash => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQUASH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_ROOT_SQUASH"),
-                2 => std::borrow::Cow::Borrowed("ROOT_SQUASH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQUASH_MODE_UNSPECIFIED"),
+                Self::NoRootSquash => std::option::Option::Some("NO_ROOT_SQUASH"),
+                Self::RootSquash => std::option::Option::Some("ROOT_SQUASH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQUASH_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SQUASH_MODE_UNSPECIFIED)
-                }
-                "NO_ROOT_SQUASH" => std::option::Option::Some(Self::NO_ROOT_SQUASH),
-                "ROOT_SQUASH" => std::option::Option::Some(Self::ROOT_SQUASH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SquashMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SquashMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SquashMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SquashMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoRootSquash,
+                2 => Self::RootSquash,
+                _ => Self::UnknownValue(squash_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SquashMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQUASH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "NO_ROOT_SQUASH" => Self::NoRootSquash,
+                "ROOT_SQUASH" => Self::RootSquash,
+                _ => Self::UnknownValue(squash_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SquashMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoRootSquash => serializer.serialize_i32(1),
+                Self::RootSquash => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SquashMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SquashMode>::new(
+                ".google.cloud.filestore.v1.NfsExportOptions.SquashMode",
+            ))
         }
     }
 }
@@ -695,132 +929,256 @@ pub mod replica_config {
     use super::*;
 
     /// The replica state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The replica is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The replica is ready.
-        pub const READY: State = State::new(3);
-
+        Ready,
         /// The replica is being removed.
-        pub const REMOVING: State = State::new(4);
-
+        Removing,
         /// The replica is experiencing an issue and might be unusable. You can get
         /// further details from the `stateReasons` field of the `ReplicaConfig`
         /// object.
-        pub const FAILED: State = State::new(5);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(3),
+                Self::Removing => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("READY"),
-                4 => std::borrow::Cow::Borrowed("REMOVING"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Removing => std::option::Option::Some("REMOVING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "REMOVING" => std::option::Option::Some(Self::REMOVING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                3 => Self::Ready,
+                4 => Self::Removing,
+                5 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "REMOVING" => Self::Removing,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(3),
+                Self::Removing => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.filestore.v1.ReplicaConfig.State",
+            ))
         }
     }
 
     /// Additional information about the replication state, if available.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StateReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StateReason {
+        /// Reason not specified.
+        Unspecified,
+        /// The peer instance is unreachable.
+        PeerInstanceUnreachable,
+        /// The remove replica peer instance operation failed.
+        RemoveFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StateReason::value] or
+        /// [StateReason::name].
+        UnknownValue(state_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StateReason {
-        /// Reason not specified.
-        pub const STATE_REASON_UNSPECIFIED: StateReason = StateReason::new(0);
-
-        /// The peer instance is unreachable.
-        pub const PEER_INSTANCE_UNREACHABLE: StateReason = StateReason::new(1);
-
-        /// The remove replica peer instance operation failed.
-        pub const REMOVE_FAILED: StateReason = StateReason::new(2);
-
-        /// Creates a new StateReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PeerInstanceUnreachable => std::option::Option::Some(1),
+                Self::RemoveFailed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PEER_INSTANCE_UNREACHABLE"),
-                2 => std::borrow::Cow::Borrowed("REMOVE_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STATE_REASON_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_REASON_UNSPECIFIED"),
+                Self::PeerInstanceUnreachable => {
+                    std::option::Option::Some("PEER_INSTANCE_UNREACHABLE")
                 }
-                "PEER_INSTANCE_UNREACHABLE" => {
-                    std::option::Option::Some(Self::PEER_INSTANCE_UNREACHABLE)
-                }
-                "REMOVE_FAILED" => std::option::Option::Some(Self::REMOVE_FAILED),
-                _ => std::option::Option::None,
+                Self::RemoveFailed => std::option::Option::Some("REMOVE_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for StateReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StateReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StateReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StateReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PeerInstanceUnreachable,
+                2 => Self::RemoveFailed,
+                _ => Self::UnknownValue(state_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StateReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_REASON_UNSPECIFIED" => Self::Unspecified,
+                "PEER_INSTANCE_UNREACHABLE" => Self::PeerInstanceUnreachable,
+                "REMOVE_FAILED" => Self::RemoveFailed,
+                _ => Self::UnknownValue(state_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StateReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PeerInstanceUnreachable => serializer.serialize_i32(1),
+                Self::RemoveFailed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StateReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StateReason>::new(
+                ".google.cloud.filestore.v1.ReplicaConfig.StateReason",
+            ))
         }
     }
 }
@@ -881,61 +1239,122 @@ pub mod replication {
     use super::*;
 
     /// Replication role.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
-
-    impl Role {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
         /// Role not set.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
+        Unspecified,
         /// The instance is the `ACTIVE` replication member, functions as
         /// the replication source instance.
-        pub const ACTIVE: Role = Role::new(1);
-
+        Active,
         /// The instance is the `STANDBY` replication member, functions as
         /// the replication destination instance.
-        pub const STANDBY: Role = Role::new(2);
+        Standby,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
 
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Role {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Standby => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("STANDBY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Standby => std::option::Option::Some("STANDBY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "STANDBY" => std::option::Option::Some(Self::STANDBY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Standby,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "STANDBY" => Self::Standby,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Standby => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.filestore.v1.Replication.Role",
+            ))
         }
     }
 }
@@ -1548,318 +1967,586 @@ pub mod instance {
     }
 
     /// The instance state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The instance is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The instance is available for use.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// Work is being done on the instance. You can get further details from the
         /// `statusMessage` field of the `Instance` resource.
-        pub const REPAIRING: State = State::new(3);
-
+        Repairing,
         /// The instance is shutting down.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The instance is experiencing an issue and might be unusable. You can get
         /// further details from the `statusMessage` field of the `Instance`
         /// resource.
-        pub const ERROR: State = State::new(6);
-
+        Error,
         /// The instance is restoring a backup to an existing file share and may be
         /// unusable during this time.
-        pub const RESTORING: State = State::new(7);
-
+        Restoring,
         /// The instance is suspended. You can get further details from
         /// the `suspension_reasons` field of the `Instance` resource.
-        pub const SUSPENDED: State = State::new(8);
-
+        Suspended,
         /// The instance is in the process of becoming suspended.
-        pub const SUSPENDING: State = State::new(9);
-
+        Suspending,
         /// The instance is in the process of becoming active.
-        pub const RESUMING: State = State::new(10);
-
+        Resuming,
         /// The instance is reverting to a snapshot.
-        pub const REVERTING: State = State::new(12);
-
+        Reverting,
         /// The replica instance is being promoted.
-        pub const PROMOTING: State = State::new(13);
+        Promoting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Repairing => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(6),
+                Self::Restoring => std::option::Option::Some(7),
+                Self::Suspended => std::option::Option::Some(8),
+                Self::Suspending => std::option::Option::Some(9),
+                Self::Resuming => std::option::Option::Some(10),
+                Self::Reverting => std::option::Option::Some(12),
+                Self::Promoting => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("REPAIRING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("RESTORING"),
-                8 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                9 => std::borrow::Cow::Borrowed("SUSPENDING"),
-                10 => std::borrow::Cow::Borrowed("RESUMING"),
-                12 => std::borrow::Cow::Borrowed("REVERTING"),
-                13 => std::borrow::Cow::Borrowed("PROMOTING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Restoring => std::option::Option::Some("RESTORING"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Suspending => std::option::Option::Some("SUSPENDING"),
+                Self::Resuming => std::option::Option::Some("RESUMING"),
+                Self::Reverting => std::option::Option::Some("REVERTING"),
+                Self::Promoting => std::option::Option::Some("PROMOTING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "RESTORING" => std::option::Option::Some(Self::RESTORING),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
-                "RESUMING" => std::option::Option::Some(Self::RESUMING),
-                "REVERTING" => std::option::Option::Some(Self::REVERTING),
-                "PROMOTING" => std::option::Option::Some(Self::PROMOTING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Repairing,
+                4 => Self::Deleting,
+                6 => Self::Error,
+                7 => Self::Restoring,
+                8 => Self::Suspended,
+                9 => Self::Suspending,
+                10 => Self::Resuming,
+                12 => Self::Reverting,
+                13 => Self::Promoting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "REPAIRING" => Self::Repairing,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "RESTORING" => Self::Restoring,
+                "SUSPENDED" => Self::Suspended,
+                "SUSPENDING" => Self::Suspending,
+                "RESUMING" => Self::Resuming,
+                "REVERTING" => Self::Reverting,
+                "PROMOTING" => Self::Promoting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Repairing => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(6),
+                Self::Restoring => serializer.serialize_i32(7),
+                Self::Suspended => serializer.serialize_i32(8),
+                Self::Suspending => serializer.serialize_i32(9),
+                Self::Resuming => serializer.serialize_i32(10),
+                Self::Reverting => serializer.serialize_i32(12),
+                Self::Promoting => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.filestore.v1.Instance.State",
+            ))
         }
     }
 
     /// Available service tiers.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
-
-    impl Tier {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
         /// Not set.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
+        Unspecified,
         /// STANDARD tier. BASIC_HDD is the preferred term for this tier.
-        pub const STANDARD: Tier = Tier::new(1);
-
+        Standard,
         /// PREMIUM tier. BASIC_SSD is the preferred term for this tier.
-        pub const PREMIUM: Tier = Tier::new(2);
-
+        Premium,
         /// BASIC instances offer a maximum capacity of 63.9 TB.
         /// BASIC_HDD is an alias for STANDARD Tier, offering economical
         /// performance backed by HDD.
-        pub const BASIC_HDD: Tier = Tier::new(3);
-
+        BasicHdd,
         /// BASIC instances offer a maximum capacity of 63.9 TB.
         /// BASIC_SSD is an alias for PREMIUM Tier, and offers improved
         /// performance backed by SSD.
-        pub const BASIC_SSD: Tier = Tier::new(4);
-
+        BasicSsd,
         /// HIGH_SCALE instances offer expanded capacity and performance scaling
         /// capabilities.
-        pub const HIGH_SCALE_SSD: Tier = Tier::new(5);
-
+        HighScaleSsd,
         /// ENTERPRISE instances offer the features and availability needed for
         /// mission-critical workloads.
-        pub const ENTERPRISE: Tier = Tier::new(6);
-
+        Enterprise,
         /// ZONAL instances offer expanded capacity and performance scaling
         /// capabilities.
-        pub const ZONAL: Tier = Tier::new(7);
-
+        Zonal,
         /// REGIONAL instances offer the features and availability needed for
         /// mission-critical workloads.
-        pub const REGIONAL: Tier = Tier::new(8);
+        Regional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
 
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Tier {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Premium => std::option::Option::Some(2),
+                Self::BasicHdd => std::option::Option::Some(3),
+                Self::BasicSsd => std::option::Option::Some(4),
+                Self::HighScaleSsd => std::option::Option::Some(5),
+                Self::Enterprise => std::option::Option::Some(6),
+                Self::Zonal => std::option::Option::Some(7),
+                Self::Regional => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("PREMIUM"),
-                3 => std::borrow::Cow::Borrowed("BASIC_HDD"),
-                4 => std::borrow::Cow::Borrowed("BASIC_SSD"),
-                5 => std::borrow::Cow::Borrowed("HIGH_SCALE_SSD"),
-                6 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                7 => std::borrow::Cow::Borrowed("ZONAL"),
-                8 => std::borrow::Cow::Borrowed("REGIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Premium => std::option::Option::Some("PREMIUM"),
+                Self::BasicHdd => std::option::Option::Some("BASIC_HDD"),
+                Self::BasicSsd => std::option::Option::Some("BASIC_SSD"),
+                Self::HighScaleSsd => std::option::Option::Some("HIGH_SCALE_SSD"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::Zonal => std::option::Option::Some("ZONAL"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "PREMIUM" => std::option::Option::Some(Self::PREMIUM),
-                "BASIC_HDD" => std::option::Option::Some(Self::BASIC_HDD),
-                "BASIC_SSD" => std::option::Option::Some(Self::BASIC_SSD),
-                "HIGH_SCALE_SSD" => std::option::Option::Some(Self::HIGH_SCALE_SSD),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                "ZONAL" => std::option::Option::Some(Self::ZONAL),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Premium,
+                3 => Self::BasicHdd,
+                4 => Self::BasicSsd,
+                5 => Self::HighScaleSsd,
+                6 => Self::Enterprise,
+                7 => Self::Zonal,
+                8 => Self::Regional,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "PREMIUM" => Self::Premium,
+                "BASIC_HDD" => Self::BasicHdd,
+                "BASIC_SSD" => Self::BasicSsd,
+                "HIGH_SCALE_SSD" => Self::HighScaleSsd,
+                "ENTERPRISE" => Self::Enterprise,
+                "ZONAL" => Self::Zonal,
+                "REGIONAL" => Self::Regional,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Premium => serializer.serialize_i32(2),
+                Self::BasicHdd => serializer.serialize_i32(3),
+                Self::BasicSsd => serializer.serialize_i32(4),
+                Self::HighScaleSsd => serializer.serialize_i32(5),
+                Self::Enterprise => serializer.serialize_i32(6),
+                Self::Zonal => serializer.serialize_i32(7),
+                Self::Regional => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.filestore.v1.Instance.Tier",
+            ))
         }
     }
 
     /// SuspensionReason contains the possible reasons for a suspension.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SuspensionReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SuspensionReason {
+        /// Not set.
+        Unspecified,
+        /// The KMS key used by the instance is either revoked or denied access to.
+        KmsKeyIssue,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SuspensionReason::value] or
+        /// [SuspensionReason::name].
+        UnknownValue(suspension_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod suspension_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SuspensionReason {
-        /// Not set.
-        pub const SUSPENSION_REASON_UNSPECIFIED: SuspensionReason = SuspensionReason::new(0);
-
-        /// The KMS key used by the instance is either revoked or denied access to.
-        pub const KMS_KEY_ISSUE: SuspensionReason = SuspensionReason::new(1);
-
-        /// Creates a new SuspensionReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::KmsKeyIssue => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SUSPENSION_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KMS_KEY_ISSUE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SUSPENSION_REASON_UNSPECIFIED"),
+                Self::KmsKeyIssue => std::option::Option::Some("KMS_KEY_ISSUE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SUSPENSION_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SUSPENSION_REASON_UNSPECIFIED)
-                }
-                "KMS_KEY_ISSUE" => std::option::Option::Some(Self::KMS_KEY_ISSUE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SuspensionReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SuspensionReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SuspensionReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SuspensionReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::KmsKeyIssue,
+                _ => Self::UnknownValue(suspension_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SuspensionReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SUSPENSION_REASON_UNSPECIFIED" => Self::Unspecified,
+                "KMS_KEY_ISSUE" => Self::KmsKeyIssue,
+                _ => Self::UnknownValue(suspension_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SuspensionReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::KmsKeyIssue => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SuspensionReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SuspensionReason>::new(
+                ".google.cloud.filestore.v1.Instance.SuspensionReason",
+            ))
         }
     }
 
     /// File access protocol.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FileProtocol(i32);
-
-    impl FileProtocol {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FileProtocol {
         /// FILE_PROTOCOL_UNSPECIFIED serves a "not set" default value when
         /// a FileProtocol is a separate field in a message.
-        pub const FILE_PROTOCOL_UNSPECIFIED: FileProtocol = FileProtocol::new(0);
-
+        Unspecified,
         /// NFS 3.0.
-        pub const NFS_V3: FileProtocol = FileProtocol::new(1);
-
+        NfsV3,
         /// NFS 4.1.
-        pub const NFS_V4_1: FileProtocol = FileProtocol::new(2);
+        NfsV41,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FileProtocol::value] or
+        /// [FileProtocol::name].
+        UnknownValue(file_protocol::UnknownValue),
+    }
 
-        /// Creates a new FileProtocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod file_protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FileProtocol {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NfsV3 => std::option::Option::Some(1),
+                Self::NfsV41 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FILE_PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NFS_V3"),
-                2 => std::borrow::Cow::Borrowed("NFS_V4_1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FILE_PROTOCOL_UNSPECIFIED"),
+                Self::NfsV3 => std::option::Option::Some("NFS_V3"),
+                Self::NfsV41 => std::option::Option::Some("NFS_V4_1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FILE_PROTOCOL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FILE_PROTOCOL_UNSPECIFIED)
-                }
-                "NFS_V3" => std::option::Option::Some(Self::NFS_V3),
-                "NFS_V4_1" => std::option::Option::Some(Self::NFS_V4_1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FileProtocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FileProtocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FileProtocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FileProtocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NfsV3,
+                2 => Self::NfsV41,
+                _ => Self::UnknownValue(file_protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FileProtocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FILE_PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "NFS_V3" => Self::NfsV3,
+                "NFS_V4_1" => Self::NfsV41,
+                _ => Self::UnknownValue(file_protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FileProtocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NfsV3 => serializer.serialize_i32(1),
+                Self::NfsV41 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FileProtocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileProtocol>::new(
+                ".google.cloud.filestore.v1.Instance.FileProtocol",
+            ))
         }
     }
 }
@@ -2495,64 +3182,127 @@ pub mod snapshot {
     use super::*;
 
     /// The snapshot state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// Snapshot is being created.
+        Creating,
+        /// Snapshot is available for use.
+        Ready,
+        /// Snapshot is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Snapshot is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Snapshot is available for use.
-        pub const READY: State = State::new(2);
-
-        /// Snapshot is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.filestore.v1.Snapshot.State",
+            ))
         }
     }
 }
@@ -3130,76 +3880,143 @@ pub mod backup {
     use super::*;
 
     /// The backup state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Backup is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Backup has been taken and the operation is being finalized. At this
         /// point, changes to the file share will not be reflected in the backup.
-        pub const FINALIZING: State = State::new(2);
-
+        Finalizing,
         /// Backup is available for use.
-        pub const READY: State = State::new(3);
-
+        Ready,
         /// Backup is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Backup is not valid and cannot be used for creating new instances or
         /// restoring existing instances.
-        pub const INVALID: State = State::new(5);
+        Invalid,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Finalizing => std::option::Option::Some(2),
+                Self::Ready => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Invalid => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("FINALIZING"),
-                3 => std::borrow::Cow::Borrowed("READY"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("INVALID"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Finalizing => std::option::Option::Some("FINALIZING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Invalid => std::option::Option::Some("INVALID"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "INVALID" => std::option::Option::Some(Self::INVALID),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Finalizing,
+                3 => Self::Ready,
+                4 => Self::Deleting,
+                5 => Self::Invalid,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "FINALIZING" => Self::Finalizing,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "INVALID" => Self::Invalid,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Finalizing => serializer.serialize_i32(2),
+                Self::Ready => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Invalid => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.filestore.v1.Backup.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -250,69 +250,134 @@ pub mod backtest_result {
     }
 
     /// The possible states of a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified, should not occur.
+        Unspecified,
+        /// The resource has not finished being created.
+        Creating,
+        /// The resource is active/ready to be used.
+        Active,
+        /// The resource is in the process of being updated.
+        Updating,
+        /// The resource is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.BacktestResult.State",
+            ))
         }
     }
 }
@@ -846,61 +911,120 @@ pub mod big_query_destination {
 
     /// WriteDisposition controls the behavior when the destination table already
     /// exists.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WriteDisposition(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WriteDisposition {
+        /// Default behavior is the same as WRITE_EMPTY.
+        Unspecified,
+        /// If the table already exists and contains data, an error is returned.
+        WriteEmpty,
+        /// If the table already exists, the data will be overwritten.
+        WriteTruncate,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WriteDisposition::value] or
+        /// [WriteDisposition::name].
+        UnknownValue(write_disposition::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod write_disposition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WriteDisposition {
-        /// Default behavior is the same as WRITE_EMPTY.
-        pub const WRITE_DISPOSITION_UNSPECIFIED: WriteDisposition = WriteDisposition::new(0);
-
-        /// If the table already exists and contains data, an error is returned.
-        pub const WRITE_EMPTY: WriteDisposition = WriteDisposition::new(1);
-
-        /// If the table already exists, the data will be overwritten.
-        pub const WRITE_TRUNCATE: WriteDisposition = WriteDisposition::new(2);
-
-        /// Creates a new WriteDisposition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::WriteEmpty => std::option::Option::Some(1),
+                Self::WriteTruncate => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WRITE_DISPOSITION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WRITE_EMPTY"),
-                2 => std::borrow::Cow::Borrowed("WRITE_TRUNCATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WRITE_DISPOSITION_UNSPECIFIED"),
+                Self::WriteEmpty => std::option::Option::Some("WRITE_EMPTY"),
+                Self::WriteTruncate => std::option::Option::Some("WRITE_TRUNCATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WRITE_DISPOSITION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WRITE_DISPOSITION_UNSPECIFIED)
-                }
-                "WRITE_EMPTY" => std::option::Option::Some(Self::WRITE_EMPTY),
-                "WRITE_TRUNCATE" => std::option::Option::Some(Self::WRITE_TRUNCATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WriteDisposition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WriteDisposition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WriteDisposition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WriteDisposition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::WriteEmpty,
+                2 => Self::WriteTruncate,
+                _ => Self::UnknownValue(write_disposition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WriteDisposition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WRITE_DISPOSITION_UNSPECIFIED" => Self::Unspecified,
+                "WRITE_EMPTY" => Self::WriteEmpty,
+                "WRITE_TRUNCATE" => Self::WriteTruncate,
+                _ => Self::UnknownValue(write_disposition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WriteDisposition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::WriteEmpty => serializer.serialize_i32(1),
+                Self::WriteTruncate => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WriteDisposition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WriteDisposition>::new(
+                ".google.cloud.financialservices.v1.BigQueryDestination.WriteDisposition",
+            ))
         }
     }
 }
@@ -1048,69 +1172,134 @@ pub mod dataset {
     use super::*;
 
     /// The possible states of a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified, should not occur.
+        Unspecified,
+        /// The resource has not finished being created.
+        Creating,
+        /// The resource is active/ready to be used.
+        Active,
+        /// The resource is in the process of being updated.
+        Updating,
+        /// The resource is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.Dataset.State",
+            ))
         }
     }
 }
@@ -1843,130 +2032,257 @@ pub mod engine_config {
     }
 
     /// The possible states of a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified, should not occur.
+        Unspecified,
+        /// The resource has not finished being created.
+        Creating,
+        /// The resource is active/ready to be used.
+        Active,
+        /// The resource is in the process of being updated.
+        Updating,
+        /// The resource is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.EngineConfig.State",
+            ))
         }
     }
 
     /// The type of the hyperparameter source.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HyperparameterSourceType(i32);
-
-    impl HyperparameterSourceType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HyperparameterSourceType {
         /// Hyperparameter source type is unspecified, defaults to TUNING.
-        pub const HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED: HyperparameterSourceType =
-            HyperparameterSourceType::new(0);
-
+        Unspecified,
         /// The EngineConfig creation starts a tuning job which selects the best
         /// hyperparameters.
-        pub const TUNING: HyperparameterSourceType = HyperparameterSourceType::new(1);
-
+        Tuning,
         /// The hyperparameters are inherited from another EngineConfig.
-        pub const INHERITED: HyperparameterSourceType = HyperparameterSourceType::new(2);
+        Inherited,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HyperparameterSourceType::value] or
+        /// [HyperparameterSourceType::name].
+        UnknownValue(hyperparameter_source_type::UnknownValue),
+    }
 
-        /// Creates a new HyperparameterSourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod hyperparameter_source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl HyperparameterSourceType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tuning => std::option::Option::Some(1),
+                Self::Inherited => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TUNING"),
-                2 => std::borrow::Cow::Borrowed("INHERITED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED")
                 }
-                "TUNING" => std::option::Option::Some(Self::TUNING),
-                "INHERITED" => std::option::Option::Some(Self::INHERITED),
-                _ => std::option::Option::None,
+                Self::Tuning => std::option::Option::Some("TUNING"),
+                Self::Inherited => std::option::Option::Some("INHERITED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for HyperparameterSourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HyperparameterSourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HyperparameterSourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HyperparameterSourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tuning,
+                2 => Self::Inherited,
+                _ => Self::UnknownValue(hyperparameter_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HyperparameterSourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HYPERPARAMETER_SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TUNING" => Self::Tuning,
+                "INHERITED" => Self::Inherited,
+                _ => Self::UnknownValue(hyperparameter_source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HyperparameterSourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tuning => serializer.serialize_i32(1),
+                Self::Inherited => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HyperparameterSourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<HyperparameterSourceType>::new(
+                    ".google.cloud.financialservices.v1.EngineConfig.HyperparameterSourceType",
+                ),
+            )
         }
     }
 }
@@ -2541,65 +2857,128 @@ pub mod engine_version {
 
     /// State determines the lifecycle of a version and the models/engine configs
     /// trained with it.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default state, should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Version is available for training and inference.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Models using this version can still be run, but new ones cannot be
         /// trained.
-        pub const LIMITED: State = State::new(2);
-
+        Limited,
         /// Version is deprecated, listed for informational purposes only.
-        pub const DECOMMISSIONED: State = State::new(3);
+        Decommissioned,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Limited => std::option::Option::Some(2),
+                Self::Decommissioned => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("LIMITED"),
-                3 => std::borrow::Cow::Borrowed("DECOMMISSIONED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Limited => std::option::Option::Some("LIMITED"),
+                Self::Decommissioned => std::option::Option::Some("DECOMMISSIONED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "LIMITED" => std::option::Option::Some(Self::LIMITED),
-                "DECOMMISSIONED" => std::option::Option::Some(Self::DECOMMISSIONED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Limited,
+                3 => Self::Decommissioned,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "LIMITED" => Self::Limited,
+                "DECOMMISSIONED" => Self::Decommissioned,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Limited => serializer.serialize_i32(2),
+                Self::Decommissioned => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.EngineVersion.State",
+            ))
         }
     }
 }
@@ -2904,69 +3283,134 @@ pub mod instance {
     use super::*;
 
     /// The Resource State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified, should not occur.
+        Unspecified,
+        /// The resource has not finished being created.
+        Creating,
+        /// The resource is active/ready to be used.
+        Active,
+        /// The resource is in the process of being updated.
+        Updating,
+        /// The resource is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.Instance.State",
+            ))
         }
     }
 }
@@ -3463,61 +3907,120 @@ pub mod import_registered_parties_request {
     use super::*;
 
     /// UpdateMode controls the behavior for ImportRegisteredParties.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UpdateMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UpdateMode {
+        /// Default mode.
+        Unspecified,
+        /// Replace parties that are removable in Parties Table with new parties.
+        Replace,
+        /// Add new parties to Parties Table.
+        Append,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UpdateMode::value] or
+        /// [UpdateMode::name].
+        UnknownValue(update_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod update_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl UpdateMode {
-        /// Default mode.
-        pub const UPDATE_MODE_UNSPECIFIED: UpdateMode = UpdateMode::new(0);
-
-        /// Replace parties that are removable in Parties Table with new parties.
-        pub const REPLACE: UpdateMode = UpdateMode::new(1);
-
-        /// Add new parties to Parties Table.
-        pub const APPEND: UpdateMode = UpdateMode::new(2);
-
-        /// Creates a new UpdateMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Replace => std::option::Option::Some(1),
+                Self::Append => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UPDATE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REPLACE"),
-                2 => std::borrow::Cow::Borrowed("APPEND"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UPDATE_MODE_UNSPECIFIED"),
+                Self::Replace => std::option::Option::Some("REPLACE"),
+                Self::Append => std::option::Option::Some("APPEND"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UPDATE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::UPDATE_MODE_UNSPECIFIED)
-                }
-                "REPLACE" => std::option::Option::Some(Self::REPLACE),
-                "APPEND" => std::option::Option::Some(Self::APPEND),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UpdateMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UpdateMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UpdateMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UpdateMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Replace,
+                2 => Self::Append,
+                _ => Self::UnknownValue(update_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UpdateMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UPDATE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "REPLACE" => Self::Replace,
+                "APPEND" => Self::Append,
+                _ => Self::UnknownValue(update_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UpdateMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Replace => serializer.serialize_i32(1),
+                Self::Append => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UpdateMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UpdateMode>::new(
+                ".google.cloud.financialservices.v1.ImportRegisteredPartiesRequest.UpdateMode",
+            ))
         }
     }
 }
@@ -3858,69 +4361,134 @@ pub mod model {
     use super::*;
 
     /// The possible states of a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified, should not occur.
+        Unspecified,
+        /// The resource has not finished being created.
+        Creating,
+        /// The resource is active/ready to be used.
+        Active,
+        /// The resource is in the process of being updated.
+        Updating,
+        /// The resource is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.Model.State",
+            ))
         }
     }
 }
@@ -4620,69 +5188,134 @@ pub mod prediction_result {
     }
 
     /// The possible states of a resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is unspecified, should not occur.
+        Unspecified,
+        /// The resource has not finished being created.
+        Creating,
+        /// The resource is active/ready to be used.
+        Active,
+        /// The resource is in the process of being updated.
+        Updating,
+        /// The resource is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is unspecified, should not occur.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The resource has not finished being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The resource is active/ready to be used.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The resource is in the process of being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The resource is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.financialservices.v1.PredictionResult.State",
+            ))
         }
     }
 }
@@ -5269,60 +5902,119 @@ impl wkt::message::Message for OperationMetadata {
 }
 
 /// Indicate which LineOfBusiness a party belongs to.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LineOfBusiness(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LineOfBusiness {
+    /// An unspecified LineOfBusiness. Do not use.
+    Unspecified,
+    /// Commercial LineOfBusiness.
+    Commercial,
+    /// Retail LineOfBusiness.
+    Retail,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LineOfBusiness::value] or
+    /// [LineOfBusiness::name].
+    UnknownValue(line_of_business::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod line_of_business {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LineOfBusiness {
-    /// An unspecified LineOfBusiness. Do not use.
-    pub const LINE_OF_BUSINESS_UNSPECIFIED: LineOfBusiness = LineOfBusiness::new(0);
-
-    /// Commercial LineOfBusiness.
-    pub const COMMERCIAL: LineOfBusiness = LineOfBusiness::new(1);
-
-    /// Retail LineOfBusiness.
-    pub const RETAIL: LineOfBusiness = LineOfBusiness::new(2);
-
-    /// Creates a new LineOfBusiness instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Commercial => std::option::Option::Some(1),
+            Self::Retail => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LINE_OF_BUSINESS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("COMMERCIAL"),
-            2 => std::borrow::Cow::Borrowed("RETAIL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LINE_OF_BUSINESS_UNSPECIFIED"),
+            Self::Commercial => std::option::Option::Some("COMMERCIAL"),
+            Self::Retail => std::option::Option::Some("RETAIL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LINE_OF_BUSINESS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LINE_OF_BUSINESS_UNSPECIFIED)
-            }
-            "COMMERCIAL" => std::option::Option::Some(Self::COMMERCIAL),
-            "RETAIL" => std::option::Option::Some(Self::RETAIL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LineOfBusiness {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LineOfBusiness {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LineOfBusiness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LineOfBusiness {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Commercial,
+            2 => Self::Retail,
+            _ => Self::UnknownValue(line_of_business::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LineOfBusiness {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LINE_OF_BUSINESS_UNSPECIFIED" => Self::Unspecified,
+            "COMMERCIAL" => Self::Commercial,
+            "RETAIL" => Self::Retail,
+            _ => Self::UnknownValue(line_of_business::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LineOfBusiness {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Commercial => serializer.serialize_i32(1),
+            Self::Retail => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LineOfBusiness {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LineOfBusiness>::new(
+            ".google.cloud.financialservices.v1.LineOfBusiness",
+        ))
     }
 }

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -246,75 +246,142 @@ pub mod function {
     use super::*;
 
     /// Describes the current state of the function.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified. Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Function has been successfully deployed and is serving.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Function deployment failed and the function is not serving.
-        pub const FAILED: State = State::new(2);
-
+        Failed,
         /// Function is being created or updated.
-        pub const DEPLOYING: State = State::new(3);
-
+        Deploying,
         /// Function is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Function deployment failed and the function serving state is undefined.
         /// The function should be updated or deleted to move it out of this state.
-        pub const UNKNOWN: State = State::new(5);
+        Unknown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Deploying => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Unknown => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("DEPLOYING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deploying => std::option::Option::Some("DEPLOYING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DEPLOYING" => std::option::Option::Some(Self::DEPLOYING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Failed,
+                3 => Self::Deploying,
+                4 => Self::Deleting,
+                5 => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "DEPLOYING" => Self::Deploying,
+                "DELETING" => Self::Deleting,
+                "UNKNOWN" => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Deploying => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Unknown => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.functions.v2.Function.State",
+            ))
         }
     }
 }
@@ -380,64 +447,127 @@ pub mod state_message {
     use super::*;
 
     /// Severity of the state message.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Not specified. Invalid severity.
+        Unspecified,
+        /// ERROR-level severity.
+        Error,
+        /// WARNING-level severity.
+        Warning,
+        /// INFO-level severity.
+        Info,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Not specified. Invalid severity.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// ERROR-level severity.
-        pub const ERROR: Severity = Severity::new(1);
-
-        /// WARNING-level severity.
-        pub const WARNING: Severity = Severity::new(2);
-
-        /// INFO-level severity.
-        pub const INFO: Severity = Severity::new(3);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Error => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Info => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ERROR"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("INFO"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Error,
+                2 => Self::Warning,
+                3 => Self::Info,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "ERROR" => Self::Error,
+                "WARNING" => Self::Warning,
+                "INFO" => Self::Info,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Error => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Info => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.functions.v2.StateMessage.Severity",
+            ))
         }
     }
 }
@@ -1169,66 +1299,125 @@ pub mod build_config {
     use super::*;
 
     /// Docker Registry to use for storing function Docker images.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DockerRegistry(i32);
-
-    impl DockerRegistry {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DockerRegistry {
         /// Unspecified.
-        pub const DOCKER_REGISTRY_UNSPECIFIED: DockerRegistry = DockerRegistry::new(0);
-
+        Unspecified,
         /// Docker images will be stored in multi-regional Container Registry
         /// repositories named `gcf`.
-        pub const CONTAINER_REGISTRY: DockerRegistry = DockerRegistry::new(1);
-
+        ContainerRegistry,
         /// Docker images will be stored in regional Artifact Registry repositories.
         /// By default, GCF will create and use repositories named `gcf-artifacts`
         /// in every region in which a function is deployed. But the repository to
         /// use can also be specified by the user using the `docker_repository`
         /// field.
-        pub const ARTIFACT_REGISTRY: DockerRegistry = DockerRegistry::new(2);
+        ArtifactRegistry,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DockerRegistry::value] or
+        /// [DockerRegistry::name].
+        UnknownValue(docker_registry::UnknownValue),
+    }
 
-        /// Creates a new DockerRegistry instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod docker_registry {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DockerRegistry {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ContainerRegistry => std::option::Option::Some(1),
+                Self::ArtifactRegistry => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DOCKER_REGISTRY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONTAINER_REGISTRY"),
-                2 => std::borrow::Cow::Borrowed("ARTIFACT_REGISTRY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DOCKER_REGISTRY_UNSPECIFIED"),
+                Self::ContainerRegistry => std::option::Option::Some("CONTAINER_REGISTRY"),
+                Self::ArtifactRegistry => std::option::Option::Some("ARTIFACT_REGISTRY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DOCKER_REGISTRY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DOCKER_REGISTRY_UNSPECIFIED)
-                }
-                "CONTAINER_REGISTRY" => std::option::Option::Some(Self::CONTAINER_REGISTRY),
-                "ARTIFACT_REGISTRY" => std::option::Option::Some(Self::ARTIFACT_REGISTRY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DockerRegistry {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DockerRegistry {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DockerRegistry {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DockerRegistry {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ContainerRegistry,
+                2 => Self::ArtifactRegistry,
+                _ => Self::UnknownValue(docker_registry::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DockerRegistry {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DOCKER_REGISTRY_UNSPECIFIED" => Self::Unspecified,
+                "CONTAINER_REGISTRY" => Self::ContainerRegistry,
+                "ARTIFACT_REGISTRY" => Self::ArtifactRegistry,
+                _ => Self::UnknownValue(docker_registry::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DockerRegistry {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ContainerRegistry => serializer.serialize_i32(1),
+                Self::ArtifactRegistry => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DockerRegistry {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DockerRegistry>::new(
+                ".google.cloud.functions.v2.BuildConfig.DockerRegistry",
+            ))
         }
     }
 
@@ -1549,64 +1738,125 @@ pub mod service_config {
     ///
     /// This controls what traffic is diverted through the VPC Access Connector
     /// resource. By default PRIVATE_RANGES_ONLY will be used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VpcConnectorEgressSettings(i32);
-
-    impl VpcConnectorEgressSettings {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VpcConnectorEgressSettings {
         /// Unspecified.
-        pub const VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED: VpcConnectorEgressSettings =
-            VpcConnectorEgressSettings::new(0);
-
+        Unspecified,
         /// Use the VPC Access Connector only for private IP space from RFC1918.
-        pub const PRIVATE_RANGES_ONLY: VpcConnectorEgressSettings =
-            VpcConnectorEgressSettings::new(1);
-
+        PrivateRangesOnly,
         /// Force the use of VPC Access Connector for all egress traffic from the
         /// function.
-        pub const ALL_TRAFFIC: VpcConnectorEgressSettings = VpcConnectorEgressSettings::new(2);
+        AllTraffic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VpcConnectorEgressSettings::value] or
+        /// [VpcConnectorEgressSettings::name].
+        UnknownValue(vpc_connector_egress_settings::UnknownValue),
+    }
 
-        /// Creates a new VpcConnectorEgressSettings instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod vpc_connector_egress_settings {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl VpcConnectorEgressSettings {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PrivateRangesOnly => std::option::Option::Some(1),
+                Self::AllTraffic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVATE_RANGES_ONLY"),
-                2 => std::borrow::Cow::Borrowed("ALL_TRAFFIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED")
                 }
-                "PRIVATE_RANGES_ONLY" => std::option::Option::Some(Self::PRIVATE_RANGES_ONLY),
-                "ALL_TRAFFIC" => std::option::Option::Some(Self::ALL_TRAFFIC),
-                _ => std::option::Option::None,
+                Self::PrivateRangesOnly => std::option::Option::Some("PRIVATE_RANGES_ONLY"),
+                Self::AllTraffic => std::option::Option::Some("ALL_TRAFFIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for VpcConnectorEgressSettings {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VpcConnectorEgressSettings {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VpcConnectorEgressSettings {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VpcConnectorEgressSettings {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PrivateRangesOnly,
+                2 => Self::AllTraffic,
+                _ => Self::UnknownValue(vpc_connector_egress_settings::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VpcConnectorEgressSettings {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED" => Self::Unspecified,
+                "PRIVATE_RANGES_ONLY" => Self::PrivateRangesOnly,
+                "ALL_TRAFFIC" => Self::AllTraffic,
+                _ => Self::UnknownValue(vpc_connector_egress_settings::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VpcConnectorEgressSettings {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PrivateRangesOnly => serializer.serialize_i32(1),
+                Self::AllTraffic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VpcConnectorEgressSettings {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<VpcConnectorEgressSettings>::new(
+                    ".google.cloud.functions.v2.ServiceConfig.VpcConnectorEgressSettings",
+                ),
+            )
         }
     }
 
@@ -1615,68 +1865,127 @@ pub mod service_config {
     /// This controls what traffic can reach the function.
     ///
     /// If unspecified, ALLOW_ALL will be used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IngressSettings(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IngressSettings {
+        /// Unspecified.
+        Unspecified,
+        /// Allow HTTP traffic from public and private sources.
+        AllowAll,
+        /// Allow HTTP traffic from only private VPC sources.
+        AllowInternalOnly,
+        /// Allow HTTP traffic from private VPC sources and through GCLB.
+        AllowInternalAndGclb,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IngressSettings::value] or
+        /// [IngressSettings::name].
+        UnknownValue(ingress_settings::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ingress_settings {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IngressSettings {
-        /// Unspecified.
-        pub const INGRESS_SETTINGS_UNSPECIFIED: IngressSettings = IngressSettings::new(0);
-
-        /// Allow HTTP traffic from public and private sources.
-        pub const ALLOW_ALL: IngressSettings = IngressSettings::new(1);
-
-        /// Allow HTTP traffic from only private VPC sources.
-        pub const ALLOW_INTERNAL_ONLY: IngressSettings = IngressSettings::new(2);
-
-        /// Allow HTTP traffic from private VPC sources and through GCLB.
-        pub const ALLOW_INTERNAL_AND_GCLB: IngressSettings = IngressSettings::new(3);
-
-        /// Creates a new IngressSettings instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllowAll => std::option::Option::Some(1),
+                Self::AllowInternalOnly => std::option::Option::Some(2),
+                Self::AllowInternalAndGclb => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INGRESS_SETTINGS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW_ALL"),
-                2 => std::borrow::Cow::Borrowed("ALLOW_INTERNAL_ONLY"),
-                3 => std::borrow::Cow::Borrowed("ALLOW_INTERNAL_AND_GCLB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INGRESS_SETTINGS_UNSPECIFIED"),
+                Self::AllowAll => std::option::Option::Some("ALLOW_ALL"),
+                Self::AllowInternalOnly => std::option::Option::Some("ALLOW_INTERNAL_ONLY"),
+                Self::AllowInternalAndGclb => std::option::Option::Some("ALLOW_INTERNAL_AND_GCLB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INGRESS_SETTINGS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INGRESS_SETTINGS_UNSPECIFIED)
-                }
-                "ALLOW_ALL" => std::option::Option::Some(Self::ALLOW_ALL),
-                "ALLOW_INTERNAL_ONLY" => std::option::Option::Some(Self::ALLOW_INTERNAL_ONLY),
-                "ALLOW_INTERNAL_AND_GCLB" => {
-                    std::option::Option::Some(Self::ALLOW_INTERNAL_AND_GCLB)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IngressSettings {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IngressSettings {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IngressSettings {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IngressSettings {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllowAll,
+                2 => Self::AllowInternalOnly,
+                3 => Self::AllowInternalAndGclb,
+                _ => Self::UnknownValue(ingress_settings::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IngressSettings {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INGRESS_SETTINGS_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW_ALL" => Self::AllowAll,
+                "ALLOW_INTERNAL_ONLY" => Self::AllowInternalOnly,
+                "ALLOW_INTERNAL_AND_GCLB" => Self::AllowInternalAndGclb,
+                _ => Self::UnknownValue(ingress_settings::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IngressSettings {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllowAll => serializer.serialize_i32(1),
+                Self::AllowInternalOnly => serializer.serialize_i32(2),
+                Self::AllowInternalAndGclb => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IngressSettings {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IngressSettings>::new(
+                ".google.cloud.functions.v2.ServiceConfig.IngressSettings",
+            ))
         }
     }
 
@@ -1686,65 +1995,124 @@ pub mod service_config {
     ///
     /// Security level is only configurable for 1st Gen functions, If unspecified,
     /// SECURE_OPTIONAL will be used. 2nd Gen functions are SECURE_ALWAYS ONLY.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SecurityLevel(i32);
-
-    impl SecurityLevel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SecurityLevel {
         /// Unspecified.
-        pub const SECURITY_LEVEL_UNSPECIFIED: SecurityLevel = SecurityLevel::new(0);
-
+        Unspecified,
         /// Requests for a URL that match this handler that do not use HTTPS are
         /// automatically redirected to the HTTPS URL with the same path. Query
         /// parameters are reserved for the redirect.
-        pub const SECURE_ALWAYS: SecurityLevel = SecurityLevel::new(1);
-
+        SecureAlways,
         /// Both HTTP and HTTPS requests with URLs that match the handler succeed
         /// without redirects. The application can examine the request to determine
         /// which protocol was used and respond accordingly.
-        pub const SECURE_OPTIONAL: SecurityLevel = SecurityLevel::new(2);
+        SecureOptional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SecurityLevel::value] or
+        /// [SecurityLevel::name].
+        UnknownValue(security_level::UnknownValue),
+    }
 
-        /// Creates a new SecurityLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod security_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SecurityLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SecureAlways => std::option::Option::Some(1),
+                Self::SecureOptional => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SECURITY_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SECURE_ALWAYS"),
-                2 => std::borrow::Cow::Borrowed("SECURE_OPTIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SECURITY_LEVEL_UNSPECIFIED"),
+                Self::SecureAlways => std::option::Option::Some("SECURE_ALWAYS"),
+                Self::SecureOptional => std::option::Option::Some("SECURE_OPTIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SECURITY_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SECURITY_LEVEL_UNSPECIFIED)
-                }
-                "SECURE_ALWAYS" => std::option::Option::Some(Self::SECURE_ALWAYS),
-                "SECURE_OPTIONAL" => std::option::Option::Some(Self::SECURE_OPTIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SecurityLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SecurityLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SecurityLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SecurityLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SecureAlways,
+                2 => Self::SecureOptional,
+                _ => Self::UnknownValue(security_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SecurityLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SECURITY_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "SECURE_ALWAYS" => Self::SecureAlways,
+                "SECURE_OPTIONAL" => Self::SecureOptional,
+                _ => Self::UnknownValue(security_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SecurityLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SecureAlways => serializer.serialize_i32(1),
+                Self::SecureOptional => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SecurityLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SecurityLevel>::new(
+                ".google.cloud.functions.v2.ServiceConfig.SecurityLevel",
+            ))
         }
     }
 }
@@ -2104,64 +2472,121 @@ pub mod event_trigger {
 
     /// Describes the retry policy in case of function's execution failure.
     /// Retried execution is charged as any other execution.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetryPolicy(i32);
-
-    impl RetryPolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RetryPolicy {
         /// Not specified.
-        pub const RETRY_POLICY_UNSPECIFIED: RetryPolicy = RetryPolicy::new(0);
-
+        Unspecified,
         /// Do not retry.
-        pub const RETRY_POLICY_DO_NOT_RETRY: RetryPolicy = RetryPolicy::new(1);
-
+        DoNotRetry,
         /// Retry on any failure, retry up to 7 days with an exponential backoff
         /// (capped at 10 seconds).
-        pub const RETRY_POLICY_RETRY: RetryPolicy = RetryPolicy::new(2);
+        Retry,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RetryPolicy::value] or
+        /// [RetryPolicy::name].
+        UnknownValue(retry_policy::UnknownValue),
+    }
 
-        /// Creates a new RetryPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod retry_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RetryPolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DoNotRetry => std::option::Option::Some(1),
+                Self::Retry => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RETRY_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RETRY_POLICY_DO_NOT_RETRY"),
-                2 => std::borrow::Cow::Borrowed("RETRY_POLICY_RETRY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RETRY_POLICY_UNSPECIFIED"),
+                Self::DoNotRetry => std::option::Option::Some("RETRY_POLICY_DO_NOT_RETRY"),
+                Self::Retry => std::option::Option::Some("RETRY_POLICY_RETRY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RETRY_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RETRY_POLICY_UNSPECIFIED)
-                }
-                "RETRY_POLICY_DO_NOT_RETRY" => {
-                    std::option::Option::Some(Self::RETRY_POLICY_DO_NOT_RETRY)
-                }
-                "RETRY_POLICY_RETRY" => std::option::Option::Some(Self::RETRY_POLICY_RETRY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RetryPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RetryPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RetryPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RetryPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DoNotRetry,
+                2 => Self::Retry,
+                _ => Self::UnknownValue(retry_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RetryPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RETRY_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "RETRY_POLICY_DO_NOT_RETRY" => Self::DoNotRetry,
+                "RETRY_POLICY_RETRY" => Self::Retry,
+                _ => Self::UnknownValue(retry_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RetryPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DoNotRetry => serializer.serialize_i32(1),
+                Self::Retry => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RetryPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RetryPolicy>::new(
+                ".google.cloud.functions.v2.EventTrigger.RetryPolicy",
+            ))
         }
     }
 }
@@ -2971,81 +3396,148 @@ pub mod list_runtimes_response {
     }
 
     /// The various stages that a runtime can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RuntimeStage(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RuntimeStage {
+        /// Not specified.
+        Unspecified,
+        /// The runtime is in development.
+        Development,
+        /// The runtime is in the Alpha stage.
+        Alpha,
+        /// The runtime is in the Beta stage.
+        Beta,
+        /// The runtime is generally available.
+        Ga,
+        /// The runtime is deprecated.
+        Deprecated,
+        /// The runtime is no longer supported.
+        Decommissioned,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RuntimeStage::value] or
+        /// [RuntimeStage::name].
+        UnknownValue(runtime_stage::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod runtime_stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RuntimeStage {
-        /// Not specified.
-        pub const RUNTIME_STAGE_UNSPECIFIED: RuntimeStage = RuntimeStage::new(0);
-
-        /// The runtime is in development.
-        pub const DEVELOPMENT: RuntimeStage = RuntimeStage::new(1);
-
-        /// The runtime is in the Alpha stage.
-        pub const ALPHA: RuntimeStage = RuntimeStage::new(2);
-
-        /// The runtime is in the Beta stage.
-        pub const BETA: RuntimeStage = RuntimeStage::new(3);
-
-        /// The runtime is generally available.
-        pub const GA: RuntimeStage = RuntimeStage::new(4);
-
-        /// The runtime is deprecated.
-        pub const DEPRECATED: RuntimeStage = RuntimeStage::new(5);
-
-        /// The runtime is no longer supported.
-        pub const DECOMMISSIONED: RuntimeStage = RuntimeStage::new(6);
-
-        /// Creates a new RuntimeStage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Development => std::option::Option::Some(1),
+                Self::Alpha => std::option::Option::Some(2),
+                Self::Beta => std::option::Option::Some(3),
+                Self::Ga => std::option::Option::Some(4),
+                Self::Deprecated => std::option::Option::Some(5),
+                Self::Decommissioned => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RUNTIME_STAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEVELOPMENT"),
-                2 => std::borrow::Cow::Borrowed("ALPHA"),
-                3 => std::borrow::Cow::Borrowed("BETA"),
-                4 => std::borrow::Cow::Borrowed("GA"),
-                5 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                6 => std::borrow::Cow::Borrowed("DECOMMISSIONED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RUNTIME_STAGE_UNSPECIFIED"),
+                Self::Development => std::option::Option::Some("DEVELOPMENT"),
+                Self::Alpha => std::option::Option::Some("ALPHA"),
+                Self::Beta => std::option::Option::Some("BETA"),
+                Self::Ga => std::option::Option::Some("GA"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::Decommissioned => std::option::Option::Some("DECOMMISSIONED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RUNTIME_STAGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RUNTIME_STAGE_UNSPECIFIED)
-                }
-                "DEVELOPMENT" => std::option::Option::Some(Self::DEVELOPMENT),
-                "ALPHA" => std::option::Option::Some(Self::ALPHA),
-                "BETA" => std::option::Option::Some(Self::BETA),
-                "GA" => std::option::Option::Some(Self::GA),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                "DECOMMISSIONED" => std::option::Option::Some(Self::DECOMMISSIONED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RuntimeStage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RuntimeStage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RuntimeStage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RuntimeStage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Development,
+                2 => Self::Alpha,
+                3 => Self::Beta,
+                4 => Self::Ga,
+                5 => Self::Deprecated,
+                6 => Self::Decommissioned,
+                _ => Self::UnknownValue(runtime_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RuntimeStage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RUNTIME_STAGE_UNSPECIFIED" => Self::Unspecified,
+                "DEVELOPMENT" => Self::Development,
+                "ALPHA" => Self::Alpha,
+                "BETA" => Self::Beta,
+                "GA" => Self::Ga,
+                "DEPRECATED" => Self::Deprecated,
+                "DECOMMISSIONED" => Self::Decommissioned,
+                _ => Self::UnknownValue(runtime_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RuntimeStage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Development => serializer.serialize_i32(1),
+                Self::Alpha => serializer.serialize_i32(2),
+                Self::Beta => serializer.serialize_i32(3),
+                Self::Ga => serializer.serialize_i32(4),
+                Self::Deprecated => serializer.serialize_i32(5),
+                Self::Decommissioned => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RuntimeStage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RuntimeStage>::new(
+                ".google.cloud.functions.v2.ListRuntimesResponse.RuntimeStage",
+            ))
         }
     }
 }
@@ -3401,262 +3893,518 @@ pub mod stage {
     use super::*;
 
     /// Possible names for a Stage
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Name(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Name {
+        /// Not specified. Invalid name.
+        Unspecified,
+        /// Artifact Registry Stage
+        ArtifactRegistry,
+        /// Build Stage
+        Build,
+        /// Service Stage
+        Service,
+        /// Trigger Stage
+        Trigger,
+        /// Service Rollback Stage
+        ServiceRollback,
+        /// Trigger Rollback Stage
+        TriggerRollback,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Name::value] or
+        /// [Name::name].
+        UnknownValue(name::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod name {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Name {
-        /// Not specified. Invalid name.
-        pub const NAME_UNSPECIFIED: Name = Name::new(0);
-
-        /// Artifact Registry Stage
-        pub const ARTIFACT_REGISTRY: Name = Name::new(1);
-
-        /// Build Stage
-        pub const BUILD: Name = Name::new(2);
-
-        /// Service Stage
-        pub const SERVICE: Name = Name::new(3);
-
-        /// Trigger Stage
-        pub const TRIGGER: Name = Name::new(4);
-
-        /// Service Rollback Stage
-        pub const SERVICE_ROLLBACK: Name = Name::new(5);
-
-        /// Trigger Rollback Stage
-        pub const TRIGGER_ROLLBACK: Name = Name::new(6);
-
-        /// Creates a new Name instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ArtifactRegistry => std::option::Option::Some(1),
+                Self::Build => std::option::Option::Some(2),
+                Self::Service => std::option::Option::Some(3),
+                Self::Trigger => std::option::Option::Some(4),
+                Self::ServiceRollback => std::option::Option::Some(5),
+                Self::TriggerRollback => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NAME_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ARTIFACT_REGISTRY"),
-                2 => std::borrow::Cow::Borrowed("BUILD"),
-                3 => std::borrow::Cow::Borrowed("SERVICE"),
-                4 => std::borrow::Cow::Borrowed("TRIGGER"),
-                5 => std::borrow::Cow::Borrowed("SERVICE_ROLLBACK"),
-                6 => std::borrow::Cow::Borrowed("TRIGGER_ROLLBACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NAME_UNSPECIFIED"),
+                Self::ArtifactRegistry => std::option::Option::Some("ARTIFACT_REGISTRY"),
+                Self::Build => std::option::Option::Some("BUILD"),
+                Self::Service => std::option::Option::Some("SERVICE"),
+                Self::Trigger => std::option::Option::Some("TRIGGER"),
+                Self::ServiceRollback => std::option::Option::Some("SERVICE_ROLLBACK"),
+                Self::TriggerRollback => std::option::Option::Some("TRIGGER_ROLLBACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NAME_UNSPECIFIED" => std::option::Option::Some(Self::NAME_UNSPECIFIED),
-                "ARTIFACT_REGISTRY" => std::option::Option::Some(Self::ARTIFACT_REGISTRY),
-                "BUILD" => std::option::Option::Some(Self::BUILD),
-                "SERVICE" => std::option::Option::Some(Self::SERVICE),
-                "TRIGGER" => std::option::Option::Some(Self::TRIGGER),
-                "SERVICE_ROLLBACK" => std::option::Option::Some(Self::SERVICE_ROLLBACK),
-                "TRIGGER_ROLLBACK" => std::option::Option::Some(Self::TRIGGER_ROLLBACK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Name {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Name {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Name {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Name {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ArtifactRegistry,
+                2 => Self::Build,
+                3 => Self::Service,
+                4 => Self::Trigger,
+                5 => Self::ServiceRollback,
+                6 => Self::TriggerRollback,
+                _ => Self::UnknownValue(name::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Name {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NAME_UNSPECIFIED" => Self::Unspecified,
+                "ARTIFACT_REGISTRY" => Self::ArtifactRegistry,
+                "BUILD" => Self::Build,
+                "SERVICE" => Self::Service,
+                "TRIGGER" => Self::Trigger,
+                "SERVICE_ROLLBACK" => Self::ServiceRollback,
+                "TRIGGER_ROLLBACK" => Self::TriggerRollback,
+                _ => Self::UnknownValue(name::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Name {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ArtifactRegistry => serializer.serialize_i32(1),
+                Self::Build => serializer.serialize_i32(2),
+                Self::Service => serializer.serialize_i32(3),
+                Self::Trigger => serializer.serialize_i32(4),
+                Self::ServiceRollback => serializer.serialize_i32(5),
+                Self::TriggerRollback => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Name {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Name>::new(
+                ".google.cloud.functions.v2.Stage.Name",
+            ))
         }
     }
 
     /// Possible states for a Stage
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not specified. Invalid state.
+        Unspecified,
+        /// Stage has not started.
+        NotStarted,
+        /// Stage is in progress.
+        InProgress,
+        /// Stage has completed.
+        Complete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not specified. Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Stage has not started.
-        pub const NOT_STARTED: State = State::new(1);
-
-        /// Stage is in progress.
-        pub const IN_PROGRESS: State = State::new(2);
-
-        /// Stage has completed.
-        pub const COMPLETE: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotStarted => std::option::Option::Some(1),
+                Self::InProgress => std::option::Option::Some(2),
+                Self::Complete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_STARTED"),
-                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("COMPLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::NotStarted => std::option::Option::Some("NOT_STARTED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Complete => std::option::Option::Some("COMPLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NOT_STARTED" => std::option::Option::Some(Self::NOT_STARTED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotStarted,
+                2 => Self::InProgress,
+                3 => Self::Complete,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NOT_STARTED" => Self::NotStarted,
+                "IN_PROGRESS" => Self::InProgress,
+                "COMPLETE" => Self::Complete,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotStarted => serializer.serialize_i32(1),
+                Self::InProgress => serializer.serialize_i32(2),
+                Self::Complete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.functions.v2.Stage.State",
+            ))
         }
     }
 }
 
 /// The type of the long running operation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperationType {
+    /// Unspecified
+    OperationtypeUnspecified,
+    /// CreateFunction
+    CreateFunction,
+    /// UpdateFunction
+    UpdateFunction,
+    /// DeleteFunction
+    DeleteFunction,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperationType::value] or
+    /// [OperationType::name].
+    UnknownValue(operation_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod operation_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl OperationType {
-    /// Unspecified
-    pub const OPERATIONTYPE_UNSPECIFIED: OperationType = OperationType::new(0);
-
-    /// CreateFunction
-    pub const CREATE_FUNCTION: OperationType = OperationType::new(1);
-
-    /// UpdateFunction
-    pub const UPDATE_FUNCTION: OperationType = OperationType::new(2);
-
-    /// DeleteFunction
-    pub const DELETE_FUNCTION: OperationType = OperationType::new(3);
-
-    /// Creates a new OperationType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::OperationtypeUnspecified => std::option::Option::Some(0),
+            Self::CreateFunction => std::option::Option::Some(1),
+            Self::UpdateFunction => std::option::Option::Some(2),
+            Self::DeleteFunction => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATIONTYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CREATE_FUNCTION"),
-            2 => std::borrow::Cow::Borrowed("UPDATE_FUNCTION"),
-            3 => std::borrow::Cow::Borrowed("DELETE_FUNCTION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATIONTYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATIONTYPE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::OperationtypeUnspecified => {
+                std::option::Option::Some("OPERATIONTYPE_UNSPECIFIED")
             }
-            "CREATE_FUNCTION" => std::option::Option::Some(Self::CREATE_FUNCTION),
-            "UPDATE_FUNCTION" => std::option::Option::Some(Self::UPDATE_FUNCTION),
-            "DELETE_FUNCTION" => std::option::Option::Some(Self::DELETE_FUNCTION),
-            _ => std::option::Option::None,
+            Self::CreateFunction => std::option::Option::Some("CREATE_FUNCTION"),
+            Self::UpdateFunction => std::option::Option::Some("UPDATE_FUNCTION"),
+            Self::DeleteFunction => std::option::Option::Some("DELETE_FUNCTION"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for OperationType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperationType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::OperationtypeUnspecified,
+            1 => Self::CreateFunction,
+            2 => Self::UpdateFunction,
+            3 => Self::DeleteFunction,
+            _ => Self::UnknownValue(operation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperationType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATIONTYPE_UNSPECIFIED" => Self::OperationtypeUnspecified,
+            "CREATE_FUNCTION" => Self::CreateFunction,
+            "UPDATE_FUNCTION" => Self::UpdateFunction,
+            "DELETE_FUNCTION" => Self::DeleteFunction,
+            _ => Self::UnknownValue(operation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperationType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::OperationtypeUnspecified => serializer.serialize_i32(0),
+            Self::CreateFunction => serializer.serialize_i32(1),
+            Self::UpdateFunction => serializer.serialize_i32(2),
+            Self::DeleteFunction => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperationType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationType>::new(
+            ".google.cloud.functions.v2.OperationType",
+        ))
     }
 }
 
 /// The environment the function is hosted on.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Environment(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Environment {
+    /// Unspecified
+    Unspecified,
+    /// Gen 1
+    Gen1,
+    /// Gen 2
+    Gen2,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Environment::value] or
+    /// [Environment::name].
+    UnknownValue(environment::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod environment {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Environment {
-    /// Unspecified
-    pub const ENVIRONMENT_UNSPECIFIED: Environment = Environment::new(0);
-
-    /// Gen 1
-    pub const GEN_1: Environment = Environment::new(1);
-
-    /// Gen 2
-    pub const GEN_2: Environment = Environment::new(2);
-
-    /// Creates a new Environment instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Gen1 => std::option::Option::Some(1),
+            Self::Gen2 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENVIRONMENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GEN_1"),
-            2 => std::borrow::Cow::Borrowed("GEN_2"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENVIRONMENT_UNSPECIFIED"),
+            Self::Gen1 => std::option::Option::Some("GEN_1"),
+            Self::Gen2 => std::option::Option::Some("GEN_2"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENVIRONMENT_UNSPECIFIED" => std::option::Option::Some(Self::ENVIRONMENT_UNSPECIFIED),
-            "GEN_1" => std::option::Option::Some(Self::GEN_1),
-            "GEN_2" => std::option::Option::Some(Self::GEN_2),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Environment {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Environment {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Environment {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Gen1,
+            2 => Self::Gen2,
+            _ => Self::UnknownValue(environment::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Environment {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENVIRONMENT_UNSPECIFIED" => Self::Unspecified,
+            "GEN_1" => Self::Gen1,
+            "GEN_2" => Self::Gen2,
+            _ => Self::UnknownValue(environment::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Environment {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Gen1 => serializer.serialize_i32(1),
+            Self::Gen2 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Environment {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Environment>::new(
+            ".google.cloud.functions.v2.Environment",
+        ))
     }
 }

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -693,77 +693,144 @@ pub mod backup {
     }
 
     /// State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The Backup resource is in the process of being created.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The Backup resource has been created and the associated BackupJob
         /// Kubernetes resource has been injected into the source cluster.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The gkebackup agent in the cluster has begun executing the backup
         /// operation.
-        pub const IN_PROGRESS: State = State::new(2);
-
+        InProgress,
         /// The backup operation has completed successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The backup operation has failed.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// This Backup resource (and its associated artifacts) is in the process
         /// of being deleted.
-        pub const DELETING: State = State::new(5);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::InProgress => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::InProgress,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "IN_PROGRESS" => Self::InProgress,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::InProgress => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkebackup.v1.Backup.State",
+            ))
         }
     }
 
@@ -1453,79 +1520,148 @@ pub mod backup_plan {
     }
 
     /// State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default first value for Enums.
+        Unspecified,
+        /// Waiting for cluster state to be RUNNING.
+        ClusterPending,
+        /// The BackupPlan is in the process of being created.
+        Provisioning,
+        /// The BackupPlan has successfully been created and is ready for Backups.
+        Ready,
+        /// BackupPlan creation has failed.
+        Failed,
+        /// The BackupPlan has been deactivated.
+        Deactivated,
+        /// The BackupPlan is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default first value for Enums.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Waiting for cluster state to be RUNNING.
-        pub const CLUSTER_PENDING: State = State::new(1);
-
-        /// The BackupPlan is in the process of being created.
-        pub const PROVISIONING: State = State::new(2);
-
-        /// The BackupPlan has successfully been created and is ready for Backups.
-        pub const READY: State = State::new(3);
-
-        /// BackupPlan creation has failed.
-        pub const FAILED: State = State::new(4);
-
-        /// The BackupPlan has been deactivated.
-        pub const DEACTIVATED: State = State::new(5);
-
-        /// The BackupPlan is in the process of being deleted.
-        pub const DELETING: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ClusterPending => std::option::Option::Some(1),
+                Self::Provisioning => std::option::Option::Some(2),
+                Self::Ready => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Deactivated => std::option::Option::Some(5),
+                Self::Deleting => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLUSTER_PENDING"),
-                2 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                3 => std::borrow::Cow::Borrowed("READY"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("DEACTIVATED"),
-                6 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::ClusterPending => std::option::Option::Some("CLUSTER_PENDING"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deactivated => std::option::Option::Some("DEACTIVATED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CLUSTER_PENDING" => std::option::Option::Some(Self::CLUSTER_PENDING),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DEACTIVATED" => std::option::Option::Some(Self::DEACTIVATED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ClusterPending,
+                2 => Self::Provisioning,
+                3 => Self::Ready,
+                4 => Self::Failed,
+                5 => Self::Deactivated,
+                6 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CLUSTER_PENDING" => Self::ClusterPending,
+                "PROVISIONING" => Self::Provisioning,
+                "READY" => Self::Ready,
+                "FAILED" => Self::Failed,
+                "DEACTIVATED" => Self::Deactivated,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ClusterPending => serializer.serialize_i32(1),
+                Self::Provisioning => serializer.serialize_i32(2),
+                Self::Ready => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Deactivated => serializer.serialize_i32(5),
+                Self::Deleting => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkebackup.v1.BackupPlan.State",
+            ))
         }
     }
 }
@@ -1995,56 +2131,113 @@ pub mod volume_type_enum {
     use super::*;
 
     /// Supported volume types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VolumeType {
+        /// Default
+        Unspecified,
+        /// Compute Engine Persistent Disk volume
+        GcePersistentDisk,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VolumeType::value] or
+        /// [VolumeType::name].
+        UnknownValue(volume_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod volume_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VolumeType {
-        /// Default
-        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new(0);
-
-        /// Compute Engine Persistent Disk volume
-        pub const GCE_PERSISTENT_DISK: VolumeType = VolumeType::new(1);
-
-        /// Creates a new VolumeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GcePersistentDisk => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VOLUME_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCE_PERSISTENT_DISK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VOLUME_TYPE_UNSPECIFIED"),
+                Self::GcePersistentDisk => std::option::Option::Some("GCE_PERSISTENT_DISK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VOLUME_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VOLUME_TYPE_UNSPECIFIED)
-                }
-                "GCE_PERSISTENT_DISK" => std::option::Option::Some(Self::GCE_PERSISTENT_DISK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VolumeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VolumeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VolumeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GcePersistentDisk,
+                _ => Self::UnknownValue(volume_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VolumeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VOLUME_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GCE_PERSISTENT_DISK" => Self::GcePersistentDisk,
+                _ => Self::UnknownValue(volume_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VolumeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GcePersistentDisk => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VolumeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VolumeType>::new(
+                ".google.cloud.gkebackup.v1.VolumeTypeEnum.VolumeType",
+            ))
         }
     }
 }
@@ -4439,77 +4632,144 @@ pub mod restore {
     }
 
     /// Possible values for state of the Restore.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The Restore resource is in the process of being created.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The Restore resource has been created and the associated RestoreJob
         /// Kubernetes resource has been injected into target cluster.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The gkebackup agent in the cluster has begun executing the restore
         /// operation.
-        pub const IN_PROGRESS: State = State::new(2);
-
+        InProgress,
         /// The restore operation has completed successfully. Restored workloads may
         /// not yet be operational.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The restore operation has failed.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// This Restore resource is in the process of being deleted.
-        pub const DELETING: State = State::new(5);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::InProgress => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::InProgress,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "IN_PROGRESS" => Self::InProgress,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::InProgress => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkebackup.v1.Restore.State",
+            ))
         }
     }
 }
@@ -5213,24 +5473,19 @@ pub mod restore_config {
         use super::*;
 
         /// Possible values for operations of a transformation rule action.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Op(i32);
-
-        impl Op {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Op {
             /// Unspecified operation
-            pub const OP_UNSPECIFIED: Op = Op::new(0);
-
+            Unspecified,
             /// The "remove" operation removes the value at the target location.
-            pub const REMOVE: Op = Op::new(1);
-
+            Remove,
             /// The "move" operation removes the value at a specified location and
             /// adds it to the target location.
-            pub const MOVE: Op = Op::new(2);
-
+            Move,
             /// The "copy" operation copies the value at a specified location to the
             /// target location.
-            pub const COPY: Op = Op::new(3);
-
+            Copy,
             /// The "add" operation performs one of the following functions,
             /// depending upon what the target location references:
             ///
@@ -5240,65 +5495,142 @@ pub mod restore_config {
             ///   already exist, a new member is added to the object.
             /// . If the target location specifies an object member that does exist,
             ///   that member's value is replaced.
-            pub const ADD: Op = Op::new(4);
-
+            Add,
             /// The "test" operation tests that a value at the target location is
             /// equal to a specified value.
-            pub const TEST: Op = Op::new(5);
-
+            Test,
             /// The "replace" operation replaces the value at the target location
             /// with a new value.  The operation object MUST contain a "value" member
             /// whose content specifies the replacement value.
-            pub const REPLACE: Op = Op::new(6);
+            Replace,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Op::value] or
+            /// [Op::name].
+            UnknownValue(op::UnknownValue),
+        }
 
-            /// Creates a new Op instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod op {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Op {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Remove => std::option::Option::Some(1),
+                    Self::Move => std::option::Option::Some(2),
+                    Self::Copy => std::option::Option::Some(3),
+                    Self::Add => std::option::Option::Some(4),
+                    Self::Test => std::option::Option::Some(5),
+                    Self::Replace => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OP_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("REMOVE"),
-                    2 => std::borrow::Cow::Borrowed("MOVE"),
-                    3 => std::borrow::Cow::Borrowed("COPY"),
-                    4 => std::borrow::Cow::Borrowed("ADD"),
-                    5 => std::borrow::Cow::Borrowed("TEST"),
-                    6 => std::borrow::Cow::Borrowed("REPLACE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OP_UNSPECIFIED"),
+                    Self::Remove => std::option::Option::Some("REMOVE"),
+                    Self::Move => std::option::Option::Some("MOVE"),
+                    Self::Copy => std::option::Option::Some("COPY"),
+                    Self::Add => std::option::Option::Some("ADD"),
+                    Self::Test => std::option::Option::Some("TEST"),
+                    Self::Replace => std::option::Option::Some("REPLACE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OP_UNSPECIFIED" => std::option::Option::Some(Self::OP_UNSPECIFIED),
-                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                    "MOVE" => std::option::Option::Some(Self::MOVE),
-                    "COPY" => std::option::Option::Some(Self::COPY),
-                    "ADD" => std::option::Option::Some(Self::ADD),
-                    "TEST" => std::option::Option::Some(Self::TEST),
-                    "REPLACE" => std::option::Option::Some(Self::REPLACE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Op {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Op {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Op {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Op {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Remove,
+                    2 => Self::Move,
+                    3 => Self::Copy,
+                    4 => Self::Add,
+                    5 => Self::Test,
+                    6 => Self::Replace,
+                    _ => Self::UnknownValue(op::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Op {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OP_UNSPECIFIED" => Self::Unspecified,
+                    "REMOVE" => Self::Remove,
+                    "MOVE" => Self::Move,
+                    "COPY" => Self::Copy,
+                    "ADD" => Self::Add,
+                    "TEST" => Self::Test,
+                    "REPLACE" => Self::Replace,
+                    _ => Self::UnknownValue(op::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Op {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Remove => serializer.serialize_i32(1),
+                    Self::Move => serializer.serialize_i32(2),
+                    Self::Copy => serializer.serialize_i32(3),
+                    Self::Add => serializer.serialize_i32(4),
+                    Self::Test => serializer.serialize_i32(5),
+                    Self::Replace => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Op {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Op>::new(
+                    ".google.cloud.gkebackup.v1.RestoreConfig.TransformationRuleAction.Op",
+                ))
             }
         }
     }
@@ -5659,162 +5991,280 @@ pub mod restore_config {
     }
 
     /// Defines how volume data should be restored.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeDataRestorePolicy(i32);
-
-    impl VolumeDataRestorePolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VolumeDataRestorePolicy {
         /// Unspecified (illegal).
-        pub const VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new(0);
-
+        Unspecified,
         /// For each PVC to be restored, create a new underlying volume and PV
         /// from the corresponding VolumeBackup contained within the Backup.
-        pub const RESTORE_VOLUME_DATA_FROM_BACKUP: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new(1);
-
+        RestoreVolumeDataFromBackup,
         /// For each PVC to be restored, attempt to reuse the original PV contained
         /// in the Backup (with its original underlying volume). This option
         /// is likely only usable when restoring a workload to its original cluster.
-        pub const REUSE_VOLUME_HANDLE_FROM_BACKUP: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new(2);
-
+        ReuseVolumeHandleFromBackup,
         /// For each PVC to be restored, create PVC without any particular
         /// action to restore data. In this case, the normal Kubernetes provisioning
         /// logic would kick in, and this would likely result in either dynamically
         /// provisioning blank PVs or binding to statically provisioned PVs.
-        pub const NO_VOLUME_DATA_RESTORATION: VolumeDataRestorePolicy =
-            VolumeDataRestorePolicy::new(3);
+        NoVolumeDataRestoration,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VolumeDataRestorePolicy::value] or
+        /// [VolumeDataRestorePolicy::name].
+        UnknownValue(volume_data_restore_policy::UnknownValue),
+    }
 
-        /// Creates a new VolumeDataRestorePolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod volume_data_restore_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl VolumeDataRestorePolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RestoreVolumeDataFromBackup => std::option::Option::Some(1),
+                Self::ReuseVolumeHandleFromBackup => std::option::Option::Some(2),
+                Self::NoVolumeDataRestoration => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESTORE_VOLUME_DATA_FROM_BACKUP"),
-                2 => std::borrow::Cow::Borrowed("REUSE_VOLUME_HANDLE_FROM_BACKUP"),
-                3 => std::borrow::Cow::Borrowed("NO_VOLUME_DATA_RESTORATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED")
+                }
+                Self::RestoreVolumeDataFromBackup => {
+                    std::option::Option::Some("RESTORE_VOLUME_DATA_FROM_BACKUP")
+                }
+                Self::ReuseVolumeHandleFromBackup => {
+                    std::option::Option::Some("REUSE_VOLUME_HANDLE_FROM_BACKUP")
+                }
+                Self::NoVolumeDataRestoration => {
+                    std::option::Option::Some("NO_VOLUME_DATA_RESTORATION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED)
-                }
-                "RESTORE_VOLUME_DATA_FROM_BACKUP" => {
-                    std::option::Option::Some(Self::RESTORE_VOLUME_DATA_FROM_BACKUP)
-                }
-                "REUSE_VOLUME_HANDLE_FROM_BACKUP" => {
-                    std::option::Option::Some(Self::REUSE_VOLUME_HANDLE_FROM_BACKUP)
-                }
-                "NO_VOLUME_DATA_RESTORATION" => {
-                    std::option::Option::Some(Self::NO_VOLUME_DATA_RESTORATION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VolumeDataRestorePolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeDataRestorePolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VolumeDataRestorePolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VolumeDataRestorePolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RestoreVolumeDataFromBackup,
+                2 => Self::ReuseVolumeHandleFromBackup,
+                3 => Self::NoVolumeDataRestoration,
+                _ => Self::UnknownValue(volume_data_restore_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VolumeDataRestorePolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VOLUME_DATA_RESTORE_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "RESTORE_VOLUME_DATA_FROM_BACKUP" => Self::RestoreVolumeDataFromBackup,
+                "REUSE_VOLUME_HANDLE_FROM_BACKUP" => Self::ReuseVolumeHandleFromBackup,
+                "NO_VOLUME_DATA_RESTORATION" => Self::NoVolumeDataRestoration,
+                _ => Self::UnknownValue(volume_data_restore_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VolumeDataRestorePolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RestoreVolumeDataFromBackup => serializer.serialize_i32(1),
+                Self::ReuseVolumeHandleFromBackup => serializer.serialize_i32(2),
+                Self::NoVolumeDataRestoration => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VolumeDataRestorePolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<VolumeDataRestorePolicy>::new(
+                    ".google.cloud.gkebackup.v1.RestoreConfig.VolumeDataRestorePolicy",
+                ),
+            )
         }
     }
 
     /// Defines the behavior for handling the situation where cluster-scoped
     /// resources being restored already exist in the target cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterResourceConflictPolicy(i32);
-
-    impl ClusterResourceConflictPolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ClusterResourceConflictPolicy {
         /// Unspecified. Only allowed if no cluster-scoped resources will be
         /// restored.
-        pub const CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED: ClusterResourceConflictPolicy =
-            ClusterResourceConflictPolicy::new(0);
-
+        Unspecified,
         /// Do not attempt to restore the conflicting resource.
-        pub const USE_EXISTING_VERSION: ClusterResourceConflictPolicy =
-            ClusterResourceConflictPolicy::new(1);
-
+        UseExistingVersion,
         /// Delete the existing version before re-creating it from the Backup.
         /// This is a dangerous option which could cause unintentional
         /// data loss if used inappropriately. For example, deleting a CRD will
         /// cause Kubernetes to delete all CRs of that type.
-        pub const USE_BACKUP_VERSION: ClusterResourceConflictPolicy =
-            ClusterResourceConflictPolicy::new(2);
+        UseBackupVersion,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ClusterResourceConflictPolicy::value] or
+        /// [ClusterResourceConflictPolicy::name].
+        UnknownValue(cluster_resource_conflict_policy::UnknownValue),
+    }
 
-        /// Creates a new ClusterResourceConflictPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cluster_resource_conflict_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ClusterResourceConflictPolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UseExistingVersion => std::option::Option::Some(1),
+                Self::UseBackupVersion => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USE_EXISTING_VERSION"),
-                2 => std::borrow::Cow::Borrowed("USE_BACKUP_VERSION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED")
                 }
-                "USE_EXISTING_VERSION" => std::option::Option::Some(Self::USE_EXISTING_VERSION),
-                "USE_BACKUP_VERSION" => std::option::Option::Some(Self::USE_BACKUP_VERSION),
-                _ => std::option::Option::None,
+                Self::UseExistingVersion => std::option::Option::Some("USE_EXISTING_VERSION"),
+                Self::UseBackupVersion => std::option::Option::Some("USE_BACKUP_VERSION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ClusterResourceConflictPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterResourceConflictPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ClusterResourceConflictPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ClusterResourceConflictPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UseExistingVersion,
+                2 => Self::UseBackupVersion,
+                _ => Self::UnknownValue(cluster_resource_conflict_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ClusterResourceConflictPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLUSTER_RESOURCE_CONFLICT_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "USE_EXISTING_VERSION" => Self::UseExistingVersion,
+                "USE_BACKUP_VERSION" => Self::UseBackupVersion,
+                _ => Self::UnknownValue(cluster_resource_conflict_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ClusterResourceConflictPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UseExistingVersion => serializer.serialize_i32(1),
+                Self::UseBackupVersion => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ClusterResourceConflictPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<ClusterResourceConflictPolicy>::new(
+                    ".google.cloud.gkebackup.v1.RestoreConfig.ClusterResourceConflictPolicy",
+                ),
+            )
         }
     }
 
     /// Defines the behavior for handling the situation where sets of namespaced
     /// resources being restored already exist in the target cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NamespacedResourceRestoreMode(i32);
-
-    impl NamespacedResourceRestoreMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NamespacedResourceRestoreMode {
         /// Unspecified (invalid).
-        pub const NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new(0);
-
+        Unspecified,
         /// When conflicting top-level resources (either Namespaces or
         /// ProtectedApplications, depending upon the scope) are encountered, this
         /// will first trigger a delete of the conflicting resource AND ALL OF ITS
@@ -5822,24 +6272,18 @@ pub mod restore_config {
         /// resources referenced by the ProtectedApplication) before restoring the
         /// resources from the Backup. This mode should only be used when you are
         /// intending to revert some portion of a cluster to an earlier state.
-        pub const DELETE_AND_RESTORE: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new(1);
-
+        DeleteAndRestore,
         /// If conflicting top-level resources (either Namespaces or
         /// ProtectedApplications, depending upon the scope) are encountered at the
         /// beginning of a restore process, the Restore will fail.  If a conflict
         /// occurs during the restore process itself (e.g., because an out of band
         /// process creates conflicting resources), a conflict will be reported.
-        pub const FAIL_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new(2);
-
+        FailOnConflict,
         /// This mode merges the backup and the target cluster and skips the
         /// conflicting resources. If a single resource to restore exists in the
         /// cluster before restoration, the resource will be skipped, otherwise it
         /// will be restored.
-        pub const MERGE_SKIP_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new(3);
-
+        MergeSkipOnConflict,
         /// This mode merges the backup and the target cluster and skips the
         /// conflicting resources except volume data. If a PVC to restore already
         /// exists, this mode will restore/reconnect the volume without overwriting
@@ -5854,9 +6298,7 @@ pub mod restore_config {
         ///   policy of the original PV.
         ///   Note that this mode could cause data loss as the original PV can be
         ///   retained or deleted depending on its reclaim policy.
-        pub const MERGE_REPLACE_VOLUME_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new(4);
-
+        MergeReplaceVolumeOnConflict,
         /// This mode merges the backup and the target cluster and replaces the
         /// conflicting resources with the ones in the backup. If a single resource
         /// to restore exists in the cluster before restoration, the resource will be
@@ -5867,61 +6309,135 @@ pub mod restore_config {
         /// Note that this mode could cause data loss as it replaces the existing
         /// resources in the target cluster, and the original PV can be retained or
         /// deleted depending on its reclaim policy.
-        pub const MERGE_REPLACE_ON_CONFLICT: NamespacedResourceRestoreMode =
-            NamespacedResourceRestoreMode::new(5);
+        MergeReplaceOnConflict,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NamespacedResourceRestoreMode::value] or
+        /// [NamespacedResourceRestoreMode::name].
+        UnknownValue(namespaced_resource_restore_mode::UnknownValue),
+    }
 
-        /// Creates a new NamespacedResourceRestoreMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod namespaced_resource_restore_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NamespacedResourceRestoreMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DeleteAndRestore => std::option::Option::Some(1),
+                Self::FailOnConflict => std::option::Option::Some(2),
+                Self::MergeSkipOnConflict => std::option::Option::Some(3),
+                Self::MergeReplaceVolumeOnConflict => std::option::Option::Some(4),
+                Self::MergeReplaceOnConflict => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DELETE_AND_RESTORE"),
-                2 => std::borrow::Cow::Borrowed("FAIL_ON_CONFLICT"),
-                3 => std::borrow::Cow::Borrowed("MERGE_SKIP_ON_CONFLICT"),
-                4 => std::borrow::Cow::Borrowed("MERGE_REPLACE_VOLUME_ON_CONFLICT"),
-                5 => std::borrow::Cow::Borrowed("MERGE_REPLACE_ON_CONFLICT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED")
+                }
+                Self::DeleteAndRestore => std::option::Option::Some("DELETE_AND_RESTORE"),
+                Self::FailOnConflict => std::option::Option::Some("FAIL_ON_CONFLICT"),
+                Self::MergeSkipOnConflict => std::option::Option::Some("MERGE_SKIP_ON_CONFLICT"),
+                Self::MergeReplaceVolumeOnConflict => {
+                    std::option::Option::Some("MERGE_REPLACE_VOLUME_ON_CONFLICT")
+                }
+                Self::MergeReplaceOnConflict => {
+                    std::option::Option::Some("MERGE_REPLACE_ON_CONFLICT")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED)
-                }
-                "DELETE_AND_RESTORE" => std::option::Option::Some(Self::DELETE_AND_RESTORE),
-                "FAIL_ON_CONFLICT" => std::option::Option::Some(Self::FAIL_ON_CONFLICT),
-                "MERGE_SKIP_ON_CONFLICT" => std::option::Option::Some(Self::MERGE_SKIP_ON_CONFLICT),
-                "MERGE_REPLACE_VOLUME_ON_CONFLICT" => {
-                    std::option::Option::Some(Self::MERGE_REPLACE_VOLUME_ON_CONFLICT)
-                }
-                "MERGE_REPLACE_ON_CONFLICT" => {
-                    std::option::Option::Some(Self::MERGE_REPLACE_ON_CONFLICT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NamespacedResourceRestoreMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NamespacedResourceRestoreMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NamespacedResourceRestoreMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NamespacedResourceRestoreMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DeleteAndRestore,
+                2 => Self::FailOnConflict,
+                3 => Self::MergeSkipOnConflict,
+                4 => Self::MergeReplaceVolumeOnConflict,
+                5 => Self::MergeReplaceOnConflict,
+                _ => Self::UnknownValue(namespaced_resource_restore_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NamespacedResourceRestoreMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NAMESPACED_RESOURCE_RESTORE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DELETE_AND_RESTORE" => Self::DeleteAndRestore,
+                "FAIL_ON_CONFLICT" => Self::FailOnConflict,
+                "MERGE_SKIP_ON_CONFLICT" => Self::MergeSkipOnConflict,
+                "MERGE_REPLACE_VOLUME_ON_CONFLICT" => Self::MergeReplaceVolumeOnConflict,
+                "MERGE_REPLACE_ON_CONFLICT" => Self::MergeReplaceOnConflict,
+                _ => Self::UnknownValue(namespaced_resource_restore_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NamespacedResourceRestoreMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DeleteAndRestore => serializer.serialize_i32(1),
+                Self::FailOnConflict => serializer.serialize_i32(2),
+                Self::MergeSkipOnConflict => serializer.serialize_i32(3),
+                Self::MergeReplaceVolumeOnConflict => serializer.serialize_i32(4),
+                Self::MergeReplaceOnConflict => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NamespacedResourceRestoreMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<NamespacedResourceRestoreMode>::new(
+                    ".google.cloud.gkebackup.v1.RestoreConfig.NamespacedResourceRestoreMode",
+                ),
+            )
         }
     }
 
@@ -6343,69 +6859,134 @@ pub mod restore_plan {
     use super::*;
 
     /// State
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default first value for Enums.
+        Unspecified,
+        /// Waiting for cluster state to be RUNNING.
+        ClusterPending,
+        /// The RestorePlan has successfully been created and is ready for Restores.
+        Ready,
+        /// RestorePlan creation has failed.
+        Failed,
+        /// The RestorePlan is in the process of being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default first value for Enums.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Waiting for cluster state to be RUNNING.
-        pub const CLUSTER_PENDING: State = State::new(1);
-
-        /// The RestorePlan has successfully been created and is ready for Restores.
-        pub const READY: State = State::new(2);
-
-        /// RestorePlan creation has failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The RestorePlan is in the process of being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ClusterPending => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLUSTER_PENDING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::ClusterPending => std::option::Option::Some("CLUSTER_PENDING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CLUSTER_PENDING" => std::option::Option::Some(Self::CLUSTER_PENDING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ClusterPending,
+                2 => Self::Ready,
+                3 => Self::Failed,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CLUSTER_PENDING" => Self::ClusterPending,
+                "READY" => Self::Ready,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ClusterPending => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkebackup.v1.RestorePlan.State",
+            ))
         }
     }
 }
@@ -6610,139 +7191,265 @@ pub mod volume_backup {
     use super::*;
 
     /// Identifies the format used for the volume backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeBackupFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VolumeBackupFormat {
+        /// Default value, not specified.
+        Unspecified,
+        /// Compute Engine Persistent Disk snapshot based volume backup.
+        GcePersistentDisk,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VolumeBackupFormat::value] or
+        /// [VolumeBackupFormat::name].
+        UnknownValue(volume_backup_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod volume_backup_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VolumeBackupFormat {
-        /// Default value, not specified.
-        pub const VOLUME_BACKUP_FORMAT_UNSPECIFIED: VolumeBackupFormat = VolumeBackupFormat::new(0);
-
-        /// Compute Engine Persistent Disk snapshot based volume backup.
-        pub const GCE_PERSISTENT_DISK: VolumeBackupFormat = VolumeBackupFormat::new(1);
-
-        /// Creates a new VolumeBackupFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GcePersistentDisk => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VOLUME_BACKUP_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCE_PERSISTENT_DISK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VOLUME_BACKUP_FORMAT_UNSPECIFIED"),
+                Self::GcePersistentDisk => std::option::Option::Some("GCE_PERSISTENT_DISK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VOLUME_BACKUP_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VOLUME_BACKUP_FORMAT_UNSPECIFIED)
-                }
-                "GCE_PERSISTENT_DISK" => std::option::Option::Some(Self::GCE_PERSISTENT_DISK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VolumeBackupFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeBackupFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VolumeBackupFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VolumeBackupFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GcePersistentDisk,
+                _ => Self::UnknownValue(volume_backup_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VolumeBackupFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VOLUME_BACKUP_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "GCE_PERSISTENT_DISK" => Self::GcePersistentDisk,
+                _ => Self::UnknownValue(volume_backup_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VolumeBackupFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GcePersistentDisk => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VolumeBackupFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VolumeBackupFormat>::new(
+                ".google.cloud.gkebackup.v1.VolumeBackup.VolumeBackupFormat",
+            ))
         }
     }
 
     /// The current state of a VolumeBackup
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// This is an illegal state and should not be encountered.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// A volume for the backup was identified and backup process is about to
         /// start.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The volume backup operation has begun and is in the initial "snapshot"
         /// phase of the process. Any defined ProtectedApplication "pre" hooks will
         /// be executed before entering this state and "post" hooks will be executed
         /// upon leaving this state.
-        pub const SNAPSHOTTING: State = State::new(2);
-
+        Snapshotting,
         /// The snapshot phase of the volume backup operation has completed and
         /// the snapshot is now being uploaded to backup storage.
-        pub const UPLOADING: State = State::new(3);
-
+        Uploading,
         /// The volume backup operation has completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
+        Succeeded,
         /// The volume backup operation has failed.
-        pub const FAILED: State = State::new(5);
-
+        Failed,
         /// This VolumeBackup resource (and its associated artifacts) is in the
         /// process of being deleted.
-        pub const DELETING: State = State::new(6);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Snapshotting => std::option::Option::Some(2),
+                Self::Uploading => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Deleting => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("SNAPSHOTTING"),
-                3 => std::borrow::Cow::Borrowed("UPLOADING"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Snapshotting => std::option::Option::Some("SNAPSHOTTING"),
+                Self::Uploading => std::option::Option::Some("UPLOADING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "SNAPSHOTTING" => std::option::Option::Some(Self::SNAPSHOTTING),
-                "UPLOADING" => std::option::Option::Some(Self::UPLOADING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Snapshotting,
+                3 => Self::Uploading,
+                4 => Self::Succeeded,
+                5 => Self::Failed,
+                6 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "SNAPSHOTTING" => Self::Snapshotting,
+                "UPLOADING" => Self::Uploading,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Snapshotting => serializer.serialize_i32(2),
+                Self::Uploading => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Deleting => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkebackup.v1.VolumeBackup.State",
+            ))
         }
     }
 }
@@ -6926,129 +7633,253 @@ pub mod volume_restore {
     use super::*;
 
     /// Supported volume types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VolumeType {
+        /// Default
+        Unspecified,
+        /// Compute Engine Persistent Disk volume
+        GcePersistentDisk,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VolumeType::value] or
+        /// [VolumeType::name].
+        UnknownValue(volume_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod volume_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VolumeType {
-        /// Default
-        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new(0);
-
-        /// Compute Engine Persistent Disk volume
-        pub const GCE_PERSISTENT_DISK: VolumeType = VolumeType::new(1);
-
-        /// Creates a new VolumeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GcePersistentDisk => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VOLUME_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCE_PERSISTENT_DISK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VOLUME_TYPE_UNSPECIFIED"),
+                Self::GcePersistentDisk => std::option::Option::Some("GCE_PERSISTENT_DISK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VOLUME_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VOLUME_TYPE_UNSPECIFIED)
-                }
-                "GCE_PERSISTENT_DISK" => std::option::Option::Some(Self::GCE_PERSISTENT_DISK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VolumeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VolumeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VolumeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GcePersistentDisk,
+                _ => Self::UnknownValue(volume_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VolumeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VOLUME_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GCE_PERSISTENT_DISK" => Self::GcePersistentDisk,
+                _ => Self::UnknownValue(volume_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VolumeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GcePersistentDisk => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VolumeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VolumeType>::new(
+                ".google.cloud.gkebackup.v1.VolumeRestore.VolumeType",
+            ))
         }
     }
 
     /// The current state of a VolumeRestore
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// This is an illegal state and should not be encountered.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// A volume for the restore was identified and restore process is about to
         /// start.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The volume is currently being restored.
-        pub const RESTORING: State = State::new(2);
-
+        Restoring,
         /// The volume has been successfully restored.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The volume restoration process failed.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// This VolumeRestore resource is in the process of being deleted.
-        pub const DELETING: State = State::new(5);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Restoring => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("RESTORING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Restoring => std::option::Option::Some("RESTORING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "RESTORING" => std::option::Option::Some(Self::RESTORING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Restoring,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "RESTORING" => Self::Restoring,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Restoring => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkebackup.v1.VolumeRestore.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/model.rs
@@ -126,60 +126,115 @@ pub mod generate_credentials_request {
     use super::*;
 
     /// Operating systems requiring specialized kubeconfigs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OperatingSystem(i32);
-
-    impl OperatingSystem {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OperatingSystem {
         /// Generates a kubeconfig that works for all operating systems not defined
         /// below.
-        pub const OPERATING_SYSTEM_UNSPECIFIED: OperatingSystem = OperatingSystem::new(0);
-
+        Unspecified,
         /// Generates a kubeconfig that is specifically designed to work with
         /// Windows.
-        pub const OPERATING_SYSTEM_WINDOWS: OperatingSystem = OperatingSystem::new(1);
+        Windows,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OperatingSystem::value] or
+        /// [OperatingSystem::name].
+        UnknownValue(operating_system::UnknownValue),
+    }
 
-        /// Creates a new OperatingSystem instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod operating_system {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OperatingSystem {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Windows => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPERATING_SYSTEM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OPERATING_SYSTEM_WINDOWS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPERATING_SYSTEM_UNSPECIFIED"),
+                Self::Windows => std::option::Option::Some("OPERATING_SYSTEM_WINDOWS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPERATING_SYSTEM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OPERATING_SYSTEM_UNSPECIFIED)
-                }
-                "OPERATING_SYSTEM_WINDOWS" => {
-                    std::option::Option::Some(Self::OPERATING_SYSTEM_WINDOWS)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OperatingSystem {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OperatingSystem {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OperatingSystem {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OperatingSystem {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Windows,
+                _ => Self::UnknownValue(operating_system::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OperatingSystem {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPERATING_SYSTEM_UNSPECIFIED" => Self::Unspecified,
+                "OPERATING_SYSTEM_WINDOWS" => Self::Windows,
+                _ => Self::UnknownValue(operating_system::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OperatingSystem {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Windows => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OperatingSystem {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperatingSystem>::new(
+                ".google.cloud.gkeconnect.gateway.v1.GenerateCredentialsRequest.OperatingSystem",
+            ))
         }
     }
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
@@ -60,7 +60,7 @@ impl super::stub::GatewayControl for GatewayControl {
         let builder = builder.query(&[("forceUseAgent", &req.force_use_agent)]);
         let builder = builder.query(&[("version", &req.version)]);
         let builder = builder.query(&[("kubernetesNamespace", &req.kubernetes_namespace)]);
-        let builder = builder.query(&[("operatingSystem", &req.operating_system.value())]);
+        let builder = builder.query(&[("operatingSystem", &req.operating_system)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -244,59 +244,120 @@ pub mod membership_spec {
     use super::*;
 
     /// Whether to automatically manage the Feature.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Management(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Management {
+        /// Unspecified
+        Unspecified,
+        /// Google will manage the Feature for the cluster.
+        Automatic,
+        /// User will manually manage the Feature for the cluster.
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Management::value] or
+        /// [Management::name].
+        UnknownValue(management::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod management {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Management {
-        /// Unspecified
-        pub const MANAGEMENT_UNSPECIFIED: Management = Management::new(0);
-
-        /// Google will manage the Feature for the cluster.
-        pub const MANAGEMENT_AUTOMATIC: Management = Management::new(1);
-
-        /// User will manually manage the Feature for the cluster.
-        pub const MANAGEMENT_MANUAL: Management = Management::new(2);
-
-        /// Creates a new Management instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MANAGEMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MANAGEMENT_AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MANAGEMENT_MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MANAGEMENT_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("MANAGEMENT_AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MANAGEMENT_MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MANAGEMENT_UNSPECIFIED" => std::option::Option::Some(Self::MANAGEMENT_UNSPECIFIED),
-                "MANAGEMENT_AUTOMATIC" => std::option::Option::Some(Self::MANAGEMENT_AUTOMATIC),
-                "MANAGEMENT_MANUAL" => std::option::Option::Some(Self::MANAGEMENT_MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Management {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Management {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Management {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Management {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(management::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Management {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MANAGEMENT_UNSPECIFIED" => Self::Unspecified,
+                "MANAGEMENT_AUTOMATIC" => Self::Automatic,
+                "MANAGEMENT_MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(management::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Management {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Management {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Management>::new(
+                ".google.cloud.gkehub.configmanagement.v1.MembershipSpec.Management",
+            ))
         }
     }
 }
@@ -1101,137 +1162,267 @@ pub mod config_sync_state {
     use super::*;
 
     /// CRDState representing the state of a CRD
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CRDState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CRDState {
+        /// CRD's state cannot be determined
+        Unspecified,
+        /// CRD is not installed
+        NotInstalled,
+        /// CRD is installed
+        Installed,
+        /// CRD is terminating (i.e., it has been deleted and is cleaning up)
+        Terminating,
+        /// CRD is installing
+        Installing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CRDState::value] or
+        /// [CRDState::name].
+        UnknownValue(crd_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod crd_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CRDState {
-        /// CRD's state cannot be determined
-        pub const CRD_STATE_UNSPECIFIED: CRDState = CRDState::new(0);
-
-        /// CRD is not installed
-        pub const NOT_INSTALLED: CRDState = CRDState::new(1);
-
-        /// CRD is installed
-        pub const INSTALLED: CRDState = CRDState::new(2);
-
-        /// CRD is terminating (i.e., it has been deleted and is cleaning up)
-        pub const TERMINATING: CRDState = CRDState::new(3);
-
-        /// CRD is installing
-        pub const INSTALLING: CRDState = CRDState::new(4);
-
-        /// Creates a new CRDState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotInstalled => std::option::Option::Some(1),
+                Self::Installed => std::option::Option::Some(2),
+                Self::Terminating => std::option::Option::Some(3),
+                Self::Installing => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CRD_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_INSTALLED"),
-                2 => std::borrow::Cow::Borrowed("INSTALLED"),
-                3 => std::borrow::Cow::Borrowed("TERMINATING"),
-                4 => std::borrow::Cow::Borrowed("INSTALLING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CRD_STATE_UNSPECIFIED"),
+                Self::NotInstalled => std::option::Option::Some("NOT_INSTALLED"),
+                Self::Installed => std::option::Option::Some("INSTALLED"),
+                Self::Terminating => std::option::Option::Some("TERMINATING"),
+                Self::Installing => std::option::Option::Some("INSTALLING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CRD_STATE_UNSPECIFIED" => std::option::Option::Some(Self::CRD_STATE_UNSPECIFIED),
-                "NOT_INSTALLED" => std::option::Option::Some(Self::NOT_INSTALLED),
-                "INSTALLED" => std::option::Option::Some(Self::INSTALLED),
-                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-                "INSTALLING" => std::option::Option::Some(Self::INSTALLING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CRDState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CRDState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    impl std::fmt::Display for CRDState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CRDState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotInstalled,
+                2 => Self::Installed,
+                3 => Self::Terminating,
+                4 => Self::Installing,
+                _ => Self::UnknownValue(crd_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CRDState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CRD_STATE_UNSPECIFIED" => Self::Unspecified,
+                "NOT_INSTALLED" => Self::NotInstalled,
+                "INSTALLED" => Self::Installed,
+                "TERMINATING" => Self::Terminating,
+                "INSTALLING" => Self::Installing,
+                _ => Self::UnknownValue(crd_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CRDState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotInstalled => serializer.serialize_i32(1),
+                Self::Installed => serializer.serialize_i32(2),
+                Self::Terminating => serializer.serialize_i32(3),
+                Self::Installing => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CRDState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CRDState>::new(
+                ".google.cloud.gkehub.configmanagement.v1.ConfigSyncState.CRDState",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// CS's state cannot be determined.
+        Unspecified,
+        /// CS is not installed.
+        ConfigSyncNotInstalled,
+        /// The expected CS version is installed successfully.
+        ConfigSyncInstalled,
+        /// CS encounters errors.
+        ConfigSyncError,
+        /// CS is installing or terminating.
+        ConfigSyncPending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// CS's state cannot be determined.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// CS is not installed.
-        pub const CONFIG_SYNC_NOT_INSTALLED: State = State::new(1);
-
-        /// The expected CS version is installed successfully.
-        pub const CONFIG_SYNC_INSTALLED: State = State::new(2);
-
-        /// CS encounters errors.
-        pub const CONFIG_SYNC_ERROR: State = State::new(3);
-
-        /// CS is installing or terminating.
-        pub const CONFIG_SYNC_PENDING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConfigSyncNotInstalled => std::option::Option::Some(1),
+                Self::ConfigSyncInstalled => std::option::Option::Some(2),
+                Self::ConfigSyncError => std::option::Option::Some(3),
+                Self::ConfigSyncPending => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFIG_SYNC_NOT_INSTALLED"),
-                2 => std::borrow::Cow::Borrowed("CONFIG_SYNC_INSTALLED"),
-                3 => std::borrow::Cow::Borrowed("CONFIG_SYNC_ERROR"),
-                4 => std::borrow::Cow::Borrowed("CONFIG_SYNC_PENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CONFIG_SYNC_NOT_INSTALLED" => {
-                    std::option::Option::Some(Self::CONFIG_SYNC_NOT_INSTALLED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::ConfigSyncNotInstalled => {
+                    std::option::Option::Some("CONFIG_SYNC_NOT_INSTALLED")
                 }
-                "CONFIG_SYNC_INSTALLED" => std::option::Option::Some(Self::CONFIG_SYNC_INSTALLED),
-                "CONFIG_SYNC_ERROR" => std::option::Option::Some(Self::CONFIG_SYNC_ERROR),
-                "CONFIG_SYNC_PENDING" => std::option::Option::Some(Self::CONFIG_SYNC_PENDING),
-                _ => std::option::Option::None,
+                Self::ConfigSyncInstalled => std::option::Option::Some("CONFIG_SYNC_INSTALLED"),
+                Self::ConfigSyncError => std::option::Option::Some("CONFIG_SYNC_ERROR"),
+                Self::ConfigSyncPending => std::option::Option::Some("CONFIG_SYNC_PENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConfigSyncNotInstalled,
+                2 => Self::ConfigSyncInstalled,
+                3 => Self::ConfigSyncError,
+                4 => Self::ConfigSyncPending,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CONFIG_SYNC_NOT_INSTALLED" => Self::ConfigSyncNotInstalled,
+                "CONFIG_SYNC_INSTALLED" => Self::ConfigSyncInstalled,
+                "CONFIG_SYNC_ERROR" => Self::ConfigSyncError,
+                "CONFIG_SYNC_PENDING" => Self::ConfigSyncPending,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConfigSyncNotInstalled => serializer.serialize_i32(1),
+                Self::ConfigSyncInstalled => serializer.serialize_i32(2),
+                Self::ConfigSyncError => serializer.serialize_i32(3),
+                Self::ConfigSyncPending => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkehub.configmanagement.v1.ConfigSyncState.State",
+            ))
         }
     }
 }
@@ -1584,84 +1775,155 @@ pub mod sync_state {
     use super::*;
 
     /// An enum representing Config Sync's status of syncing configs to a cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SyncCode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SyncCode {
+        /// Config Sync cannot determine a sync code
+        Unspecified,
+        /// Config Sync successfully synced the git Repo with the cluster
+        Synced,
+        /// Config Sync is in the progress of syncing a new change
+        Pending,
+        /// Indicates an error configuring Config Sync, and user action is required
+        Error,
+        /// Config Sync has been installed but not configured
+        NotConfigured,
+        /// Config Sync has not been installed
+        NotInstalled,
+        /// Error authorizing with the cluster
+        Unauthorized,
+        /// Cluster could not be reached
+        Unreachable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SyncCode::value] or
+        /// [SyncCode::name].
+        UnknownValue(sync_code::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sync_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SyncCode {
-        /// Config Sync cannot determine a sync code
-        pub const SYNC_CODE_UNSPECIFIED: SyncCode = SyncCode::new(0);
-
-        /// Config Sync successfully synced the git Repo with the cluster
-        pub const SYNCED: SyncCode = SyncCode::new(1);
-
-        /// Config Sync is in the progress of syncing a new change
-        pub const PENDING: SyncCode = SyncCode::new(2);
-
-        /// Indicates an error configuring Config Sync, and user action is required
-        pub const ERROR: SyncCode = SyncCode::new(3);
-
-        /// Config Sync has been installed but not configured
-        pub const NOT_CONFIGURED: SyncCode = SyncCode::new(4);
-
-        /// Config Sync has not been installed
-        pub const NOT_INSTALLED: SyncCode = SyncCode::new(5);
-
-        /// Error authorizing with the cluster
-        pub const UNAUTHORIZED: SyncCode = SyncCode::new(6);
-
-        /// Cluster could not be reached
-        pub const UNREACHABLE: SyncCode = SyncCode::new(7);
-
-        /// Creates a new SyncCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Synced => std::option::Option::Some(1),
+                Self::Pending => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::NotConfigured => std::option::Option::Some(4),
+                Self::NotInstalled => std::option::Option::Some(5),
+                Self::Unauthorized => std::option::Option::Some(6),
+                Self::Unreachable => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SYNC_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SYNCED"),
-                2 => std::borrow::Cow::Borrowed("PENDING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                4 => std::borrow::Cow::Borrowed("NOT_CONFIGURED"),
-                5 => std::borrow::Cow::Borrowed("NOT_INSTALLED"),
-                6 => std::borrow::Cow::Borrowed("UNAUTHORIZED"),
-                7 => std::borrow::Cow::Borrowed("UNREACHABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SYNC_CODE_UNSPECIFIED"),
+                Self::Synced => std::option::Option::Some("SYNCED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::NotConfigured => std::option::Option::Some("NOT_CONFIGURED"),
+                Self::NotInstalled => std::option::Option::Some("NOT_INSTALLED"),
+                Self::Unauthorized => std::option::Option::Some("UNAUTHORIZED"),
+                Self::Unreachable => std::option::Option::Some("UNREACHABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SYNC_CODE_UNSPECIFIED" => std::option::Option::Some(Self::SYNC_CODE_UNSPECIFIED),
-                "SYNCED" => std::option::Option::Some(Self::SYNCED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "NOT_CONFIGURED" => std::option::Option::Some(Self::NOT_CONFIGURED),
-                "NOT_INSTALLED" => std::option::Option::Some(Self::NOT_INSTALLED),
-                "UNAUTHORIZED" => std::option::Option::Some(Self::UNAUTHORIZED),
-                "UNREACHABLE" => std::option::Option::Some(Self::UNREACHABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SyncCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SyncCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SyncCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SyncCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Synced,
+                2 => Self::Pending,
+                3 => Self::Error,
+                4 => Self::NotConfigured,
+                5 => Self::NotInstalled,
+                6 => Self::Unauthorized,
+                7 => Self::Unreachable,
+                _ => Self::UnknownValue(sync_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SyncCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SYNC_CODE_UNSPECIFIED" => Self::Unspecified,
+                "SYNCED" => Self::Synced,
+                "PENDING" => Self::Pending,
+                "ERROR" => Self::Error,
+                "NOT_CONFIGURED" => Self::NotConfigured,
+                "NOT_INSTALLED" => Self::NotInstalled,
+                "UNAUTHORIZED" => Self::Unauthorized,
+                "UNREACHABLE" => Self::Unreachable,
+                _ => Self::UnknownValue(sync_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SyncCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Synced => serializer.serialize_i32(1),
+                Self::Pending => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::NotConfigured => serializer.serialize_i32(4),
+                Self::NotInstalled => serializer.serialize_i32(5),
+                Self::Unauthorized => serializer.serialize_i32(6),
+                Self::Unreachable => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SyncCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SyncCode>::new(
+                ".google.cloud.gkehub.configmanagement.v1.SyncState.SyncCode",
+            ))
         }
     }
 }
@@ -1979,70 +2241,133 @@ impl wkt::message::Message for GatekeeperDeploymentState {
 }
 
 /// Enum representing the state of an ACM's deployment on a cluster
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DeploymentState {
+    /// Deployment's state cannot be determined
+    Unspecified,
+    /// Deployment is not installed
+    NotInstalled,
+    /// Deployment is installed
+    Installed,
+    /// Deployment was attempted to be installed, but has errors
+    Error,
+    /// Deployment is installing or terminating
+    Pending,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DeploymentState::value] or
+    /// [DeploymentState::name].
+    UnknownValue(deployment_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod deployment_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DeploymentState {
-    /// Deployment's state cannot be determined
-    pub const DEPLOYMENT_STATE_UNSPECIFIED: DeploymentState = DeploymentState::new(0);
-
-    /// Deployment is not installed
-    pub const NOT_INSTALLED: DeploymentState = DeploymentState::new(1);
-
-    /// Deployment is installed
-    pub const INSTALLED: DeploymentState = DeploymentState::new(2);
-
-    /// Deployment was attempted to be installed, but has errors
-    pub const ERROR: DeploymentState = DeploymentState::new(3);
-
-    /// Deployment is installing or terminating
-    pub const PENDING: DeploymentState = DeploymentState::new(4);
-
-    /// Creates a new DeploymentState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NotInstalled => std::option::Option::Some(1),
+            Self::Installed => std::option::Option::Some(2),
+            Self::Error => std::option::Option::Some(3),
+            Self::Pending => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NOT_INSTALLED"),
-            2 => std::borrow::Cow::Borrowed("INSTALLED"),
-            3 => std::borrow::Cow::Borrowed("ERROR"),
-            4 => std::borrow::Cow::Borrowed("PENDING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DEPLOYMENT_STATE_UNSPECIFIED"),
+            Self::NotInstalled => std::option::Option::Some("NOT_INSTALLED"),
+            Self::Installed => std::option::Option::Some("INSTALLED"),
+            Self::Error => std::option::Option::Some("ERROR"),
+            Self::Pending => std::option::Option::Some("PENDING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DEPLOYMENT_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DEPLOYMENT_STATE_UNSPECIFIED)
-            }
-            "NOT_INSTALLED" => std::option::Option::Some(Self::NOT_INSTALLED),
-            "INSTALLED" => std::option::Option::Some(Self::INSTALLED),
-            "ERROR" => std::option::Option::Some(Self::ERROR),
-            "PENDING" => std::option::Option::Some(Self::PENDING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DeploymentState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DeploymentState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DeploymentState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NotInstalled,
+            2 => Self::Installed,
+            3 => Self::Error,
+            4 => Self::Pending,
+            _ => Self::UnknownValue(deployment_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DeploymentState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DEPLOYMENT_STATE_UNSPECIFIED" => Self::Unspecified,
+            "NOT_INSTALLED" => Self::NotInstalled,
+            "INSTALLED" => Self::Installed,
+            "ERROR" => Self::Error,
+            "PENDING" => Self::Pending,
+            _ => Self::UnknownValue(deployment_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DeploymentState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NotInstalled => serializer.serialize_i32(1),
+            Self::Installed => serializer.serialize_i32(2),
+            Self::Error => serializer.serialize_i32(3),
+            Self::Pending => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DeploymentState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeploymentState>::new(
+            ".google.cloud.gkehub.configmanagement.v1.DeploymentState",
+        ))
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -271,77 +271,144 @@ pub mod feature_resource_state {
     use super::*;
 
     /// State describes the lifecycle status of a Feature.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State is unknown or not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The Feature is being enabled, and the Feature resource is being created.
         /// Once complete, the corresponding Feature will be enabled in this Hub.
-        pub const ENABLING: State = State::new(1);
-
+        Enabling,
         /// The Feature is enabled in this Hub, and the Feature resource is fully
         /// available.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The Feature is being disabled in this Hub, and the Feature resource
         /// is being deleted.
-        pub const DISABLING: State = State::new(3);
-
+        Disabling,
         /// The Feature resource is being updated.
-        pub const UPDATING: State = State::new(4);
-
+        Updating,
         /// The Feature resource is being updated by the Hub Service.
-        pub const SERVICE_UPDATING: State = State::new(5);
+        ServiceUpdating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabling => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Disabling => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::ServiceUpdating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DISABLING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("SERVICE_UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabling => std::option::Option::Some("ENABLING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Disabling => std::option::Option::Some("DISABLING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::ServiceUpdating => std::option::Option::Some("SERVICE_UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLING" => std::option::Option::Some(Self::ENABLING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DISABLING" => std::option::Option::Some(Self::DISABLING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "SERVICE_UPDATING" => std::option::Option::Some(Self::SERVICE_UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabling,
+                2 => Self::Active,
+                3 => Self::Disabling,
+                4 => Self::Updating,
+                5 => Self::ServiceUpdating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLING" => Self::Enabling,
+                "ACTIVE" => Self::Active,
+                "DISABLING" => Self::Disabling,
+                "UPDATING" => Self::Updating,
+                "SERVICE_UPDATING" => Self::ServiceUpdating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabling => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Disabling => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::ServiceUpdating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkehub.v1.FeatureResourceState.State",
+            ))
         }
     }
 }
@@ -411,70 +478,133 @@ pub mod feature_state {
     use super::*;
 
     /// Code represents a machine-readable, high-level status of the Feature.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// Unknown or not set.
-        pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+        Unspecified,
         /// The Feature is operating normally.
-        pub const OK: Code = Code::new(1);
-
+        Ok,
         /// The Feature has encountered an issue, and is operating in a degraded
         /// state. The Feature may need intervention to return to normal operation.
         /// See the description and any associated Feature-specific details for more
         /// information.
-        pub const WARNING: Code = Code::new(2);
-
+        Warning,
         /// The Feature is not operating or is in a severely degraded state.
         /// The Feature may need intervention to return to normal operation.
         /// See the description and any associated Feature-specific details for more
         /// information.
-        pub const ERROR: Code = Code::new(3);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OK"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                "OK" => std::option::Option::Some(Self::OK),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ok,
+                2 => Self::Warning,
+                3 => Self::Error,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CODE_UNSPECIFIED" => Self::Unspecified,
+                "OK" => Self::Ok,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.cloud.gkehub.v1.FeatureState.Code",
+            ))
         }
     }
 }
@@ -1613,74 +1743,141 @@ pub mod membership_state {
     use super::*;
 
     /// Code describes the state of a Membership resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
+        /// The code is not set.
+        Unspecified,
+        /// The cluster is being registered.
+        Creating,
+        /// The cluster is registered.
+        Ready,
+        /// The cluster is being unregistered.
+        Deleting,
+        /// The Membership is being updated.
+        Updating,
+        /// The Membership is being updated by the Hub Service.
+        ServiceUpdating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Code {
-        /// The code is not set.
-        pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
-        /// The cluster is being registered.
-        pub const CREATING: Code = Code::new(1);
-
-        /// The cluster is registered.
-        pub const READY: Code = Code::new(2);
-
-        /// The cluster is being unregistered.
-        pub const DELETING: Code = Code::new(3);
-
-        /// The Membership is being updated.
-        pub const UPDATING: Code = Code::new(4);
-
-        /// The Membership is being updated by the Hub Service.
-        pub const SERVICE_UPDATING: Code = Code::new(5);
-
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::ServiceUpdating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("SERVICE_UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::ServiceUpdating => std::option::Option::Some("SERVICE_UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "SERVICE_UPDATING" => std::option::Option::Some(Self::SERVICE_UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                4 => Self::Updating,
+                5 => Self::ServiceUpdating,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CODE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "SERVICE_UPDATING" => Self::ServiceUpdating,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::ServiceUpdating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.cloud.gkehub.v1.MembershipState.Code",
+            ))
         }
     }
 }

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -417,83 +417,152 @@ pub mod attached_cluster {
     use super::*;
 
     /// The lifecycle state of the cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the cluster is being registered.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the cluster has been register and is fully
         /// usable.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading software components.
-        pub const RECONCILING: State = State::new(3);
-
+        Reconciling,
         /// The STOPPING state indicates the cluster is being de-registered.
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The ERROR state indicates the cluster is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// The DEGRADED state indicates the cluster requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new(6);
+        Degraded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Reconciling => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Degraded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RECONCILING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("DEGRADED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Degraded => std::option::Option::Some("DEGRADED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Reconciling,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "DEGRADED" => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Reconciling => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Degraded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkemulticloud.v1.AttachedCluster.State",
+            ))
         }
     }
 }
@@ -2120,83 +2189,152 @@ pub mod aws_cluster {
     use super::*;
 
     /// The lifecycle state of the cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the cluster is being created.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the cluster has been created and is fully
         /// usable.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading the control plane replicas.
-        pub const RECONCILING: State = State::new(3);
-
+        Reconciling,
         /// The STOPPING state indicates the cluster is being deleted.
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The ERROR state indicates the cluster is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// The DEGRADED state indicates the cluster requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new(6);
+        Degraded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Reconciling => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Degraded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RECONCILING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("DEGRADED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Degraded => std::option::Option::Some("DEGRADED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Reconciling,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "DEGRADED" => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Reconciling => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Degraded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkemulticloud.v1.AwsCluster.State",
+            ))
         }
     }
 }
@@ -2759,61 +2897,120 @@ pub mod aws_volume_template {
     /// volumes.
     /// See <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html>
     /// for more information.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VolumeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VolumeType {
+        /// Not set.
+        Unspecified,
+        /// GP2 (General Purpose SSD volume type).
+        Gp2,
+        /// GP3 (General Purpose SSD volume type).
+        Gp3,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VolumeType::value] or
+        /// [VolumeType::name].
+        UnknownValue(volume_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod volume_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VolumeType {
-        /// Not set.
-        pub const VOLUME_TYPE_UNSPECIFIED: VolumeType = VolumeType::new(0);
-
-        /// GP2 (General Purpose SSD volume type).
-        pub const GP2: VolumeType = VolumeType::new(1);
-
-        /// GP3 (General Purpose SSD volume type).
-        pub const GP3: VolumeType = VolumeType::new(2);
-
-        /// Creates a new VolumeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gp2 => std::option::Option::Some(1),
+                Self::Gp3 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VOLUME_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GP2"),
-                2 => std::borrow::Cow::Borrowed("GP3"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VOLUME_TYPE_UNSPECIFIED"),
+                Self::Gp2 => std::option::Option::Some("GP2"),
+                Self::Gp3 => std::option::Option::Some("GP3"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VOLUME_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VOLUME_TYPE_UNSPECIFIED)
-                }
-                "GP2" => std::option::Option::Some(Self::GP2),
-                "GP3" => std::option::Option::Some(Self::GP3),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VolumeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VolumeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VolumeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VolumeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Gp2,
+                2 => Self::Gp3,
+                _ => Self::UnknownValue(volume_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VolumeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VOLUME_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GP2" => Self::Gp2,
+                "GP3" => Self::Gp3,
+                _ => Self::UnknownValue(volume_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VolumeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gp2 => serializer.serialize_i32(1),
+                Self::Gp3 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VolumeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VolumeType>::new(
+                ".google.cloud.gkemulticloud.v1.AwsVolumeTemplate.VolumeType",
+            ))
         }
     }
 }
@@ -3179,82 +3376,151 @@ pub mod aws_node_pool {
     use super::*;
 
     /// The lifecycle state of the node pool.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the node pool is being created.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the node pool has been created
         /// and is fully usable.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The RECONCILING state indicates that the node pool is being reconciled.
-        pub const RECONCILING: State = State::new(3);
-
+        Reconciling,
         /// The STOPPING state indicates the node pool is being deleted.
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The ERROR state indicates the node pool is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// The DEGRADED state indicates the node pool requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new(6);
+        Degraded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Reconciling => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Degraded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RECONCILING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("DEGRADED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Degraded => std::option::Option::Some("DEGRADED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Reconciling,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "DEGRADED" => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Reconciling => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Degraded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkemulticloud.v1.AwsNodePool.State",
+            ))
         }
     }
 }
@@ -4155,64 +4421,127 @@ pub mod aws_instance_placement {
     use super::*;
 
     /// Tenancy defines how EC2 instances are distributed across physical hardware.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tenancy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tenancy {
+        /// Not set.
+        Unspecified,
+        /// Use default VPC tenancy.
+        Default,
+        /// Run a dedicated instance.
+        Dedicated,
+        /// Launch this instance to a dedicated host.
+        Host,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tenancy::value] or
+        /// [Tenancy::name].
+        UnknownValue(tenancy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tenancy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Tenancy {
-        /// Not set.
-        pub const TENANCY_UNSPECIFIED: Tenancy = Tenancy::new(0);
-
-        /// Use default VPC tenancy.
-        pub const DEFAULT: Tenancy = Tenancy::new(1);
-
-        /// Run a dedicated instance.
-        pub const DEDICATED: Tenancy = Tenancy::new(2);
-
-        /// Launch this instance to a dedicated host.
-        pub const HOST: Tenancy = Tenancy::new(3);
-
-        /// Creates a new Tenancy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::Dedicated => std::option::Option::Some(2),
+                Self::Host => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TENANCY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("DEDICATED"),
-                3 => std::borrow::Cow::Borrowed("HOST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TENANCY_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Dedicated => std::option::Option::Some("DEDICATED"),
+                Self::Host => std::option::Option::Some("HOST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TENANCY_UNSPECIFIED" => std::option::Option::Some(Self::TENANCY_UNSPECIFIED),
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "DEDICATED" => std::option::Option::Some(Self::DEDICATED),
-                "HOST" => std::option::Option::Some(Self::HOST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tenancy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tenancy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tenancy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tenancy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::Dedicated,
+                3 => Self::Host,
+                _ => Self::UnknownValue(tenancy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tenancy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TENANCY_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "DEDICATED" => Self::Dedicated,
+                "HOST" => Self::Host,
+                _ => Self::UnknownValue(tenancy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tenancy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::Dedicated => serializer.serialize_i32(2),
+                Self::Host => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tenancy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tenancy>::new(
+                ".google.cloud.gkemulticloud.v1.AwsInstancePlacement.Tenancy",
+            ))
         }
     }
 }
@@ -6117,83 +6446,152 @@ pub mod azure_cluster {
     use super::*;
 
     /// The lifecycle state of the cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the cluster is being created.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the cluster has been created and is fully
         /// usable.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading the control plane replicas.
-        pub const RECONCILING: State = State::new(3);
-
+        Reconciling,
         /// The STOPPING state indicates the cluster is being deleted.
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The ERROR state indicates the cluster is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// The DEGRADED state indicates the cluster requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new(6);
+        Degraded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Reconciling => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Degraded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RECONCILING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("DEGRADED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Degraded => std::option::Option::Some("DEGRADED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Reconciling,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "DEGRADED" => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Reconciling => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Degraded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkemulticloud.v1.AzureCluster.State",
+            ))
         }
     }
 }
@@ -7329,82 +7727,151 @@ pub mod azure_node_pool {
     use super::*;
 
     /// The lifecycle state of the node pool.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the node pool is being created.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the node pool has been created and is fully
         /// usable.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The RECONCILING state indicates that the node pool is being reconciled.
-        pub const RECONCILING: State = State::new(3);
-
+        Reconciling,
         /// The STOPPING state indicates the node pool is being deleted.
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The ERROR state indicates the node pool is in a broken unrecoverable
         /// state.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// The DEGRADED state indicates the node pool requires user action to
         /// restore full functionality.
-        pub const DEGRADED: State = State::new(6);
+        Degraded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Reconciling => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Degraded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RECONCILING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("DEGRADED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Degraded => std::option::Option::Some("DEGRADED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Reconciling,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "DEGRADED" => Self::Degraded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Reconciling => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Degraded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.gkemulticloud.v1.AzureNodePool.State",
+            ))
         }
     }
 }
@@ -10120,70 +10587,133 @@ pub mod node_taint {
     use super::*;
 
     /// The taint effect.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Effect(i32);
-
-    impl Effect {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Effect {
         /// Not set.
-        pub const EFFECT_UNSPECIFIED: Effect = Effect::new(0);
-
+        Unspecified,
         /// Do not allow new pods to schedule onto the node unless they tolerate the
         /// taint, but allow all pods submitted to Kubelet without going through the
         /// scheduler to start, and allow all already-running pods to continue
         /// running. Enforced by the scheduler.
-        pub const NO_SCHEDULE: Effect = Effect::new(1);
-
+        NoSchedule,
         /// Like TaintEffectNoSchedule, but the scheduler tries not to schedule
         /// new pods onto the node, rather than prohibiting new pods from scheduling
         /// onto the node entirely. Enforced by the scheduler.
-        pub const PREFER_NO_SCHEDULE: Effect = Effect::new(2);
-
+        PreferNoSchedule,
         /// Evict any already-running pods that do not tolerate the taint.
         /// Currently enforced by NodeController.
-        pub const NO_EXECUTE: Effect = Effect::new(3);
+        NoExecute,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Effect::value] or
+        /// [Effect::name].
+        UnknownValue(effect::UnknownValue),
+    }
 
-        /// Creates a new Effect instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod effect {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Effect {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoSchedule => std::option::Option::Some(1),
+                Self::PreferNoSchedule => std::option::Option::Some(2),
+                Self::NoExecute => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EFFECT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_SCHEDULE"),
-                2 => std::borrow::Cow::Borrowed("PREFER_NO_SCHEDULE"),
-                3 => std::borrow::Cow::Borrowed("NO_EXECUTE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EFFECT_UNSPECIFIED"),
+                Self::NoSchedule => std::option::Option::Some("NO_SCHEDULE"),
+                Self::PreferNoSchedule => std::option::Option::Some("PREFER_NO_SCHEDULE"),
+                Self::NoExecute => std::option::Option::Some("NO_EXECUTE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EFFECT_UNSPECIFIED" => std::option::Option::Some(Self::EFFECT_UNSPECIFIED),
-                "NO_SCHEDULE" => std::option::Option::Some(Self::NO_SCHEDULE),
-                "PREFER_NO_SCHEDULE" => std::option::Option::Some(Self::PREFER_NO_SCHEDULE),
-                "NO_EXECUTE" => std::option::Option::Some(Self::NO_EXECUTE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Effect {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Effect {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Effect {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Effect {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoSchedule,
+                2 => Self::PreferNoSchedule,
+                3 => Self::NoExecute,
+                _ => Self::UnknownValue(effect::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Effect {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EFFECT_UNSPECIFIED" => Self::Unspecified,
+                "NO_SCHEDULE" => Self::NoSchedule,
+                "PREFER_NO_SCHEDULE" => Self::PreferNoSchedule,
+                "NO_EXECUTE" => Self::NoExecute,
+                _ => Self::UnknownValue(effect::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Effect {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoSchedule => serializer.serialize_i32(1),
+                Self::PreferNoSchedule => serializer.serialize_i32(2),
+                Self::NoExecute => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Effect {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Effect>::new(
+                ".google.cloud.gkemulticloud.v1.NodeTaint.Effect",
+            ))
         }
     }
 }
@@ -10449,59 +10979,120 @@ pub mod logging_component_config {
     use super::*;
 
     /// The components of the logging configuration;
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Component(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Component {
+        /// No component is specified
+        Unspecified,
+        /// This indicates that system logging components is enabled.
+        SystemComponents,
+        /// This indicates that user workload logging component is enabled.
+        Workloads,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Component::value] or
+        /// [Component::name].
+        UnknownValue(component::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod component {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Component {
-        /// No component is specified
-        pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
-
-        /// This indicates that system logging components is enabled.
-        pub const SYSTEM_COMPONENTS: Component = Component::new(1);
-
-        /// This indicates that user workload logging component is enabled.
-        pub const WORKLOADS: Component = Component::new(2);
-
-        /// Creates a new Component instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SystemComponents => std::option::Option::Some(1),
+                Self::Workloads => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SYSTEM_COMPONENTS"),
-                2 => std::borrow::Cow::Borrowed("WORKLOADS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPONENT_UNSPECIFIED"),
+                Self::SystemComponents => std::option::Option::Some("SYSTEM_COMPONENTS"),
+                Self::Workloads => std::option::Option::Some("WORKLOADS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
-                "SYSTEM_COMPONENTS" => std::option::Option::Some(Self::SYSTEM_COMPONENTS),
-                "WORKLOADS" => std::option::Option::Some(Self::WORKLOADS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Component {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Component {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Component {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Component {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SystemComponents,
+                2 => Self::Workloads,
+                _ => Self::UnknownValue(component::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Component {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPONENT_UNSPECIFIED" => Self::Unspecified,
+                "SYSTEM_COMPONENTS" => Self::SystemComponents,
+                "WORKLOADS" => Self::Workloads,
+                _ => Self::UnknownValue(component::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Component {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SystemComponents => serializer.serialize_i32(1),
+                Self::Workloads => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Component {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Component>::new(
+                ".google.cloud.gkemulticloud.v1.LoggingComponentConfig.Component",
+            ))
         }
     }
 }
@@ -10670,64 +11261,123 @@ pub mod binary_authorization {
     use super::*;
 
     /// Binary Authorization mode of operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationMode(i32);
-
-    impl EvaluationMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EvaluationMode {
         /// Default value
-        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode = EvaluationMode::new(0);
-
+        Unspecified,
         /// Disable BinaryAuthorization
-        pub const DISABLED: EvaluationMode = EvaluationMode::new(1);
-
+        Disabled,
         /// Enforce Kubernetes admission requests with BinaryAuthorization using the
         /// project's singleton policy.
-        pub const PROJECT_SINGLETON_POLICY_ENFORCE: EvaluationMode = EvaluationMode::new(2);
+        ProjectSingletonPolicyEnforce,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EvaluationMode::value] or
+        /// [EvaluationMode::name].
+        UnknownValue(evaluation_mode::UnknownValue),
+    }
 
-        /// Creates a new EvaluationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod evaluation_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EvaluationMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::ProjectSingletonPolicyEnforce => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVALUATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("PROJECT_SINGLETON_POLICY_ENFORCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVALUATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVALUATION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVALUATION_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::ProjectSingletonPolicyEnforce => {
+                    std::option::Option::Some("PROJECT_SINGLETON_POLICY_ENFORCE")
                 }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "PROJECT_SINGLETON_POLICY_ENFORCE" => {
-                    std::option::Option::Some(Self::PROJECT_SINGLETON_POLICY_ENFORCE)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for EvaluationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EvaluationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EvaluationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::ProjectSingletonPolicyEnforce,
+                _ => Self::UnknownValue(evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EvaluationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVALUATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "PROJECT_SINGLETON_POLICY_ENFORCE" => Self::ProjectSingletonPolicyEnforce,
+                _ => Self::UnknownValue(evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EvaluationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::ProjectSingletonPolicyEnforce => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EvaluationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EvaluationMode>::new(
+                ".google.cloud.gkemulticloud.v1.BinaryAuthorization.EvaluationMode",
+            ))
         }
     }
 }
@@ -10775,64 +11425,123 @@ pub mod security_posture_config {
     use super::*;
 
     /// VulnerabilityMode defines enablement mode for vulnerability scanning.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VulnerabilityMode(i32);
-
-    impl VulnerabilityMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VulnerabilityMode {
         /// Default value not specified.
-        pub const VULNERABILITY_MODE_UNSPECIFIED: VulnerabilityMode = VulnerabilityMode::new(0);
-
+        Unspecified,
         /// Disables vulnerability scanning on the cluster.
-        pub const VULNERABILITY_DISABLED: VulnerabilityMode = VulnerabilityMode::new(1);
-
+        VulnerabilityDisabled,
         /// Applies the Security Posture's vulnerability on cluster Enterprise level
         /// features.
-        pub const VULNERABILITY_ENTERPRISE: VulnerabilityMode = VulnerabilityMode::new(2);
+        VulnerabilityEnterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VulnerabilityMode::value] or
+        /// [VulnerabilityMode::name].
+        UnknownValue(vulnerability_mode::UnknownValue),
+    }
 
-        /// Creates a new VulnerabilityMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod vulnerability_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl VulnerabilityMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VulnerabilityDisabled => std::option::Option::Some(1),
+                Self::VulnerabilityEnterprise => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VULNERABILITY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VULNERABILITY_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("VULNERABILITY_ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VULNERABILITY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VULNERABILITY_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VULNERABILITY_MODE_UNSPECIFIED"),
+                Self::VulnerabilityDisabled => std::option::Option::Some("VULNERABILITY_DISABLED"),
+                Self::VulnerabilityEnterprise => {
+                    std::option::Option::Some("VULNERABILITY_ENTERPRISE")
                 }
-                "VULNERABILITY_DISABLED" => std::option::Option::Some(Self::VULNERABILITY_DISABLED),
-                "VULNERABILITY_ENTERPRISE" => {
-                    std::option::Option::Some(Self::VULNERABILITY_ENTERPRISE)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for VulnerabilityMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VulnerabilityMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VulnerabilityMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VulnerabilityMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VulnerabilityDisabled,
+                2 => Self::VulnerabilityEnterprise,
+                _ => Self::UnknownValue(vulnerability_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VulnerabilityMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VULNERABILITY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "VULNERABILITY_DISABLED" => Self::VulnerabilityDisabled,
+                "VULNERABILITY_ENTERPRISE" => Self::VulnerabilityEnterprise,
+                _ => Self::UnknownValue(vulnerability_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VulnerabilityMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VulnerabilityDisabled => serializer.serialize_i32(1),
+                Self::VulnerabilityEnterprise => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VulnerabilityMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VulnerabilityMode>::new(
+                ".google.cloud.gkemulticloud.v1.SecurityPostureConfig.VulnerabilityMode",
+            ))
         }
     }
 }

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -694,63 +694,120 @@ pub mod access_settings {
     use super::*;
 
     /// Types of identity source supported by IAP.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IdentitySource(i32);
-
-    impl IdentitySource {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IdentitySource {
         /// IdentitySource Unspecified.
         /// When selected, IAP relies on which identity settings are fully configured
         /// to redirect the traffic to. The precedence order is
         /// WorkforceIdentitySettings > GcipSettings. If none is set, default to use
         /// Google identity.
-        pub const IDENTITY_SOURCE_UNSPECIFIED: IdentitySource = IdentitySource::new(0);
-
+        Unspecified,
         /// Use external identities set up on Google Cloud Workforce Identity
         /// Federation.
-        pub const WORKFORCE_IDENTITY_FEDERATION: IdentitySource = IdentitySource::new(3);
+        WorkforceIdentityFederation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IdentitySource::value] or
+        /// [IdentitySource::name].
+        UnknownValue(identity_source::UnknownValue),
+    }
 
-        /// Creates a new IdentitySource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod identity_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl IdentitySource {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::WorkforceIdentityFederation => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IDENTITY_SOURCE_UNSPECIFIED"),
-                3 => std::borrow::Cow::Borrowed("WORKFORCE_IDENTITY_FEDERATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IDENTITY_SOURCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IDENTITY_SOURCE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IDENTITY_SOURCE_UNSPECIFIED"),
+                Self::WorkforceIdentityFederation => {
+                    std::option::Option::Some("WORKFORCE_IDENTITY_FEDERATION")
                 }
-                "WORKFORCE_IDENTITY_FEDERATION" => {
-                    std::option::Option::Some(Self::WORKFORCE_IDENTITY_FEDERATION)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for IdentitySource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IdentitySource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IdentitySource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IdentitySource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                3 => Self::WorkforceIdentityFederation,
+                _ => Self::UnknownValue(identity_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IdentitySource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IDENTITY_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "WORKFORCE_IDENTITY_FEDERATION" => Self::WorkforceIdentityFederation,
+                _ => Self::UnknownValue(identity_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IdentitySource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::WorkforceIdentityFederation => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IdentitySource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IdentitySource>::new(
+                ".google.cloud.iap.v1.AccessSettings.IdentitySource",
+            ))
         }
     }
 }
@@ -1083,130 +1140,252 @@ pub mod reauth_settings {
     use super::*;
 
     /// Types of reauthentication methods supported by IAP.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Method(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Method {
+        /// Reauthentication disabled.
+        Unspecified,
+        /// Prompts the user to log in again.
+        Login,
+        Password,
+        /// User must use their secure key 2nd factor device.
+        SecureKey,
+        /// User can use any enabled 2nd factor.
+        EnrolledSecondFactors,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Method::value] or
+        /// [Method::name].
+        UnknownValue(method::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Method {
-        /// Reauthentication disabled.
-        pub const METHOD_UNSPECIFIED: Method = Method::new(0);
-
-        /// Prompts the user to log in again.
-        pub const LOGIN: Method = Method::new(1);
-
-        pub const PASSWORD: Method = Method::new(2);
-
-        /// User must use their secure key 2nd factor device.
-        pub const SECURE_KEY: Method = Method::new(3);
-
-        /// User can use any enabled 2nd factor.
-        pub const ENROLLED_SECOND_FACTORS: Method = Method::new(4);
-
-        /// Creates a new Method instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Login => std::option::Option::Some(1),
+                Self::Password => std::option::Option::Some(2),
+                Self::SecureKey => std::option::Option::Some(3),
+                Self::EnrolledSecondFactors => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOGIN"),
-                2 => std::borrow::Cow::Borrowed("PASSWORD"),
-                3 => std::borrow::Cow::Borrowed("SECURE_KEY"),
-                4 => std::borrow::Cow::Borrowed("ENROLLED_SECOND_FACTORS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METHOD_UNSPECIFIED"),
+                Self::Login => std::option::Option::Some("LOGIN"),
+                Self::Password => std::option::Option::Some("PASSWORD"),
+                Self::SecureKey => std::option::Option::Some("SECURE_KEY"),
+                Self::EnrolledSecondFactors => std::option::Option::Some("ENROLLED_SECOND_FACTORS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
-                "LOGIN" => std::option::Option::Some(Self::LOGIN),
-                "PASSWORD" => std::option::Option::Some(Self::PASSWORD),
-                "SECURE_KEY" => std::option::Option::Some(Self::SECURE_KEY),
-                "ENROLLED_SECOND_FACTORS" => {
-                    std::option::Option::Some(Self::ENROLLED_SECOND_FACTORS)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Method {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Method {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Method {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Method {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Login,
+                2 => Self::Password,
+                3 => Self::SecureKey,
+                4 => Self::EnrolledSecondFactors,
+                _ => Self::UnknownValue(method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Method {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METHOD_UNSPECIFIED" => Self::Unspecified,
+                "LOGIN" => Self::Login,
+                "PASSWORD" => Self::Password,
+                "SECURE_KEY" => Self::SecureKey,
+                "ENROLLED_SECOND_FACTORS" => Self::EnrolledSecondFactors,
+                _ => Self::UnknownValue(method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Method {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Login => serializer.serialize_i32(1),
+                Self::Password => serializer.serialize_i32(2),
+                Self::SecureKey => serializer.serialize_i32(3),
+                Self::EnrolledSecondFactors => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Method {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Method>::new(
+                ".google.cloud.iap.v1.ReauthSettings.Method",
+            ))
         }
     }
 
     /// Type of policy in the case of hierarchical policies.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyType(i32);
-
-    impl PolicyType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PolicyType {
         /// Default value. This value is unused.
-        pub const POLICY_TYPE_UNSPECIFIED: PolicyType = PolicyType::new(0);
-
+        Unspecified,
         /// This policy acts as a minimum to other policies, lower in the hierarchy.
         /// Effective policy may only be the same or stricter.
-        pub const MINIMUM: PolicyType = PolicyType::new(1);
-
+        Minimum,
         /// This policy acts as a default if no other reauth policy is set.
-        pub const DEFAULT: PolicyType = PolicyType::new(2);
+        Default,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PolicyType::value] or
+        /// [PolicyType::name].
+        UnknownValue(policy_type::UnknownValue),
+    }
 
-        /// Creates a new PolicyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod policy_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PolicyType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Minimum => std::option::Option::Some(1),
+                Self::Default => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POLICY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MINIMUM"),
-                2 => std::borrow::Cow::Borrowed("DEFAULT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POLICY_TYPE_UNSPECIFIED"),
+                Self::Minimum => std::option::Option::Some("MINIMUM"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POLICY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POLICY_TYPE_UNSPECIFIED)
-                }
-                "MINIMUM" => std::option::Option::Some(Self::MINIMUM),
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PolicyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PolicyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PolicyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Minimum,
+                2 => Self::Default,
+                _ => Self::UnknownValue(policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PolicyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POLICY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MINIMUM" => Self::Minimum,
+                "DEFAULT" => Self::Default,
+                _ => Self::UnknownValue(policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PolicyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Minimum => serializer.serialize_i32(1),
+                Self::Default => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PolicyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PolicyType>::new(
+                ".google.cloud.iap.v1.ReauthSettings.PolicyType",
+            ))
         }
     }
 }
@@ -1554,68 +1733,129 @@ pub mod attribute_propagation_settings {
     /// Supported output credentials for attribute propagation. Each output
     /// credential maps to a "field" in the response. For example, selecting JWT
     /// will propagate all attributes in the IAP JWT, header in the headers, etc.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OutputCredentials(i32);
-
-    impl OutputCredentials {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OutputCredentials {
         /// An output credential is required.
-        pub const OUTPUT_CREDENTIALS_UNSPECIFIED: OutputCredentials = OutputCredentials::new(0);
-
+        Unspecified,
         /// Propagate attributes in the headers with "x-goog-iap-attr-" prefix.
-        pub const HEADER: OutputCredentials = OutputCredentials::new(1);
-
+        Header,
         /// Propagate attributes in the JWT of the form: `"additional_claims": {
         /// "my_attribute": ["value1", "value2"] }`
-        pub const JWT: OutputCredentials = OutputCredentials::new(2);
-
+        Jwt,
         /// Propagate attributes in the RCToken of the form: `"additional_claims": {
         /// "my_attribute": ["value1", "value2"] }`
-        pub const RCTOKEN: OutputCredentials = OutputCredentials::new(3);
+        Rctoken,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OutputCredentials::value] or
+        /// [OutputCredentials::name].
+        UnknownValue(output_credentials::UnknownValue),
+    }
 
-        /// Creates a new OutputCredentials instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod output_credentials {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OutputCredentials {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Header => std::option::Option::Some(1),
+                Self::Jwt => std::option::Option::Some(2),
+                Self::Rctoken => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OUTPUT_CREDENTIALS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HEADER"),
-                2 => std::borrow::Cow::Borrowed("JWT"),
-                3 => std::borrow::Cow::Borrowed("RCTOKEN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OUTPUT_CREDENTIALS_UNSPECIFIED"),
+                Self::Header => std::option::Option::Some("HEADER"),
+                Self::Jwt => std::option::Option::Some("JWT"),
+                Self::Rctoken => std::option::Option::Some("RCTOKEN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OUTPUT_CREDENTIALS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OUTPUT_CREDENTIALS_UNSPECIFIED)
-                }
-                "HEADER" => std::option::Option::Some(Self::HEADER),
-                "JWT" => std::option::Option::Some(Self::JWT),
-                "RCTOKEN" => std::option::Option::Some(Self::RCTOKEN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OutputCredentials {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OutputCredentials {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OutputCredentials {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OutputCredentials {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Header,
+                2 => Self::Jwt,
+                3 => Self::Rctoken,
+                _ => Self::UnknownValue(output_credentials::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OutputCredentials {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OUTPUT_CREDENTIALS_UNSPECIFIED" => Self::Unspecified,
+                "HEADER" => Self::Header,
+                "JWT" => Self::Jwt,
+                "RCTOKEN" => Self::Rctoken,
+                _ => Self::UnknownValue(output_credentials::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OutputCredentials {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Header => serializer.serialize_i32(1),
+                Self::Jwt => serializer.serialize_i32(2),
+                Self::Rctoken => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OutputCredentials {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OutputCredentials>::new(
+                ".google.cloud.iap.v1.AttributePropagationSettings.OutputCredentials",
+            ))
         }
     }
 }

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -188,136 +188,266 @@ pub mod endpoint {
     use super::*;
 
     /// Threat severity levels.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Not set.
+        Unspecified,
+        /// Informational alerts.
+        Informational,
+        /// Low severity alerts.
+        Low,
+        /// Medium severity alerts.
+        Medium,
+        /// High severity alerts.
+        High,
+        /// Critical severity alerts.
+        Critical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Not set.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// Informational alerts.
-        pub const INFORMATIONAL: Severity = Severity::new(1);
-
-        /// Low severity alerts.
-        pub const LOW: Severity = Severity::new(2);
-
-        /// Medium severity alerts.
-        pub const MEDIUM: Severity = Severity::new(3);
-
-        /// High severity alerts.
-        pub const HIGH: Severity = Severity::new(4);
-
-        /// Critical severity alerts.
-        pub const CRITICAL: Severity = Severity::new(5);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Informational => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::Critical => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INFORMATIONAL"),
-                2 => std::borrow::Cow::Borrowed("LOW"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HIGH"),
-                5 => std::borrow::Cow::Borrowed("CRITICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Informational => std::option::Option::Some("INFORMATIONAL"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "INFORMATIONAL" => std::option::Option::Some(Self::INFORMATIONAL),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Informational,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                5 => Self::Critical,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "INFORMATIONAL" => Self::Informational,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                "CRITICAL" => Self::Critical,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Informational => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::Critical => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.ids.v1.Endpoint.Severity",
+            ))
         }
     }
 
     /// Endpoint state
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not set.
+        Unspecified,
+        /// Being created.
+        Creating,
+        /// Active and ready for traffic.
+        Ready,
+        /// Being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Active and ready for traffic.
-        pub const READY: State = State::new(2);
-
-        /// Being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.ids.v1.Endpoint.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/kms/v1/src/client.rs
+++ b/src/generated/cloud/kms/v1/src/client.rs
@@ -927,8 +927,8 @@ impl KeyManagementService {
     /// or
     /// [ASYMMETRIC_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT].
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ASYMMETRIC_DECRYPT
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: crate::model::crypto_key::crypto_key_purpose::ASYMMETRIC_SIGN
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::AsymmetricDecrypt
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: crate::model::crypto_key::CryptoKeyPurpose::AsymmetricSign
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     pub fn get_public_key(
@@ -990,7 +990,7 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     pub fn create_crypto_key_version(
         &self,
@@ -1061,8 +1061,8 @@ impl KeyManagementService {
     /// to move between other states.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Disabled
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
     /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
@@ -1082,7 +1082,7 @@ impl KeyManagementService {
     /// [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     pub fn update_crypto_key_primary_version(
         &self,
@@ -1118,8 +1118,8 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.destroy_scheduled_duration]: crate::model::CryptoKey::destroy_scheduled_duration
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROYED
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROY_SCHEDULED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::CryptoKeyVersionState::Destroyed
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::CryptoKeyVersionState::DestroyScheduled
     /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: crate::model::CryptoKeyVersion::destroy_time
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
@@ -1142,8 +1142,8 @@ impl KeyManagementService {
     /// be cleared.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROY_SCHEDULED
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::CryptoKeyVersionState::DestroyScheduled
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Disabled
     /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: crate::model::CryptoKeyVersion::destroy_time
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     pub fn restore_crypto_key_version(
@@ -1159,7 +1159,7 @@ impl KeyManagementService {
     /// [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
     /// [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
     pub fn encrypt(
@@ -1175,7 +1175,7 @@ impl KeyManagementService {
     /// [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
     /// [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
     pub fn decrypt(
@@ -1193,7 +1193,7 @@ impl KeyManagementService {
     /// [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] must be
     /// [RAW_ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT].
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::RAW_ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::RawEncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
@@ -1210,7 +1210,7 @@ impl KeyManagementService {
     /// must be
     /// [RAW_ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT].
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::RAW_ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::RawEncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     pub fn raw_decrypt(
         &self,

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -578,66 +578,129 @@ pub mod autokey_config {
     use super::*;
 
     /// The states AutokeyConfig can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the AutokeyConfig is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The AutokeyConfig is currently active.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// A previously configured key project has been deleted and the current
         /// AutokeyConfig is unusable.
-        pub const KEY_PROJECT_DELETED: State = State::new(2);
-
+        KeyProjectDeleted,
         /// The AutokeyConfig is not yet initialized or has been reset to its default
         /// uninitialized state.
-        pub const UNINITIALIZED: State = State::new(3);
+        Uninitialized,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::KeyProjectDeleted => std::option::Option::Some(2),
+                Self::Uninitialized => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("KEY_PROJECT_DELETED"),
-                3 => std::borrow::Cow::Borrowed("UNINITIALIZED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::KeyProjectDeleted => std::option::Option::Some("KEY_PROJECT_DELETED"),
+                Self::Uninitialized => std::option::Option::Some("UNINITIALIZED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "KEY_PROJECT_DELETED" => std::option::Option::Some(Self::KEY_PROJECT_DELETED),
-                "UNINITIALIZED" => std::option::Option::Some(Self::UNINITIALIZED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::KeyProjectDeleted,
+                3 => Self::Uninitialized,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "KEY_PROJECT_DELETED" => Self::KeyProjectDeleted,
+                "UNINITIALIZED" => Self::Uninitialized,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::KeyProjectDeleted => serializer.serialize_i32(2),
+                Self::Uninitialized => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.kms.v1.AutokeyConfig.State",
+            ))
         }
     }
 }
@@ -1317,7 +1380,7 @@ impl wkt::message::Message for Certificate {
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
 /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
 /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
+/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1360,7 +1423,7 @@ pub struct EkmConnection {
     /// unset, this defaults to
     /// [MANUAL][google.cloud.kms.v1.EkmConnection.KeyManagementMode.MANUAL].
     ///
-    /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode.MANUAL]: crate::model::ekm_connection::key_management_mode::MANUAL
+    /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode.MANUAL]: crate::model::ekm_connection::KeyManagementMode::Manual
     pub key_management_mode: crate::model::ekm_connection::KeyManagementMode,
 
     /// Optional. Identifies the EKM Crypto Space that this
@@ -1371,7 +1434,7 @@ pub struct EkmConnection {
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
     /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode]: crate::model::ekm_connection::KeyManagementMode
-    /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode.CLOUD_KMS]: crate::model::ekm_connection::key_management_mode::CLOUD_KMS
+    /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode.CLOUD_KMS]: crate::model::ekm_connection::KeyManagementMode::CloudKms
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub crypto_space_path: std::string::String,
 
@@ -1543,13 +1606,11 @@ pub mod ekm_connection {
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
     /// [google.cloud.kms.v1.EkmConnection.KeyManagementMode]: crate::model::ekm_connection::KeyManagementMode
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyManagementMode(i32);
-
-    impl KeyManagementMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KeyManagementMode {
         /// Not specified.
-        pub const KEY_MANAGEMENT_MODE_UNSPECIFIED: KeyManagementMode = KeyManagementMode::new(0);
-
+        Unspecified,
         /// EKM-side key management operations on
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] created with this
         /// [EkmConnection][google.cloud.kms.v1.EkmConnection] must be initiated from
@@ -1568,8 +1629,7 @@ pub mod ekm_connection {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
-        pub const MANUAL: KeyManagementMode = KeyManagementMode::new(1);
-
+        Manual,
         /// All [CryptoKeys][google.cloud.kms.v1.CryptoKey] created with this
         /// [EkmConnection][google.cloud.kms.v1.EkmConnection] use EKM-side key
         /// management operations initiated from Cloud KMS. This means that:
@@ -1590,50 +1650,112 @@ pub mod ekm_connection {
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
         /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
-        pub const CLOUD_KMS: KeyManagementMode = KeyManagementMode::new(2);
+        CloudKms,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KeyManagementMode::value] or
+        /// [KeyManagementMode::name].
+        UnknownValue(key_management_mode::UnknownValue),
+    }
 
-        /// Creates a new KeyManagementMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod key_management_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KeyManagementMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Manual => std::option::Option::Some(1),
+                Self::CloudKms => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KEY_MANAGEMENT_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MANUAL"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_KMS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KEY_MANAGEMENT_MODE_UNSPECIFIED"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::CloudKms => std::option::Option::Some("CLOUD_KMS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KEY_MANAGEMENT_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KEY_MANAGEMENT_MODE_UNSPECIFIED)
-                }
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                "CLOUD_KMS" => std::option::Option::Some(Self::CLOUD_KMS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for KeyManagementMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyManagementMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KeyManagementMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KeyManagementMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Manual,
+                2 => Self::CloudKms,
+                _ => Self::UnknownValue(key_management_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KeyManagementMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KEY_MANAGEMENT_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MANUAL" => Self::Manual,
+                "CLOUD_KMS" => Self::CloudKms,
+                _ => Self::UnknownValue(key_management_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KeyManagementMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Manual => serializer.serialize_i32(1),
+                Self::CloudKms => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KeyManagementMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KeyManagementMode>::new(
+                ".google.cloud.kms.v1.EkmConnection.KeyManagementMode",
+            ))
         }
     }
 }
@@ -1650,7 +1772,7 @@ pub mod ekm_connection {
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
 /// [google.cloud.kms.v1.EkmConfig]: crate::model::EkmConfig
 /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
+/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1860,7 +1982,7 @@ pub struct CryptoKey {
     /// may have a primary. For other keys, this field will be omitted.
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.EncryptRequest.name]: crate::model::EncryptRequest::name
@@ -1900,7 +2022,7 @@ pub struct CryptoKey {
     /// support automatic rotation. For other keys, this field must be omitted.
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.next_rotation_time]: crate::model::CryptoKey::next_rotation_time
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
@@ -1935,8 +2057,8 @@ pub struct CryptoKey {
     /// [DESTROYED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED].
     /// If not specified at creation time, the default duration is 30 days.
     ///
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROYED
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROY_SCHEDULED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::CryptoKeyVersionState::Destroyed
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::CryptoKeyVersionState::DestroyScheduled
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub destroy_scheduled_duration: std::option::Option<wkt::Duration>,
 
@@ -1954,7 +2076,7 @@ pub struct CryptoKey {
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub crypto_key_backend: std::string::String,
 
@@ -2149,13 +2271,11 @@ pub mod crypto_key {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose]: crate::model::crypto_key::CryptoKeyPurpose
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyPurpose(i32);
-
-    impl CryptoKeyPurpose {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CryptoKeyPurpose {
         /// Not specified.
-        pub const CRYPTO_KEY_PURPOSE_UNSPECIFIED: CryptoKeyPurpose = CryptoKeyPurpose::new(0);
-
+        Unspecified,
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [Encrypt][google.cloud.kms.v1.KeyManagementService.Encrypt] and
         /// [Decrypt][google.cloud.kms.v1.KeyManagementService.Decrypt].
@@ -2163,8 +2283,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
         /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
-        pub const ENCRYPT_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new(1);
-
+        EncryptDecrypt,
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with
         /// [AsymmetricSign][google.cloud.kms.v1.KeyManagementService.AsymmetricSign]
@@ -2174,8 +2293,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.AsymmetricSign]: crate::client::KeyManagementService::asymmetric_sign
         /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
-        pub const ASYMMETRIC_SIGN: CryptoKeyPurpose = CryptoKeyPurpose::new(5);
-
+        AsymmetricSign,
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with
         /// [AsymmetricDecrypt][google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]
@@ -2185,8 +2303,7 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.AsymmetricDecrypt]: crate::client::KeyManagementService::asymmetric_decrypt
         /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
-        pub const ASYMMETRIC_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new(6);
-
+        AsymmetricDecrypt,
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [RawEncrypt][google.cloud.kms.v1.KeyManagementService.RawEncrypt]
         /// and [RawDecrypt][google.cloud.kms.v1.KeyManagementService.RawDecrypt].
@@ -2196,63 +2313,133 @@ pub mod crypto_key {
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.RawDecrypt]: crate::client::KeyManagementService::raw_decrypt
         /// [google.cloud.kms.v1.KeyManagementService.RawEncrypt]: crate::client::KeyManagementService::raw_encrypt
-        pub const RAW_ENCRYPT_DECRYPT: CryptoKeyPurpose = CryptoKeyPurpose::new(7);
-
+        RawEncryptDecrypt,
         /// [CryptoKeys][google.cloud.kms.v1.CryptoKey] with this purpose may be used
         /// with [MacSign][google.cloud.kms.v1.KeyManagementService.MacSign].
         ///
         /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
         /// [google.cloud.kms.v1.KeyManagementService.MacSign]: crate::client::KeyManagementService::mac_sign
-        pub const MAC: CryptoKeyPurpose = CryptoKeyPurpose::new(9);
+        Mac,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CryptoKeyPurpose::value] or
+        /// [CryptoKeyPurpose::name].
+        UnknownValue(crypto_key_purpose::UnknownValue),
+    }
 
-        /// Creates a new CryptoKeyPurpose instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod crypto_key_purpose {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CryptoKeyPurpose {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::EncryptDecrypt => std::option::Option::Some(1),
+                Self::AsymmetricSign => std::option::Option::Some(5),
+                Self::AsymmetricDecrypt => std::option::Option::Some(6),
+                Self::RawEncryptDecrypt => std::option::Option::Some(7),
+                Self::Mac => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_PURPOSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENCRYPT_DECRYPT"),
-                5 => std::borrow::Cow::Borrowed("ASYMMETRIC_SIGN"),
-                6 => std::borrow::Cow::Borrowed("ASYMMETRIC_DECRYPT"),
-                7 => std::borrow::Cow::Borrowed("RAW_ENCRYPT_DECRYPT"),
-                9 => std::borrow::Cow::Borrowed("MAC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CRYPTO_KEY_PURPOSE_UNSPECIFIED"),
+                Self::EncryptDecrypt => std::option::Option::Some("ENCRYPT_DECRYPT"),
+                Self::AsymmetricSign => std::option::Option::Some("ASYMMETRIC_SIGN"),
+                Self::AsymmetricDecrypt => std::option::Option::Some("ASYMMETRIC_DECRYPT"),
+                Self::RawEncryptDecrypt => std::option::Option::Some("RAW_ENCRYPT_DECRYPT"),
+                Self::Mac => std::option::Option::Some("MAC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CRYPTO_KEY_PURPOSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CRYPTO_KEY_PURPOSE_UNSPECIFIED)
-                }
-                "ENCRYPT_DECRYPT" => std::option::Option::Some(Self::ENCRYPT_DECRYPT),
-                "ASYMMETRIC_SIGN" => std::option::Option::Some(Self::ASYMMETRIC_SIGN),
-                "ASYMMETRIC_DECRYPT" => std::option::Option::Some(Self::ASYMMETRIC_DECRYPT),
-                "RAW_ENCRYPT_DECRYPT" => std::option::Option::Some(Self::RAW_ENCRYPT_DECRYPT),
-                "MAC" => std::option::Option::Some(Self::MAC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CryptoKeyPurpose {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyPurpose {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CryptoKeyPurpose {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CryptoKeyPurpose {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::EncryptDecrypt,
+                5 => Self::AsymmetricSign,
+                6 => Self::AsymmetricDecrypt,
+                7 => Self::RawEncryptDecrypt,
+                9 => Self::Mac,
+                _ => Self::UnknownValue(crypto_key_purpose::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CryptoKeyPurpose {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CRYPTO_KEY_PURPOSE_UNSPECIFIED" => Self::Unspecified,
+                "ENCRYPT_DECRYPT" => Self::EncryptDecrypt,
+                "ASYMMETRIC_SIGN" => Self::AsymmetricSign,
+                "ASYMMETRIC_DECRYPT" => Self::AsymmetricDecrypt,
+                "RAW_ENCRYPT_DECRYPT" => Self::RawEncryptDecrypt,
+                "MAC" => Self::Mac,
+                _ => Self::UnknownValue(crypto_key_purpose::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CryptoKeyPurpose {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::EncryptDecrypt => serializer.serialize_i32(1),
+                Self::AsymmetricSign => serializer.serialize_i32(5),
+                Self::AsymmetricDecrypt => serializer.serialize_i32(6),
+                Self::RawEncryptDecrypt => serializer.serialize_i32(7),
+                Self::Mac => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CryptoKeyPurpose {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CryptoKeyPurpose>::new(
+                ".google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose",
+            ))
         }
     }
 
@@ -2274,7 +2461,7 @@ pub mod crypto_key {
         /// [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]
         /// support automatic rotation. For other keys, this field must be omitted.
         ///
-        /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+        /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
         /// [google.cloud.kms.v1.CryptoKey.next_rotation_time]: crate::model::CryptoKey::next_rotation_time
         /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
         /// [google.cloud.kms.v1.CryptoKey.rotation_period]: crate::model::CryptoKey::rotation_schedule
@@ -2304,7 +2491,7 @@ pub struct CryptoKeyVersionTemplate {
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::protection_level::SOFTWARE
+    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::ProtectionLevel::Software
     pub protection_level: crate::model::ProtectionLevel,
 
     /// Required.
@@ -2318,7 +2505,7 @@ pub struct CryptoKeyVersionTemplate {
     /// [CryptoKey.purpose][google.cloud.kms.v1.CryptoKey.purpose] is
     /// [ENCRYPT_DECRYPT][google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT].
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm]: crate::model::crypto_key_version::CryptoKeyVersionAlgorithm
@@ -2503,66 +2690,125 @@ pub mod key_operation_attestation {
     }
 
     /// Attestation formats provided by the HSM.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttestationFormat(i32);
-
-    impl AttestationFormat {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttestationFormat {
         /// Not specified.
-        pub const ATTESTATION_FORMAT_UNSPECIFIED: AttestationFormat = AttestationFormat::new(0);
-
+        Unspecified,
         /// Cavium HSM attestation compressed with gzip. Note that this format is
         /// defined by Cavium and subject to change at any time.
         ///
         /// See
         /// <https://www.marvell.com/products/security-solutions/nitrox-hs-adapters/software-key-attestation.html>.
-        pub const CAVIUM_V1_COMPRESSED: AttestationFormat = AttestationFormat::new(3);
-
+        CaviumV1Compressed,
         /// Cavium HSM attestation V2 compressed with gzip. This is a new format
         /// introduced in Cavium's version 3.2-08.
-        pub const CAVIUM_V2_COMPRESSED: AttestationFormat = AttestationFormat::new(4);
+        CaviumV2Compressed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttestationFormat::value] or
+        /// [AttestationFormat::name].
+        UnknownValue(attestation_format::UnknownValue),
+    }
 
-        /// Creates a new AttestationFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attestation_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttestationFormat {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CaviumV1Compressed => std::option::Option::Some(3),
+                Self::CaviumV2Compressed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTESTATION_FORMAT_UNSPECIFIED"),
-                3 => std::borrow::Cow::Borrowed("CAVIUM_V1_COMPRESSED"),
-                4 => std::borrow::Cow::Borrowed("CAVIUM_V2_COMPRESSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTESTATION_FORMAT_UNSPECIFIED"),
+                Self::CaviumV1Compressed => std::option::Option::Some("CAVIUM_V1_COMPRESSED"),
+                Self::CaviumV2Compressed => std::option::Option::Some("CAVIUM_V2_COMPRESSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTESTATION_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTESTATION_FORMAT_UNSPECIFIED)
-                }
-                "CAVIUM_V1_COMPRESSED" => std::option::Option::Some(Self::CAVIUM_V1_COMPRESSED),
-                "CAVIUM_V2_COMPRESSED" => std::option::Option::Some(Self::CAVIUM_V2_COMPRESSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttestationFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttestationFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttestationFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttestationFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                3 => Self::CaviumV1Compressed,
+                4 => Self::CaviumV2Compressed,
+                _ => Self::UnknownValue(attestation_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttestationFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTESTATION_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "CAVIUM_V1_COMPRESSED" => Self::CaviumV1Compressed,
+                "CAVIUM_V2_COMPRESSED" => Self::CaviumV2Compressed,
+                _ => Self::UnknownValue(attestation_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttestationFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CaviumV1Compressed => serializer.serialize_i32(3),
+                Self::CaviumV2Compressed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttestationFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttestationFormat>::new(
+                ".google.cloud.kms.v1.KeyOperationAttestation.AttestationFormat",
+            ))
         }
     }
 }
@@ -2580,7 +2826,7 @@ pub mod key_operation_attestation {
 /// authorized user or application invokes Cloud KMS.
 ///
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-/// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
+/// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -2624,7 +2870,7 @@ pub struct CryptoKeyVersion {
     /// [HSM][google.cloud.kms.v1.ProtectionLevel.HSM].
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion.protection_level]: crate::model::CryptoKeyVersion::protection_level
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub attestation: std::option::Option<crate::model::KeyOperationAttestation>,
 
@@ -2650,7 +2896,7 @@ pub struct CryptoKeyVersion {
     /// [DESTROY_SCHEDULED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED].
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROY_SCHEDULED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED]: crate::model::crypto_key_version::CryptoKeyVersionState::DestroyScheduled
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub destroy_time: std::option::Option<wkt::Timestamp>,
@@ -2660,7 +2906,7 @@ pub struct CryptoKeyVersion {
     /// [state][google.cloud.kms.v1.CryptoKeyVersion.state] is
     /// [DESTROYED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED].
     ///
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROYED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::CryptoKeyVersionState::Destroyed
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub destroy_event_time: std::option::Option<wkt::Timestamp>,
@@ -2687,7 +2933,7 @@ pub struct CryptoKeyVersion {
     /// if [state][google.cloud.kms.v1.CryptoKeyVersion.state] is
     /// [IMPORT_FAILED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.IMPORT_FAILED].
     ///
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.IMPORT_FAILED]: crate::model::crypto_key_version::crypto_key_version_state::IMPORT_FAILED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.IMPORT_FAILED]: crate::model::crypto_key_version::CryptoKeyVersionState::ImportFailed
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub import_failure_reason: std::string::String,
@@ -2696,7 +2942,7 @@ pub struct CryptoKeyVersion {
     /// present if [state][google.cloud.kms.v1.CryptoKeyVersion.state] is
     /// [GENERATION_FAILED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.GENERATION_FAILED].
     ///
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.GENERATION_FAILED]: crate::model::crypto_key_version::crypto_key_version_state::GENERATION_FAILED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.GENERATION_FAILED]: crate::model::crypto_key_version::CryptoKeyVersionState::GenerationFailed
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub generation_failure_reason: std::string::String,
@@ -2706,7 +2952,7 @@ pub struct CryptoKeyVersion {
     /// [state][google.cloud.kms.v1.CryptoKeyVersion.state] is
     /// [EXTERNAL_DESTRUCTION_FAILED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.EXTERNAL_DESTRUCTION_FAILED].
     ///
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.EXTERNAL_DESTRUCTION_FAILED]: crate::model::crypto_key_version::crypto_key_version_state::EXTERNAL_DESTRUCTION_FAILED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.EXTERNAL_DESTRUCTION_FAILED]: crate::model::crypto_key_version::CryptoKeyVersionState::ExternalDestructionFailed
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub external_destruction_failure_reason: std::string::String,
@@ -2719,8 +2965,8 @@ pub struct CryptoKeyVersion {
     /// protection levels.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::protection_level::EXTERNAL
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::ProtectionLevel::External
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub external_protection_level_options:
         std::option::Option<crate::model::ExternalProtectionLevelOptions>,
@@ -2943,322 +3189,416 @@ pub mod crypto_key_version {
     /// For more information, see [Key purposes and algorithms]
     /// (<https://cloud.google.com/kms/docs/algorithms>).
     ///
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ASYMMETRIC_DECRYPT
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: crate::model::crypto_key::crypto_key_purpose::ASYMMETRIC_SIGN
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::crypto_key_purpose::ENCRYPT_DECRYPT
-    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.MAC]: crate::model::crypto_key::crypto_key_purpose::MAC
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::AsymmetricDecrypt
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: crate::model::crypto_key::CryptoKeyPurpose::AsymmetricSign
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
+    /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.MAC]: crate::model::crypto_key::CryptoKeyPurpose::Mac
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.GOOGLE_SYMMETRIC_ENCRYPTION]: crate::model::crypto_key_version::crypto_key_version_algorithm::GOOGLE_SYMMETRIC_ENCRYPTION
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256]: crate::model::crypto_key_version::crypto_key_version_algorithm::RSA_SIGN_PSS_2048_SHA256
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyVersionAlgorithm(i32);
-
-    impl CryptoKeyVersionAlgorithm {
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.GOOGLE_SYMMETRIC_ENCRYPTION]: crate::model::crypto_key_version::CryptoKeyVersionAlgorithm::GoogleSymmetricEncryption
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256]: crate::model::crypto_key_version::CryptoKeyVersionAlgorithm::RsaSignPss2048Sha256
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CryptoKeyVersionAlgorithm {
         /// Not specified.
-        pub const CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(0);
-
+        Unspecified,
         /// Creates symmetric encryption keys.
-        pub const GOOGLE_SYMMETRIC_ENCRYPTION: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(1);
-
+        GoogleSymmetricEncryption,
         /// AES-GCM (Galois Counter Mode) using 128-bit keys.
-        pub const AES_128_GCM: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(41);
-
+        Aes128Gcm,
         /// AES-GCM (Galois Counter Mode) using 256-bit keys.
-        pub const AES_256_GCM: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(19);
-
+        Aes256Gcm,
         /// AES-CBC (Cipher Block Chaining Mode) using 128-bit keys.
-        pub const AES_128_CBC: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(42);
-
+        Aes128Cbc,
         /// AES-CBC (Cipher Block Chaining Mode) using 256-bit keys.
-        pub const AES_256_CBC: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(43);
-
+        Aes256Cbc,
         /// AES-CTR (Counter Mode) using 128-bit keys.
-        pub const AES_128_CTR: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(44);
-
+        Aes128Ctr,
         /// AES-CTR (Counter Mode) using 256-bit keys.
-        pub const AES_256_CTR: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(45);
-
+        Aes256Ctr,
         /// RSASSA-PSS 2048 bit key with a SHA256 digest.
-        pub const RSA_SIGN_PSS_2048_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(2);
-
+        RsaSignPss2048Sha256,
         /// RSASSA-PSS 3072 bit key with a SHA256 digest.
-        pub const RSA_SIGN_PSS_3072_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(3);
-
+        RsaSignPss3072Sha256,
         /// RSASSA-PSS 4096 bit key with a SHA256 digest.
-        pub const RSA_SIGN_PSS_4096_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(4);
-
+        RsaSignPss4096Sha256,
         /// RSASSA-PSS 4096 bit key with a SHA512 digest.
-        pub const RSA_SIGN_PSS_4096_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(15);
-
+        RsaSignPss4096Sha512,
         /// RSASSA-PKCS1-v1_5 with a 2048 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_2048_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(5);
-
+        RsaSignPkcs12048Sha256,
         /// RSASSA-PKCS1-v1_5 with a 3072 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_3072_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(6);
-
+        RsaSignPkcs13072Sha256,
         /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA256 digest.
-        pub const RSA_SIGN_PKCS1_4096_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(7);
-
+        RsaSignPkcs14096Sha256,
         /// RSASSA-PKCS1-v1_5 with a 4096 bit key and a SHA512 digest.
-        pub const RSA_SIGN_PKCS1_4096_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(16);
-
+        RsaSignPkcs14096Sha512,
         /// RSASSA-PKCS1-v1_5 signing without encoding, with a 2048 bit key.
-        pub const RSA_SIGN_RAW_PKCS1_2048: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(28);
-
+        RsaSignRawPkcs12048,
         /// RSASSA-PKCS1-v1_5 signing without encoding, with a 3072 bit key.
-        pub const RSA_SIGN_RAW_PKCS1_3072: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(29);
-
+        RsaSignRawPkcs13072,
         /// RSASSA-PKCS1-v1_5 signing without encoding, with a 4096 bit key.
-        pub const RSA_SIGN_RAW_PKCS1_4096: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(30);
-
+        RsaSignRawPkcs14096,
         /// RSAES-OAEP 2048 bit key with a SHA256 digest.
-        pub const RSA_DECRYPT_OAEP_2048_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(8);
-
+        RsaDecryptOaep2048Sha256,
         /// RSAES-OAEP 3072 bit key with a SHA256 digest.
-        pub const RSA_DECRYPT_OAEP_3072_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(9);
-
+        RsaDecryptOaep3072Sha256,
         /// RSAES-OAEP 4096 bit key with a SHA256 digest.
-        pub const RSA_DECRYPT_OAEP_4096_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(10);
-
+        RsaDecryptOaep4096Sha256,
         /// RSAES-OAEP 4096 bit key with a SHA512 digest.
-        pub const RSA_DECRYPT_OAEP_4096_SHA512: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(17);
-
+        RsaDecryptOaep4096Sha512,
         /// RSAES-OAEP 2048 bit key with a SHA1 digest.
-        pub const RSA_DECRYPT_OAEP_2048_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(37);
-
+        RsaDecryptOaep2048Sha1,
         /// RSAES-OAEP 3072 bit key with a SHA1 digest.
-        pub const RSA_DECRYPT_OAEP_3072_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(38);
-
+        RsaDecryptOaep3072Sha1,
         /// RSAES-OAEP 4096 bit key with a SHA1 digest.
-        pub const RSA_DECRYPT_OAEP_4096_SHA1: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(39);
-
+        RsaDecryptOaep4096Sha1,
         /// ECDSA on the NIST P-256 curve with a SHA256 digest.
         /// Other hash functions can also be used:
         /// <https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms>
-        pub const EC_SIGN_P256_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(12);
-
+        EcSignP256Sha256,
         /// ECDSA on the NIST P-384 curve with a SHA384 digest.
         /// Other hash functions can also be used:
         /// <https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms>
-        pub const EC_SIGN_P384_SHA384: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(13);
-
+        EcSignP384Sha384,
         /// ECDSA on the non-NIST secp256k1 curve. This curve is only supported for
         /// HSM protection level.
         /// Other hash functions can also be used:
         /// <https://cloud.google.com/kms/docs/create-validate-signatures#ecdsa_support_for_other_hash_algorithms>
-        pub const EC_SIGN_SECP256K1_SHA256: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(31);
-
+        EcSignSecp256K1Sha256,
         /// EdDSA on the Curve25519 in pure mode (taking data as input).
-        pub const EC_SIGN_ED25519: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(40);
-
+        EcSignEd25519,
         /// HMAC-SHA256 signing with a 256 bit key.
-        pub const HMAC_SHA256: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(32);
-
+        HmacSha256,
         /// HMAC-SHA1 signing with a 160 bit key.
-        pub const HMAC_SHA1: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(33);
-
+        HmacSha1,
         /// HMAC-SHA384 signing with a 384 bit key.
-        pub const HMAC_SHA384: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(34);
-
+        HmacSha384,
         /// HMAC-SHA512 signing with a 512 bit key.
-        pub const HMAC_SHA512: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(35);
-
+        HmacSha512,
         /// HMAC-SHA224 signing with a 224 bit key.
-        pub const HMAC_SHA224: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(36);
-
+        HmacSha224,
         /// Algorithm representing symmetric encryption by an external key manager.
-        pub const EXTERNAL_SYMMETRIC_ENCRYPTION: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(18);
-
+        ExternalSymmetricEncryption,
         /// The post-quantum Module-Lattice-Based Digital Signature Algorithm, at
         /// security level 3. Randomized version.
-        pub const PQ_SIGN_ML_DSA_65: CryptoKeyVersionAlgorithm = CryptoKeyVersionAlgorithm::new(56);
-
+        PqSignMlDsa65,
         /// The post-quantum stateless hash-based digital signature algorithm, at
         /// security level 1. Randomized version.
-        pub const PQ_SIGN_SLH_DSA_SHA2_128S: CryptoKeyVersionAlgorithm =
-            CryptoKeyVersionAlgorithm::new(57);
+        PqSignSlhDsaSha2128S,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CryptoKeyVersionAlgorithm::value] or
+        /// [CryptoKeyVersionAlgorithm::name].
+        UnknownValue(crypto_key_version_algorithm::UnknownValue),
+    }
 
-        /// Creates a new CryptoKeyVersionAlgorithm instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod crypto_key_version_algorithm {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CryptoKeyVersionAlgorithm {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleSymmetricEncryption => std::option::Option::Some(1),
+                Self::Aes128Gcm => std::option::Option::Some(41),
+                Self::Aes256Gcm => std::option::Option::Some(19),
+                Self::Aes128Cbc => std::option::Option::Some(42),
+                Self::Aes256Cbc => std::option::Option::Some(43),
+                Self::Aes128Ctr => std::option::Option::Some(44),
+                Self::Aes256Ctr => std::option::Option::Some(45),
+                Self::RsaSignPss2048Sha256 => std::option::Option::Some(2),
+                Self::RsaSignPss3072Sha256 => std::option::Option::Some(3),
+                Self::RsaSignPss4096Sha256 => std::option::Option::Some(4),
+                Self::RsaSignPss4096Sha512 => std::option::Option::Some(15),
+                Self::RsaSignPkcs12048Sha256 => std::option::Option::Some(5),
+                Self::RsaSignPkcs13072Sha256 => std::option::Option::Some(6),
+                Self::RsaSignPkcs14096Sha256 => std::option::Option::Some(7),
+                Self::RsaSignPkcs14096Sha512 => std::option::Option::Some(16),
+                Self::RsaSignRawPkcs12048 => std::option::Option::Some(28),
+                Self::RsaSignRawPkcs13072 => std::option::Option::Some(29),
+                Self::RsaSignRawPkcs14096 => std::option::Option::Some(30),
+                Self::RsaDecryptOaep2048Sha256 => std::option::Option::Some(8),
+                Self::RsaDecryptOaep3072Sha256 => std::option::Option::Some(9),
+                Self::RsaDecryptOaep4096Sha256 => std::option::Option::Some(10),
+                Self::RsaDecryptOaep4096Sha512 => std::option::Option::Some(17),
+                Self::RsaDecryptOaep2048Sha1 => std::option::Option::Some(37),
+                Self::RsaDecryptOaep3072Sha1 => std::option::Option::Some(38),
+                Self::RsaDecryptOaep4096Sha1 => std::option::Option::Some(39),
+                Self::EcSignP256Sha256 => std::option::Option::Some(12),
+                Self::EcSignP384Sha384 => std::option::Option::Some(13),
+                Self::EcSignSecp256K1Sha256 => std::option::Option::Some(31),
+                Self::EcSignEd25519 => std::option::Option::Some(40),
+                Self::HmacSha256 => std::option::Option::Some(32),
+                Self::HmacSha1 => std::option::Option::Some(33),
+                Self::HmacSha384 => std::option::Option::Some(34),
+                Self::HmacSha512 => std::option::Option::Some(35),
+                Self::HmacSha224 => std::option::Option::Some(36),
+                Self::ExternalSymmetricEncryption => std::option::Option::Some(18),
+                Self::PqSignMlDsa65 => std::option::Option::Some(56),
+                Self::PqSignSlhDsaSha2128S => std::option::Option::Some(57),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_SYMMETRIC_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_2048_SHA256"),
-                3 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_3072_SHA256"),
-                4 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_4096_SHA256"),
-                5 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_2048_SHA256"),
-                6 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_3072_SHA256"),
-                7 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA256"),
-                8 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_2048_SHA256"),
-                9 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_3072_SHA256"),
-                10 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_4096_SHA256"),
-                12 => std::borrow::Cow::Borrowed("EC_SIGN_P256_SHA256"),
-                13 => std::borrow::Cow::Borrowed("EC_SIGN_P384_SHA384"),
-                15 => std::borrow::Cow::Borrowed("RSA_SIGN_PSS_4096_SHA512"),
-                16 => std::borrow::Cow::Borrowed("RSA_SIGN_PKCS1_4096_SHA512"),
-                17 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_4096_SHA512"),
-                18 => std::borrow::Cow::Borrowed("EXTERNAL_SYMMETRIC_ENCRYPTION"),
-                19 => std::borrow::Cow::Borrowed("AES_256_GCM"),
-                28 => std::borrow::Cow::Borrowed("RSA_SIGN_RAW_PKCS1_2048"),
-                29 => std::borrow::Cow::Borrowed("RSA_SIGN_RAW_PKCS1_3072"),
-                30 => std::borrow::Cow::Borrowed("RSA_SIGN_RAW_PKCS1_4096"),
-                31 => std::borrow::Cow::Borrowed("EC_SIGN_SECP256K1_SHA256"),
-                32 => std::borrow::Cow::Borrowed("HMAC_SHA256"),
-                33 => std::borrow::Cow::Borrowed("HMAC_SHA1"),
-                34 => std::borrow::Cow::Borrowed("HMAC_SHA384"),
-                35 => std::borrow::Cow::Borrowed("HMAC_SHA512"),
-                36 => std::borrow::Cow::Borrowed("HMAC_SHA224"),
-                37 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_2048_SHA1"),
-                38 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_3072_SHA1"),
-                39 => std::borrow::Cow::Borrowed("RSA_DECRYPT_OAEP_4096_SHA1"),
-                40 => std::borrow::Cow::Borrowed("EC_SIGN_ED25519"),
-                41 => std::borrow::Cow::Borrowed("AES_128_GCM"),
-                42 => std::borrow::Cow::Borrowed("AES_128_CBC"),
-                43 => std::borrow::Cow::Borrowed("AES_256_CBC"),
-                44 => std::borrow::Cow::Borrowed("AES_128_CTR"),
-                45 => std::borrow::Cow::Borrowed("AES_256_CTR"),
-                56 => std::borrow::Cow::Borrowed("PQ_SIGN_ML_DSA_65"),
-                57 => std::borrow::Cow::Borrowed("PQ_SIGN_SLH_DSA_SHA2_128S"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED")
+                }
+                Self::GoogleSymmetricEncryption => {
+                    std::option::Option::Some("GOOGLE_SYMMETRIC_ENCRYPTION")
+                }
+                Self::Aes128Gcm => std::option::Option::Some("AES_128_GCM"),
+                Self::Aes256Gcm => std::option::Option::Some("AES_256_GCM"),
+                Self::Aes128Cbc => std::option::Option::Some("AES_128_CBC"),
+                Self::Aes256Cbc => std::option::Option::Some("AES_256_CBC"),
+                Self::Aes128Ctr => std::option::Option::Some("AES_128_CTR"),
+                Self::Aes256Ctr => std::option::Option::Some("AES_256_CTR"),
+                Self::RsaSignPss2048Sha256 => std::option::Option::Some("RSA_SIGN_PSS_2048_SHA256"),
+                Self::RsaSignPss3072Sha256 => std::option::Option::Some("RSA_SIGN_PSS_3072_SHA256"),
+                Self::RsaSignPss4096Sha256 => std::option::Option::Some("RSA_SIGN_PSS_4096_SHA256"),
+                Self::RsaSignPss4096Sha512 => std::option::Option::Some("RSA_SIGN_PSS_4096_SHA512"),
+                Self::RsaSignPkcs12048Sha256 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_2048_SHA256")
+                }
+                Self::RsaSignPkcs13072Sha256 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_3072_SHA256")
+                }
+                Self::RsaSignPkcs14096Sha256 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_4096_SHA256")
+                }
+                Self::RsaSignPkcs14096Sha512 => {
+                    std::option::Option::Some("RSA_SIGN_PKCS1_4096_SHA512")
+                }
+                Self::RsaSignRawPkcs12048 => std::option::Option::Some("RSA_SIGN_RAW_PKCS1_2048"),
+                Self::RsaSignRawPkcs13072 => std::option::Option::Some("RSA_SIGN_RAW_PKCS1_3072"),
+                Self::RsaSignRawPkcs14096 => std::option::Option::Some("RSA_SIGN_RAW_PKCS1_4096"),
+                Self::RsaDecryptOaep2048Sha256 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_2048_SHA256")
+                }
+                Self::RsaDecryptOaep3072Sha256 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_3072_SHA256")
+                }
+                Self::RsaDecryptOaep4096Sha256 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_4096_SHA256")
+                }
+                Self::RsaDecryptOaep4096Sha512 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_4096_SHA512")
+                }
+                Self::RsaDecryptOaep2048Sha1 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_2048_SHA1")
+                }
+                Self::RsaDecryptOaep3072Sha1 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_3072_SHA1")
+                }
+                Self::RsaDecryptOaep4096Sha1 => {
+                    std::option::Option::Some("RSA_DECRYPT_OAEP_4096_SHA1")
+                }
+                Self::EcSignP256Sha256 => std::option::Option::Some("EC_SIGN_P256_SHA256"),
+                Self::EcSignP384Sha384 => std::option::Option::Some("EC_SIGN_P384_SHA384"),
+                Self::EcSignSecp256K1Sha256 => {
+                    std::option::Option::Some("EC_SIGN_SECP256K1_SHA256")
+                }
+                Self::EcSignEd25519 => std::option::Option::Some("EC_SIGN_ED25519"),
+                Self::HmacSha256 => std::option::Option::Some("HMAC_SHA256"),
+                Self::HmacSha1 => std::option::Option::Some("HMAC_SHA1"),
+                Self::HmacSha384 => std::option::Option::Some("HMAC_SHA384"),
+                Self::HmacSha512 => std::option::Option::Some("HMAC_SHA512"),
+                Self::HmacSha224 => std::option::Option::Some("HMAC_SHA224"),
+                Self::ExternalSymmetricEncryption => {
+                    std::option::Option::Some("EXTERNAL_SYMMETRIC_ENCRYPTION")
+                }
+                Self::PqSignMlDsa65 => std::option::Option::Some("PQ_SIGN_ML_DSA_65"),
+                Self::PqSignSlhDsaSha2128S => {
+                    std::option::Option::Some("PQ_SIGN_SLH_DSA_SHA2_128S")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED)
-                }
-                "GOOGLE_SYMMETRIC_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_SYMMETRIC_ENCRYPTION)
-                }
-                "AES_128_GCM" => std::option::Option::Some(Self::AES_128_GCM),
-                "AES_256_GCM" => std::option::Option::Some(Self::AES_256_GCM),
-                "AES_128_CBC" => std::option::Option::Some(Self::AES_128_CBC),
-                "AES_256_CBC" => std::option::Option::Some(Self::AES_256_CBC),
-                "AES_128_CTR" => std::option::Option::Some(Self::AES_128_CTR),
-                "AES_256_CTR" => std::option::Option::Some(Self::AES_256_CTR),
-                "RSA_SIGN_PSS_2048_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PSS_2048_SHA256)
-                }
-                "RSA_SIGN_PSS_3072_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PSS_3072_SHA256)
-                }
-                "RSA_SIGN_PSS_4096_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PSS_4096_SHA256)
-                }
-                "RSA_SIGN_PSS_4096_SHA512" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PSS_4096_SHA512)
-                }
-                "RSA_SIGN_PKCS1_2048_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_2048_SHA256)
-                }
-                "RSA_SIGN_PKCS1_3072_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_3072_SHA256)
-                }
-                "RSA_SIGN_PKCS1_4096_SHA256" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA256)
-                }
-                "RSA_SIGN_PKCS1_4096_SHA512" => {
-                    std::option::Option::Some(Self::RSA_SIGN_PKCS1_4096_SHA512)
-                }
-                "RSA_SIGN_RAW_PKCS1_2048" => {
-                    std::option::Option::Some(Self::RSA_SIGN_RAW_PKCS1_2048)
-                }
-                "RSA_SIGN_RAW_PKCS1_3072" => {
-                    std::option::Option::Some(Self::RSA_SIGN_RAW_PKCS1_3072)
-                }
-                "RSA_SIGN_RAW_PKCS1_4096" => {
-                    std::option::Option::Some(Self::RSA_SIGN_RAW_PKCS1_4096)
-                }
-                "RSA_DECRYPT_OAEP_2048_SHA256" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_2048_SHA256)
-                }
-                "RSA_DECRYPT_OAEP_3072_SHA256" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_3072_SHA256)
-                }
-                "RSA_DECRYPT_OAEP_4096_SHA256" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_4096_SHA256)
-                }
-                "RSA_DECRYPT_OAEP_4096_SHA512" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_4096_SHA512)
-                }
-                "RSA_DECRYPT_OAEP_2048_SHA1" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_2048_SHA1)
-                }
-                "RSA_DECRYPT_OAEP_3072_SHA1" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_3072_SHA1)
-                }
-                "RSA_DECRYPT_OAEP_4096_SHA1" => {
-                    std::option::Option::Some(Self::RSA_DECRYPT_OAEP_4096_SHA1)
-                }
-                "EC_SIGN_P256_SHA256" => std::option::Option::Some(Self::EC_SIGN_P256_SHA256),
-                "EC_SIGN_P384_SHA384" => std::option::Option::Some(Self::EC_SIGN_P384_SHA384),
-                "EC_SIGN_SECP256K1_SHA256" => {
-                    std::option::Option::Some(Self::EC_SIGN_SECP256K1_SHA256)
-                }
-                "EC_SIGN_ED25519" => std::option::Option::Some(Self::EC_SIGN_ED25519),
-                "HMAC_SHA256" => std::option::Option::Some(Self::HMAC_SHA256),
-                "HMAC_SHA1" => std::option::Option::Some(Self::HMAC_SHA1),
-                "HMAC_SHA384" => std::option::Option::Some(Self::HMAC_SHA384),
-                "HMAC_SHA512" => std::option::Option::Some(Self::HMAC_SHA512),
-                "HMAC_SHA224" => std::option::Option::Some(Self::HMAC_SHA224),
-                "EXTERNAL_SYMMETRIC_ENCRYPTION" => {
-                    std::option::Option::Some(Self::EXTERNAL_SYMMETRIC_ENCRYPTION)
-                }
-                "PQ_SIGN_ML_DSA_65" => std::option::Option::Some(Self::PQ_SIGN_ML_DSA_65),
-                "PQ_SIGN_SLH_DSA_SHA2_128S" => {
-                    std::option::Option::Some(Self::PQ_SIGN_SLH_DSA_SHA2_128S)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CryptoKeyVersionAlgorithm {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyVersionAlgorithm {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CryptoKeyVersionAlgorithm {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CryptoKeyVersionAlgorithm {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleSymmetricEncryption,
+                2 => Self::RsaSignPss2048Sha256,
+                3 => Self::RsaSignPss3072Sha256,
+                4 => Self::RsaSignPss4096Sha256,
+                5 => Self::RsaSignPkcs12048Sha256,
+                6 => Self::RsaSignPkcs13072Sha256,
+                7 => Self::RsaSignPkcs14096Sha256,
+                8 => Self::RsaDecryptOaep2048Sha256,
+                9 => Self::RsaDecryptOaep3072Sha256,
+                10 => Self::RsaDecryptOaep4096Sha256,
+                12 => Self::EcSignP256Sha256,
+                13 => Self::EcSignP384Sha384,
+                15 => Self::RsaSignPss4096Sha512,
+                16 => Self::RsaSignPkcs14096Sha512,
+                17 => Self::RsaDecryptOaep4096Sha512,
+                18 => Self::ExternalSymmetricEncryption,
+                19 => Self::Aes256Gcm,
+                28 => Self::RsaSignRawPkcs12048,
+                29 => Self::RsaSignRawPkcs13072,
+                30 => Self::RsaSignRawPkcs14096,
+                31 => Self::EcSignSecp256K1Sha256,
+                32 => Self::HmacSha256,
+                33 => Self::HmacSha1,
+                34 => Self::HmacSha384,
+                35 => Self::HmacSha512,
+                36 => Self::HmacSha224,
+                37 => Self::RsaDecryptOaep2048Sha1,
+                38 => Self::RsaDecryptOaep3072Sha1,
+                39 => Self::RsaDecryptOaep4096Sha1,
+                40 => Self::EcSignEd25519,
+                41 => Self::Aes128Gcm,
+                42 => Self::Aes128Cbc,
+                43 => Self::Aes256Cbc,
+                44 => Self::Aes128Ctr,
+                45 => Self::Aes256Ctr,
+                56 => Self::PqSignMlDsa65,
+                57 => Self::PqSignSlhDsaSha2128S,
+                _ => Self::UnknownValue(crypto_key_version_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CryptoKeyVersionAlgorithm {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_SYMMETRIC_ENCRYPTION" => Self::GoogleSymmetricEncryption,
+                "AES_128_GCM" => Self::Aes128Gcm,
+                "AES_256_GCM" => Self::Aes256Gcm,
+                "AES_128_CBC" => Self::Aes128Cbc,
+                "AES_256_CBC" => Self::Aes256Cbc,
+                "AES_128_CTR" => Self::Aes128Ctr,
+                "AES_256_CTR" => Self::Aes256Ctr,
+                "RSA_SIGN_PSS_2048_SHA256" => Self::RsaSignPss2048Sha256,
+                "RSA_SIGN_PSS_3072_SHA256" => Self::RsaSignPss3072Sha256,
+                "RSA_SIGN_PSS_4096_SHA256" => Self::RsaSignPss4096Sha256,
+                "RSA_SIGN_PSS_4096_SHA512" => Self::RsaSignPss4096Sha512,
+                "RSA_SIGN_PKCS1_2048_SHA256" => Self::RsaSignPkcs12048Sha256,
+                "RSA_SIGN_PKCS1_3072_SHA256" => Self::RsaSignPkcs13072Sha256,
+                "RSA_SIGN_PKCS1_4096_SHA256" => Self::RsaSignPkcs14096Sha256,
+                "RSA_SIGN_PKCS1_4096_SHA512" => Self::RsaSignPkcs14096Sha512,
+                "RSA_SIGN_RAW_PKCS1_2048" => Self::RsaSignRawPkcs12048,
+                "RSA_SIGN_RAW_PKCS1_3072" => Self::RsaSignRawPkcs13072,
+                "RSA_SIGN_RAW_PKCS1_4096" => Self::RsaSignRawPkcs14096,
+                "RSA_DECRYPT_OAEP_2048_SHA256" => Self::RsaDecryptOaep2048Sha256,
+                "RSA_DECRYPT_OAEP_3072_SHA256" => Self::RsaDecryptOaep3072Sha256,
+                "RSA_DECRYPT_OAEP_4096_SHA256" => Self::RsaDecryptOaep4096Sha256,
+                "RSA_DECRYPT_OAEP_4096_SHA512" => Self::RsaDecryptOaep4096Sha512,
+                "RSA_DECRYPT_OAEP_2048_SHA1" => Self::RsaDecryptOaep2048Sha1,
+                "RSA_DECRYPT_OAEP_3072_SHA1" => Self::RsaDecryptOaep3072Sha1,
+                "RSA_DECRYPT_OAEP_4096_SHA1" => Self::RsaDecryptOaep4096Sha1,
+                "EC_SIGN_P256_SHA256" => Self::EcSignP256Sha256,
+                "EC_SIGN_P384_SHA384" => Self::EcSignP384Sha384,
+                "EC_SIGN_SECP256K1_SHA256" => Self::EcSignSecp256K1Sha256,
+                "EC_SIGN_ED25519" => Self::EcSignEd25519,
+                "HMAC_SHA256" => Self::HmacSha256,
+                "HMAC_SHA1" => Self::HmacSha1,
+                "HMAC_SHA384" => Self::HmacSha384,
+                "HMAC_SHA512" => Self::HmacSha512,
+                "HMAC_SHA224" => Self::HmacSha224,
+                "EXTERNAL_SYMMETRIC_ENCRYPTION" => Self::ExternalSymmetricEncryption,
+                "PQ_SIGN_ML_DSA_65" => Self::PqSignMlDsa65,
+                "PQ_SIGN_SLH_DSA_SHA2_128S" => Self::PqSignSlhDsaSha2128S,
+                _ => Self::UnknownValue(crypto_key_version_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CryptoKeyVersionAlgorithm {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleSymmetricEncryption => serializer.serialize_i32(1),
+                Self::Aes128Gcm => serializer.serialize_i32(41),
+                Self::Aes256Gcm => serializer.serialize_i32(19),
+                Self::Aes128Cbc => serializer.serialize_i32(42),
+                Self::Aes256Cbc => serializer.serialize_i32(43),
+                Self::Aes128Ctr => serializer.serialize_i32(44),
+                Self::Aes256Ctr => serializer.serialize_i32(45),
+                Self::RsaSignPss2048Sha256 => serializer.serialize_i32(2),
+                Self::RsaSignPss3072Sha256 => serializer.serialize_i32(3),
+                Self::RsaSignPss4096Sha256 => serializer.serialize_i32(4),
+                Self::RsaSignPss4096Sha512 => serializer.serialize_i32(15),
+                Self::RsaSignPkcs12048Sha256 => serializer.serialize_i32(5),
+                Self::RsaSignPkcs13072Sha256 => serializer.serialize_i32(6),
+                Self::RsaSignPkcs14096Sha256 => serializer.serialize_i32(7),
+                Self::RsaSignPkcs14096Sha512 => serializer.serialize_i32(16),
+                Self::RsaSignRawPkcs12048 => serializer.serialize_i32(28),
+                Self::RsaSignRawPkcs13072 => serializer.serialize_i32(29),
+                Self::RsaSignRawPkcs14096 => serializer.serialize_i32(30),
+                Self::RsaDecryptOaep2048Sha256 => serializer.serialize_i32(8),
+                Self::RsaDecryptOaep3072Sha256 => serializer.serialize_i32(9),
+                Self::RsaDecryptOaep4096Sha256 => serializer.serialize_i32(10),
+                Self::RsaDecryptOaep4096Sha512 => serializer.serialize_i32(17),
+                Self::RsaDecryptOaep2048Sha1 => serializer.serialize_i32(37),
+                Self::RsaDecryptOaep3072Sha1 => serializer.serialize_i32(38),
+                Self::RsaDecryptOaep4096Sha1 => serializer.serialize_i32(39),
+                Self::EcSignP256Sha256 => serializer.serialize_i32(12),
+                Self::EcSignP384Sha384 => serializer.serialize_i32(13),
+                Self::EcSignSecp256K1Sha256 => serializer.serialize_i32(31),
+                Self::EcSignEd25519 => serializer.serialize_i32(40),
+                Self::HmacSha256 => serializer.serialize_i32(32),
+                Self::HmacSha1 => serializer.serialize_i32(33),
+                Self::HmacSha384 => serializer.serialize_i32(34),
+                Self::HmacSha512 => serializer.serialize_i32(35),
+                Self::HmacSha224 => serializer.serialize_i32(36),
+                Self::ExternalSymmetricEncryption => serializer.serialize_i32(18),
+                Self::PqSignMlDsa65 => serializer.serialize_i32(56),
+                Self::PqSignSlhDsaSha2128S => serializer.serialize_i32(57),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CryptoKeyVersionAlgorithm {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<CryptoKeyVersionAlgorithm>::new(
+                    ".google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm",
+                ),
+            )
         }
     }
 
@@ -3266,34 +3606,28 @@ pub mod crypto_key_version {
     /// indicating if it can be used.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyVersionState(i32);
-
-    impl CryptoKeyVersionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CryptoKeyVersionState {
         /// Not specified.
-        pub const CRYPTO_KEY_VERSION_STATE_UNSPECIFIED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new(0);
-
+        Unspecified,
         /// This version is still being generated. It may not be used, enabled,
         /// disabled, or destroyed yet. Cloud KMS will automatically mark this
         /// version
         /// [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]
         /// as soon as the version is ready.
         ///
-        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
-        pub const PENDING_GENERATION: CryptoKeyVersionState = CryptoKeyVersionState::new(5);
-
+        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
+        PendingGeneration,
         /// This version may be used for cryptographic operations.
-        pub const ENABLED: CryptoKeyVersionState = CryptoKeyVersionState::new(1);
-
+        Enabled,
         /// This version may not be used, but the key material is still available,
         /// and the version can be placed back into the
         /// [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]
         /// state.
         ///
-        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
-        pub const DISABLED: CryptoKeyVersionState = CryptoKeyVersionState::new(2);
-
+        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
+        Disabled,
         /// This version is destroyed, and the key material is no longer stored.
         /// This version may only become
         /// [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]
@@ -3302,11 +3636,10 @@ pub mod crypto_key_version {
         /// and the original key material is reimported with a call to
         /// [KeyManagementService.ImportCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion].
         ///
-        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
+        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
         /// [google.cloud.kms.v1.CryptoKeyVersion.reimport_eligible]: crate::model::CryptoKeyVersion::reimport_eligible
         /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
-        pub const DESTROYED: CryptoKeyVersionState = CryptoKeyVersionState::new(3);
-
+        Destroyed,
         /// This version is scheduled for destruction, and will be destroyed soon.
         /// Call
         /// [RestoreCryptoKeyVersion][google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]
@@ -3314,40 +3647,34 @@ pub mod crypto_key_version {
         /// [DISABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]
         /// state.
         ///
-        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::crypto_key_version_state::DISABLED
+        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Disabled
         /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
-        pub const DESTROY_SCHEDULED: CryptoKeyVersionState = CryptoKeyVersionState::new(4);
-
+        DestroyScheduled,
         /// This version is still being imported. It may not be used, enabled,
         /// disabled, or destroyed yet. Cloud KMS will automatically mark this
         /// version
         /// [ENABLED][google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]
         /// as soon as the version is ready.
         ///
-        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::crypto_key_version_state::ENABLED
-        pub const PENDING_IMPORT: CryptoKeyVersionState = CryptoKeyVersionState::new(6);
-
+        /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
+        PendingImport,
         /// This version was not imported successfully. It may not be used, enabled,
         /// disabled, or destroyed. The submitted key material has been discarded.
         /// Additional details can be found in
         /// [CryptoKeyVersion.import_failure_reason][google.cloud.kms.v1.CryptoKeyVersion.import_failure_reason].
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.import_failure_reason]: crate::model::CryptoKeyVersion::import_failure_reason
-        pub const IMPORT_FAILED: CryptoKeyVersionState = CryptoKeyVersionState::new(7);
-
+        ImportFailed,
         /// This version was not generated successfully. It may not be used, enabled,
         /// disabled, or destroyed. Additional details can be found in
         /// [CryptoKeyVersion.generation_failure_reason][google.cloud.kms.v1.CryptoKeyVersion.generation_failure_reason].
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.generation_failure_reason]: crate::model::CryptoKeyVersion::generation_failure_reason
-        pub const GENERATION_FAILED: CryptoKeyVersionState = CryptoKeyVersionState::new(8);
-
+        GenerationFailed,
         /// This version was destroyed, and it may not be used or enabled again.
         /// Cloud KMS is waiting for the corresponding key material residing in an
         /// external key manager to be destroyed.
-        pub const PENDING_EXTERNAL_DESTRUCTION: CryptoKeyVersionState =
-            CryptoKeyVersionState::new(9);
-
+        PendingExternalDestruction,
         /// This version was destroyed, and it may not be used or enabled again.
         /// However, Cloud KMS could not confirm that the corresponding key material
         /// residing in an external key manager was destroyed. Additional details can
@@ -3355,71 +3682,158 @@ pub mod crypto_key_version {
         /// [CryptoKeyVersion.external_destruction_failure_reason][google.cloud.kms.v1.CryptoKeyVersion.external_destruction_failure_reason].
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion.external_destruction_failure_reason]: crate::model::CryptoKeyVersion::external_destruction_failure_reason
-        pub const EXTERNAL_DESTRUCTION_FAILED: CryptoKeyVersionState =
-            CryptoKeyVersionState::new(10);
+        ExternalDestructionFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CryptoKeyVersionState::value] or
+        /// [CryptoKeyVersionState::name].
+        UnknownValue(crypto_key_version_state::UnknownValue),
+    }
 
-        /// Creates a new CryptoKeyVersionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod crypto_key_version_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CryptoKeyVersionState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PendingGeneration => std::option::Option::Some(5),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Destroyed => std::option::Option::Some(3),
+                Self::DestroyScheduled => std::option::Option::Some(4),
+                Self::PendingImport => std::option::Option::Some(6),
+                Self::ImportFailed => std::option::Option::Some(7),
+                Self::GenerationFailed => std::option::Option::Some(8),
+                Self::PendingExternalDestruction => std::option::Option::Some(9),
+                Self::ExternalDestructionFailed => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_VERSION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("DESTROYED"),
-                4 => std::borrow::Cow::Borrowed("DESTROY_SCHEDULED"),
-                5 => std::borrow::Cow::Borrowed("PENDING_GENERATION"),
-                6 => std::borrow::Cow::Borrowed("PENDING_IMPORT"),
-                7 => std::borrow::Cow::Borrowed("IMPORT_FAILED"),
-                8 => std::borrow::Cow::Borrowed("GENERATION_FAILED"),
-                9 => std::borrow::Cow::Borrowed("PENDING_EXTERNAL_DESTRUCTION"),
-                10 => std::borrow::Cow::Borrowed("EXTERNAL_DESTRUCTION_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CRYPTO_KEY_VERSION_STATE_UNSPECIFIED")
+                }
+                Self::PendingGeneration => std::option::Option::Some("PENDING_GENERATION"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Destroyed => std::option::Option::Some("DESTROYED"),
+                Self::DestroyScheduled => std::option::Option::Some("DESTROY_SCHEDULED"),
+                Self::PendingImport => std::option::Option::Some("PENDING_IMPORT"),
+                Self::ImportFailed => std::option::Option::Some("IMPORT_FAILED"),
+                Self::GenerationFailed => std::option::Option::Some("GENERATION_FAILED"),
+                Self::PendingExternalDestruction => {
+                    std::option::Option::Some("PENDING_EXTERNAL_DESTRUCTION")
+                }
+                Self::ExternalDestructionFailed => {
+                    std::option::Option::Some("EXTERNAL_DESTRUCTION_FAILED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CRYPTO_KEY_VERSION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CRYPTO_KEY_VERSION_STATE_UNSPECIFIED)
-                }
-                "PENDING_GENERATION" => std::option::Option::Some(Self::PENDING_GENERATION),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
-                "DESTROY_SCHEDULED" => std::option::Option::Some(Self::DESTROY_SCHEDULED),
-                "PENDING_IMPORT" => std::option::Option::Some(Self::PENDING_IMPORT),
-                "IMPORT_FAILED" => std::option::Option::Some(Self::IMPORT_FAILED),
-                "GENERATION_FAILED" => std::option::Option::Some(Self::GENERATION_FAILED),
-                "PENDING_EXTERNAL_DESTRUCTION" => {
-                    std::option::Option::Some(Self::PENDING_EXTERNAL_DESTRUCTION)
-                }
-                "EXTERNAL_DESTRUCTION_FAILED" => {
-                    std::option::Option::Some(Self::EXTERNAL_DESTRUCTION_FAILED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CryptoKeyVersionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyVersionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CryptoKeyVersionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CryptoKeyVersionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Destroyed,
+                4 => Self::DestroyScheduled,
+                5 => Self::PendingGeneration,
+                6 => Self::PendingImport,
+                7 => Self::ImportFailed,
+                8 => Self::GenerationFailed,
+                9 => Self::PendingExternalDestruction,
+                10 => Self::ExternalDestructionFailed,
+                _ => Self::UnknownValue(crypto_key_version_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CryptoKeyVersionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CRYPTO_KEY_VERSION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING_GENERATION" => Self::PendingGeneration,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "DESTROYED" => Self::Destroyed,
+                "DESTROY_SCHEDULED" => Self::DestroyScheduled,
+                "PENDING_IMPORT" => Self::PendingImport,
+                "IMPORT_FAILED" => Self::ImportFailed,
+                "GENERATION_FAILED" => Self::GenerationFailed,
+                "PENDING_EXTERNAL_DESTRUCTION" => Self::PendingExternalDestruction,
+                "EXTERNAL_DESTRUCTION_FAILED" => Self::ExternalDestructionFailed,
+                _ => Self::UnknownValue(crypto_key_version_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CryptoKeyVersionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PendingGeneration => serializer.serialize_i32(5),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Destroyed => serializer.serialize_i32(3),
+                Self::DestroyScheduled => serializer.serialize_i32(4),
+                Self::PendingImport => serializer.serialize_i32(6),
+                Self::ImportFailed => serializer.serialize_i32(7),
+                Self::GenerationFailed => serializer.serialize_i32(8),
+                Self::PendingExternalDestruction => serializer.serialize_i32(9),
+                Self::ExternalDestructionFailed => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CryptoKeyVersionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CryptoKeyVersionState>::new(
+                ".google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState",
+            ))
         }
     }
 
@@ -3433,10 +3847,9 @@ pub mod crypto_key_version {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeyVersions]: crate::client::KeyManagementService::list_crypto_key_versions
     /// [google.cloud.kms.v1.KeyManagementService.ListCryptoKeys]: crate::client::KeyManagementService::list_crypto_keys
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CryptoKeyVersionView(i32);
-
-    impl CryptoKeyVersionView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CryptoKeyVersionView {
         /// Default view for each
         /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]. Does not
         /// include the
@@ -3444,57 +3857,116 @@ pub mod crypto_key_version {
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.CryptoKeyVersion.attestation]: crate::model::CryptoKeyVersion::attestation
-        pub const CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED: CryptoKeyVersionView =
-            CryptoKeyVersionView::new(0);
-
+        Unspecified,
         /// Provides all fields in each
         /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion], including the
         /// [attestation][google.cloud.kms.v1.CryptoKeyVersion.attestation].
         ///
         /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
         /// [google.cloud.kms.v1.CryptoKeyVersion.attestation]: crate::model::CryptoKeyVersion::attestation
-        pub const FULL: CryptoKeyVersionView = CryptoKeyVersionView::new(1);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CryptoKeyVersionView::value] or
+        /// [CryptoKeyVersionView::name].
+        UnknownValue(crypto_key_version_view::UnknownValue),
+    }
 
-        /// Creates a new CryptoKeyVersionView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod crypto_key_version_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CryptoKeyVersionView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Full => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED")
                 }
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CryptoKeyVersionView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CryptoKeyVersionView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CryptoKeyVersionView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CryptoKeyVersionView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Full,
+                _ => Self::UnknownValue(crypto_key_version_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CryptoKeyVersionView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CRYPTO_KEY_VERSION_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(crypto_key_version_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CryptoKeyVersionView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Full => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CryptoKeyVersionView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CryptoKeyVersionView>::new(
+                ".google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionView",
+            ))
         }
     }
 }
@@ -3731,10 +4203,9 @@ pub mod public_key {
     /// The supported [PublicKey][google.cloud.kms.v1.PublicKey] formats.
     ///
     /// [google.cloud.kms.v1.PublicKey]: crate::model::PublicKey
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PublicKeyFormat(i32);
-
-    impl PublicKeyFormat {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PublicKeyFormat {
         /// If the
         /// [public_key_format][google.cloud.kms.v1.GetPublicKeyRequest.public_key_format]
         /// field is not specified:
@@ -3750,62 +4221,122 @@ pub mod public_key {
         /// [google.cloud.kms.v1.GetPublicKeyRequest.public_key_format]: crate::model::GetPublicKeyRequest::public_key_format
         /// [google.cloud.kms.v1.PublicKey.pem]: crate::model::PublicKey::pem
         /// [google.cloud.kms.v1.PublicKey.public_key]: crate::model::PublicKey::public_key
-        pub const PUBLIC_KEY_FORMAT_UNSPECIFIED: PublicKeyFormat = PublicKeyFormat::new(0);
-
+        Unspecified,
         /// The returned public key will be encoded in PEM format.
         /// See the [RFC7468](https://tools.ietf.org/html/rfc7468) sections for
         /// [General Considerations](https://tools.ietf.org/html/rfc7468#section-2)
         /// and [Textual Encoding of Subject Public Key Info]
         /// (<https://tools.ietf.org/html/rfc7468#section-13>) for more information.
-        pub const PEM: PublicKeyFormat = PublicKeyFormat::new(1);
-
+        Pem,
         /// This is supported only for PQC algorithms.
         /// The key material is returned in the format defined by NIST PQC
         /// standards (FIPS 203, FIPS 204, and FIPS 205).
-        pub const NIST_PQC: PublicKeyFormat = PublicKeyFormat::new(3);
+        NistPqc,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PublicKeyFormat::value] or
+        /// [PublicKeyFormat::name].
+        UnknownValue(public_key_format::UnknownValue),
+    }
 
-        /// Creates a new PublicKeyFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod public_key_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PublicKeyFormat {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pem => std::option::Option::Some(1),
+                Self::NistPqc => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PUBLIC_KEY_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PEM"),
-                3 => std::borrow::Cow::Borrowed("NIST_PQC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PUBLIC_KEY_FORMAT_UNSPECIFIED"),
+                Self::Pem => std::option::Option::Some("PEM"),
+                Self::NistPqc => std::option::Option::Some("NIST_PQC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PUBLIC_KEY_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PUBLIC_KEY_FORMAT_UNSPECIFIED)
-                }
-                "PEM" => std::option::Option::Some(Self::PEM),
-                "NIST_PQC" => std::option::Option::Some(Self::NIST_PQC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PublicKeyFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PublicKeyFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PublicKeyFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PublicKeyFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pem,
+                3 => Self::NistPqc,
+                _ => Self::UnknownValue(public_key_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PublicKeyFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PUBLIC_KEY_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "PEM" => Self::Pem,
+                "NIST_PQC" => Self::NistPqc,
+                _ => Self::UnknownValue(public_key_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PublicKeyFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pem => serializer.serialize_i32(1),
+                Self::NistPqc => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PublicKeyFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PublicKeyFormat>::new(
+                ".google.cloud.kms.v1.PublicKey.PublicKeyFormat",
+            ))
         }
     }
 }
@@ -3847,7 +4378,7 @@ pub mod public_key {
 /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
 /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
-/// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::import_job_state::ACTIVE
+/// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::ImportJobState::Active
 /// [google.cloud.kms.v1.ImportJob.import_method]: crate::model::ImportJob::import_method
 /// [google.cloud.kms.v1.ImportJob.public_key]: crate::model::ImportJob::public_key
 /// [google.cloud.kms.v1.ImportJob.state]: crate::model::ImportJob::state
@@ -3909,7 +4440,7 @@ pub struct ImportJob {
     /// [EXPIRED][google.cloud.kms.v1.ImportJob.ImportJobState.EXPIRED].
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
-    /// [google.cloud.kms.v1.ImportJob.ImportJobState.EXPIRED]: crate::model::import_job::import_job_state::EXPIRED
+    /// [google.cloud.kms.v1.ImportJob.ImportJobState.EXPIRED]: crate::model::import_job::ImportJobState::Expired
     /// [google.cloud.kms.v1.ImportJob.state]: crate::model::ImportJob::state
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub expire_event_time: std::option::Option<wkt::Timestamp>,
@@ -3924,7 +4455,7 @@ pub struct ImportJob {
     /// import. Only returned if [state][google.cloud.kms.v1.ImportJob.state] is
     /// [ACTIVE][google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE].
     ///
-    /// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::import_job_state::ACTIVE
+    /// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::ImportJobState::Active
     /// [google.cloud.kms.v1.ImportJob.state]: crate::model::ImportJob::state
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub public_key: std::option::Option<crate::model::import_job::WrappingPublicKey>,
@@ -3937,7 +4468,7 @@ pub struct ImportJob {
     /// protection level of [HSM][google.cloud.kms.v1.ProtectionLevel.HSM].
     ///
     /// [google.cloud.kms.v1.ImportJob.ImportMethod]: crate::model::import_job::ImportMethod
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub attestation: std::option::Option<crate::model::KeyOperationAttestation>,
 
@@ -4099,115 +4630,182 @@ pub mod import_job {
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
     /// [google.cloud.kms.v1.ImportJob.ImportMethod]: crate::model::import_job::ImportMethod
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportMethod(i32);
-
-    impl ImportMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ImportMethod {
         /// Not specified.
-        pub const IMPORT_METHOD_UNSPECIFIED: ImportMethod = ImportMethod::new(0);
-
+        Unspecified,
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
         /// wrapping the raw key with an ephemeral AES key, and wrapping the
         /// ephemeral AES key with a 3072 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_3072_SHA1_AES_256: ImportMethod = ImportMethod::new(1);
-
+        RsaOaep3072Sha1Aes256,
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
         /// wrapping the raw key with an ephemeral AES key, and wrapping the
         /// ephemeral AES key with a 4096 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_4096_SHA1_AES_256: ImportMethod = ImportMethod::new(2);
-
+        RsaOaep4096Sha1Aes256,
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
         /// wrapping the raw key with an ephemeral AES key, and wrapping the
         /// ephemeral AES key with a 3072 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_3072_SHA256_AES_256: ImportMethod = ImportMethod::new(3);
-
+        RsaOaep3072Sha256Aes256,
         /// This ImportMethod represents the CKM_RSA_AES_KEY_WRAP key wrapping
         /// scheme defined in the PKCS #11 standard. In summary, this involves
         /// wrapping the raw key with an ephemeral AES key, and wrapping the
         /// ephemeral AES key with a 4096 bit RSA key. For more details, see
         /// [RSA AES key wrap
         /// mechanism](http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908).
-        pub const RSA_OAEP_4096_SHA256_AES_256: ImportMethod = ImportMethod::new(4);
-
+        RsaOaep4096Sha256Aes256,
         /// This ImportMethod represents RSAES-OAEP with a 3072 bit RSA key. The
         /// key material to be imported is wrapped directly with the RSA key. Due
         /// to technical limitations of RSA wrapping, this method cannot be used to
         /// wrap RSA keys for import.
-        pub const RSA_OAEP_3072_SHA256: ImportMethod = ImportMethod::new(5);
-
+        RsaOaep3072Sha256,
         /// This ImportMethod represents RSAES-OAEP with a 4096 bit RSA key. The
         /// key material to be imported is wrapped directly with the RSA key. Due
         /// to technical limitations of RSA wrapping, this method cannot be used to
         /// wrap RSA keys for import.
-        pub const RSA_OAEP_4096_SHA256: ImportMethod = ImportMethod::new(6);
+        RsaOaep4096Sha256,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ImportMethod::value] or
+        /// [ImportMethod::name].
+        UnknownValue(import_method::UnknownValue),
+    }
 
-        /// Creates a new ImportMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod import_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ImportMethod {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RsaOaep3072Sha1Aes256 => std::option::Option::Some(1),
+                Self::RsaOaep4096Sha1Aes256 => std::option::Option::Some(2),
+                Self::RsaOaep3072Sha256Aes256 => std::option::Option::Some(3),
+                Self::RsaOaep4096Sha256Aes256 => std::option::Option::Some(4),
+                Self::RsaOaep3072Sha256 => std::option::Option::Some(5),
+                Self::RsaOaep4096Sha256 => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPORT_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RSA_OAEP_3072_SHA1_AES_256"),
-                2 => std::borrow::Cow::Borrowed("RSA_OAEP_4096_SHA1_AES_256"),
-                3 => std::borrow::Cow::Borrowed("RSA_OAEP_3072_SHA256_AES_256"),
-                4 => std::borrow::Cow::Borrowed("RSA_OAEP_4096_SHA256_AES_256"),
-                5 => std::borrow::Cow::Borrowed("RSA_OAEP_3072_SHA256"),
-                6 => std::borrow::Cow::Borrowed("RSA_OAEP_4096_SHA256"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPORT_METHOD_UNSPECIFIED"),
+                Self::RsaOaep3072Sha1Aes256 => {
+                    std::option::Option::Some("RSA_OAEP_3072_SHA1_AES_256")
+                }
+                Self::RsaOaep4096Sha1Aes256 => {
+                    std::option::Option::Some("RSA_OAEP_4096_SHA1_AES_256")
+                }
+                Self::RsaOaep3072Sha256Aes256 => {
+                    std::option::Option::Some("RSA_OAEP_3072_SHA256_AES_256")
+                }
+                Self::RsaOaep4096Sha256Aes256 => {
+                    std::option::Option::Some("RSA_OAEP_4096_SHA256_AES_256")
+                }
+                Self::RsaOaep3072Sha256 => std::option::Option::Some("RSA_OAEP_3072_SHA256"),
+                Self::RsaOaep4096Sha256 => std::option::Option::Some("RSA_OAEP_4096_SHA256"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPORT_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IMPORT_METHOD_UNSPECIFIED)
-                }
-                "RSA_OAEP_3072_SHA1_AES_256" => {
-                    std::option::Option::Some(Self::RSA_OAEP_3072_SHA1_AES_256)
-                }
-                "RSA_OAEP_4096_SHA1_AES_256" => {
-                    std::option::Option::Some(Self::RSA_OAEP_4096_SHA1_AES_256)
-                }
-                "RSA_OAEP_3072_SHA256_AES_256" => {
-                    std::option::Option::Some(Self::RSA_OAEP_3072_SHA256_AES_256)
-                }
-                "RSA_OAEP_4096_SHA256_AES_256" => {
-                    std::option::Option::Some(Self::RSA_OAEP_4096_SHA256_AES_256)
-                }
-                "RSA_OAEP_3072_SHA256" => std::option::Option::Some(Self::RSA_OAEP_3072_SHA256),
-                "RSA_OAEP_4096_SHA256" => std::option::Option::Some(Self::RSA_OAEP_4096_SHA256),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ImportMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ImportMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ImportMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RsaOaep3072Sha1Aes256,
+                2 => Self::RsaOaep4096Sha1Aes256,
+                3 => Self::RsaOaep3072Sha256Aes256,
+                4 => Self::RsaOaep4096Sha256Aes256,
+                5 => Self::RsaOaep3072Sha256,
+                6 => Self::RsaOaep4096Sha256,
+                _ => Self::UnknownValue(import_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ImportMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPORT_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "RSA_OAEP_3072_SHA1_AES_256" => Self::RsaOaep3072Sha1Aes256,
+                "RSA_OAEP_4096_SHA1_AES_256" => Self::RsaOaep4096Sha1Aes256,
+                "RSA_OAEP_3072_SHA256_AES_256" => Self::RsaOaep3072Sha256Aes256,
+                "RSA_OAEP_4096_SHA256_AES_256" => Self::RsaOaep4096Sha256Aes256,
+                "RSA_OAEP_3072_SHA256" => Self::RsaOaep3072Sha256,
+                "RSA_OAEP_4096_SHA256" => Self::RsaOaep4096Sha256,
+                _ => Self::UnknownValue(import_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ImportMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RsaOaep3072Sha1Aes256 => serializer.serialize_i32(1),
+                Self::RsaOaep4096Sha1Aes256 => serializer.serialize_i32(2),
+                Self::RsaOaep3072Sha256Aes256 => serializer.serialize_i32(3),
+                Self::RsaOaep4096Sha256Aes256 => serializer.serialize_i32(4),
+                Self::RsaOaep3072Sha256 => serializer.serialize_i32(5),
+                Self::RsaOaep4096Sha256 => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ImportMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportMethod>::new(
+                ".google.cloud.kms.v1.ImportJob.ImportMethod",
+            ))
         }
     }
 
@@ -4215,21 +4813,18 @@ pub mod import_job {
     /// it can be used.
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportJobState(i32);
-
-    impl ImportJobState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ImportJobState {
         /// Not specified.
-        pub const IMPORT_JOB_STATE_UNSPECIFIED: ImportJobState = ImportJobState::new(0);
-
+        Unspecified,
         /// The wrapping key for this job is still being generated. It may not be
         /// used. Cloud KMS will automatically mark this job as
         /// [ACTIVE][google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE] as soon as
         /// the wrapping key is generated.
         ///
-        /// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::import_job_state::ACTIVE
-        pub const PENDING_GENERATION: ImportJobState = ImportJobState::new(1);
-
+        /// [google.cloud.kms.v1.ImportJob.ImportJobState.ACTIVE]: crate::model::import_job::ImportJobState::Active
+        PendingGeneration,
         /// This job may be used in
         /// [CreateCryptoKey][google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]
         /// and
@@ -4238,55 +4833,119 @@ pub mod import_job {
         ///
         /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKey]: crate::client::KeyManagementService::create_crypto_key
         /// [google.cloud.kms.v1.KeyManagementService.CreateCryptoKeyVersion]: crate::client::KeyManagementService::create_crypto_key_version
-        pub const ACTIVE: ImportJobState = ImportJobState::new(2);
-
+        Active,
         /// This job can no longer be used and may not leave this state once entered.
-        pub const EXPIRED: ImportJobState = ImportJobState::new(3);
+        Expired,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ImportJobState::value] or
+        /// [ImportJobState::name].
+        UnknownValue(import_job_state::UnknownValue),
+    }
 
-        /// Creates a new ImportJobState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod import_job_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ImportJobState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PendingGeneration => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Expired => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING_GENERATION"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("EXPIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPORT_JOB_STATE_UNSPECIFIED"),
+                Self::PendingGeneration => std::option::Option::Some("PENDING_GENERATION"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Expired => std::option::Option::Some("EXPIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPORT_JOB_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_UNSPECIFIED)
-                }
-                "PENDING_GENERATION" => std::option::Option::Some(Self::PENDING_GENERATION),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ImportJobState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportJobState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ImportJobState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ImportJobState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PendingGeneration,
+                2 => Self::Active,
+                3 => Self::Expired,
+                _ => Self::UnknownValue(import_job_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ImportJobState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPORT_JOB_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING_GENERATION" => Self::PendingGeneration,
+                "ACTIVE" => Self::Active,
+                "EXPIRED" => Self::Expired,
+                _ => Self::UnknownValue(import_job_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ImportJobState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PendingGeneration => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Expired => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ImportJobState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportJobState>::new(
+                ".google.cloud.kms.v1.ImportJob.ImportJobState",
+            ))
         }
     }
 }
@@ -4299,8 +4958,8 @@ pub mod import_job {
 /// levels.
 ///
 /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::protection_level::EXTERNAL
-/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
+/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::ProtectionLevel::External
+/// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -5631,8 +6290,8 @@ pub struct ImportCryptoKeyVersionRequest {
     /// key material.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::crypto_key_version_state::DESTROYED
-    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.IMPORT_FAILED]: crate::model::crypto_key_version::crypto_key_version_state::IMPORT_FAILED
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED]: crate::model::crypto_key_version::CryptoKeyVersionState::Destroyed
+    /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.IMPORT_FAILED]: crate::model::crypto_key_version::CryptoKeyVersionState::ImportFailed
     /// [google.cloud.kms.v1.CryptoKeyVersion.name]: crate::model::CryptoKeyVersion::name
     /// [google.cloud.kms.v1.ImportCryptoKeyVersionRequest.parent]: crate::model::ImportCryptoKeyVersionRequest::parent
     /// [google.cloud.kms.v1.KeyManagementService.ImportCryptoKeyVersion]: crate::client::KeyManagementService::import_crypto_key_version
@@ -5689,12 +6348,12 @@ pub struct ImportCryptoKeyVersionRequest {
     /// [public_key][google.cloud.kms.v1.ImportJob.public_key] using RSAES-OAEP
     /// with SHA-256, MGF1 with SHA-256, and an empty label.
     ///
-    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256]: crate::model::import_job::import_method::RSA_OAEP_3072_SHA1_AES_256
-    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA256]: crate::model::import_job::import_method::RSA_OAEP_3072_SHA256
-    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA256_AES_256]: crate::model::import_job::import_method::RSA_OAEP_3072_SHA256_AES_256
-    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256]: crate::model::import_job::import_method::RSA_OAEP_4096_SHA1_AES_256
-    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA256]: crate::model::import_job::import_method::RSA_OAEP_4096_SHA256
-    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA256_AES_256]: crate::model::import_job::import_method::RSA_OAEP_4096_SHA256_AES_256
+    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA1_AES_256]: crate::model::import_job::ImportMethod::RsaOaep3072Sha1Aes256
+    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA256]: crate::model::import_job::ImportMethod::RsaOaep3072Sha256
+    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_3072_SHA256_AES_256]: crate::model::import_job::ImportMethod::RsaOaep3072Sha256Aes256
+    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA1_AES_256]: crate::model::import_job::ImportMethod::RsaOaep4096Sha1Aes256
+    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA256]: crate::model::import_job::ImportMethod::RsaOaep4096Sha256
+    /// [google.cloud.kms.v1.ImportJob.ImportMethod.RSA_OAEP_4096_SHA256_AES_256]: crate::model::import_job::ImportMethod::RsaOaep4096Sha256Aes256
     /// [google.cloud.kms.v1.ImportJob.public_key]: crate::model::ImportJob::public_key
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
@@ -6173,10 +6832,10 @@ pub struct EncryptRequest {
     /// than 8KiB.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]: crate::model::CryptoKeyVersionTemplate::protection_level
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::protection_level::EXTERNAL
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
-    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::protection_level::SOFTWARE
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::ProtectionLevel::External
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
+    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::ProtectionLevel::Software
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
     pub plaintext: ::bytes::Bytes,
@@ -6197,10 +6856,10 @@ pub struct EncryptRequest {
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]: crate::model::CryptoKeyVersionTemplate::protection_level
     /// [google.cloud.kms.v1.DecryptRequest.additional_authenticated_data]: crate::model::DecryptRequest::additional_authenticated_data
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::protection_level::EXTERNAL
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::protection_level::EXTERNAL_VPC
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
-    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::protection_level::SOFTWARE
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::ProtectionLevel::External
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL_VPC]: crate::model::ProtectionLevel::ExternalVpc
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
+    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::ProtectionLevel::Software
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
     pub additional_authenticated_data: ::bytes::Bytes,
@@ -6492,8 +7151,8 @@ pub struct RawEncryptRequest {
     /// than 8KiB.
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]: crate::model::CryptoKeyVersionTemplate::protection_level
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
-    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::protection_level::SOFTWARE
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
+    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::ProtectionLevel::Software
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
     pub plaintext: ::bytes::Bytes,
@@ -6516,8 +7175,8 @@ pub struct RawEncryptRequest {
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion.algorithm]: crate::model::CryptoKeyVersion::algorithm
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]: crate::model::CryptoKeyVersionTemplate::protection_level
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
-    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::protection_level::SOFTWARE
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
+    /// [google.cloud.kms.v1.ProtectionLevel.SOFTWARE]: crate::model::ProtectionLevel::Software
     /// [google.cloud.kms.v1.RawDecryptRequest.additional_authenticated_data]: crate::model::RawDecryptRequest::additional_authenticated_data
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
@@ -7371,7 +8030,7 @@ pub struct GenerateRandomBytesRequest {
     /// supported.
     ///
     /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
     pub protection_level: crate::model::ProtectionLevel,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8807,7 +9466,7 @@ pub struct LocationMetadata {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]: crate::model::CryptoKeyVersionTemplate::protection_level
-    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::protection_level::HSM
+    /// [google.cloud.kms.v1.ProtectionLevel.HSM]: crate::model::ProtectionLevel::Hsm
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub hsm_available: bool,
 
@@ -8818,7 +9477,7 @@ pub struct LocationMetadata {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.protection_level]: crate::model::CryptoKeyVersionTemplate::protection_level
-    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::protection_level::EXTERNAL
+    /// [google.cloud.kms.v1.ProtectionLevel.EXTERNAL]: crate::model::ProtectionLevel::External
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub ekm_available: bool,
 
@@ -8855,107 +9514,161 @@ impl wkt::message::Message for LocationMetadata {
 /// levels] (<https://cloud.google.com/kms/docs/algorithms#protection_levels>).
 ///
 /// [google.cloud.kms.v1.ProtectionLevel]: crate::model::ProtectionLevel
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ProtectionLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ProtectionLevel {
+    /// Not specified.
+    Unspecified,
+    /// Crypto operations are performed in software.
+    Software,
+    /// Crypto operations are performed in a Hardware Security Module.
+    Hsm,
+    /// Crypto operations are performed by an external key manager.
+    External,
+    /// Crypto operations are performed in an EKM-over-VPC backend.
+    ExternalVpc,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ProtectionLevel::value] or
+    /// [ProtectionLevel::name].
+    UnknownValue(protection_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod protection_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ProtectionLevel {
-    /// Not specified.
-    pub const PROTECTION_LEVEL_UNSPECIFIED: ProtectionLevel = ProtectionLevel::new(0);
-
-    /// Crypto operations are performed in software.
-    pub const SOFTWARE: ProtectionLevel = ProtectionLevel::new(1);
-
-    /// Crypto operations are performed in a Hardware Security Module.
-    pub const HSM: ProtectionLevel = ProtectionLevel::new(2);
-
-    /// Crypto operations are performed by an external key manager.
-    pub const EXTERNAL: ProtectionLevel = ProtectionLevel::new(3);
-
-    /// Crypto operations are performed in an EKM-over-VPC backend.
-    pub const EXTERNAL_VPC: ProtectionLevel = ProtectionLevel::new(4);
-
-    /// Creates a new ProtectionLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Software => std::option::Option::Some(1),
+            Self::Hsm => std::option::Option::Some(2),
+            Self::External => std::option::Option::Some(3),
+            Self::ExternalVpc => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PROTECTION_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SOFTWARE"),
-            2 => std::borrow::Cow::Borrowed("HSM"),
-            3 => std::borrow::Cow::Borrowed("EXTERNAL"),
-            4 => std::borrow::Cow::Borrowed("EXTERNAL_VPC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PROTECTION_LEVEL_UNSPECIFIED"),
+            Self::Software => std::option::Option::Some("SOFTWARE"),
+            Self::Hsm => std::option::Option::Some("HSM"),
+            Self::External => std::option::Option::Some("EXTERNAL"),
+            Self::ExternalVpc => std::option::Option::Some("EXTERNAL_VPC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PROTECTION_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PROTECTION_LEVEL_UNSPECIFIED)
-            }
-            "SOFTWARE" => std::option::Option::Some(Self::SOFTWARE),
-            "HSM" => std::option::Option::Some(Self::HSM),
-            "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-            "EXTERNAL_VPC" => std::option::Option::Some(Self::EXTERNAL_VPC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ProtectionLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ProtectionLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ProtectionLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ProtectionLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Software,
+            2 => Self::Hsm,
+            3 => Self::External,
+            4 => Self::ExternalVpc,
+            _ => Self::UnknownValue(protection_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ProtectionLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PROTECTION_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "SOFTWARE" => Self::Software,
+            "HSM" => Self::Hsm,
+            "EXTERNAL" => Self::External,
+            "EXTERNAL_VPC" => Self::ExternalVpc,
+            _ => Self::UnknownValue(protection_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ProtectionLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Software => serializer.serialize_i32(1),
+            Self::Hsm => serializer.serialize_i32(2),
+            Self::External => serializer.serialize_i32(3),
+            Self::ExternalVpc => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ProtectionLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProtectionLevel>::new(
+            ".google.cloud.kms.v1.ProtectionLevel",
+        ))
     }
 }
 
 /// Describes the reason for a data access. Please refer to
 /// <https://cloud.google.com/assured-workloads/key-access-justifications/docs/justification-codes>
 /// for the detailed semantic meaning of justification reason codes.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessReason(i32);
-
-impl AccessReason {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AccessReason {
     /// Unspecified access reason.
-    pub const REASON_UNSPECIFIED: AccessReason = AccessReason::new(0);
-
+    ReasonUnspecified,
     /// Customer-initiated support.
-    pub const CUSTOMER_INITIATED_SUPPORT: AccessReason = AccessReason::new(1);
-
+    CustomerInitiatedSupport,
     /// Google-initiated access for system management and troubleshooting.
-    pub const GOOGLE_INITIATED_SERVICE: AccessReason = AccessReason::new(2);
-
+    GoogleInitiatedService,
     /// Google-initiated access in response to a legal request or legal process.
-    pub const THIRD_PARTY_DATA_REQUEST: AccessReason = AccessReason::new(3);
-
+    ThirdPartyDataRequest,
     /// Google-initiated access for security, fraud, abuse, or compliance purposes.
-    pub const GOOGLE_INITIATED_REVIEW: AccessReason = AccessReason::new(4);
-
+    GoogleInitiatedReview,
     /// Customer uses their account to perform any access to their own data which
     /// their IAM policy authorizes.
-    pub const CUSTOMER_INITIATED_ACCESS: AccessReason = AccessReason::new(5);
-
+    CustomerInitiatedAccess,
     /// Google systems access customer data to help optimize the structure of the
     /// data or quality for future uses by the customer.
-    pub const GOOGLE_INITIATED_SYSTEM_OPERATION: AccessReason = AccessReason::new(6);
-
+    GoogleInitiatedSystemOperation,
     /// No reason is expected for this key request.
-    pub const REASON_NOT_EXPECTED: AccessReason = AccessReason::new(7);
-
+    ReasonNotExpected,
     /// Customer uses their account to perform any access to their own data which
     /// their IAM policy authorizes, and one of the following is true:
     ///
@@ -8964,8 +9677,7 @@ impl AccessReason {
     /// * A Google-initiated emergency access operation has interacted with a
     ///   resource in the same project or folder as the currently accessed resource
     ///   within the past 7 days.
-    pub const MODIFIED_CUSTOMER_INITIATED_ACCESS: AccessReason = AccessReason::new(8);
-
+    ModifiedCustomerInitiatedAccess,
     /// Google systems access customer data to help optimize the structure of the
     /// data or quality for future uses by the customer, and one of the following
     /// is true:
@@ -8975,11 +9687,9 @@ impl AccessReason {
     /// * A Google-initiated emergency access operation has interacted with a
     ///   resource in the same project or folder as the currently accessed resource
     ///   within the past 7 days.
-    pub const MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION: AccessReason = AccessReason::new(9);
-
+    ModifiedGoogleInitiatedSystemOperation,
     /// Google-initiated access to maintain system reliability.
-    pub const GOOGLE_RESPONSE_TO_PRODUCTION_ALERT: AccessReason = AccessReason::new(10);
-
+    GoogleResponseToProductionAlert,
     /// One of the following operations is being executed while simultaneously
     /// encountering an internal technical issue which prevented a more precise
     /// justification code from being generated:
@@ -8990,79 +9700,170 @@ impl AccessReason {
     ///   IAM policy authorizes.
     /// * Customer-initiated Google support access.
     /// * Google-initiated support access to protect system reliability.
-    pub const CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING: AccessReason = AccessReason::new(11);
+    CustomerAuthorizedWorkflowServicing,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AccessReason::value] or
+    /// [AccessReason::name].
+    UnknownValue(access_reason::UnknownValue),
+}
 
-    /// Creates a new AccessReason instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod access_reason {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AccessReason {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::ReasonUnspecified => std::option::Option::Some(0),
+            Self::CustomerInitiatedSupport => std::option::Option::Some(1),
+            Self::GoogleInitiatedService => std::option::Option::Some(2),
+            Self::ThirdPartyDataRequest => std::option::Option::Some(3),
+            Self::GoogleInitiatedReview => std::option::Option::Some(4),
+            Self::CustomerInitiatedAccess => std::option::Option::Some(5),
+            Self::GoogleInitiatedSystemOperation => std::option::Option::Some(6),
+            Self::ReasonNotExpected => std::option::Option::Some(7),
+            Self::ModifiedCustomerInitiatedAccess => std::option::Option::Some(8),
+            Self::ModifiedGoogleInitiatedSystemOperation => std::option::Option::Some(9),
+            Self::GoogleResponseToProductionAlert => std::option::Option::Some(10),
+            Self::CustomerAuthorizedWorkflowServicing => std::option::Option::Some(11),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_SUPPORT"),
-            2 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SERVICE"),
-            3 => std::borrow::Cow::Borrowed("THIRD_PARTY_DATA_REQUEST"),
-            4 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_REVIEW"),
-            5 => std::borrow::Cow::Borrowed("CUSTOMER_INITIATED_ACCESS"),
-            6 => std::borrow::Cow::Borrowed("GOOGLE_INITIATED_SYSTEM_OPERATION"),
-            7 => std::borrow::Cow::Borrowed("REASON_NOT_EXPECTED"),
-            8 => std::borrow::Cow::Borrowed("MODIFIED_CUSTOMER_INITIATED_ACCESS"),
-            9 => std::borrow::Cow::Borrowed("MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION"),
-            10 => std::borrow::Cow::Borrowed("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT"),
-            11 => std::borrow::Cow::Borrowed("CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::ReasonUnspecified => std::option::Option::Some("REASON_UNSPECIFIED"),
+            Self::CustomerInitiatedSupport => {
+                std::option::Option::Some("CUSTOMER_INITIATED_SUPPORT")
+            }
+            Self::GoogleInitiatedService => std::option::Option::Some("GOOGLE_INITIATED_SERVICE"),
+            Self::ThirdPartyDataRequest => std::option::Option::Some("THIRD_PARTY_DATA_REQUEST"),
+            Self::GoogleInitiatedReview => std::option::Option::Some("GOOGLE_INITIATED_REVIEW"),
+            Self::CustomerInitiatedAccess => std::option::Option::Some("CUSTOMER_INITIATED_ACCESS"),
+            Self::GoogleInitiatedSystemOperation => {
+                std::option::Option::Some("GOOGLE_INITIATED_SYSTEM_OPERATION")
+            }
+            Self::ReasonNotExpected => std::option::Option::Some("REASON_NOT_EXPECTED"),
+            Self::ModifiedCustomerInitiatedAccess => {
+                std::option::Option::Some("MODIFIED_CUSTOMER_INITIATED_ACCESS")
+            }
+            Self::ModifiedGoogleInitiatedSystemOperation => {
+                std::option::Option::Some("MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION")
+            }
+            Self::GoogleResponseToProductionAlert => {
+                std::option::Option::Some("GOOGLE_RESPONSE_TO_PRODUCTION_ALERT")
+            }
+            Self::CustomerAuthorizedWorkflowServicing => {
+                std::option::Option::Some("CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
-            "CUSTOMER_INITIATED_SUPPORT" => {
-                std::option::Option::Some(Self::CUSTOMER_INITIATED_SUPPORT)
-            }
-            "GOOGLE_INITIATED_SERVICE" => std::option::Option::Some(Self::GOOGLE_INITIATED_SERVICE),
-            "THIRD_PARTY_DATA_REQUEST" => std::option::Option::Some(Self::THIRD_PARTY_DATA_REQUEST),
-            "GOOGLE_INITIATED_REVIEW" => std::option::Option::Some(Self::GOOGLE_INITIATED_REVIEW),
-            "CUSTOMER_INITIATED_ACCESS" => {
-                std::option::Option::Some(Self::CUSTOMER_INITIATED_ACCESS)
-            }
-            "GOOGLE_INITIATED_SYSTEM_OPERATION" => {
-                std::option::Option::Some(Self::GOOGLE_INITIATED_SYSTEM_OPERATION)
-            }
-            "REASON_NOT_EXPECTED" => std::option::Option::Some(Self::REASON_NOT_EXPECTED),
-            "MODIFIED_CUSTOMER_INITIATED_ACCESS" => {
-                std::option::Option::Some(Self::MODIFIED_CUSTOMER_INITIATED_ACCESS)
-            }
-            "MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION" => {
-                std::option::Option::Some(Self::MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION)
-            }
-            "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => {
-                std::option::Option::Some(Self::GOOGLE_RESPONSE_TO_PRODUCTION_ALERT)
-            }
-            "CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING" => {
-                std::option::Option::Some(Self::CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AccessReason {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessReason {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AccessReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AccessReason {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::ReasonUnspecified,
+            1 => Self::CustomerInitiatedSupport,
+            2 => Self::GoogleInitiatedService,
+            3 => Self::ThirdPartyDataRequest,
+            4 => Self::GoogleInitiatedReview,
+            5 => Self::CustomerInitiatedAccess,
+            6 => Self::GoogleInitiatedSystemOperation,
+            7 => Self::ReasonNotExpected,
+            8 => Self::ModifiedCustomerInitiatedAccess,
+            9 => Self::ModifiedGoogleInitiatedSystemOperation,
+            10 => Self::GoogleResponseToProductionAlert,
+            11 => Self::CustomerAuthorizedWorkflowServicing,
+            _ => Self::UnknownValue(access_reason::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AccessReason {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REASON_UNSPECIFIED" => Self::ReasonUnspecified,
+            "CUSTOMER_INITIATED_SUPPORT" => Self::CustomerInitiatedSupport,
+            "GOOGLE_INITIATED_SERVICE" => Self::GoogleInitiatedService,
+            "THIRD_PARTY_DATA_REQUEST" => Self::ThirdPartyDataRequest,
+            "GOOGLE_INITIATED_REVIEW" => Self::GoogleInitiatedReview,
+            "CUSTOMER_INITIATED_ACCESS" => Self::CustomerInitiatedAccess,
+            "GOOGLE_INITIATED_SYSTEM_OPERATION" => Self::GoogleInitiatedSystemOperation,
+            "REASON_NOT_EXPECTED" => Self::ReasonNotExpected,
+            "MODIFIED_CUSTOMER_INITIATED_ACCESS" => Self::ModifiedCustomerInitiatedAccess,
+            "MODIFIED_GOOGLE_INITIATED_SYSTEM_OPERATION" => {
+                Self::ModifiedGoogleInitiatedSystemOperation
+            }
+            "GOOGLE_RESPONSE_TO_PRODUCTION_ALERT" => Self::GoogleResponseToProductionAlert,
+            "CUSTOMER_AUTHORIZED_WORKFLOW_SERVICING" => Self::CustomerAuthorizedWorkflowServicing,
+            _ => Self::UnknownValue(access_reason::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AccessReason {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::ReasonUnspecified => serializer.serialize_i32(0),
+            Self::CustomerInitiatedSupport => serializer.serialize_i32(1),
+            Self::GoogleInitiatedService => serializer.serialize_i32(2),
+            Self::ThirdPartyDataRequest => serializer.serialize_i32(3),
+            Self::GoogleInitiatedReview => serializer.serialize_i32(4),
+            Self::CustomerInitiatedAccess => serializer.serialize_i32(5),
+            Self::GoogleInitiatedSystemOperation => serializer.serialize_i32(6),
+            Self::ReasonNotExpected => serializer.serialize_i32(7),
+            Self::ModifiedCustomerInitiatedAccess => serializer.serialize_i32(8),
+            Self::ModifiedGoogleInitiatedSystemOperation => serializer.serialize_i32(9),
+            Self::GoogleResponseToProductionAlert => serializer.serialize_i32(10),
+            Self::CustomerAuthorizedWorkflowServicing => serializer.serialize_i32(11),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AccessReason {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessReason>::new(
+            ".google.cloud.kms.v1.AccessReason",
+        ))
     }
 }

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -880,7 +880,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("versionView", &req.version_view.value())]);
+        let builder = builder.query(&[("versionView", &req.version_view)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         self.inner
@@ -907,7 +907,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         self.inner
@@ -1012,7 +1012,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("publicKeyFormat", &req.public_key_format.value())]);
+        let builder = builder.query(&[("publicKeyFormat", &req.public_key_format)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -148,59 +148,120 @@ pub mod document {
     use super::*;
 
     /// The document types enum.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// The content type is not specified.
+        Unspecified,
+        /// Plain text
+        PlainText,
+        /// HTML
+        Html,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// The content type is not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Plain text
-        pub const PLAIN_TEXT: Type = Type::new(1);
-
-        /// HTML
-        pub const HTML: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PlainText => std::option::Option::Some(1),
+                Self::Html => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PLAIN_TEXT"),
-                2 => std::borrow::Cow::Borrowed("HTML"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::PlainText => std::option::Option::Some("PLAIN_TEXT"),
+                Self::Html => std::option::Option::Some("HTML"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PLAIN_TEXT" => std::option::Option::Some(Self::PLAIN_TEXT),
-                "HTML" => std::option::Option::Some(Self::HTML),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PlainText,
+                2 => Self::Html,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PLAIN_TEXT" => Self::PlainText,
+                "HTML" => Self::Html,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PlainText => serializer.serialize_i32(1),
+                Self::Html => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.language.v2.Document.Type",
+            ))
         }
     }
 
@@ -376,34 +437,25 @@ pub mod entity {
     /// The type of the entity. The table
     /// below lists the associated fields for entities that have different
     /// metadata.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Unknown
-        pub const UNKNOWN: Type = Type::new(0);
-
+        Unknown,
         /// Person
-        pub const PERSON: Type = Type::new(1);
-
+        Person,
         /// Location
-        pub const LOCATION: Type = Type::new(2);
-
+        Location,
         /// Organization
-        pub const ORGANIZATION: Type = Type::new(3);
-
+        Organization,
         /// Event
-        pub const EVENT: Type = Type::new(4);
-
+        Event,
         /// Artwork
-        pub const WORK_OF_ART: Type = Type::new(5);
-
+        WorkOfArt,
         /// Consumer product
-        pub const CONSUMER_GOOD: Type = Type::new(6);
-
+        ConsumerGood,
         /// Other types of entities
-        pub const OTHER: Type = Type::new(7);
-
+        Other,
         /// Phone number
         ///
         /// The metadata lists the phone number, formatted according to local
@@ -415,8 +467,7 @@ pub mod entity {
         /// * `area_code` - region or area code, if detected
         /// * `extension` - phone extension (to be dialed after connection), if
         ///   detected
-        pub const PHONE_NUMBER: Type = Type::new(9);
-
+        PhoneNumber,
         /// Address
         ///
         /// The metadata identifies the street number and locality plus whichever
@@ -432,8 +483,7 @@ pub mod entity {
         ///   detected
         /// * `sublocality` - used in Asian addresses to demark a district within a
         ///   city, if detected
-        pub const ADDRESS: Type = Type::new(10);
-
+        Address,
         /// Date
         ///
         /// The metadata identifies the components of the date:
@@ -441,78 +491,170 @@ pub mod entity {
         /// * `year` - four digit year, if detected
         /// * `month` - two digit month number, if detected
         /// * `day` - two digit day number, if detected
-        pub const DATE: Type = Type::new(11);
-
+        Date,
         /// Number
         ///
         /// The metadata is the number itself.
-        pub const NUMBER: Type = Type::new(12);
-
+        Number,
         /// Price
         ///
         /// The metadata identifies the `value` and `currency`.
-        pub const PRICE: Type = Type::new(13);
+        Price,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Person => std::option::Option::Some(1),
+                Self::Location => std::option::Option::Some(2),
+                Self::Organization => std::option::Option::Some(3),
+                Self::Event => std::option::Option::Some(4),
+                Self::WorkOfArt => std::option::Option::Some(5),
+                Self::ConsumerGood => std::option::Option::Some(6),
+                Self::Other => std::option::Option::Some(7),
+                Self::PhoneNumber => std::option::Option::Some(9),
+                Self::Address => std::option::Option::Some(10),
+                Self::Date => std::option::Option::Some(11),
+                Self::Number => std::option::Option::Some(12),
+                Self::Price => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("PERSON"),
-                2 => std::borrow::Cow::Borrowed("LOCATION"),
-                3 => std::borrow::Cow::Borrowed("ORGANIZATION"),
-                4 => std::borrow::Cow::Borrowed("EVENT"),
-                5 => std::borrow::Cow::Borrowed("WORK_OF_ART"),
-                6 => std::borrow::Cow::Borrowed("CONSUMER_GOOD"),
-                7 => std::borrow::Cow::Borrowed("OTHER"),
-                9 => std::borrow::Cow::Borrowed("PHONE_NUMBER"),
-                10 => std::borrow::Cow::Borrowed("ADDRESS"),
-                11 => std::borrow::Cow::Borrowed("DATE"),
-                12 => std::borrow::Cow::Borrowed("NUMBER"),
-                13 => std::borrow::Cow::Borrowed("PRICE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Person => std::option::Option::Some("PERSON"),
+                Self::Location => std::option::Option::Some("LOCATION"),
+                Self::Organization => std::option::Option::Some("ORGANIZATION"),
+                Self::Event => std::option::Option::Some("EVENT"),
+                Self::WorkOfArt => std::option::Option::Some("WORK_OF_ART"),
+                Self::ConsumerGood => std::option::Option::Some("CONSUMER_GOOD"),
+                Self::Other => std::option::Option::Some("OTHER"),
+                Self::PhoneNumber => std::option::Option::Some("PHONE_NUMBER"),
+                Self::Address => std::option::Option::Some("ADDRESS"),
+                Self::Date => std::option::Option::Some("DATE"),
+                Self::Number => std::option::Option::Some("NUMBER"),
+                Self::Price => std::option::Option::Some("PRICE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "PERSON" => std::option::Option::Some(Self::PERSON),
-                "LOCATION" => std::option::Option::Some(Self::LOCATION),
-                "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
-                "EVENT" => std::option::Option::Some(Self::EVENT),
-                "WORK_OF_ART" => std::option::Option::Some(Self::WORK_OF_ART),
-                "CONSUMER_GOOD" => std::option::Option::Some(Self::CONSUMER_GOOD),
-                "OTHER" => std::option::Option::Some(Self::OTHER),
-                "PHONE_NUMBER" => std::option::Option::Some(Self::PHONE_NUMBER),
-                "ADDRESS" => std::option::Option::Some(Self::ADDRESS),
-                "DATE" => std::option::Option::Some(Self::DATE),
-                "NUMBER" => std::option::Option::Some(Self::NUMBER),
-                "PRICE" => std::option::Option::Some(Self::PRICE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Person,
+                2 => Self::Location,
+                3 => Self::Organization,
+                4 => Self::Event,
+                5 => Self::WorkOfArt,
+                6 => Self::ConsumerGood,
+                7 => Self::Other,
+                9 => Self::PhoneNumber,
+                10 => Self::Address,
+                11 => Self::Date,
+                12 => Self::Number,
+                13 => Self::Price,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "PERSON" => Self::Person,
+                "LOCATION" => Self::Location,
+                "ORGANIZATION" => Self::Organization,
+                "EVENT" => Self::Event,
+                "WORK_OF_ART" => Self::WorkOfArt,
+                "CONSUMER_GOOD" => Self::ConsumerGood,
+                "OTHER" => Self::Other,
+                "PHONE_NUMBER" => Self::PhoneNumber,
+                "ADDRESS" => Self::Address,
+                "DATE" => Self::Date,
+                "NUMBER" => Self::Number,
+                "PRICE" => Self::Price,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Person => serializer.serialize_i32(1),
+                Self::Location => serializer.serialize_i32(2),
+                Self::Organization => serializer.serialize_i32(3),
+                Self::Event => serializer.serialize_i32(4),
+                Self::WorkOfArt => serializer.serialize_i32(5),
+                Self::ConsumerGood => serializer.serialize_i32(6),
+                Self::Other => serializer.serialize_i32(7),
+                Self::PhoneNumber => serializer.serialize_i32(9),
+                Self::Address => serializer.serialize_i32(10),
+                Self::Date => serializer.serialize_i32(11),
+                Self::Number => serializer.serialize_i32(12),
+                Self::Price => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.language.v2.Entity.Type",
+            ))
         }
     }
 }
@@ -647,59 +789,120 @@ pub mod entity_mention {
     use super::*;
 
     /// The supported types of mentions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unknown
+        Unknown,
+        /// Proper name
+        Proper,
+        /// Common noun (or noun compound)
+        Common,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unknown
-        pub const TYPE_UNKNOWN: Type = Type::new(0);
-
-        /// Proper name
-        pub const PROPER: Type = Type::new(1);
-
-        /// Common noun (or noun compound)
-        pub const COMMON: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Proper => std::option::Option::Some(1),
+                Self::Common => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("PROPER"),
-                2 => std::borrow::Cow::Borrowed("COMMON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("TYPE_UNKNOWN"),
+                Self::Proper => std::option::Option::Some("PROPER"),
+                Self::Common => std::option::Option::Some("COMMON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNKNOWN" => std::option::Option::Some(Self::TYPE_UNKNOWN),
-                "PROPER" => std::option::Option::Some(Self::PROPER),
-                "COMMON" => std::option::Option::Some(Self::COMMON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Proper,
+                2 => Self::Common,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNKNOWN" => Self::Unknown,
+                "PROPER" => Self::Proper,
+                "COMMON" => Self::Common,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Proper => serializer.serialize_i32(1),
+                Self::Common => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.language.v2.EntityMention.Type",
+            ))
         }
     }
 }
@@ -1188,65 +1391,124 @@ pub mod moderate_text_request {
     use super::*;
 
     /// The model version to use for ModerateText.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ModelVersion(i32);
-
-    impl ModelVersion {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ModelVersion {
         /// The default model version.
-        pub const MODEL_VERSION_UNSPECIFIED: ModelVersion = ModelVersion::new(0);
-
+        Unspecified,
         /// Use the v1 model, this model is used by default when not provided.
         /// The v1 model only returns probability (confidence) score for each
         /// category.
-        pub const MODEL_VERSION_1: ModelVersion = ModelVersion::new(1);
-
+        _1,
         /// Use the v2 model.
         /// The v2 model only returns probability (confidence) score for each
         /// category, and returns severity score for a subset of the categories.
-        pub const MODEL_VERSION_2: ModelVersion = ModelVersion::new(2);
+        _2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ModelVersion::value] or
+        /// [ModelVersion::name].
+        UnknownValue(model_version::UnknownValue),
+    }
 
-        /// Creates a new ModelVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod model_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ModelVersion {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::_1 => std::option::Option::Some(1),
+                Self::_2 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODEL_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODEL_VERSION_1"),
-                2 => std::borrow::Cow::Borrowed("MODEL_VERSION_2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODEL_VERSION_UNSPECIFIED"),
+                Self::_1 => std::option::Option::Some("MODEL_VERSION_1"),
+                Self::_2 => std::option::Option::Some("MODEL_VERSION_2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODEL_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MODEL_VERSION_UNSPECIFIED)
-                }
-                "MODEL_VERSION_1" => std::option::Option::Some(Self::MODEL_VERSION_1),
-                "MODEL_VERSION_2" => std::option::Option::Some(Self::MODEL_VERSION_2),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ModelVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ModelVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ModelVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ModelVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::_1,
+                2 => Self::_2,
+                _ => Self::UnknownValue(model_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ModelVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODEL_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "MODEL_VERSION_1" => Self::_1,
+                "MODEL_VERSION_2" => Self::_2,
+                _ => Self::UnknownValue(model_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ModelVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::_1 => serializer.serialize_i32(1),
+                Self::_2 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ModelVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ModelVersion>::new(
+                ".google.cloud.language.v2.ModerateTextRequest.ModelVersion",
+            ))
         }
     }
 }
@@ -1582,70 +1844,133 @@ impl wkt::message::Message for AnnotateTextResponse {
 /// beginning offsets for various outputs, such as tokens and mentions, and
 /// languages that natively use different text encodings may access offsets
 /// differently.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncodingType(i32);
-
-impl EncodingType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EncodingType {
     /// If `EncodingType` is not specified, encoding-dependent information (such as
     /// `begin_offset`) will be set at `-1`.
-    pub const NONE: EncodingType = EncodingType::new(0);
-
+    None,
     /// Encoding-dependent information (such as `begin_offset`) is calculated based
     /// on the UTF-8 encoding of the input. C++ and Go are examples of languages
     /// that use this encoding natively.
-    pub const UTF8: EncodingType = EncodingType::new(1);
-
+    Utf8,
     /// Encoding-dependent information (such as `begin_offset`) is calculated based
     /// on the UTF-16 encoding of the input. Java and JavaScript are examples of
     /// languages that use this encoding natively.
-    pub const UTF16: EncodingType = EncodingType::new(2);
-
+    Utf16,
     /// Encoding-dependent information (such as `begin_offset`) is calculated based
     /// on the UTF-32 encoding of the input. Python is an example of a language
     /// that uses this encoding natively.
-    pub const UTF32: EncodingType = EncodingType::new(3);
+    Utf32,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EncodingType::value] or
+    /// [EncodingType::name].
+    UnknownValue(encoding_type::UnknownValue),
+}
 
-    /// Creates a new EncodingType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod encoding_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl EncodingType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::None => std::option::Option::Some(0),
+            Self::Utf8 => std::option::Option::Some(1),
+            Self::Utf16 => std::option::Option::Some(2),
+            Self::Utf32 => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NONE"),
-            1 => std::borrow::Cow::Borrowed("UTF8"),
-            2 => std::borrow::Cow::Borrowed("UTF16"),
-            3 => std::borrow::Cow::Borrowed("UTF32"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::None => std::option::Option::Some("NONE"),
+            Self::Utf8 => std::option::Option::Some("UTF8"),
+            Self::Utf16 => std::option::Option::Some("UTF16"),
+            Self::Utf32 => std::option::Option::Some("UTF32"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NONE" => std::option::Option::Some(Self::NONE),
-            "UTF8" => std::option::Option::Some(Self::UTF8),
-            "UTF16" => std::option::Option::Some(Self::UTF16),
-            "UTF32" => std::option::Option::Some(Self::UTF32),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EncodingType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EncodingType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EncodingType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EncodingType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::None,
+            1 => Self::Utf8,
+            2 => Self::Utf16,
+            3 => Self::Utf32,
+            _ => Self::UnknownValue(encoding_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EncodingType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NONE" => Self::None,
+            "UTF8" => Self::Utf8,
+            "UTF16" => Self::Utf16,
+            "UTF32" => Self::Utf32,
+            _ => Self::UnknownValue(encoding_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EncodingType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::None => serializer.serialize_i32(0),
+            Self::Utf8 => serializer.serialize_i32(1),
+            Self::Utf16 => serializer.serialize_i32(2),
+            Self::Utf32 => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EncodingType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncodingType>::new(
+            ".google.cloud.language.v2.EncodingType",
+        ))
     }
 }

--- a/src/generated/cloud/licensemanager/v1/src/model.rs
+++ b/src/generated/cloud/licensemanager/v1/src/model.rs
@@ -187,64 +187,127 @@ pub mod configuration {
     use super::*;
 
     /// State of the configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The Status of the configuration is unspecified
+        Unspecified,
+        /// Configuration is in active state.
+        Active,
+        /// Configuration is in deactivated state.
+        Suspended,
+        /// Configuration is in deleted state.
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The Status of the configuration is unspecified
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Configuration is in active state.
-        pub const STATE_ACTIVE: State = State::new(1);
-
-        /// Configuration is in deactivated state.
-        pub const STATE_SUSPENDED: State = State::new(2);
-
-        /// Configuration is in deleted state.
-        pub const STATE_DELETED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Suspended => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATE_ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("STATE_SUSPENDED"),
-                3 => std::borrow::Cow::Borrowed("STATE_DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("STATE_ACTIVE"),
+                Self::Suspended => std::option::Option::Some("STATE_SUSPENDED"),
+                Self::Deleted => std::option::Option::Some("STATE_DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STATE_ACTIVE" => std::option::Option::Some(Self::STATE_ACTIVE),
-                "STATE_SUSPENDED" => std::option::Option::Some(Self::STATE_SUSPENDED),
-                "STATE_DELETED" => std::option::Option::Some(Self::STATE_DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Suspended,
+                3 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STATE_ACTIVE" => Self::Active,
+                "STATE_SUSPENDED" => Self::Suspended,
+                "STATE_DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Suspended => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.licensemanager.v1.Configuration.State",
+            ))
         }
     }
 }
@@ -524,69 +587,134 @@ pub mod product {
     use super::*;
 
     /// State of the product.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The Status of the product is unknown.
+        Unspecified,
+        /// Product is under provisioning stage.
+        Provisioning,
+        /// Product is ok to run on instances.
+        Running,
+        /// The product is about to terminate or has been announced for termination.
+        Terminating,
+        /// The product has been terminated.
+        Terminated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The Status of the product is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Product is under provisioning stage.
-        pub const STATE_PROVISIONING: State = State::new(1);
-
-        /// Product is ok to run on instances.
-        pub const STATE_RUNNING: State = State::new(2);
-
-        /// The product is about to terminate or has been announced for termination.
-        pub const STATE_TERMINATING: State = State::new(3);
-
-        /// The product has been terminated.
-        pub const STATE_TERMINATED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Terminating => std::option::Option::Some(3),
+                Self::Terminated => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATE_PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("STATE_RUNNING"),
-                3 => std::borrow::Cow::Borrowed("STATE_TERMINATING"),
-                4 => std::borrow::Cow::Borrowed("STATE_TERMINATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("STATE_PROVISIONING"),
+                Self::Running => std::option::Option::Some("STATE_RUNNING"),
+                Self::Terminating => std::option::Option::Some("STATE_TERMINATING"),
+                Self::Terminated => std::option::Option::Some("STATE_TERMINATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STATE_PROVISIONING" => std::option::Option::Some(Self::STATE_PROVISIONING),
-                "STATE_RUNNING" => std::option::Option::Some(Self::STATE_RUNNING),
-                "STATE_TERMINATING" => std::option::Option::Some(Self::STATE_TERMINATING),
-                "STATE_TERMINATED" => std::option::Option::Some(Self::STATE_TERMINATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Terminating,
+                4 => Self::Terminated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STATE_PROVISIONING" => Self::Provisioning,
+                "STATE_RUNNING" => Self::Running,
+                "STATE_TERMINATING" => Self::Terminating,
+                "STATE_TERMINATED" => Self::Terminated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Terminating => serializer.serialize_i32(3),
+                Self::Terminated => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.licensemanager.v1.Product.State",
+            ))
         }
     }
 }
@@ -734,86 +862,157 @@ pub mod instance {
     use super::*;
 
     /// VM status enum.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The Status of the VM is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Resources are being allocated for the instance.
-        pub const PROVISIONING: State = State::new(1);
-
+        Provisioning,
         /// All required resources have been allocated and
         /// the instance is being started.
-        pub const STAGING: State = State::new(2);
-
+        Staging,
         /// The instance is running.
-        pub const RUNNING: State = State::new(3);
-
+        Running,
         /// The instance is currently stopping (either being deleted or terminated).
-        pub const STOPPING: State = State::new(4);
-
+        Stopping,
         /// The instance has stopped due to various reasons (user request, VM
         /// preemption, project freezing, etc.).
-        pub const STOPPED: State = State::new(5);
-
+        Stopped,
         /// The instance has failed in some way.
-        pub const TERMINATED: State = State::new(6);
-
+        Terminated,
         /// The instance is in repair.
-        pub const REPAIRING: State = State::new(7);
+        Repairing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Staging => std::option::Option::Some(2),
+                Self::Running => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Stopped => std::option::Option::Some(5),
+                Self::Terminated => std::option::Option::Some(6),
+                Self::Repairing => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("STAGING"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("STOPPED"),
-                6 => std::borrow::Cow::Borrowed("TERMINATED"),
-                7 => std::borrow::Cow::Borrowed("REPAIRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Staging => std::option::Option::Some("STAGING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "STAGING" => std::option::Option::Some(Self::STAGING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Staging,
+                3 => Self::Running,
+                4 => Self::Stopping,
+                5 => Self::Stopped,
+                6 => Self::Terminated,
+                7 => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "STAGING" => Self::Staging,
+                "RUNNING" => Self::Running,
+                "STOPPING" => Self::Stopping,
+                "STOPPED" => Self::Stopped,
+                "TERMINATED" => Self::Terminated,
+                "REPAIRING" => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Staging => serializer.serialize_i32(2),
+                Self::Running => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Stopped => serializer.serialize_i32(5),
+                Self::Terminated => serializer.serialize_i32(6),
+                Self::Repairing => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.licensemanager.v1.Instance.State",
+            ))
         }
     }
 }
@@ -2164,153 +2363,267 @@ impl wkt::message::Message for OperationMetadata {
 }
 
 /// Different types of licenses that are supported.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LicenseType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LicenseType {
+    /// unspecified.
+    Unspecified,
+    /// Billing will be based on number of users listed per month.
+    PerMonthPerUser,
+    /// Bring your own license.
+    BringYourOwnLicense,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LicenseType::value] or
+    /// [LicenseType::name].
+    UnknownValue(license_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod license_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LicenseType {
-    /// unspecified.
-    pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
-
-    /// Billing will be based on number of users listed per month.
-    pub const LICENSE_TYPE_PER_MONTH_PER_USER: LicenseType = LicenseType::new(1);
-
-    /// Bring your own license.
-    pub const LICENSE_TYPE_BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
-
-    /// Creates a new LicenseType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PerMonthPerUser => std::option::Option::Some(1),
+            Self::BringYourOwnLicense => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LICENSE_TYPE_PER_MONTH_PER_USER"),
-            2 => std::borrow::Cow::Borrowed("LICENSE_TYPE_BRING_YOUR_OWN_LICENSE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LICENSE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED),
-            "LICENSE_TYPE_PER_MONTH_PER_USER" => {
-                std::option::Option::Some(Self::LICENSE_TYPE_PER_MONTH_PER_USER)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LICENSE_TYPE_UNSPECIFIED"),
+            Self::PerMonthPerUser => std::option::Option::Some("LICENSE_TYPE_PER_MONTH_PER_USER"),
+            Self::BringYourOwnLicense => {
+                std::option::Option::Some("LICENSE_TYPE_BRING_YOUR_OWN_LICENSE")
             }
-            "LICENSE_TYPE_BRING_YOUR_OWN_LICENSE" => {
-                std::option::Option::Some(Self::LICENSE_TYPE_BRING_YOUR_OWN_LICENSE)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for LicenseType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LicenseType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LicenseType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LicenseType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PerMonthPerUser,
+            2 => Self::BringYourOwnLicense,
+            _ => Self::UnknownValue(license_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LicenseType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LICENSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "LICENSE_TYPE_PER_MONTH_PER_USER" => Self::PerMonthPerUser,
+            "LICENSE_TYPE_BRING_YOUR_OWN_LICENSE" => Self::BringYourOwnLicense,
+            _ => Self::UnknownValue(license_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LicenseType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PerMonthPerUser => serializer.serialize_i32(1),
+            Self::BringYourOwnLicense => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LicenseType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LicenseType>::new(
+            ".google.cloud.licensemanager.v1.LicenseType",
+        ))
     }
 }
 
 /// State of the License Key activation on the instance.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ActivationState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ActivationState {
+    /// The Status of the activation is unspecified
+    Unspecified,
+    /// Activation key (MAK) requested for the instance.
+    KeyRequested,
+    /// License activation process is running on the instance.
+    Activating,
+    /// License activation is complete on the instance.
+    Activated,
+    /// License Key is deactivating on the instance.
+    Deactivating,
+    /// License Key is deactivated on the instance.
+    Deactivated,
+    /// License Key activation failed on the instance.
+    Terminated,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ActivationState::value] or
+    /// [ActivationState::name].
+    UnknownValue(activation_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod activation_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ActivationState {
-    /// The Status of the activation is unspecified
-    pub const ACTIVATION_STATE_UNSPECIFIED: ActivationState = ActivationState::new(0);
-
-    /// Activation key (MAK) requested for the instance.
-    pub const ACTIVATION_STATE_KEY_REQUESTED: ActivationState = ActivationState::new(1);
-
-    /// License activation process is running on the instance.
-    pub const ACTIVATION_STATE_ACTIVATING: ActivationState = ActivationState::new(2);
-
-    /// License activation is complete on the instance.
-    pub const ACTIVATION_STATE_ACTIVATED: ActivationState = ActivationState::new(3);
-
-    /// License Key is deactivating on the instance.
-    pub const ACTIVATION_STATE_DEACTIVATING: ActivationState = ActivationState::new(4);
-
-    /// License Key is deactivated on the instance.
-    pub const ACTIVATION_STATE_DEACTIVATED: ActivationState = ActivationState::new(5);
-
-    /// License Key activation failed on the instance.
-    pub const ACTIVATION_STATE_TERMINATED: ActivationState = ActivationState::new(6);
-
-    /// Creates a new ActivationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::KeyRequested => std::option::Option::Some(1),
+            Self::Activating => std::option::Option::Some(2),
+            Self::Activated => std::option::Option::Some(3),
+            Self::Deactivating => std::option::Option::Some(4),
+            Self::Deactivated => std::option::Option::Some(5),
+            Self::Terminated => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_KEY_REQUESTED"),
-            2 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_ACTIVATING"),
-            3 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_ACTIVATED"),
-            4 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_DEACTIVATING"),
-            5 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_DEACTIVATED"),
-            6 => std::borrow::Cow::Borrowed("ACTIVATION_STATE_TERMINATED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ACTIVATION_STATE_UNSPECIFIED"),
+            Self::KeyRequested => std::option::Option::Some("ACTIVATION_STATE_KEY_REQUESTED"),
+            Self::Activating => std::option::Option::Some("ACTIVATION_STATE_ACTIVATING"),
+            Self::Activated => std::option::Option::Some("ACTIVATION_STATE_ACTIVATED"),
+            Self::Deactivating => std::option::Option::Some("ACTIVATION_STATE_DEACTIVATING"),
+            Self::Deactivated => std::option::Option::Some("ACTIVATION_STATE_DEACTIVATED"),
+            Self::Terminated => std::option::Option::Some("ACTIVATION_STATE_TERMINATED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ACTIVATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_UNSPECIFIED)
-            }
-            "ACTIVATION_STATE_KEY_REQUESTED" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_KEY_REQUESTED)
-            }
-            "ACTIVATION_STATE_ACTIVATING" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_ACTIVATING)
-            }
-            "ACTIVATION_STATE_ACTIVATED" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_ACTIVATED)
-            }
-            "ACTIVATION_STATE_DEACTIVATING" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_DEACTIVATING)
-            }
-            "ACTIVATION_STATE_DEACTIVATED" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_DEACTIVATED)
-            }
-            "ACTIVATION_STATE_TERMINATED" => {
-                std::option::Option::Some(Self::ACTIVATION_STATE_TERMINATED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ActivationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ActivationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ActivationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ActivationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::KeyRequested,
+            2 => Self::Activating,
+            3 => Self::Activated,
+            4 => Self::Deactivating,
+            5 => Self::Deactivated,
+            6 => Self::Terminated,
+            _ => Self::UnknownValue(activation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ActivationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ACTIVATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVATION_STATE_KEY_REQUESTED" => Self::KeyRequested,
+            "ACTIVATION_STATE_ACTIVATING" => Self::Activating,
+            "ACTIVATION_STATE_ACTIVATED" => Self::Activated,
+            "ACTIVATION_STATE_DEACTIVATING" => Self::Deactivating,
+            "ACTIVATION_STATE_DEACTIVATED" => Self::Deactivated,
+            "ACTIVATION_STATE_TERMINATED" => Self::Terminated,
+            _ => Self::UnknownValue(activation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ActivationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::KeyRequested => serializer.serialize_i32(1),
+            Self::Activating => serializer.serialize_i32(2),
+            Self::Activated => serializer.serialize_i32(3),
+            Self::Deactivating => serializer.serialize_i32(4),
+            Self::Deactivated => serializer.serialize_i32(5),
+            Self::Terminated => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ActivationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ActivationState>::new(
+            ".google.cloud.licensemanager.v1.ActivationState",
+        ))
     }
 }

--- a/src/generated/cloud/lustre/v1/src/model.rs
+++ b/src/generated/cloud/lustre/v1/src/model.rs
@@ -204,79 +204,148 @@ pub mod instance {
     use super::*;
 
     /// The possible states of an instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not set.
+        Unspecified,
+        /// The instance is available for use.
+        Active,
+        /// The instance is being created and is not yet ready for use.
+        Creating,
+        /// The instance is being deleted.
+        Deleting,
+        /// The instance is being upgraded.
+        Upgrading,
+        /// The instance is being repaired.
+        Repairing,
+        /// The instance is stopped.
+        Stopped,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The instance is available for use.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The instance is being created and is not yet ready for use.
-        pub const CREATING: State = State::new(2);
-
-        /// The instance is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The instance is being upgraded.
-        pub const UPGRADING: State = State::new(4);
-
-        /// The instance is being repaired.
-        pub const REPAIRING: State = State::new(5);
-
-        /// The instance is stopped.
-        pub const STOPPED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Upgrading => std::option::Option::Some(4),
+                Self::Repairing => std::option::Option::Some(5),
+                Self::Stopped => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPGRADING"),
-                5 => std::borrow::Cow::Borrowed("REPAIRING"),
-                6 => std::borrow::Cow::Borrowed("STOPPED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Upgrading => std::option::Option::Some("UPGRADING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Deleting,
+                4 => Self::Upgrading,
+                5 => Self::Repairing,
+                6 => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPGRADING" => Self::Upgrading,
+                "REPAIRING" => Self::Repairing,
+                "STOPPED" => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Upgrading => serializer.serialize_i32(4),
+                Self::Repairing => serializer.serialize_i32(5),
+                Self::Stopped => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.lustre.v1.Instance.State",
+            ))
         }
     }
 }
@@ -1948,60 +2017,119 @@ pub mod transfer_operation_metadata {
 }
 
 /// Type of transfer that occurred.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransferType {
+    /// Zero is an illegal value.
+    Unspecified,
+    /// Imports to Lustre.
+    Import,
+    /// Exports from Lustre.
+    Export,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransferType::value] or
+    /// [TransferType::name].
+    UnknownValue(transfer_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod transfer_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TransferType {
-    /// Zero is an illegal value.
-    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType = TransferType::new(0);
-
-    /// Imports to Lustre.
-    pub const IMPORT: TransferType = TransferType::new(1);
-
-    /// Exports from Lustre.
-    pub const EXPORT: TransferType = TransferType::new(2);
-
-    /// Creates a new TransferType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Import => std::option::Option::Some(1),
+            Self::Export => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFER_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IMPORT"),
-            2 => std::borrow::Cow::Borrowed("EXPORT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFER_TYPE_UNSPECIFIED"),
+            Self::Import => std::option::Option::Some("IMPORT"),
+            Self::Export => std::option::Option::Some("EXPORT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFER_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFER_TYPE_UNSPECIFIED)
-            }
-            "IMPORT" => std::option::Option::Some(Self::IMPORT),
-            "EXPORT" => std::option::Option::Some(Self::EXPORT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransferType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransferType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransferType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Import,
+            2 => Self::Export,
+            _ => Self::UnknownValue(transfer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransferType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFER_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "IMPORT" => Self::Import,
+            "EXPORT" => Self::Export,
+            _ => Self::UnknownValue(transfer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransferType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Import => serializer.serialize_i32(1),
+            Self::Export => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransferType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransferType>::new(
+            ".google.cloud.lustre.v1.TransferType",
+        ))
     }
 }

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -949,85 +949,156 @@ pub mod domain {
     use super::*;
 
     /// Represents the different states of a managed domain.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The domain is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The domain has been created and is fully usable.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The domain's configuration is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The domain is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The domain is being repaired and may be unusable. Details
         /// can be found in the `status_message` field.
-        pub const REPAIRING: State = State::new(5);
-
+        Repairing,
         /// The domain is undergoing maintenance.
-        pub const PERFORMING_MAINTENANCE: State = State::new(6);
-
+        PerformingMaintenance,
         /// The domain is not serving requests.
-        pub const UNAVAILABLE: State = State::new(7);
+        Unavailable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Repairing => std::option::Option::Some(5),
+                Self::PerformingMaintenance => std::option::Option::Some(6),
+                Self::Unavailable => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("REPAIRING"),
-                6 => std::borrow::Cow::Borrowed("PERFORMING_MAINTENANCE"),
-                7 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::PerformingMaintenance => std::option::Option::Some("PERFORMING_MAINTENANCE"),
+                Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                "PERFORMING_MAINTENANCE" => std::option::Option::Some(Self::PERFORMING_MAINTENANCE),
-                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Repairing,
+                6 => Self::PerformingMaintenance,
+                7 => Self::Unavailable,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "REPAIRING" => Self::Repairing,
+                "PERFORMING_MAINTENANCE" => Self::PerformingMaintenance,
+                "UNAVAILABLE" => Self::Unavailable,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Repairing => serializer.serialize_i32(5),
+                Self::PerformingMaintenance => serializer.serialize_i32(6),
+                Self::Unavailable => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.managedidentities.v1.Domain.State",
+            ))
         }
     }
 }
@@ -1205,131 +1276,259 @@ pub mod trust {
     use super::*;
 
     /// Represents the different states of a domain trust.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not set.
+        Unspecified,
+        /// The domain trust is being created.
+        Creating,
+        /// The domain trust is being updated.
+        Updating,
+        /// The domain trust is being deleted.
+        Deleting,
+        /// The domain trust is connected.
+        Connected,
+        /// The domain trust is disconnected.
+        Disconnected,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The domain trust is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The domain trust is being updated.
-        pub const UPDATING: State = State::new(2);
-
-        /// The domain trust is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The domain trust is connected.
-        pub const CONNECTED: State = State::new(4);
-
-        /// The domain trust is disconnected.
-        pub const DISCONNECTED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Connected => std::option::Option::Some(4),
+                Self::Disconnected => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("CONNECTED"),
-                5 => std::borrow::Cow::Borrowed("DISCONNECTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Connected => std::option::Option::Some("CONNECTED"),
+                Self::Disconnected => std::option::Option::Some("DISCONNECTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "CONNECTED" => std::option::Option::Some(Self::CONNECTED),
-                "DISCONNECTED" => std::option::Option::Some(Self::DISCONNECTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Updating,
+                3 => Self::Deleting,
+                4 => Self::Connected,
+                5 => Self::Disconnected,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "CONNECTED" => Self::Connected,
+                "DISCONNECTED" => Self::Disconnected,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Connected => serializer.serialize_i32(4),
+                Self::Disconnected => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.managedidentities.v1.Trust.State",
+            ))
         }
     }
 
     /// Represents the different inter-forest trust types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrustType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TrustType {
+        /// Not set.
+        Unspecified,
+        /// The forest trust.
+        Forest,
+        /// The external domain trust.
+        External,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TrustType::value] or
+        /// [TrustType::name].
+        UnknownValue(trust_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod trust_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TrustType {
-        /// Not set.
-        pub const TRUST_TYPE_UNSPECIFIED: TrustType = TrustType::new(0);
-
-        /// The forest trust.
-        pub const FOREST: TrustType = TrustType::new(1);
-
-        /// The external domain trust.
-        pub const EXTERNAL: TrustType = TrustType::new(2);
-
-        /// Creates a new TrustType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Forest => std::option::Option::Some(1),
+                Self::External => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRUST_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FOREST"),
-                2 => std::borrow::Cow::Borrowed("EXTERNAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRUST_TYPE_UNSPECIFIED"),
+                Self::Forest => std::option::Option::Some("FOREST"),
+                Self::External => std::option::Option::Some("EXTERNAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRUST_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TRUST_TYPE_UNSPECIFIED),
-                "FOREST" => std::option::Option::Some(Self::FOREST),
-                "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TrustType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TrustType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TrustType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TrustType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Forest,
+                2 => Self::External,
+                _ => Self::UnknownValue(trust_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TrustType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRUST_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FOREST" => Self::Forest,
+                "EXTERNAL" => Self::External,
+                _ => Self::UnknownValue(trust_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TrustType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Forest => serializer.serialize_i32(1),
+                Self::External => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TrustType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TrustType>::new(
+                ".google.cloud.managedidentities.v1.Trust.TrustType",
+            ))
         }
     }
 
@@ -1337,66 +1536,127 @@ pub mod trust {
     /// See
     /// [System.DirectoryServices.ActiveDirectory.TrustDirection](https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trustdirection?view=netframework-4.7.2)
     /// for more information.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrustDirection(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TrustDirection {
+        /// Not set.
+        Unspecified,
+        /// The inbound direction represents the trusting side.
+        Inbound,
+        /// The outboud direction represents the trusted side.
+        Outbound,
+        /// The bidirectional direction represents the trusted / trusting side.
+        Bidirectional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TrustDirection::value] or
+        /// [TrustDirection::name].
+        UnknownValue(trust_direction::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod trust_direction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TrustDirection {
-        /// Not set.
-        pub const TRUST_DIRECTION_UNSPECIFIED: TrustDirection = TrustDirection::new(0);
-
-        /// The inbound direction represents the trusting side.
-        pub const INBOUND: TrustDirection = TrustDirection::new(1);
-
-        /// The outboud direction represents the trusted side.
-        pub const OUTBOUND: TrustDirection = TrustDirection::new(2);
-
-        /// The bidirectional direction represents the trusted / trusting side.
-        pub const BIDIRECTIONAL: TrustDirection = TrustDirection::new(3);
-
-        /// Creates a new TrustDirection instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Inbound => std::option::Option::Some(1),
+                Self::Outbound => std::option::Option::Some(2),
+                Self::Bidirectional => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRUST_DIRECTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INBOUND"),
-                2 => std::borrow::Cow::Borrowed("OUTBOUND"),
-                3 => std::borrow::Cow::Borrowed("BIDIRECTIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRUST_DIRECTION_UNSPECIFIED"),
+                Self::Inbound => std::option::Option::Some("INBOUND"),
+                Self::Outbound => std::option::Option::Some("OUTBOUND"),
+                Self::Bidirectional => std::option::Option::Some("BIDIRECTIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRUST_DIRECTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRUST_DIRECTION_UNSPECIFIED)
-                }
-                "INBOUND" => std::option::Option::Some(Self::INBOUND),
-                "OUTBOUND" => std::option::Option::Some(Self::OUTBOUND),
-                "BIDIRECTIONAL" => std::option::Option::Some(Self::BIDIRECTIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TrustDirection {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TrustDirection {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TrustDirection {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TrustDirection {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Inbound,
+                2 => Self::Outbound,
+                3 => Self::Bidirectional,
+                _ => Self::UnknownValue(trust_direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TrustDirection {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRUST_DIRECTION_UNSPECIFIED" => Self::Unspecified,
+                "INBOUND" => Self::Inbound,
+                "OUTBOUND" => Self::Outbound,
+                "BIDIRECTIONAL" => Self::Bidirectional,
+                _ => Self::UnknownValue(trust_direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TrustDirection {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Inbound => serializer.serialize_i32(1),
+                Self::Outbound => serializer.serialize_i32(2),
+                Self::Bidirectional => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TrustDirection {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TrustDirection>::new(
+                ".google.cloud.managedidentities.v1.Trust.TrustDirection",
+            ))
         }
     }
 }

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -467,69 +467,137 @@ pub mod instance {
         use super::*;
 
         /// Different states of a Memcached node.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// Node state is not set.
+            Unspecified,
+            /// Node is being created.
+            Creating,
+            /// Node has been created and ready to be used.
+            Ready,
+            /// Node is being deleted.
+            Deleting,
+            /// Node is being updated.
+            Updating,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// Node state is not set.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// Node is being created.
-            pub const CREATING: State = State::new(1);
-
-            /// Node has been created and ready to be used.
-            pub const READY: State = State::new(2);
-
-            /// Node is being deleted.
-            pub const DELETING: State = State::new(3);
-
-            /// Node is being updated.
-            pub const UPDATING: State = State::new(4);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Creating => std::option::Option::Some(1),
+                    Self::Ready => std::option::Option::Some(2),
+                    Self::Deleting => std::option::Option::Some(3),
+                    Self::Updating => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CREATING"),
-                    2 => std::borrow::Cow::Borrowed("READY"),
-                    3 => std::borrow::Cow::Borrowed("DELETING"),
-                    4 => std::borrow::Cow::Borrowed("UPDATING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Creating => std::option::Option::Some("CREATING"),
+                    Self::Ready => std::option::Option::Some("READY"),
+                    Self::Deleting => std::option::Option::Some("DELETING"),
+                    Self::Updating => std::option::Option::Some("UPDATING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "CREATING" => std::option::Option::Some(Self::CREATING),
-                    "READY" => std::option::Option::Some(Self::READY),
-                    "DELETING" => std::option::Option::Some(Self::DELETING),
-                    "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Creating,
+                    2 => Self::Ready,
+                    3 => Self::Deleting,
+                    4 => Self::Updating,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "CREATING" => Self::Creating,
+                    "READY" => Self::Ready,
+                    "DELETING" => Self::Deleting,
+                    "UPDATING" => Self::Updating,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Creating => serializer.serialize_i32(1),
+                    Self::Ready => serializer.serialize_i32(2),
+                    Self::Deleting => serializer.serialize_i32(3),
+                    Self::Updating => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.memcache.v1.Instance.Node.State",
+                ))
             }
         }
     }
@@ -582,130 +650,259 @@ pub mod instance {
         #[allow(unused_imports)]
         use super::*;
 
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Code {
+            /// Message Code not set.
+            Unspecified,
+            /// Memcached nodes are distributed unevenly.
+            ZoneDistributionUnbalanced,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Code::value] or
+            /// [Code::name].
+            UnknownValue(code::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod code {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Code {
-            /// Message Code not set.
-            pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
-            /// Memcached nodes are distributed unevenly.
-            pub const ZONE_DISTRIBUTION_UNBALANCED: Code = Code::new(1);
-
-            /// Creates a new Code instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ZoneDistributionUnbalanced => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ZONE_DISTRIBUTION_UNBALANCED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                    "ZONE_DISTRIBUTION_UNBALANCED" => {
-                        std::option::Option::Some(Self::ZONE_DISTRIBUTION_UNBALANCED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                    Self::ZoneDistributionUnbalanced => {
+                        std::option::Option::Some("ZONE_DISTRIBUTION_UNBALANCED")
                     }
-                    _ => std::option::Option::None,
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for Code {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Code {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ZoneDistributionUnbalanced,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Code {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CODE_UNSPECIFIED" => Self::Unspecified,
+                    "ZONE_DISTRIBUTION_UNBALANCED" => Self::ZoneDistributionUnbalanced,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Code {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ZoneDistributionUnbalanced => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Code {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                    ".google.cloud.memcache.v1.Instance.InstanceMessage.Code",
+                ))
             }
         }
     }
 
     /// Different states of a Memcached instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Memcached instance is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Memcached instance has been created and ready to be used.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// Memcached instance is updating configuration such as maintenance policy
         /// and schedule.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// Memcached instance is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Memcached instance is going through maintenance, e.g. data plane rollout.
-        pub const PERFORMING_MAINTENANCE: State = State::new(5);
+        PerformingMaintenance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::PerformingMaintenance => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("PERFORMING_MAINTENANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::PerformingMaintenance => std::option::Option::Some("PERFORMING_MAINTENANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "PERFORMING_MAINTENANCE" => std::option::Option::Some(Self::PERFORMING_MAINTENANCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::PerformingMaintenance,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "PERFORMING_MAINTENANCE" => Self::PerformingMaintenance,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::PerformingMaintenance => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.memcache.v1.Instance.State",
+            ))
         }
     }
 }
@@ -978,67 +1175,128 @@ pub mod reschedule_maintenance_request {
     use super::*;
 
     /// Reschedule options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(i32);
-
-    impl RescheduleType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RescheduleType {
         /// Not set.
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
-
+        Unspecified,
         /// If the user wants to schedule the maintenance to happen now.
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
-
+        Immediate,
         /// If the user wants to use the existing maintenance policy to find the
         /// next available window.
-        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new(2);
-
+        NextAvailableWindow,
         /// If the user wants to reschedule the maintenance to a specific time.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
+        SpecificTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RescheduleType::value] or
+        /// [RescheduleType::name].
+        UnknownValue(reschedule_type::UnknownValue),
+    }
 
-        /// Creates a new RescheduleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reschedule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RescheduleType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Immediate => std::option::Option::Some(1),
+                Self::NextAvailableWindow => std::option::Option::Some(2),
+                Self::SpecificTime => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
-                2 => std::borrow::Cow::Borrowed("NEXT_AVAILABLE_WINDOW"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESCHEDULE_TYPE_UNSPECIFIED"),
+                Self::Immediate => std::option::Option::Some("IMMEDIATE"),
+                Self::NextAvailableWindow => std::option::Option::Some("NEXT_AVAILABLE_WINDOW"),
+                Self::SpecificTime => std::option::Option::Some("SPECIFIC_TIME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESCHEDULE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED)
-                }
-                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
-                "NEXT_AVAILABLE_WINDOW" => std::option::Option::Some(Self::NEXT_AVAILABLE_WINDOW),
-                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RescheduleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RescheduleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Immediate,
+                2 => Self::NextAvailableWindow,
+                3 => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RescheduleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMMEDIATE" => Self::Immediate,
+                "NEXT_AVAILABLE_WINDOW" => Self::NextAvailableWindow,
+                "SPECIFIC_TIME" => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RescheduleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Immediate => serializer.serialize_i32(1),
+                Self::NextAvailableWindow => serializer.serialize_i32(2),
+                Self::SpecificTime => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RescheduleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RescheduleType>::new(
+                ".google.cloud.memcache.v1.RescheduleMaintenanceRequest.RescheduleType",
+            ))
         }
     }
 }
@@ -1747,54 +2005,111 @@ impl wkt::message::Message for ZoneMetadata {
 }
 
 /// Memcached versions supported by our service.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MemcacheVersion(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MemcacheVersion {
+    Unspecified,
+    /// Memcached 1.5 version.
+    Memcache15,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MemcacheVersion::value] or
+    /// [MemcacheVersion::name].
+    UnknownValue(memcache_version::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod memcache_version {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl MemcacheVersion {
-    pub const MEMCACHE_VERSION_UNSPECIFIED: MemcacheVersion = MemcacheVersion::new(0);
-
-    /// Memcached 1.5 version.
-    pub const MEMCACHE_1_5: MemcacheVersion = MemcacheVersion::new(1);
-
-    /// Creates a new MemcacheVersion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Memcache15 => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MEMCACHE_VERSION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MEMCACHE_1_5"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MEMCACHE_VERSION_UNSPECIFIED"),
+            Self::Memcache15 => std::option::Option::Some("MEMCACHE_1_5"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MEMCACHE_VERSION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MEMCACHE_VERSION_UNSPECIFIED)
-            }
-            "MEMCACHE_1_5" => std::option::Option::Some(Self::MEMCACHE_1_5),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MemcacheVersion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MemcacheVersion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MemcacheVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MemcacheVersion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Memcache15,
+            _ => Self::UnknownValue(memcache_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MemcacheVersion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MEMCACHE_VERSION_UNSPECIFIED" => Self::Unspecified,
+            "MEMCACHE_1_5" => Self::Memcache15,
+            _ => Self::UnknownValue(memcache_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MemcacheVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Memcache15 => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MemcacheVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MemcacheVersion>::new(
+            ".google.cloud.memcache.v1.MemcacheVersion",
+        ))
     }
 }

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -653,322 +653,633 @@ pub mod instance {
     }
 
     /// Possible states of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not set.
+        Unspecified,
+        /// Instance is being created.
+        Creating,
+        /// Instance has been created and is usable.
+        Active,
+        /// Instance is being updated.
+        Updating,
+        /// Instance is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Instance is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Instance has been created and is usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// Instance is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// Instance is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.memorystore.v1.Instance.State",
+            ))
         }
     }
 
     /// Possible authorization modes of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthorizationMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AuthorizationMode {
+        /// Not set.
+        Unspecified,
+        /// Authorization disabled.
+        AuthDisabled,
+        /// IAM basic authorization.
+        IamAuth,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AuthorizationMode::value] or
+        /// [AuthorizationMode::name].
+        UnknownValue(authorization_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod authorization_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AuthorizationMode {
-        /// Not set.
-        pub const AUTHORIZATION_MODE_UNSPECIFIED: AuthorizationMode = AuthorizationMode::new(0);
-
-        /// Authorization disabled.
-        pub const AUTH_DISABLED: AuthorizationMode = AuthorizationMode::new(1);
-
-        /// IAM basic authorization.
-        pub const IAM_AUTH: AuthorizationMode = AuthorizationMode::new(2);
-
-        /// Creates a new AuthorizationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AuthDisabled => std::option::Option::Some(1),
+                Self::IamAuth => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTHORIZATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTH_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("IAM_AUTH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTHORIZATION_MODE_UNSPECIFIED"),
+                Self::AuthDisabled => std::option::Option::Some("AUTH_DISABLED"),
+                Self::IamAuth => std::option::Option::Some("IAM_AUTH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTHORIZATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTHORIZATION_MODE_UNSPECIFIED)
-                }
-                "AUTH_DISABLED" => std::option::Option::Some(Self::AUTH_DISABLED),
-                "IAM_AUTH" => std::option::Option::Some(Self::IAM_AUTH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AuthorizationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthorizationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AuthorizationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AuthorizationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AuthDisabled,
+                2 => Self::IamAuth,
+                _ => Self::UnknownValue(authorization_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AuthorizationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTHORIZATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTH_DISABLED" => Self::AuthDisabled,
+                "IAM_AUTH" => Self::IamAuth,
+                _ => Self::UnknownValue(authorization_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AuthorizationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AuthDisabled => serializer.serialize_i32(1),
+                Self::IamAuth => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AuthorizationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthorizationMode>::new(
+                ".google.cloud.memorystore.v1.Instance.AuthorizationMode",
+            ))
         }
     }
 
     /// Possible in-transit encryption modes of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransitEncryptionMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TransitEncryptionMode {
+        /// Not set.
+        Unspecified,
+        /// In-transit encryption is disabled.
+        TransitEncryptionDisabled,
+        /// Server-managed encryption is used for in-transit encryption.
+        ServerAuthentication,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TransitEncryptionMode::value] or
+        /// [TransitEncryptionMode::name].
+        UnknownValue(transit_encryption_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod transit_encryption_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TransitEncryptionMode {
-        /// Not set.
-        pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
-            TransitEncryptionMode::new(0);
-
-        /// In-transit encryption is disabled.
-        pub const TRANSIT_ENCRYPTION_DISABLED: TransitEncryptionMode =
-            TransitEncryptionMode::new(1);
-
-        /// Server-managed encryption is used for in-transit encryption.
-        pub const SERVER_AUTHENTICATION: TransitEncryptionMode = TransitEncryptionMode::new(2);
-
-        /// Creates a new TransitEncryptionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TransitEncryptionDisabled => std::option::Option::Some(1),
+                Self::ServerAuthentication => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("SERVER_AUTHENTICATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED")
                 }
-                "TRANSIT_ENCRYPTION_DISABLED" => {
-                    std::option::Option::Some(Self::TRANSIT_ENCRYPTION_DISABLED)
+                Self::TransitEncryptionDisabled => {
+                    std::option::Option::Some("TRANSIT_ENCRYPTION_DISABLED")
                 }
-                "SERVER_AUTHENTICATION" => std::option::Option::Some(Self::SERVER_AUTHENTICATION),
-                _ => std::option::Option::None,
+                Self::ServerAuthentication => std::option::Option::Some("SERVER_AUTHENTICATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TransitEncryptionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TransitEncryptionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TransitEncryptionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TransitEncryptionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TransitEncryptionDisabled,
+                2 => Self::ServerAuthentication,
+                _ => Self::UnknownValue(transit_encryption_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TransitEncryptionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "TRANSIT_ENCRYPTION_DISABLED" => Self::TransitEncryptionDisabled,
+                "SERVER_AUTHENTICATION" => Self::ServerAuthentication,
+                _ => Self::UnknownValue(transit_encryption_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TransitEncryptionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TransitEncryptionDisabled => serializer.serialize_i32(1),
+                Self::ServerAuthentication => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TransitEncryptionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransitEncryptionMode>::new(
+                ".google.cloud.memorystore.v1.Instance.TransitEncryptionMode",
+            ))
         }
     }
 
     /// Possible node types of the instance. See
     /// <https://cloud.google.com/memorystore/docs/valkey/instance-node-specification>
     /// for more information.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NodeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NodeType {
+        /// Not set.
+        Unspecified,
+        /// Shared core nano.
+        SharedCoreNano,
+        /// High memory medium.
+        HighmemMedium,
+        /// High memory extra large.
+        HighmemXlarge,
+        /// Standard small.
+        StandardSmall,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NodeType::value] or
+        /// [NodeType::name].
+        UnknownValue(node_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod node_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl NodeType {
-        /// Not set.
-        pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new(0);
-
-        /// Shared core nano.
-        pub const SHARED_CORE_NANO: NodeType = NodeType::new(1);
-
-        /// High memory medium.
-        pub const HIGHMEM_MEDIUM: NodeType = NodeType::new(2);
-
-        /// High memory extra large.
-        pub const HIGHMEM_XLARGE: NodeType = NodeType::new(3);
-
-        /// Standard small.
-        pub const STANDARD_SMALL: NodeType = NodeType::new(4);
-
-        /// Creates a new NodeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SharedCoreNano => std::option::Option::Some(1),
+                Self::HighmemMedium => std::option::Option::Some(2),
+                Self::HighmemXlarge => std::option::Option::Some(3),
+                Self::StandardSmall => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NODE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SHARED_CORE_NANO"),
-                2 => std::borrow::Cow::Borrowed("HIGHMEM_MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("HIGHMEM_XLARGE"),
-                4 => std::borrow::Cow::Borrowed("STANDARD_SMALL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NODE_TYPE_UNSPECIFIED"),
+                Self::SharedCoreNano => std::option::Option::Some("SHARED_CORE_NANO"),
+                Self::HighmemMedium => std::option::Option::Some("HIGHMEM_MEDIUM"),
+                Self::HighmemXlarge => std::option::Option::Some("HIGHMEM_XLARGE"),
+                Self::StandardSmall => std::option::Option::Some("STANDARD_SMALL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NODE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NODE_TYPE_UNSPECIFIED),
-                "SHARED_CORE_NANO" => std::option::Option::Some(Self::SHARED_CORE_NANO),
-                "HIGHMEM_MEDIUM" => std::option::Option::Some(Self::HIGHMEM_MEDIUM),
-                "HIGHMEM_XLARGE" => std::option::Option::Some(Self::HIGHMEM_XLARGE),
-                "STANDARD_SMALL" => std::option::Option::Some(Self::STANDARD_SMALL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NodeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NodeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NodeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NodeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SharedCoreNano,
+                2 => Self::HighmemMedium,
+                3 => Self::HighmemXlarge,
+                4 => Self::StandardSmall,
+                _ => Self::UnknownValue(node_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NodeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NODE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SHARED_CORE_NANO" => Self::SharedCoreNano,
+                "HIGHMEM_MEDIUM" => Self::HighmemMedium,
+                "HIGHMEM_XLARGE" => Self::HighmemXlarge,
+                "STANDARD_SMALL" => Self::StandardSmall,
+                _ => Self::UnknownValue(node_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NodeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SharedCoreNano => serializer.serialize_i32(1),
+                Self::HighmemMedium => serializer.serialize_i32(2),
+                Self::HighmemXlarge => serializer.serialize_i32(3),
+                Self::StandardSmall => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NodeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodeType>::new(
+                ".google.cloud.memorystore.v1.Instance.NodeType",
+            ))
         }
     }
 
     /// The mode config, which is used to enable/disable cluster mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Mode is not specified.
+        Unspecified,
+        /// Deprecated: Use CLUSTER_DISABLED instead.
+        Standalone,
+        /// Instance is in cluster mode.
+        Cluster,
+        /// Cluster mode is disabled for the instance.
+        ClusterDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Mode is not specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// Deprecated: Use CLUSTER_DISABLED instead.
-        pub const STANDALONE: Mode = Mode::new(1);
-
-        /// Instance is in cluster mode.
-        pub const CLUSTER: Mode = Mode::new(2);
-
-        /// Cluster mode is disabled for the instance.
-        pub const CLUSTER_DISABLED: Mode = Mode::new(4);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standalone => std::option::Option::Some(1),
+                Self::Cluster => std::option::Option::Some(2),
+                Self::ClusterDisabled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDALONE"),
-                2 => std::borrow::Cow::Borrowed("CLUSTER"),
-                4 => std::borrow::Cow::Borrowed("CLUSTER_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Standalone => std::option::Option::Some("STANDALONE"),
+                Self::Cluster => std::option::Option::Some("CLUSTER"),
+                Self::ClusterDisabled => std::option::Option::Some("CLUSTER_DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "STANDALONE" => std::option::Option::Some(Self::STANDALONE),
-                "CLUSTER" => std::option::Option::Some(Self::CLUSTER),
-                "CLUSTER_DISABLED" => std::option::Option::Some(Self::CLUSTER_DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standalone,
+                2 => Self::Cluster,
+                4 => Self::ClusterDisabled,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "STANDALONE" => Self::Standalone,
+                "CLUSTER" => Self::Cluster,
+                "CLUSTER_DISABLED" => Self::ClusterDisabled,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standalone => serializer.serialize_i32(1),
+                Self::Cluster => serializer.serialize_i32(2),
+                Self::ClusterDisabled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.memorystore.v1.Instance.Mode",
+            ))
         }
     }
 }
@@ -1457,71 +1768,137 @@ pub mod persistence_config {
         use super::*;
 
         /// Possible snapshot periods.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SnapshotPeriod(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SnapshotPeriod {
+            /// Not set.
+            Unspecified,
+            /// One hour.
+            OneHour,
+            /// Six hours.
+            SixHours,
+            /// Twelve hours.
+            TwelveHours,
+            /// Twenty four hours.
+            TwentyFourHours,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SnapshotPeriod::value] or
+            /// [SnapshotPeriod::name].
+            UnknownValue(snapshot_period::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod snapshot_period {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SnapshotPeriod {
-            /// Not set.
-            pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod = SnapshotPeriod::new(0);
-
-            /// One hour.
-            pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new(1);
-
-            /// Six hours.
-            pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new(2);
-
-            /// Twelve hours.
-            pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new(3);
-
-            /// Twenty four hours.
-            pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new(4);
-
-            /// Creates a new SnapshotPeriod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::OneHour => std::option::Option::Some(1),
+                    Self::SixHours => std::option::Option::Some(2),
+                    Self::TwelveHours => std::option::Option::Some(3),
+                    Self::TwentyFourHours => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SNAPSHOT_PERIOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ONE_HOUR"),
-                    2 => std::borrow::Cow::Borrowed("SIX_HOURS"),
-                    3 => std::borrow::Cow::Borrowed("TWELVE_HOURS"),
-                    4 => std::borrow::Cow::Borrowed("TWENTY_FOUR_HOURS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SNAPSHOT_PERIOD_UNSPECIFIED"),
+                    Self::OneHour => std::option::Option::Some("ONE_HOUR"),
+                    Self::SixHours => std::option::Option::Some("SIX_HOURS"),
+                    Self::TwelveHours => std::option::Option::Some("TWELVE_HOURS"),
+                    Self::TwentyFourHours => std::option::Option::Some("TWENTY_FOUR_HOURS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SNAPSHOT_PERIOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SNAPSHOT_PERIOD_UNSPECIFIED)
-                    }
-                    "ONE_HOUR" => std::option::Option::Some(Self::ONE_HOUR),
-                    "SIX_HOURS" => std::option::Option::Some(Self::SIX_HOURS),
-                    "TWELVE_HOURS" => std::option::Option::Some(Self::TWELVE_HOURS),
-                    "TWENTY_FOUR_HOURS" => std::option::Option::Some(Self::TWENTY_FOUR_HOURS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SnapshotPeriod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SnapshotPeriod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SnapshotPeriod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SnapshotPeriod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::OneHour,
+                    2 => Self::SixHours,
+                    3 => Self::TwelveHours,
+                    4 => Self::TwentyFourHours,
+                    _ => Self::UnknownValue(snapshot_period::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SnapshotPeriod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SNAPSHOT_PERIOD_UNSPECIFIED" => Self::Unspecified,
+                    "ONE_HOUR" => Self::OneHour,
+                    "SIX_HOURS" => Self::SixHours,
+                    "TWELVE_HOURS" => Self::TwelveHours,
+                    "TWENTY_FOUR_HOURS" => Self::TwentyFourHours,
+                    _ => Self::UnknownValue(snapshot_period::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SnapshotPeriod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::OneHour => serializer.serialize_i32(1),
+                    Self::SixHours => serializer.serialize_i32(2),
+                    Self::TwelveHours => serializer.serialize_i32(3),
+                    Self::TwentyFourHours => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SnapshotPeriod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SnapshotPeriod>::new(
+                    ".google.cloud.memorystore.v1.PersistenceConfig.RDBConfig.SnapshotPeriod",
+                ))
             }
         }
     }
@@ -1568,134 +1945,259 @@ pub mod persistence_config {
         use super::*;
 
         /// Possible fsync modes.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AppendFsync(i32);
-
-        impl AppendFsync {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum AppendFsync {
             /// Not set. Default: EVERY_SEC
-            pub const APPEND_FSYNC_UNSPECIFIED: AppendFsync = AppendFsync::new(0);
-
+            Unspecified,
             /// Never fsync. Normally Linux will flush data every 30 seconds with this
             /// configuration, but it's up to the kernel's exact tuning.
-            pub const NEVER: AppendFsync = AppendFsync::new(1);
-
+            Never,
             /// Fsync every second. You may lose 1 second of data if there is a
             /// disaster.
-            pub const EVERY_SEC: AppendFsync = AppendFsync::new(2);
-
+            EverySec,
             /// Fsync every time new write commands are appended to the AOF. The best
             /// data loss protection at the cost of performance.
-            pub const ALWAYS: AppendFsync = AppendFsync::new(3);
+            Always,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [AppendFsync::value] or
+            /// [AppendFsync::name].
+            UnknownValue(append_fsync::UnknownValue),
+        }
 
-            /// Creates a new AppendFsync instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod append_fsync {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl AppendFsync {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Never => std::option::Option::Some(1),
+                    Self::EverySec => std::option::Option::Some(2),
+                    Self::Always => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("APPEND_FSYNC_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NEVER"),
-                    2 => std::borrow::Cow::Borrowed("EVERY_SEC"),
-                    3 => std::borrow::Cow::Borrowed("ALWAYS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("APPEND_FSYNC_UNSPECIFIED"),
+                    Self::Never => std::option::Option::Some("NEVER"),
+                    Self::EverySec => std::option::Option::Some("EVERY_SEC"),
+                    Self::Always => std::option::Option::Some("ALWAYS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "APPEND_FSYNC_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::APPEND_FSYNC_UNSPECIFIED)
-                    }
-                    "NEVER" => std::option::Option::Some(Self::NEVER),
-                    "EVERY_SEC" => std::option::Option::Some(Self::EVERY_SEC),
-                    "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for AppendFsync {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for AppendFsync {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for AppendFsync {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for AppendFsync {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Never,
+                    2 => Self::EverySec,
+                    3 => Self::Always,
+                    _ => Self::UnknownValue(append_fsync::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for AppendFsync {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "APPEND_FSYNC_UNSPECIFIED" => Self::Unspecified,
+                    "NEVER" => Self::Never,
+                    "EVERY_SEC" => Self::EverySec,
+                    "ALWAYS" => Self::Always,
+                    _ => Self::UnknownValue(append_fsync::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for AppendFsync {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Never => serializer.serialize_i32(1),
+                    Self::EverySec => serializer.serialize_i32(2),
+                    Self::Always => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for AppendFsync {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AppendFsync>::new(
+                    ".google.cloud.memorystore.v1.PersistenceConfig.AOFConfig.AppendFsync",
+                ))
             }
         }
     }
 
     /// Possible persistence modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PersistenceMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PersistenceMode {
+        /// Not set.
+        Unspecified,
+        /// Persistence is disabled, and any snapshot data is deleted.
+        Disabled,
+        /// RDB based persistence is enabled.
+        Rdb,
+        /// AOF based persistence is enabled.
+        Aof,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PersistenceMode::value] or
+        /// [PersistenceMode::name].
+        UnknownValue(persistence_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod persistence_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PersistenceMode {
-        /// Not set.
-        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode = PersistenceMode::new(0);
-
-        /// Persistence is disabled, and any snapshot data is deleted.
-        pub const DISABLED: PersistenceMode = PersistenceMode::new(1);
-
-        /// RDB based persistence is enabled.
-        pub const RDB: PersistenceMode = PersistenceMode::new(2);
-
-        /// AOF based persistence is enabled.
-        pub const AOF: PersistenceMode = PersistenceMode::new(3);
-
-        /// Creates a new PersistenceMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Rdb => std::option::Option::Some(2),
+                Self::Aof => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERSISTENCE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("RDB"),
-                3 => std::borrow::Cow::Borrowed("AOF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERSISTENCE_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Rdb => std::option::Option::Some("RDB"),
+                Self::Aof => std::option::Option::Some("AOF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERSISTENCE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PERSISTENCE_MODE_UNSPECIFIED)
-                }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "RDB" => std::option::Option::Some(Self::RDB),
-                "AOF" => std::option::Option::Some(Self::AOF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PersistenceMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PersistenceMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PersistenceMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PersistenceMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Rdb,
+                3 => Self::Aof,
+                _ => Self::UnknownValue(persistence_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PersistenceMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERSISTENCE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "RDB" => Self::Rdb,
+                "AOF" => Self::Aof,
+                _ => Self::UnknownValue(persistence_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PersistenceMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Rdb => serializer.serialize_i32(2),
+                Self::Aof => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PersistenceMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PersistenceMode>::new(
+                ".google.cloud.memorystore.v1.PersistenceConfig.PersistenceMode",
+            ))
         }
     }
 }
@@ -1785,63 +2287,123 @@ pub mod zone_distribution_config {
     use super::*;
 
     /// Possible zone distribution modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ZoneDistributionMode(i32);
-
-    impl ZoneDistributionMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ZoneDistributionMode {
         /// Not Set. Default: MULTI_ZONE
-        pub const ZONE_DISTRIBUTION_MODE_UNSPECIFIED: ZoneDistributionMode =
-            ZoneDistributionMode::new(0);
-
+        Unspecified,
         /// Distribute resources across 3 zones picked at random within the
         /// region.
-        pub const MULTI_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(1);
-
+        MultiZone,
         /// Provision resources in a single zone. Zone field must be specified.
-        pub const SINGLE_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(2);
+        SingleZone,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ZoneDistributionMode::value] or
+        /// [ZoneDistributionMode::name].
+        UnknownValue(zone_distribution_mode::UnknownValue),
+    }
 
-        /// Creates a new ZoneDistributionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod zone_distribution_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ZoneDistributionMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MultiZone => std::option::Option::Some(1),
+                Self::SingleZone => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ZONE_DISTRIBUTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MULTI_ZONE"),
-                2 => std::borrow::Cow::Borrowed("SINGLE_ZONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ZONE_DISTRIBUTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ZONE_DISTRIBUTION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("ZONE_DISTRIBUTION_MODE_UNSPECIFIED")
                 }
-                "MULTI_ZONE" => std::option::Option::Some(Self::MULTI_ZONE),
-                "SINGLE_ZONE" => std::option::Option::Some(Self::SINGLE_ZONE),
-                _ => std::option::Option::None,
+                Self::MultiZone => std::option::Option::Some("MULTI_ZONE"),
+                Self::SingleZone => std::option::Option::Some("SINGLE_ZONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ZoneDistributionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ZoneDistributionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ZoneDistributionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ZoneDistributionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MultiZone,
+                2 => Self::SingleZone,
+                _ => Self::UnknownValue(zone_distribution_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ZoneDistributionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ZONE_DISTRIBUTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MULTI_ZONE" => Self::MultiZone,
+                "SINGLE_ZONE" => Self::SingleZone,
+                _ => Self::UnknownValue(zone_distribution_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ZoneDistributionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MultiZone => serializer.serialize_i32(1),
+                Self::SingleZone => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ZoneDistributionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ZoneDistributionMode>::new(
+                ".google.cloud.memorystore.v1.ZoneDistributionConfig.ZoneDistributionMode",
+            ))
         }
     }
 }
@@ -2574,126 +3136,244 @@ impl wkt::message::Message for OperationMetadata {
 }
 
 /// Status of the PSC connection.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PscConnectionStatus(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PscConnectionStatus {
+    /// PSC connection status is not specified.
+    Unspecified,
+    /// The connection is active
+    Active,
+    /// Connection not found
+    NotFound,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PscConnectionStatus::value] or
+    /// [PscConnectionStatus::name].
+    UnknownValue(psc_connection_status::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod psc_connection_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl PscConnectionStatus {
-    /// PSC connection status is not specified.
-    pub const PSC_CONNECTION_STATUS_UNSPECIFIED: PscConnectionStatus = PscConnectionStatus::new(0);
-
-    /// The connection is active
-    pub const ACTIVE: PscConnectionStatus = PscConnectionStatus::new(1);
-
-    /// Connection not found
-    pub const NOT_FOUND: PscConnectionStatus = PscConnectionStatus::new(2);
-
-    /// Creates a new PscConnectionStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Active => std::option::Option::Some(1),
+            Self::NotFound => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVE"),
-            2 => std::borrow::Cow::Borrowed("NOT_FOUND"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PSC_CONNECTION_STATUS_UNSPECIFIED"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::NotFound => std::option::Option::Some("NOT_FOUND"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PSC_CONNECTION_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_UNSPECIFIED)
-            }
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PscConnectionStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PscConnectionStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PscConnectionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PscConnectionStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Active,
+            2 => Self::NotFound,
+            _ => Self::UnknownValue(psc_connection_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PscConnectionStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PSC_CONNECTION_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVE" => Self::Active,
+            "NOT_FOUND" => Self::NotFound,
+            _ => Self::UnknownValue(psc_connection_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PscConnectionStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Active => serializer.serialize_i32(1),
+            Self::NotFound => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PscConnectionStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PscConnectionStatus>::new(
+            ".google.cloud.memorystore.v1.PscConnectionStatus",
+        ))
     }
 }
 
 /// Type of a PSC connection
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectionType {
+    /// Connection Type is not set
+    Unspecified,
+    /// Connection that will be used for topology discovery.
+    Discovery,
+    /// Connection that will be used as primary endpoint to access primary.
+    Primary,
+    /// Connection that will be used as reader endpoint to access replicas.
+    Reader,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConnectionType::value] or
+    /// [ConnectionType::name].
+    UnknownValue(connection_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod connection_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ConnectionType {
-    /// Connection Type is not set
-    pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
-
-    /// Connection that will be used for topology discovery.
-    pub const CONNECTION_TYPE_DISCOVERY: ConnectionType = ConnectionType::new(1);
-
-    /// Connection that will be used as primary endpoint to access primary.
-    pub const CONNECTION_TYPE_PRIMARY: ConnectionType = ConnectionType::new(2);
-
-    /// Connection that will be used as reader endpoint to access replicas.
-    pub const CONNECTION_TYPE_READER: ConnectionType = ConnectionType::new(3);
-
-    /// Creates a new ConnectionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Discovery => std::option::Option::Some(1),
+            Self::Primary => std::option::Option::Some(2),
+            Self::Reader => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_DISCOVERY"),
-            2 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_PRIMARY"),
-            3 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_READER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONNECTION_TYPE_UNSPECIFIED"),
+            Self::Discovery => std::option::Option::Some("CONNECTION_TYPE_DISCOVERY"),
+            Self::Primary => std::option::Option::Some("CONNECTION_TYPE_PRIMARY"),
+            Self::Reader => std::option::Option::Some("CONNECTION_TYPE_READER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONNECTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
-            }
-            "CONNECTION_TYPE_DISCOVERY" => {
-                std::option::Option::Some(Self::CONNECTION_TYPE_DISCOVERY)
-            }
-            "CONNECTION_TYPE_PRIMARY" => std::option::Option::Some(Self::CONNECTION_TYPE_PRIMARY),
-            "CONNECTION_TYPE_READER" => std::option::Option::Some(Self::CONNECTION_TYPE_READER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConnectionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConnectionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConnectionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Discovery,
+            2 => Self::Primary,
+            3 => Self::Reader,
+            _ => Self::UnknownValue(connection_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConnectionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONNECTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "CONNECTION_TYPE_DISCOVERY" => Self::Discovery,
+            "CONNECTION_TYPE_PRIMARY" => Self::Primary,
+            "CONNECTION_TYPE_READER" => Self::Reader,
+            _ => Self::UnknownValue(connection_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConnectionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Discovery => serializer.serialize_i32(1),
+            Self::Primary => serializer.serialize_i32(2),
+            Self::Reader => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConnectionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionType>::new(
+            ".google.cloud.memorystore.v1.ConnectionType",
+        ))
     }
 }

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -377,269 +377,519 @@ pub mod service {
     use super::*;
 
     /// The current state of the metastore service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the metastore service is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The metastore service is in the process of being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The metastore service is running and ready to serve queries.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The metastore service is entering suspension. Its query-serving
         /// availability may cease unexpectedly.
-        pub const SUSPENDING: State = State::new(3);
-
+        Suspending,
         /// The metastore service is suspended and unable to serve queries.
-        pub const SUSPENDED: State = State::new(4);
-
+        Suspended,
         /// The metastore service is being updated. It remains usable but cannot
         /// accept additional update requests or be deleted at this time.
-        pub const UPDATING: State = State::new(5);
-
+        Updating,
         /// The metastore service is undergoing deletion. It cannot be used.
-        pub const DELETING: State = State::new(6);
-
+        Deleting,
         /// The metastore service has encountered an error and cannot be used. The
         /// metastore service should be deleted.
-        pub const ERROR: State = State::new(7);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Suspending => std::option::Option::Some(3),
+                Self::Suspended => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::Deleting => std::option::Option::Some(6),
+                Self::Error => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("SUSPENDING"),
-                4 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                6 => std::borrow::Cow::Borrowed("DELETING"),
-                7 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Suspending => std::option::Option::Some("SUSPENDING"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Suspending,
+                4 => Self::Suspended,
+                5 => Self::Updating,
+                6 => Self::Deleting,
+                7 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "SUSPENDING" => Self::Suspending,
+                "SUSPENDED" => Self::Suspended,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Suspending => serializer.serialize_i32(3),
+                Self::Suspended => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::Deleting => serializer.serialize_i32(6),
+                Self::Error => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.metastore.v1.Service.State",
+            ))
         }
     }
 
     /// Available service tiers.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
-
-    impl Tier {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
         /// The tier is not set.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
+        Unspecified,
         /// The developer tier provides limited scalability and no fault tolerance.
         /// Good for low-cost proof-of-concept.
-        pub const DEVELOPER: Tier = Tier::new(1);
-
+        Developer,
         /// The enterprise tier provides multi-zone high availability, and sufficient
         /// scalability for enterprise-level Dataproc Metastore workloads.
-        pub const ENTERPRISE: Tier = Tier::new(3);
+        Enterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
 
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Tier {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Developer => std::option::Option::Some(1),
+                Self::Enterprise => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEVELOPER"),
-                3 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Developer => std::option::Option::Some("DEVELOPER"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "DEVELOPER" => std::option::Option::Some(Self::DEVELOPER),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Developer,
+                3 => Self::Enterprise,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "DEVELOPER" => Self::Developer,
+                "ENTERPRISE" => Self::Enterprise,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Developer => serializer.serialize_i32(1),
+                Self::Enterprise => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.metastore.v1.Service.Tier",
+            ))
         }
     }
 
     /// Release channels bundle features of varying levels of stability. Newer
     /// features may be introduced initially into less stable release channels and
     /// can be automatically promoted into more stable release channels.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReleaseChannel(i32);
-
-    impl ReleaseChannel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReleaseChannel {
         /// Release channel is not specified.
-        pub const RELEASE_CHANNEL_UNSPECIFIED: ReleaseChannel = ReleaseChannel::new(0);
-
+        Unspecified,
         /// The `CANARY` release channel contains the newest features, which may be
         /// unstable and subject to unresolved issues with no known workarounds.
         /// Services using the `CANARY` release channel are not subject to any SLAs.
-        pub const CANARY: ReleaseChannel = ReleaseChannel::new(1);
-
+        Canary,
         /// The `STABLE` release channel contains features that are considered stable
         /// and have been validated for production use.
-        pub const STABLE: ReleaseChannel = ReleaseChannel::new(2);
+        Stable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReleaseChannel::value] or
+        /// [ReleaseChannel::name].
+        UnknownValue(release_channel::UnknownValue),
+    }
 
-        /// Creates a new ReleaseChannel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod release_channel {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ReleaseChannel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Canary => std::option::Option::Some(1),
+                Self::Stable => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RELEASE_CHANNEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CANARY"),
-                2 => std::borrow::Cow::Borrowed("STABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RELEASE_CHANNEL_UNSPECIFIED"),
+                Self::Canary => std::option::Option::Some("CANARY"),
+                Self::Stable => std::option::Option::Some("STABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RELEASE_CHANNEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RELEASE_CHANNEL_UNSPECIFIED)
-                }
-                "CANARY" => std::option::Option::Some(Self::CANARY),
-                "STABLE" => std::option::Option::Some(Self::STABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReleaseChannel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReleaseChannel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReleaseChannel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReleaseChannel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Canary,
+                2 => Self::Stable,
+                _ => Self::UnknownValue(release_channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReleaseChannel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RELEASE_CHANNEL_UNSPECIFIED" => Self::Unspecified,
+                "CANARY" => Self::Canary,
+                "STABLE" => Self::Stable,
+                _ => Self::UnknownValue(release_channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReleaseChannel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Canary => serializer.serialize_i32(1),
+                Self::Stable => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReleaseChannel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReleaseChannel>::new(
+                ".google.cloud.metastore.v1.Service.ReleaseChannel",
+            ))
         }
     }
 
     /// The backend database type for the metastore service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseType {
+        /// The DATABASE_TYPE is not set.
+        Unspecified,
+        /// MySQL is used to persist the metastore data.
+        Mysql,
+        /// Spanner is used to persist the metastore data.
+        Spanner,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseType::value] or
+        /// [DatabaseType::name].
+        UnknownValue(database_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseType {
-        /// The DATABASE_TYPE is not set.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
-
-        /// MySQL is used to persist the metastore data.
-        pub const MYSQL: DatabaseType = DatabaseType::new(1);
-
-        /// Spanner is used to persist the metastore data.
-        pub const SPANNER: DatabaseType = DatabaseType::new(2);
-
-        /// Creates a new DatabaseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Mysql => std::option::Option::Some(1),
+                Self::Spanner => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MYSQL"),
-                2 => std::borrow::Cow::Borrowed("SPANNER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_TYPE_UNSPECIFIED"),
+                Self::Mysql => std::option::Option::Some("MYSQL"),
+                Self::Spanner => std::option::Option::Some("SPANNER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
-                }
-                "MYSQL" => std::option::Option::Some(Self::MYSQL),
-                "SPANNER" => std::option::Option::Some(Self::SPANNER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Mysql,
+                2 => Self::Spanner,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MYSQL" => Self::Mysql,
+                "SPANNER" => Self::Spanner,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Mysql => serializer.serialize_i32(1),
+                Self::Spanner => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseType>::new(
+                ".google.cloud.metastore.v1.Service.DatabaseType",
+            ))
         }
     }
 
@@ -817,61 +1067,120 @@ pub mod hive_metastore_config {
     use super::*;
 
     /// Protocols available for serving the metastore service endpoint.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EndpointProtocol(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EndpointProtocol {
+        /// The protocol is not set.
+        Unspecified,
+        /// Use the legacy Apache Thrift protocol for the metastore service endpoint.
+        Thrift,
+        /// Use the modernized gRPC protocol for the metastore service endpoint.
+        Grpc,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EndpointProtocol::value] or
+        /// [EndpointProtocol::name].
+        UnknownValue(endpoint_protocol::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod endpoint_protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EndpointProtocol {
-        /// The protocol is not set.
-        pub const ENDPOINT_PROTOCOL_UNSPECIFIED: EndpointProtocol = EndpointProtocol::new(0);
-
-        /// Use the legacy Apache Thrift protocol for the metastore service endpoint.
-        pub const THRIFT: EndpointProtocol = EndpointProtocol::new(1);
-
-        /// Use the modernized gRPC protocol for the metastore service endpoint.
-        pub const GRPC: EndpointProtocol = EndpointProtocol::new(2);
-
-        /// Creates a new EndpointProtocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Thrift => std::option::Option::Some(1),
+                Self::Grpc => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENDPOINT_PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("THRIFT"),
-                2 => std::borrow::Cow::Borrowed("GRPC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENDPOINT_PROTOCOL_UNSPECIFIED"),
+                Self::Thrift => std::option::Option::Some("THRIFT"),
+                Self::Grpc => std::option::Option::Some("GRPC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENDPOINT_PROTOCOL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENDPOINT_PROTOCOL_UNSPECIFIED)
-                }
-                "THRIFT" => std::option::Option::Some(Self::THRIFT),
-                "GRPC" => std::option::Option::Some(Self::GRPC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EndpointProtocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EndpointProtocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EndpointProtocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EndpointProtocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Thrift,
+                2 => Self::Grpc,
+                _ => Self::UnknownValue(endpoint_protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EndpointProtocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENDPOINT_PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "THRIFT" => Self::Thrift,
+                "GRPC" => Self::Grpc,
+                _ => Self::UnknownValue(endpoint_protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EndpointProtocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Thrift => serializer.serialize_i32(1),
+                Self::Grpc => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EndpointProtocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EndpointProtocol>::new(
+                ".google.cloud.metastore.v1.HiveMetastoreConfig.EndpointProtocol",
+            ))
         }
     }
 }
@@ -1320,59 +1629,120 @@ pub mod telemetry_config {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogFormat {
+        /// The LOG_FORMAT is not set.
+        Unspecified,
+        /// Logging output uses the legacy `textPayload` format.
+        Legacy,
+        /// Logging output uses the `jsonPayload` format.
+        Json,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogFormat::value] or
+        /// [LogFormat::name].
+        UnknownValue(log_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod log_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LogFormat {
-        /// The LOG_FORMAT is not set.
-        pub const LOG_FORMAT_UNSPECIFIED: LogFormat = LogFormat::new(0);
-
-        /// Logging output uses the legacy `textPayload` format.
-        pub const LEGACY: LogFormat = LogFormat::new(1);
-
-        /// Logging output uses the `jsonPayload` format.
-        pub const JSON: LogFormat = LogFormat::new(2);
-
-        /// Creates a new LogFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Legacy => std::option::Option::Some(1),
+                Self::Json => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LEGACY"),
-                2 => std::borrow::Cow::Borrowed("JSON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_FORMAT_UNSPECIFIED"),
+                Self::Legacy => std::option::Option::Some("LEGACY"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::LOG_FORMAT_UNSPECIFIED),
-                "LEGACY" => std::option::Option::Some(Self::LEGACY),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LogFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LogFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LogFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LogFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Legacy,
+                2 => Self::Json,
+                _ => Self::UnknownValue(log_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LogFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "LEGACY" => Self::Legacy,
+                "JSON" => Self::Json,
+                _ => Self::UnknownValue(log_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LogFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Legacy => serializer.serialize_i32(1),
+                Self::Json => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LogFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogFormat>::new(
+                ".google.cloud.metastore.v1.TelemetryConfig.LogFormat",
+            ))
         }
     }
 }
@@ -1660,125 +2030,250 @@ pub mod metadata_import {
         use super::*;
 
         /// The type of the database.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DatabaseType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DatabaseType {
+            /// The type of the source database is unknown.
+            Unspecified,
+            /// The type of the source database is MySQL.
+            Mysql,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DatabaseType::value] or
+            /// [DatabaseType::name].
+            UnknownValue(database_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod database_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl DatabaseType {
-            /// The type of the source database is unknown.
-            pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
-
-            /// The type of the source database is MySQL.
-            pub const MYSQL: DatabaseType = DatabaseType::new(1);
-
-            /// Creates a new DatabaseType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Mysql => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MYSQL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("DATABASE_TYPE_UNSPECIFIED"),
+                    Self::Mysql => std::option::Option::Some("MYSQL"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DATABASE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
-                    }
-                    "MYSQL" => std::option::Option::Some(Self::MYSQL),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for DatabaseType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for DatabaseType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for DatabaseType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for DatabaseType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Mysql,
+                    _ => Self::UnknownValue(database_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for DatabaseType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DATABASE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "MYSQL" => Self::Mysql,
+                    _ => Self::UnknownValue(database_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for DatabaseType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Mysql => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for DatabaseType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseType>::new(
+                    ".google.cloud.metastore.v1.MetadataImport.DatabaseDump.DatabaseType",
+                ))
             }
         }
     }
 
     /// The current state of the metadata import.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the metadata import is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The metadata import is running.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The metadata import completed successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// The metadata import is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The metadata import failed, and attempted metadata changes were rolled
         /// back.
-        pub const FAILED: State = State::new(4);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Updating,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "UPDATING" => Self::Updating,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.metastore.v1.MetadataImport.State",
+            ))
         }
     }
 
@@ -1915,69 +2410,134 @@ pub mod metadata_export {
     use super::*;
 
     /// The current state of the metadata export.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the metadata export is unknown.
+        Unspecified,
+        /// The metadata export is running.
+        Running,
+        /// The metadata export completed successfully.
+        Succeeded,
+        /// The metadata export failed.
+        Failed,
+        /// The metadata export is cancelled.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the metadata export is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The metadata export is running.
-        pub const RUNNING: State = State::new(1);
-
-        /// The metadata export completed successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The metadata export failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The metadata export is cancelled.
-        pub const CANCELLED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.metastore.v1.MetadataExport.State",
+            ))
         }
     }
 
@@ -2108,74 +2668,141 @@ pub mod backup {
     use super::*;
 
     /// The current state of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the backup is unknown.
+        Unspecified,
+        /// The backup is being created.
+        Creating,
+        /// The backup is being deleted.
+        Deleting,
+        /// The backup is active and ready to use.
+        Active,
+        /// The backup failed.
+        Failed,
+        /// The backup is being restored.
+        Restoring,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the backup is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The backup is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The backup is being deleted.
-        pub const DELETING: State = State::new(2);
-
-        /// The backup is active and ready to use.
-        pub const ACTIVE: State = State::new(3);
-
-        /// The backup failed.
-        pub const FAILED: State = State::new(4);
-
-        /// The backup is being restored.
-        pub const RESTORING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Deleting => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Restoring => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("DELETING"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("RESTORING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Restoring => std::option::Option::Some("RESTORING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "RESTORING" => std::option::Option::Some(Self::RESTORING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Deleting,
+                3 => Self::Active,
+                4 => Self::Failed,
+                5 => Self::Restoring,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "RESTORING" => Self::Restoring,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Deleting => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Restoring => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.metastore.v1.Backup.State",
+            ))
         }
     }
 }
@@ -2280,128 +2907,252 @@ pub mod restore {
     use super::*;
 
     /// The current state of the restore.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state of the metadata restore is unknown.
+        Unspecified,
+        /// The metadata restore is running.
+        Running,
+        /// The metadata restore completed successfully.
+        Succeeded,
+        /// The metadata restore failed.
+        Failed,
+        /// The metadata restore is cancelled.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state of the metadata restore is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The metadata restore is running.
-        pub const RUNNING: State = State::new(1);
-
-        /// The metadata restore completed successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The metadata restore failed.
-        pub const FAILED: State = State::new(3);
-
-        /// The metadata restore is cancelled.
-        pub const CANCELLED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.metastore.v1.Restore.State",
+            ))
         }
     }
 
     /// The type of restore. If unspecified, defaults to `METADATA_ONLY`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestoreType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RestoreType {
+        /// The restore type is unknown.
+        Unspecified,
+        /// The service's metadata and configuration are restored.
+        Full,
+        /// Only the service's metadata is restored.
+        MetadataOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RestoreType::value] or
+        /// [RestoreType::name].
+        UnknownValue(restore_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod restore_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RestoreType {
-        /// The restore type is unknown.
-        pub const RESTORE_TYPE_UNSPECIFIED: RestoreType = RestoreType::new(0);
-
-        /// The service's metadata and configuration are restored.
-        pub const FULL: RestoreType = RestoreType::new(1);
-
-        /// Only the service's metadata is restored.
-        pub const METADATA_ONLY: RestoreType = RestoreType::new(2);
-
-        /// Creates a new RestoreType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Full => std::option::Option::Some(1),
+                Self::MetadataOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESTORE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FULL"),
-                2 => std::borrow::Cow::Borrowed("METADATA_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESTORE_TYPE_UNSPECIFIED"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::MetadataOnly => std::option::Option::Some("METADATA_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESTORE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESTORE_TYPE_UNSPECIFIED)
-                }
-                "FULL" => std::option::Option::Some(Self::FULL),
-                "METADATA_ONLY" => std::option::Option::Some(Self::METADATA_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RestoreType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RestoreType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RestoreType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RestoreType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Full,
+                2 => Self::MetadataOnly,
+                _ => Self::UnknownValue(restore_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RestoreType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESTORE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FULL" => Self::Full,
+                "METADATA_ONLY" => Self::MetadataOnly,
+                _ => Self::UnknownValue(restore_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RestoreType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Full => serializer.serialize_i32(1),
+                Self::MetadataOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RestoreType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestoreType>::new(
+                ".google.cloud.metastore.v1.Restore.RestoreType",
+            ))
         }
     }
 }
@@ -2508,76 +3259,141 @@ pub mod scaling_config {
     use super::*;
 
     /// Metastore instance sizes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceSize(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstanceSize {
+        /// Unspecified instance size
+        Unspecified,
+        /// Extra small instance size, maps to a scaling factor of 0.1.
+        ExtraSmall,
+        /// Small instance size, maps to a scaling factor of 0.5.
+        Small,
+        /// Medium instance size, maps to a scaling factor of 1.0.
+        Medium,
+        /// Large instance size, maps to a scaling factor of 3.0.
+        Large,
+        /// Extra large instance size, maps to a scaling factor of 6.0.
+        ExtraLarge,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstanceSize::value] or
+        /// [InstanceSize::name].
+        UnknownValue(instance_size::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod instance_size {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl InstanceSize {
-        /// Unspecified instance size
-        pub const INSTANCE_SIZE_UNSPECIFIED: InstanceSize = InstanceSize::new(0);
-
-        /// Extra small instance size, maps to a scaling factor of 0.1.
-        pub const EXTRA_SMALL: InstanceSize = InstanceSize::new(1);
-
-        /// Small instance size, maps to a scaling factor of 0.5.
-        pub const SMALL: InstanceSize = InstanceSize::new(2);
-
-        /// Medium instance size, maps to a scaling factor of 1.0.
-        pub const MEDIUM: InstanceSize = InstanceSize::new(3);
-
-        /// Large instance size, maps to a scaling factor of 3.0.
-        pub const LARGE: InstanceSize = InstanceSize::new(4);
-
-        /// Extra large instance size, maps to a scaling factor of 6.0.
-        pub const EXTRA_LARGE: InstanceSize = InstanceSize::new(5);
-
-        /// Creates a new InstanceSize instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ExtraSmall => std::option::Option::Some(1),
+                Self::Small => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::Large => std::option::Option::Some(4),
+                Self::ExtraLarge => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_SIZE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXTRA_SMALL"),
-                2 => std::borrow::Cow::Borrowed("SMALL"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("LARGE"),
-                5 => std::borrow::Cow::Borrowed("EXTRA_LARGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INSTANCE_SIZE_UNSPECIFIED"),
+                Self::ExtraSmall => std::option::Option::Some("EXTRA_SMALL"),
+                Self::Small => std::option::Option::Some("SMALL"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::Large => std::option::Option::Some("LARGE"),
+                Self::ExtraLarge => std::option::Option::Some("EXTRA_LARGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_SIZE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_SIZE_UNSPECIFIED)
-                }
-                "EXTRA_SMALL" => std::option::Option::Some(Self::EXTRA_SMALL),
-                "SMALL" => std::option::Option::Some(Self::SMALL),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "LARGE" => std::option::Option::Some(Self::LARGE),
-                "EXTRA_LARGE" => std::option::Option::Some(Self::EXTRA_LARGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InstanceSize {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceSize {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstanceSize {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstanceSize {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ExtraSmall,
+                2 => Self::Small,
+                3 => Self::Medium,
+                4 => Self::Large,
+                5 => Self::ExtraLarge,
+                _ => Self::UnknownValue(instance_size::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstanceSize {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_SIZE_UNSPECIFIED" => Self::Unspecified,
+                "EXTRA_SMALL" => Self::ExtraSmall,
+                "SMALL" => Self::Small,
+                "MEDIUM" => Self::Medium,
+                "LARGE" => Self::Large,
+                "EXTRA_LARGE" => Self::ExtraLarge,
+                _ => Self::UnknownValue(instance_size::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstanceSize {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ExtraSmall => serializer.serialize_i32(1),
+                Self::Small => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::Large => serializer.serialize_i32(4),
+                Self::ExtraLarge => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstanceSize {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstanceSize>::new(
+                ".google.cloud.metastore.v1.ScalingConfig.InstanceSize",
+            ))
         }
     }
 
@@ -4213,59 +5029,120 @@ pub mod database_dump_spec {
     use super::*;
 
     /// The type of the database dump.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// The type of the database dump is unknown.
+        Unspecified,
+        /// Database dump is a MySQL dump file.
+        Mysql,
+        /// Database dump contains Avro files.
+        Avro,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// The type of the database dump is unknown.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Database dump is a MySQL dump file.
-        pub const MYSQL: Type = Type::new(1);
-
-        /// Database dump contains Avro files.
-        pub const AVRO: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Mysql => std::option::Option::Some(1),
+                Self::Avro => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MYSQL"),
-                2 => std::borrow::Cow::Borrowed("AVRO"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Mysql => std::option::Option::Some("MYSQL"),
+                Self::Avro => std::option::Option::Some("AVRO"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "MYSQL" => std::option::Option::Some(Self::MYSQL),
-                "AVRO" => std::option::Option::Some(Self::AVRO),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Mysql,
+                2 => Self::Avro,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MYSQL" => Self::Mysql,
+                "AVRO" => Self::Avro,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Mysql => serializer.serialize_i32(1),
+                Self::Avro => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.metastore.v1.DatabaseDumpSpec.Type",
+            ))
         }
     }
 }
@@ -4747,76 +5624,143 @@ pub mod federation {
     use super::*;
 
     /// The current state of the federation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the metastore federation is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The metastore federation is in the process of being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The metastore federation is running and ready to serve queries.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The metastore federation is being updated. It remains usable but cannot
         /// accept additional update requests or be deleted at this time.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The metastore federation is undergoing deletion. It cannot be used.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The metastore federation has encountered an error and cannot be used. The
         /// metastore federation should be deleted.
-        pub const ERROR: State = State::new(5);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.metastore.v1.Federation.State",
+            ))
         }
     }
 }
@@ -4880,61 +5824,120 @@ pub mod backend_metastore {
     use super::*;
 
     /// The type of the backend metastore.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MetastoreType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MetastoreType {
+        /// The metastore type is not set.
+        Unspecified,
+        /// The backend metastore is BigQuery.
+        Bigquery,
+        /// The backend metastore is Dataproc Metastore.
+        DataprocMetastore,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MetastoreType::value] or
+        /// [MetastoreType::name].
+        UnknownValue(metastore_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod metastore_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MetastoreType {
-        /// The metastore type is not set.
-        pub const METASTORE_TYPE_UNSPECIFIED: MetastoreType = MetastoreType::new(0);
-
-        /// The backend metastore is BigQuery.
-        pub const BIGQUERY: MetastoreType = MetastoreType::new(2);
-
-        /// The backend metastore is Dataproc Metastore.
-        pub const DATAPROC_METASTORE: MetastoreType = MetastoreType::new(3);
-
-        /// Creates a new MetastoreType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bigquery => std::option::Option::Some(2),
+                Self::DataprocMetastore => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METASTORE_TYPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("BIGQUERY"),
-                3 => std::borrow::Cow::Borrowed("DATAPROC_METASTORE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METASTORE_TYPE_UNSPECIFIED"),
+                Self::Bigquery => std::option::Option::Some("BIGQUERY"),
+                Self::DataprocMetastore => std::option::Option::Some("DATAPROC_METASTORE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METASTORE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METASTORE_TYPE_UNSPECIFIED)
-                }
-                "BIGQUERY" => std::option::Option::Some(Self::BIGQUERY),
-                "DATAPROC_METASTORE" => std::option::Option::Some(Self::DATAPROC_METASTORE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MetastoreType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MetastoreType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MetastoreType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MetastoreType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Bigquery,
+                3 => Self::DataprocMetastore,
+                _ => Self::UnknownValue(metastore_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MetastoreType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METASTORE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BIGQUERY" => Self::Bigquery,
+                "DATAPROC_METASTORE" => Self::DataprocMetastore,
+                _ => Self::UnknownValue(metastore_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MetastoreType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bigquery => serializer.serialize_i32(2),
+                Self::DataprocMetastore => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MetastoreType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetastoreType>::new(
+                ".google.cloud.metastore.v1.BackendMetastore.MetastoreType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -544,98 +544,157 @@ pub mod import_job {
     use super::*;
 
     /// Enumerates possible states of an import job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ImportJobState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ImportJobState {
+        /// Default value.
+        Unspecified,
+        /// The import job is pending.
+        Pending,
+        /// The processing of the import job is ongoing.
+        Running,
+        /// The import job processing has completed.
+        Completed,
+        /// The import job failed to be processed.
+        Failed,
+        /// The import job is being validated.
+        Validating,
+        /// The import job contains blocking errors.
+        FailedValidation,
+        /// The validation of the job completed with no blocking errors.
+        Ready,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ImportJobState::value] or
+        /// [ImportJobState::name].
+        UnknownValue(import_job_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod import_job_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ImportJobState {
-        /// Default value.
-        pub const IMPORT_JOB_STATE_UNSPECIFIED: ImportJobState = ImportJobState::new(0);
-
-        /// The import job is pending.
-        pub const IMPORT_JOB_STATE_PENDING: ImportJobState = ImportJobState::new(1);
-
-        /// The processing of the import job is ongoing.
-        pub const IMPORT_JOB_STATE_RUNNING: ImportJobState = ImportJobState::new(2);
-
-        /// The import job processing has completed.
-        pub const IMPORT_JOB_STATE_COMPLETED: ImportJobState = ImportJobState::new(3);
-
-        /// The import job failed to be processed.
-        pub const IMPORT_JOB_STATE_FAILED: ImportJobState = ImportJobState::new(4);
-
-        /// The import job is being validated.
-        pub const IMPORT_JOB_STATE_VALIDATING: ImportJobState = ImportJobState::new(5);
-
-        /// The import job contains blocking errors.
-        pub const IMPORT_JOB_STATE_FAILED_VALIDATION: ImportJobState = ImportJobState::new(6);
-
-        /// The validation of the job completed with no blocking errors.
-        pub const IMPORT_JOB_STATE_READY: ImportJobState = ImportJobState::new(7);
-
-        /// Creates a new ImportJobState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Completed => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Validating => std::option::Option::Some(5),
+                Self::FailedValidation => std::option::Option::Some(6),
+                Self::Ready => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_PENDING"),
-                2 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_RUNNING"),
-                3 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_COMPLETED"),
-                4 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_FAILED"),
-                5 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_VALIDATING"),
-                6 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_FAILED_VALIDATION"),
-                7 => std::borrow::Cow::Borrowed("IMPORT_JOB_STATE_READY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPORT_JOB_STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("IMPORT_JOB_STATE_PENDING"),
+                Self::Running => std::option::Option::Some("IMPORT_JOB_STATE_RUNNING"),
+                Self::Completed => std::option::Option::Some("IMPORT_JOB_STATE_COMPLETED"),
+                Self::Failed => std::option::Option::Some("IMPORT_JOB_STATE_FAILED"),
+                Self::Validating => std::option::Option::Some("IMPORT_JOB_STATE_VALIDATING"),
+                Self::FailedValidation => {
+                    std::option::Option::Some("IMPORT_JOB_STATE_FAILED_VALIDATION")
+                }
+                Self::Ready => std::option::Option::Some("IMPORT_JOB_STATE_READY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPORT_JOB_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_UNSPECIFIED)
-                }
-                "IMPORT_JOB_STATE_PENDING" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_PENDING)
-                }
-                "IMPORT_JOB_STATE_RUNNING" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_RUNNING)
-                }
-                "IMPORT_JOB_STATE_COMPLETED" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_COMPLETED)
-                }
-                "IMPORT_JOB_STATE_FAILED" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_FAILED)
-                }
-                "IMPORT_JOB_STATE_VALIDATING" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_VALIDATING)
-                }
-                "IMPORT_JOB_STATE_FAILED_VALIDATION" => {
-                    std::option::Option::Some(Self::IMPORT_JOB_STATE_FAILED_VALIDATION)
-                }
-                "IMPORT_JOB_STATE_READY" => std::option::Option::Some(Self::IMPORT_JOB_STATE_READY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ImportJobState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ImportJobState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ImportJobState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ImportJobState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Completed,
+                4 => Self::Failed,
+                5 => Self::Validating,
+                6 => Self::FailedValidation,
+                7 => Self::Ready,
+                _ => Self::UnknownValue(import_job_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ImportJobState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPORT_JOB_STATE_UNSPECIFIED" => Self::Unspecified,
+                "IMPORT_JOB_STATE_PENDING" => Self::Pending,
+                "IMPORT_JOB_STATE_RUNNING" => Self::Running,
+                "IMPORT_JOB_STATE_COMPLETED" => Self::Completed,
+                "IMPORT_JOB_STATE_FAILED" => Self::Failed,
+                "IMPORT_JOB_STATE_VALIDATING" => Self::Validating,
+                "IMPORT_JOB_STATE_FAILED_VALIDATION" => Self::FailedValidation,
+                "IMPORT_JOB_STATE_READY" => Self::Ready,
+                _ => Self::UnknownValue(import_job_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ImportJobState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Completed => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Validating => serializer.serialize_i32(5),
+                Self::FailedValidation => serializer.serialize_i32(6),
+                Self::Ready => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ImportJobState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportJobState>::new(
+                ".google.cloud.migrationcenter.v1.ImportJob.ImportJobState",
+            ))
         }
     }
 
@@ -785,59 +844,120 @@ pub mod import_data_file {
     use super::*;
 
     /// Enumerates possible states of an import data file.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default value.
+        Unspecified,
+        /// The data file is being created.
+        Creating,
+        /// The data file completed initialization.
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The data file is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The data file completed initialization.
-        pub const ACTIVE: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.migrationcenter.v1.ImportDataFile.State",
+            ))
         }
     }
 
@@ -1170,136 +1290,260 @@ pub mod source {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SourceType {
+        /// Unspecified
+        Unknown,
+        /// Manually uploaded file (e.g. CSV)
+        Upload,
+        /// Guest-level info
+        GuestOsScan,
+        /// Inventory-level scan
+        InventoryScan,
+        /// Third-party owned sources.
+        Custom,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SourceType::value] or
+        /// [SourceType::name].
+        UnknownValue(source_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SourceType {
-        /// Unspecified
-        pub const SOURCE_TYPE_UNKNOWN: SourceType = SourceType::new(0);
-
-        /// Manually uploaded file (e.g. CSV)
-        pub const SOURCE_TYPE_UPLOAD: SourceType = SourceType::new(1);
-
-        /// Guest-level info
-        pub const SOURCE_TYPE_GUEST_OS_SCAN: SourceType = SourceType::new(2);
-
-        /// Inventory-level scan
-        pub const SOURCE_TYPE_INVENTORY_SCAN: SourceType = SourceType::new(3);
-
-        /// Third-party owned sources.
-        pub const SOURCE_TYPE_CUSTOM: SourceType = SourceType::new(4);
-
-        /// Creates a new SourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Upload => std::option::Option::Some(1),
+                Self::GuestOsScan => std::option::Option::Some(2),
+                Self::InventoryScan => std::option::Option::Some(3),
+                Self::Custom => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UPLOAD"),
-                2 => std::borrow::Cow::Borrowed("SOURCE_TYPE_GUEST_OS_SCAN"),
-                3 => std::borrow::Cow::Borrowed("SOURCE_TYPE_INVENTORY_SCAN"),
-                4 => std::borrow::Cow::Borrowed("SOURCE_TYPE_CUSTOM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("SOURCE_TYPE_UNKNOWN"),
+                Self::Upload => std::option::Option::Some("SOURCE_TYPE_UPLOAD"),
+                Self::GuestOsScan => std::option::Option::Some("SOURCE_TYPE_GUEST_OS_SCAN"),
+                Self::InventoryScan => std::option::Option::Some("SOURCE_TYPE_INVENTORY_SCAN"),
+                Self::Custom => std::option::Option::Some("SOURCE_TYPE_CUSTOM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SOURCE_TYPE_UNKNOWN" => std::option::Option::Some(Self::SOURCE_TYPE_UNKNOWN),
-                "SOURCE_TYPE_UPLOAD" => std::option::Option::Some(Self::SOURCE_TYPE_UPLOAD),
-                "SOURCE_TYPE_GUEST_OS_SCAN" => {
-                    std::option::Option::Some(Self::SOURCE_TYPE_GUEST_OS_SCAN)
-                }
-                "SOURCE_TYPE_INVENTORY_SCAN" => {
-                    std::option::Option::Some(Self::SOURCE_TYPE_INVENTORY_SCAN)
-                }
-                "SOURCE_TYPE_CUSTOM" => std::option::Option::Some(Self::SOURCE_TYPE_CUSTOM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Upload,
+                2 => Self::GuestOsScan,
+                3 => Self::InventoryScan,
+                4 => Self::Custom,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SOURCE_TYPE_UNKNOWN" => Self::Unknown,
+                "SOURCE_TYPE_UPLOAD" => Self::Upload,
+                "SOURCE_TYPE_GUEST_OS_SCAN" => Self::GuestOsScan,
+                "SOURCE_TYPE_INVENTORY_SCAN" => Self::InventoryScan,
+                "SOURCE_TYPE_CUSTOM" => Self::Custom,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Upload => serializer.serialize_i32(1),
+                Self::GuestOsScan => serializer.serialize_i32(2),
+                Self::InventoryScan => serializer.serialize_i32(3),
+                Self::Custom => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceType>::new(
+                ".google.cloud.migrationcenter.v1.Source.SourceType",
+            ))
         }
     }
 
     /// Enumerates possible states of a source.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The source is active and ready to be used.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// In the process of being deleted.
-        pub const DELETING: State = State::new(2);
-
+        Deleting,
         /// Source is in an invalid state. Asset frames reported to it will be
         /// ignored.
-        pub const INVALID: State = State::new(3);
+        Invalid,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Deleting => std::option::Option::Some(2),
+                Self::Invalid => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DELETING"),
-                3 => std::borrow::Cow::Borrowed("INVALID"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Invalid => std::option::Option::Some("INVALID"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "INVALID" => std::option::Option::Some(Self::INVALID),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Deleting,
+                3 => Self::Invalid,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "INVALID" => Self::Invalid,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Deleting => serializer.serialize_i32(2),
+                Self::Invalid => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.migrationcenter.v1.Source.State",
+            ))
         }
     }
 }
@@ -1566,118 +1810,238 @@ pub mod report {
     use super::*;
 
     /// Report type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Default Report type.
+        Unspecified,
+        /// Total cost of ownership Report type.
+        TotalCostOfOwnership,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Default Report type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Total cost of ownership Report type.
-        pub const TOTAL_COST_OF_OWNERSHIP: Type = Type::new(1);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TotalCostOfOwnership => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TOTAL_COST_OF_OWNERSHIP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::TotalCostOfOwnership => std::option::Option::Some("TOTAL_COST_OF_OWNERSHIP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TOTAL_COST_OF_OWNERSHIP" => {
-                    std::option::Option::Some(Self::TOTAL_COST_OF_OWNERSHIP)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TotalCostOfOwnership,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TOTAL_COST_OF_OWNERSHIP" => Self::TotalCostOfOwnership,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TotalCostOfOwnership => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.migrationcenter.v1.Report.Type",
+            ))
         }
     }
 
     /// Report creation state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default Report creation state.
+        Unspecified,
+        /// Creating Report.
+        Pending,
+        /// Successfully created Report.
+        Succeeded,
+        /// Failed to create Report.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default Report creation state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Creating Report.
-        pub const PENDING: State = State::new(1);
-
-        /// Successfully created Report.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// Failed to create Report.
-        pub const FAILED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.migrationcenter.v1.Report.State",
+            ))
         }
     }
 }
@@ -5942,83 +6306,150 @@ pub mod machine_details {
     use super::*;
 
     /// Machine power state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PowerState(i32);
-
-    impl PowerState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PowerState {
         /// Power state is unknown.
-        pub const POWER_STATE_UNSPECIFIED: PowerState = PowerState::new(0);
-
+        Unspecified,
         /// The machine is preparing to enter the ACTIVE state. An instance may enter
         /// the PENDING state when it launches for the first time, or when it is
         /// started after being in the SUSPENDED state.
-        pub const PENDING: PowerState = PowerState::new(1);
-
+        Pending,
         /// The machine is active.
-        pub const ACTIVE: PowerState = PowerState::new(2);
-
+        Active,
         /// The machine is being turned off.
-        pub const SUSPENDING: PowerState = PowerState::new(3);
-
+        Suspending,
         /// The machine is off.
-        pub const SUSPENDED: PowerState = PowerState::new(4);
-
+        Suspended,
         /// The machine is being deleted from the hosting platform.
-        pub const DELETING: PowerState = PowerState::new(5);
-
+        Deleting,
         /// The machine is deleted from the hosting platform.
-        pub const DELETED: PowerState = PowerState::new(6);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PowerState::value] or
+        /// [PowerState::name].
+        UnknownValue(power_state::UnknownValue),
+    }
 
-        /// Creates a new PowerState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod power_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PowerState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Suspending => std::option::Option::Some(3),
+                Self::Suspended => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Deleted => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POWER_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("SUSPENDING"),
-                4 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POWER_STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Suspending => std::option::Option::Some("SUSPENDING"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POWER_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POWER_STATE_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PowerState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PowerState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PowerState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PowerState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Active,
+                3 => Self::Suspending,
+                4 => Self::Suspended,
+                5 => Self::Deleting,
+                6 => Self::Deleted,
+                _ => Self::UnknownValue(power_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PowerState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POWER_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "ACTIVE" => Self::Active,
+                "SUSPENDING" => Self::Suspending,
+                "SUSPENDED" => Self::Suspended,
+                "DELETING" => Self::Deleting,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(power_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PowerState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Suspending => serializer.serialize_i32(3),
+                Self::Suspended => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Deleted => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PowerState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PowerState>::new(
+                ".google.cloud.migrationcenter.v1.MachineDetails.PowerState",
+            ))
         }
     }
 }
@@ -6145,120 +6576,238 @@ pub mod machine_architecture_details {
     use super::*;
 
     /// Firmware type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FirmwareType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FirmwareType {
+        /// Unspecified or unknown.
+        Unspecified,
+        /// BIOS firmware.
+        Bios,
+        /// EFI firmware.
+        Efi,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FirmwareType::value] or
+        /// [FirmwareType::name].
+        UnknownValue(firmware_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod firmware_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FirmwareType {
-        /// Unspecified or unknown.
-        pub const FIRMWARE_TYPE_UNSPECIFIED: FirmwareType = FirmwareType::new(0);
-
-        /// BIOS firmware.
-        pub const BIOS: FirmwareType = FirmwareType::new(1);
-
-        /// EFI firmware.
-        pub const EFI: FirmwareType = FirmwareType::new(2);
-
-        /// Creates a new FirmwareType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Bios => std::option::Option::Some(1),
+                Self::Efi => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FIRMWARE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BIOS"),
-                2 => std::borrow::Cow::Borrowed("EFI"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FIRMWARE_TYPE_UNSPECIFIED"),
+                Self::Bios => std::option::Option::Some("BIOS"),
+                Self::Efi => std::option::Option::Some("EFI"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FIRMWARE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FIRMWARE_TYPE_UNSPECIFIED)
-                }
-                "BIOS" => std::option::Option::Some(Self::BIOS),
-                "EFI" => std::option::Option::Some(Self::EFI),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FirmwareType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FirmwareType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FirmwareType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FirmwareType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Bios,
+                2 => Self::Efi,
+                _ => Self::UnknownValue(firmware_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FirmwareType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FIRMWARE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BIOS" => Self::Bios,
+                "EFI" => Self::Efi,
+                _ => Self::UnknownValue(firmware_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FirmwareType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Bios => serializer.serialize_i32(1),
+                Self::Efi => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FirmwareType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FirmwareType>::new(
+                ".google.cloud.migrationcenter.v1.MachineArchitectureDetails.FirmwareType",
+            ))
         }
     }
 
     /// CPU hyper-threading support.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CpuHyperThreading(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CpuHyperThreading {
+        /// Unspecified or unknown.
+        Unspecified,
+        /// Hyper-threading is disabled.
+        Disabled,
+        /// Hyper-threading is enabled.
+        Enabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CpuHyperThreading::value] or
+        /// [CpuHyperThreading::name].
+        UnknownValue(cpu_hyper_threading::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod cpu_hyper_threading {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CpuHyperThreading {
-        /// Unspecified or unknown.
-        pub const CPU_HYPER_THREADING_UNSPECIFIED: CpuHyperThreading = CpuHyperThreading::new(0);
-
-        /// Hyper-threading is disabled.
-        pub const DISABLED: CpuHyperThreading = CpuHyperThreading::new(1);
-
-        /// Hyper-threading is enabled.
-        pub const ENABLED: CpuHyperThreading = CpuHyperThreading::new(2);
-
-        /// Creates a new CpuHyperThreading instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Enabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CPU_HYPER_THREADING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CPU_HYPER_THREADING_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CPU_HYPER_THREADING_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CPU_HYPER_THREADING_UNSPECIFIED)
-                }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CpuHyperThreading {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CpuHyperThreading {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CpuHyperThreading {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CpuHyperThreading {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Enabled,
+                _ => Self::UnknownValue(cpu_hyper_threading::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CpuHyperThreading {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CPU_HYPER_THREADING_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "ENABLED" => Self::Enabled,
+                _ => Self::UnknownValue(cpu_hyper_threading::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CpuHyperThreading {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Enabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CpuHyperThreading {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CpuHyperThreading>::new(
+                ".google.cloud.migrationcenter.v1.MachineArchitectureDetails.CpuHyperThreading",
+            ))
         }
     }
 }
@@ -6639,65 +7188,120 @@ pub mod network_address {
     use super::*;
 
     /// Network address assignment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AddressAssignment(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AddressAssignment {
+        /// Unknown (default value).
+        Unspecified,
+        /// Staticly assigned IP.
+        Static,
+        /// Dynamically assigned IP (DHCP).
+        Dhcp,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AddressAssignment::value] or
+        /// [AddressAssignment::name].
+        UnknownValue(address_assignment::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod address_assignment {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AddressAssignment {
-        /// Unknown (default value).
-        pub const ADDRESS_ASSIGNMENT_UNSPECIFIED: AddressAssignment = AddressAssignment::new(0);
-
-        /// Staticly assigned IP.
-        pub const ADDRESS_ASSIGNMENT_STATIC: AddressAssignment = AddressAssignment::new(1);
-
-        /// Dynamically assigned IP (DHCP).
-        pub const ADDRESS_ASSIGNMENT_DHCP: AddressAssignment = AddressAssignment::new(2);
-
-        /// Creates a new AddressAssignment instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Static => std::option::Option::Some(1),
+                Self::Dhcp => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ADDRESS_ASSIGNMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADDRESS_ASSIGNMENT_STATIC"),
-                2 => std::borrow::Cow::Borrowed("ADDRESS_ASSIGNMENT_DHCP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ADDRESS_ASSIGNMENT_UNSPECIFIED"),
+                Self::Static => std::option::Option::Some("ADDRESS_ASSIGNMENT_STATIC"),
+                Self::Dhcp => std::option::Option::Some("ADDRESS_ASSIGNMENT_DHCP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ADDRESS_ASSIGNMENT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ADDRESS_ASSIGNMENT_UNSPECIFIED)
-                }
-                "ADDRESS_ASSIGNMENT_STATIC" => {
-                    std::option::Option::Some(Self::ADDRESS_ASSIGNMENT_STATIC)
-                }
-                "ADDRESS_ASSIGNMENT_DHCP" => {
-                    std::option::Option::Some(Self::ADDRESS_ASSIGNMENT_DHCP)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AddressAssignment {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AddressAssignment {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AddressAssignment {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AddressAssignment {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Static,
+                2 => Self::Dhcp,
+                _ => Self::UnknownValue(address_assignment::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AddressAssignment {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ADDRESS_ASSIGNMENT_UNSPECIFIED" => Self::Unspecified,
+                "ADDRESS_ASSIGNMENT_STATIC" => Self::Static,
+                "ADDRESS_ASSIGNMENT_DHCP" => Self::Dhcp,
+                _ => Self::UnknownValue(address_assignment::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AddressAssignment {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Static => serializer.serialize_i32(1),
+                Self::Dhcp => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AddressAssignment {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AddressAssignment>::new(
+                ".google.cloud.migrationcenter.v1.NetworkAddress.AddressAssignment",
+            ))
         }
     }
 }
@@ -6946,86 +7550,155 @@ pub mod disk_entry {
     use super::*;
 
     /// Disks interface type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InterfaceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InterfaceType {
+        /// Interface type unknown or unspecified.
+        Unspecified,
+        /// IDE interface type.
+        Ide,
+        /// SATA interface type.
+        Sata,
+        /// SAS interface type.
+        Sas,
+        /// SCSI interface type.
+        Scsi,
+        /// NVME interface type.
+        Nvme,
+        /// FC interface type.
+        Fc,
+        /// iSCSI interface type.
+        Iscsi,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InterfaceType::value] or
+        /// [InterfaceType::name].
+        UnknownValue(interface_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod interface_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl InterfaceType {
-        /// Interface type unknown or unspecified.
-        pub const INTERFACE_TYPE_UNSPECIFIED: InterfaceType = InterfaceType::new(0);
-
-        /// IDE interface type.
-        pub const IDE: InterfaceType = InterfaceType::new(1);
-
-        /// SATA interface type.
-        pub const SATA: InterfaceType = InterfaceType::new(2);
-
-        /// SAS interface type.
-        pub const SAS: InterfaceType = InterfaceType::new(3);
-
-        /// SCSI interface type.
-        pub const SCSI: InterfaceType = InterfaceType::new(4);
-
-        /// NVME interface type.
-        pub const NVME: InterfaceType = InterfaceType::new(5);
-
-        /// FC interface type.
-        pub const FC: InterfaceType = InterfaceType::new(6);
-
-        /// iSCSI interface type.
-        pub const ISCSI: InterfaceType = InterfaceType::new(7);
-
-        /// Creates a new InterfaceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ide => std::option::Option::Some(1),
+                Self::Sata => std::option::Option::Some(2),
+                Self::Sas => std::option::Option::Some(3),
+                Self::Scsi => std::option::Option::Some(4),
+                Self::Nvme => std::option::Option::Some(5),
+                Self::Fc => std::option::Option::Some(6),
+                Self::Iscsi => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INTERFACE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IDE"),
-                2 => std::borrow::Cow::Borrowed("SATA"),
-                3 => std::borrow::Cow::Borrowed("SAS"),
-                4 => std::borrow::Cow::Borrowed("SCSI"),
-                5 => std::borrow::Cow::Borrowed("NVME"),
-                6 => std::borrow::Cow::Borrowed("FC"),
-                7 => std::borrow::Cow::Borrowed("ISCSI"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INTERFACE_TYPE_UNSPECIFIED"),
+                Self::Ide => std::option::Option::Some("IDE"),
+                Self::Sata => std::option::Option::Some("SATA"),
+                Self::Sas => std::option::Option::Some("SAS"),
+                Self::Scsi => std::option::Option::Some("SCSI"),
+                Self::Nvme => std::option::Option::Some("NVME"),
+                Self::Fc => std::option::Option::Some("FC"),
+                Self::Iscsi => std::option::Option::Some("ISCSI"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INTERFACE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INTERFACE_TYPE_UNSPECIFIED)
-                }
-                "IDE" => std::option::Option::Some(Self::IDE),
-                "SATA" => std::option::Option::Some(Self::SATA),
-                "SAS" => std::option::Option::Some(Self::SAS),
-                "SCSI" => std::option::Option::Some(Self::SCSI),
-                "NVME" => std::option::Option::Some(Self::NVME),
-                "FC" => std::option::Option::Some(Self::FC),
-                "ISCSI" => std::option::Option::Some(Self::ISCSI),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InterfaceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InterfaceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InterfaceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InterfaceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ide,
+                2 => Self::Sata,
+                3 => Self::Sas,
+                4 => Self::Scsi,
+                5 => Self::Nvme,
+                6 => Self::Fc,
+                7 => Self::Iscsi,
+                _ => Self::UnknownValue(interface_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InterfaceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INTERFACE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IDE" => Self::Ide,
+                "SATA" => Self::Sata,
+                "SAS" => Self::Sas,
+                "SCSI" => Self::Scsi,
+                "NVME" => Self::Nvme,
+                "FC" => Self::Fc,
+                "ISCSI" => Self::Iscsi,
+                _ => Self::UnknownValue(interface_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InterfaceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ide => serializer.serialize_i32(1),
+                Self::Sata => serializer.serialize_i32(2),
+                Self::Sas => serializer.serialize_i32(3),
+                Self::Scsi => serializer.serialize_i32(4),
+                Self::Nvme => serializer.serialize_i32(5),
+                Self::Fc => serializer.serialize_i32(6),
+                Self::Iscsi => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InterfaceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InterfaceType>::new(
+                ".google.cloud.migrationcenter.v1.DiskEntry.InterfaceType",
+            ))
         }
     }
 
@@ -7254,218 +7927,407 @@ pub mod vmware_disk_config {
     use super::*;
 
     /// VMDK backing type possible values.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackingType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BackingType {
+        /// Default value.
+        Unspecified,
+        /// Flat v1.
+        FlatV1,
+        /// Flat v2.
+        FlatV2,
+        /// Persistent memory, also known as Non-Volatile Memory (NVM).
+        Pmem,
+        /// Raw Disk Memory v1.
+        RdmV1,
+        /// Raw Disk Memory v2.
+        RdmV2,
+        /// SEsparse is a snapshot format introduced in vSphere 5.5 for large disks.
+        Sesparse,
+        /// SEsparse v1.
+        SesparseV1,
+        /// SEsparse v1.
+        SesparseV2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BackingType::value] or
+        /// [BackingType::name].
+        UnknownValue(backing_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod backing_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BackingType {
-        /// Default value.
-        pub const BACKING_TYPE_UNSPECIFIED: BackingType = BackingType::new(0);
-
-        /// Flat v1.
-        pub const BACKING_TYPE_FLAT_V1: BackingType = BackingType::new(1);
-
-        /// Flat v2.
-        pub const BACKING_TYPE_FLAT_V2: BackingType = BackingType::new(2);
-
-        /// Persistent memory, also known as Non-Volatile Memory (NVM).
-        pub const BACKING_TYPE_PMEM: BackingType = BackingType::new(3);
-
-        /// Raw Disk Memory v1.
-        pub const BACKING_TYPE_RDM_V1: BackingType = BackingType::new(4);
-
-        /// Raw Disk Memory v2.
-        pub const BACKING_TYPE_RDM_V2: BackingType = BackingType::new(5);
-
-        /// SEsparse is a snapshot format introduced in vSphere 5.5 for large disks.
-        pub const BACKING_TYPE_SESPARSE: BackingType = BackingType::new(6);
-
-        /// SEsparse v1.
-        pub const BACKING_TYPE_SESPARSE_V1: BackingType = BackingType::new(7);
-
-        /// SEsparse v1.
-        pub const BACKING_TYPE_SESPARSE_V2: BackingType = BackingType::new(8);
-
-        /// Creates a new BackingType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FlatV1 => std::option::Option::Some(1),
+                Self::FlatV2 => std::option::Option::Some(2),
+                Self::Pmem => std::option::Option::Some(3),
+                Self::RdmV1 => std::option::Option::Some(4),
+                Self::RdmV2 => std::option::Option::Some(5),
+                Self::Sesparse => std::option::Option::Some(6),
+                Self::SesparseV1 => std::option::Option::Some(7),
+                Self::SesparseV2 => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BACKING_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BACKING_TYPE_FLAT_V1"),
-                2 => std::borrow::Cow::Borrowed("BACKING_TYPE_FLAT_V2"),
-                3 => std::borrow::Cow::Borrowed("BACKING_TYPE_PMEM"),
-                4 => std::borrow::Cow::Borrowed("BACKING_TYPE_RDM_V1"),
-                5 => std::borrow::Cow::Borrowed("BACKING_TYPE_RDM_V2"),
-                6 => std::borrow::Cow::Borrowed("BACKING_TYPE_SESPARSE"),
-                7 => std::borrow::Cow::Borrowed("BACKING_TYPE_SESPARSE_V1"),
-                8 => std::borrow::Cow::Borrowed("BACKING_TYPE_SESPARSE_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BACKING_TYPE_UNSPECIFIED"),
+                Self::FlatV1 => std::option::Option::Some("BACKING_TYPE_FLAT_V1"),
+                Self::FlatV2 => std::option::Option::Some("BACKING_TYPE_FLAT_V2"),
+                Self::Pmem => std::option::Option::Some("BACKING_TYPE_PMEM"),
+                Self::RdmV1 => std::option::Option::Some("BACKING_TYPE_RDM_V1"),
+                Self::RdmV2 => std::option::Option::Some("BACKING_TYPE_RDM_V2"),
+                Self::Sesparse => std::option::Option::Some("BACKING_TYPE_SESPARSE"),
+                Self::SesparseV1 => std::option::Option::Some("BACKING_TYPE_SESPARSE_V1"),
+                Self::SesparseV2 => std::option::Option::Some("BACKING_TYPE_SESPARSE_V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BACKING_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BACKING_TYPE_UNSPECIFIED)
-                }
-                "BACKING_TYPE_FLAT_V1" => std::option::Option::Some(Self::BACKING_TYPE_FLAT_V1),
-                "BACKING_TYPE_FLAT_V2" => std::option::Option::Some(Self::BACKING_TYPE_FLAT_V2),
-                "BACKING_TYPE_PMEM" => std::option::Option::Some(Self::BACKING_TYPE_PMEM),
-                "BACKING_TYPE_RDM_V1" => std::option::Option::Some(Self::BACKING_TYPE_RDM_V1),
-                "BACKING_TYPE_RDM_V2" => std::option::Option::Some(Self::BACKING_TYPE_RDM_V2),
-                "BACKING_TYPE_SESPARSE" => std::option::Option::Some(Self::BACKING_TYPE_SESPARSE),
-                "BACKING_TYPE_SESPARSE_V1" => {
-                    std::option::Option::Some(Self::BACKING_TYPE_SESPARSE_V1)
-                }
-                "BACKING_TYPE_SESPARSE_V2" => {
-                    std::option::Option::Some(Self::BACKING_TYPE_SESPARSE_V2)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BackingType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BackingType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BackingType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BackingType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FlatV1,
+                2 => Self::FlatV2,
+                3 => Self::Pmem,
+                4 => Self::RdmV1,
+                5 => Self::RdmV2,
+                6 => Self::Sesparse,
+                7 => Self::SesparseV1,
+                8 => Self::SesparseV2,
+                _ => Self::UnknownValue(backing_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BackingType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BACKING_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BACKING_TYPE_FLAT_V1" => Self::FlatV1,
+                "BACKING_TYPE_FLAT_V2" => Self::FlatV2,
+                "BACKING_TYPE_PMEM" => Self::Pmem,
+                "BACKING_TYPE_RDM_V1" => Self::RdmV1,
+                "BACKING_TYPE_RDM_V2" => Self::RdmV2,
+                "BACKING_TYPE_SESPARSE" => Self::Sesparse,
+                "BACKING_TYPE_SESPARSE_V1" => Self::SesparseV1,
+                "BACKING_TYPE_SESPARSE_V2" => Self::SesparseV2,
+                _ => Self::UnknownValue(backing_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BackingType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FlatV1 => serializer.serialize_i32(1),
+                Self::FlatV2 => serializer.serialize_i32(2),
+                Self::Pmem => serializer.serialize_i32(3),
+                Self::RdmV1 => serializer.serialize_i32(4),
+                Self::RdmV2 => serializer.serialize_i32(5),
+                Self::Sesparse => serializer.serialize_i32(6),
+                Self::SesparseV1 => serializer.serialize_i32(7),
+                Self::SesparseV2 => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BackingType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackingType>::new(
+                ".google.cloud.migrationcenter.v1.VmwareDiskConfig.BackingType",
+            ))
         }
     }
 
     /// VMDK disk mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VmdkMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VmdkMode {
+        /// VMDK disk mode unspecified or unknown.
+        Unspecified,
+        /// Dependent disk mode.
+        Dependent,
+        /// Independent - Persistent disk mode.
+        IndependentPersistent,
+        /// Independent - Nonpersistent disk mode.
+        IndependentNonpersistent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VmdkMode::value] or
+        /// [VmdkMode::name].
+        UnknownValue(vmdk_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod vmdk_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VmdkMode {
-        /// VMDK disk mode unspecified or unknown.
-        pub const VMDK_MODE_UNSPECIFIED: VmdkMode = VmdkMode::new(0);
-
-        /// Dependent disk mode.
-        pub const DEPENDENT: VmdkMode = VmdkMode::new(1);
-
-        /// Independent - Persistent disk mode.
-        pub const INDEPENDENT_PERSISTENT: VmdkMode = VmdkMode::new(2);
-
-        /// Independent - Nonpersistent disk mode.
-        pub const INDEPENDENT_NONPERSISTENT: VmdkMode = VmdkMode::new(3);
-
-        /// Creates a new VmdkMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dependent => std::option::Option::Some(1),
+                Self::IndependentPersistent => std::option::Option::Some(2),
+                Self::IndependentNonpersistent => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VMDK_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEPENDENT"),
-                2 => std::borrow::Cow::Borrowed("INDEPENDENT_PERSISTENT"),
-                3 => std::borrow::Cow::Borrowed("INDEPENDENT_NONPERSISTENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VMDK_MODE_UNSPECIFIED" => std::option::Option::Some(Self::VMDK_MODE_UNSPECIFIED),
-                "DEPENDENT" => std::option::Option::Some(Self::DEPENDENT),
-                "INDEPENDENT_PERSISTENT" => std::option::Option::Some(Self::INDEPENDENT_PERSISTENT),
-                "INDEPENDENT_NONPERSISTENT" => {
-                    std::option::Option::Some(Self::INDEPENDENT_NONPERSISTENT)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VMDK_MODE_UNSPECIFIED"),
+                Self::Dependent => std::option::Option::Some("DEPENDENT"),
+                Self::IndependentPersistent => std::option::Option::Some("INDEPENDENT_PERSISTENT"),
+                Self::IndependentNonpersistent => {
+                    std::option::Option::Some("INDEPENDENT_NONPERSISTENT")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for VmdkMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VmdkMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VmdkMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VmdkMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dependent,
+                2 => Self::IndependentPersistent,
+                3 => Self::IndependentNonpersistent,
+                _ => Self::UnknownValue(vmdk_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VmdkMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VMDK_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DEPENDENT" => Self::Dependent,
+                "INDEPENDENT_PERSISTENT" => Self::IndependentPersistent,
+                "INDEPENDENT_NONPERSISTENT" => Self::IndependentNonpersistent,
+                _ => Self::UnknownValue(vmdk_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VmdkMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dependent => serializer.serialize_i32(1),
+                Self::IndependentPersistent => serializer.serialize_i32(2),
+                Self::IndependentNonpersistent => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VmdkMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VmdkMode>::new(
+                ".google.cloud.migrationcenter.v1.VmwareDiskConfig.VmdkMode",
+            ))
         }
     }
 
     /// RDM compatibility mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RdmCompatibility(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RdmCompatibility {
+        /// Compatibility mode unspecified or unknown.
+        Unspecified,
+        /// Physical compatibility mode.
+        PhysicalCompatibility,
+        /// Virtual compatibility mode.
+        VirtualCompatibility,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RdmCompatibility::value] or
+        /// [RdmCompatibility::name].
+        UnknownValue(rdm_compatibility::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod rdm_compatibility {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RdmCompatibility {
-        /// Compatibility mode unspecified or unknown.
-        pub const RDM_COMPATIBILITY_UNSPECIFIED: RdmCompatibility = RdmCompatibility::new(0);
-
-        /// Physical compatibility mode.
-        pub const PHYSICAL_COMPATIBILITY: RdmCompatibility = RdmCompatibility::new(1);
-
-        /// Virtual compatibility mode.
-        pub const VIRTUAL_COMPATIBILITY: RdmCompatibility = RdmCompatibility::new(2);
-
-        /// Creates a new RdmCompatibility instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PhysicalCompatibility => std::option::Option::Some(1),
+                Self::VirtualCompatibility => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RDM_COMPATIBILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PHYSICAL_COMPATIBILITY"),
-                2 => std::borrow::Cow::Borrowed("VIRTUAL_COMPATIBILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RDM_COMPATIBILITY_UNSPECIFIED"),
+                Self::PhysicalCompatibility => std::option::Option::Some("PHYSICAL_COMPATIBILITY"),
+                Self::VirtualCompatibility => std::option::Option::Some("VIRTUAL_COMPATIBILITY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RDM_COMPATIBILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RDM_COMPATIBILITY_UNSPECIFIED)
-                }
-                "PHYSICAL_COMPATIBILITY" => std::option::Option::Some(Self::PHYSICAL_COMPATIBILITY),
-                "VIRTUAL_COMPATIBILITY" => std::option::Option::Some(Self::VIRTUAL_COMPATIBILITY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RdmCompatibility {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RdmCompatibility {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RdmCompatibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RdmCompatibility {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PhysicalCompatibility,
+                2 => Self::VirtualCompatibility,
+                _ => Self::UnknownValue(rdm_compatibility::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RdmCompatibility {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RDM_COMPATIBILITY_UNSPECIFIED" => Self::Unspecified,
+                "PHYSICAL_COMPATIBILITY" => Self::PhysicalCompatibility,
+                "VIRTUAL_COMPATIBILITY" => Self::VirtualCompatibility,
+                _ => Self::UnknownValue(rdm_compatibility::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RdmCompatibility {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PhysicalCompatibility => serializer.serialize_i32(1),
+                Self::VirtualCompatibility => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RdmCompatibility {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RdmCompatibility>::new(
+                ".google.cloud.migrationcenter.v1.VmwareDiskConfig.RdmCompatibility",
+            ))
         }
     }
 }
@@ -7647,70 +8509,127 @@ pub mod guest_config_details {
     use super::*;
 
     /// Security-Enhanced Linux (SELinux) mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SeLinuxMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SeLinuxMode {
+        /// SELinux mode unknown or unspecified.
+        Unspecified,
+        /// SELinux is disabled.
+        Disabled,
+        /// SELinux permissive mode.
+        Permissive,
+        /// SELinux enforcing mode.
+        Enforcing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SeLinuxMode::value] or
+        /// [SeLinuxMode::name].
+        UnknownValue(se_linux_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod se_linux_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SeLinuxMode {
-        /// SELinux mode unknown or unspecified.
-        pub const SE_LINUX_MODE_UNSPECIFIED: SeLinuxMode = SeLinuxMode::new(0);
-
-        /// SELinux is disabled.
-        pub const SE_LINUX_MODE_DISABLED: SeLinuxMode = SeLinuxMode::new(1);
-
-        /// SELinux permissive mode.
-        pub const SE_LINUX_MODE_PERMISSIVE: SeLinuxMode = SeLinuxMode::new(2);
-
-        /// SELinux enforcing mode.
-        pub const SE_LINUX_MODE_ENFORCING: SeLinuxMode = SeLinuxMode::new(3);
-
-        /// Creates a new SeLinuxMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Permissive => std::option::Option::Some(2),
+                Self::Enforcing => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_PERMISSIVE"),
-                3 => std::borrow::Cow::Borrowed("SE_LINUX_MODE_ENFORCING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SE_LINUX_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("SE_LINUX_MODE_DISABLED"),
+                Self::Permissive => std::option::Option::Some("SE_LINUX_MODE_PERMISSIVE"),
+                Self::Enforcing => std::option::Option::Some("SE_LINUX_MODE_ENFORCING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SE_LINUX_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SE_LINUX_MODE_UNSPECIFIED)
-                }
-                "SE_LINUX_MODE_DISABLED" => std::option::Option::Some(Self::SE_LINUX_MODE_DISABLED),
-                "SE_LINUX_MODE_PERMISSIVE" => {
-                    std::option::Option::Some(Self::SE_LINUX_MODE_PERMISSIVE)
-                }
-                "SE_LINUX_MODE_ENFORCING" => {
-                    std::option::Option::Some(Self::SE_LINUX_MODE_ENFORCING)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SeLinuxMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SeLinuxMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SeLinuxMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SeLinuxMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Permissive,
+                3 => Self::Enforcing,
+                _ => Self::UnknownValue(se_linux_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SeLinuxMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SE_LINUX_MODE_UNSPECIFIED" => Self::Unspecified,
+                "SE_LINUX_MODE_DISABLED" => Self::Disabled,
+                "SE_LINUX_MODE_PERMISSIVE" => Self::Permissive,
+                "SE_LINUX_MODE_ENFORCING" => Self::Enforcing,
+                _ => Self::UnknownValue(se_linux_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SeLinuxMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Permissive => serializer.serialize_i32(2),
+                Self::Enforcing => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SeLinuxMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SeLinuxMode>::new(
+                ".google.cloud.migrationcenter.v1.GuestConfigDetails.SeLinuxMode",
+            ))
         }
     }
 }
@@ -8266,136 +9185,266 @@ pub mod running_service {
     use super::*;
 
     /// Service state (OS-agnostic).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Service state unspecified.
+        Unspecified,
+        /// Service is active.
+        Active,
+        /// Service is paused.
+        Paused,
+        /// Service is stopped.
+        Stopped,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Service state unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Service is active.
-        pub const ACTIVE: State = State::new(1);
-
-        /// Service is paused.
-        pub const PAUSED: State = State::new(2);
-
-        /// Service is stopped.
-        pub const STOPPED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Stopped => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("STOPPED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Paused,
+                3 => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "PAUSED" => Self::Paused,
+                "STOPPED" => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Stopped => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.migrationcenter.v1.RunningService.State",
+            ))
         }
     }
 
     /// Service start mode (OS-agnostic).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StartMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StartMode {
+        /// Start mode unspecified.
+        Unspecified,
+        /// The service is a device driver started by the system loader.
+        Boot,
+        /// The service is a device driver started by the IOInitSystem function.
+        System,
+        /// The service is started by the operating system, at system start-up
+        Auto,
+        /// The service is started only manually, by a user.
+        Manual,
+        /// The service is disabled.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StartMode::value] or
+        /// [StartMode::name].
+        UnknownValue(start_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod start_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StartMode {
-        /// Start mode unspecified.
-        pub const START_MODE_UNSPECIFIED: StartMode = StartMode::new(0);
-
-        /// The service is a device driver started by the system loader.
-        pub const BOOT: StartMode = StartMode::new(1);
-
-        /// The service is a device driver started by the IOInitSystem function.
-        pub const SYSTEM: StartMode = StartMode::new(2);
-
-        /// The service is started by the operating system, at system start-up
-        pub const AUTO: StartMode = StartMode::new(3);
-
-        /// The service is started only manually, by a user.
-        pub const MANUAL: StartMode = StartMode::new(4);
-
-        /// The service is disabled.
-        pub const DISABLED: StartMode = StartMode::new(5);
-
-        /// Creates a new StartMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Boot => std::option::Option::Some(1),
+                Self::System => std::option::Option::Some(2),
+                Self::Auto => std::option::Option::Some(3),
+                Self::Manual => std::option::Option::Some(4),
+                Self::Disabled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("START_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BOOT"),
-                2 => std::borrow::Cow::Borrowed("SYSTEM"),
-                3 => std::borrow::Cow::Borrowed("AUTO"),
-                4 => std::borrow::Cow::Borrowed("MANUAL"),
-                5 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("START_MODE_UNSPECIFIED"),
+                Self::Boot => std::option::Option::Some("BOOT"),
+                Self::System => std::option::Option::Some("SYSTEM"),
+                Self::Auto => std::option::Option::Some("AUTO"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "START_MODE_UNSPECIFIED" => std::option::Option::Some(Self::START_MODE_UNSPECIFIED),
-                "BOOT" => std::option::Option::Some(Self::BOOT),
-                "SYSTEM" => std::option::Option::Some(Self::SYSTEM),
-                "AUTO" => std::option::Option::Some(Self::AUTO),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StartMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StartMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StartMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StartMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Boot,
+                2 => Self::System,
+                3 => Self::Auto,
+                4 => Self::Manual,
+                5 => Self::Disabled,
+                _ => Self::UnknownValue(start_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StartMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "START_MODE_UNSPECIFIED" => Self::Unspecified,
+                "BOOT" => Self::Boot,
+                "SYSTEM" => Self::System,
+                "AUTO" => Self::Auto,
+                "MANUAL" => Self::Manual,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(start_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StartMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Boot => serializer.serialize_i32(1),
+                Self::System => serializer.serialize_i32(2),
+                Self::Auto => serializer.serialize_i32(3),
+                Self::Manual => serializer.serialize_i32(4),
+                Self::Disabled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StartMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StartMode>::new(
+                ".google.cloud.migrationcenter.v1.RunningService.StartMode",
+            ))
         }
     }
 }
@@ -8719,74 +9768,141 @@ pub mod network_connection {
     use super::*;
 
     /// Network connection state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Connection state is unknown or unspecified.
+        Unspecified,
+        /// The connection is being opened.
+        Opening,
+        /// The connection is open.
+        Open,
+        /// Listening for incoming connections.
+        Listen,
+        /// The connection is being closed.
+        Closing,
+        /// The connection is closed.
+        Closed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Connection state is unknown or unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The connection is being opened.
-        pub const OPENING: State = State::new(1);
-
-        /// The connection is open.
-        pub const OPEN: State = State::new(2);
-
-        /// Listening for incoming connections.
-        pub const LISTEN: State = State::new(3);
-
-        /// The connection is being closed.
-        pub const CLOSING: State = State::new(4);
-
-        /// The connection is closed.
-        pub const CLOSED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Opening => std::option::Option::Some(1),
+                Self::Open => std::option::Option::Some(2),
+                Self::Listen => std::option::Option::Some(3),
+                Self::Closing => std::option::Option::Some(4),
+                Self::Closed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OPENING"),
-                2 => std::borrow::Cow::Borrowed("OPEN"),
-                3 => std::borrow::Cow::Borrowed("LISTEN"),
-                4 => std::borrow::Cow::Borrowed("CLOSING"),
-                5 => std::borrow::Cow::Borrowed("CLOSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Opening => std::option::Option::Some("OPENING"),
+                Self::Open => std::option::Option::Some("OPEN"),
+                Self::Listen => std::option::Option::Some("LISTEN"),
+                Self::Closing => std::option::Option::Some("CLOSING"),
+                Self::Closed => std::option::Option::Some("CLOSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "OPENING" => std::option::Option::Some(Self::OPENING),
-                "OPEN" => std::option::Option::Some(Self::OPEN),
-                "LISTEN" => std::option::Option::Some(Self::LISTEN),
-                "CLOSING" => std::option::Option::Some(Self::CLOSING),
-                "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Opening,
+                2 => Self::Open,
+                3 => Self::Listen,
+                4 => Self::Closing,
+                5 => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "OPENING" => Self::Opening,
+                "OPEN" => Self::Open,
+                "LISTEN" => Self::Listen,
+                "CLOSING" => Self::Closing,
+                "CLOSED" => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Opening => serializer.serialize_i32(1),
+                Self::Open => serializer.serialize_i32(2),
+                Self::Listen => serializer.serialize_i32(3),
+                Self::Closing => serializer.serialize_i32(4),
+                Self::Closed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.migrationcenter.v1.NetworkConnection.State",
+            ))
         }
     }
 }
@@ -10635,64 +11751,127 @@ pub mod fit_descriptor {
     use super::*;
 
     /// Fit level.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FitLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FitLevel {
+        /// Not enough information.
+        Unspecified,
+        /// Fit.
+        Fit,
+        /// No Fit.
+        NoFit,
+        /// Fit with effort.
+        RequiresEffort,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FitLevel::value] or
+        /// [FitLevel::name].
+        UnknownValue(fit_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod fit_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FitLevel {
-        /// Not enough information.
-        pub const FIT_LEVEL_UNSPECIFIED: FitLevel = FitLevel::new(0);
-
-        /// Fit.
-        pub const FIT: FitLevel = FitLevel::new(1);
-
-        /// No Fit.
-        pub const NO_FIT: FitLevel = FitLevel::new(2);
-
-        /// Fit with effort.
-        pub const REQUIRES_EFFORT: FitLevel = FitLevel::new(3);
-
-        /// Creates a new FitLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Fit => std::option::Option::Some(1),
+                Self::NoFit => std::option::Option::Some(2),
+                Self::RequiresEffort => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FIT_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIT"),
-                2 => std::borrow::Cow::Borrowed("NO_FIT"),
-                3 => std::borrow::Cow::Borrowed("REQUIRES_EFFORT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FIT_LEVEL_UNSPECIFIED"),
+                Self::Fit => std::option::Option::Some("FIT"),
+                Self::NoFit => std::option::Option::Some("NO_FIT"),
+                Self::RequiresEffort => std::option::Option::Some("REQUIRES_EFFORT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FIT_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::FIT_LEVEL_UNSPECIFIED),
-                "FIT" => std::option::Option::Some(Self::FIT),
-                "NO_FIT" => std::option::Option::Some(Self::NO_FIT),
-                "REQUIRES_EFFORT" => std::option::Option::Some(Self::REQUIRES_EFFORT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FitLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FitLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FitLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FitLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Fit,
+                2 => Self::NoFit,
+                3 => Self::RequiresEffort,
+                _ => Self::UnknownValue(fit_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FitLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FIT_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "FIT" => Self::Fit,
+                "NO_FIT" => Self::NoFit,
+                "REQUIRES_EFFORT" => Self::RequiresEffort,
+                _ => Self::UnknownValue(fit_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FitLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Fit => serializer.serialize_i32(1),
+                Self::NoFit => serializer.serialize_i32(2),
+                Self::RequiresEffort => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FitLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FitLevel>::new(
+                ".google.cloud.migrationcenter.v1.FitDescriptor.FitLevel",
+            ))
         }
     }
 }
@@ -11615,60 +12794,123 @@ pub mod import_error {
     use super::*;
 
     /// Enumerate possible error severity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        Unspecified,
+        Error,
+        Warning,
+        Info,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        pub const ERROR: Severity = Severity::new(1);
-
-        pub const WARNING: Severity = Severity::new(2);
-
-        pub const INFO: Severity = Severity::new(3);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Error => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Info => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ERROR"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("INFO"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Error,
+                2 => Self::Warning,
+                3 => Self::Info,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "ERROR" => Self::Error,
+                "WARNING" => Self::Warning,
+                "INFO" => Self::Info,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Error => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Info => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.migrationcenter.v1.ImportError.Severity",
+            ))
         }
     }
 }
@@ -12231,84 +13473,149 @@ pub mod vmware_engine_preferences {
     use super::*;
 
     /// Type of committed use discount.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommitmentPlan(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CommitmentPlan {
+        /// Unspecified commitment plan.
+        Unspecified,
+        /// No commitment plan (on-demand usage).
+        OnDemand,
+        /// 1 year commitment (monthly payments).
+        Commitment1YearMonthlyPayments,
+        /// 3 year commitment (monthly payments).
+        Commitment3YearMonthlyPayments,
+        /// 1 year commitment (upfront payment).
+        Commitment1YearUpfrontPayment,
+        /// 3 years commitment (upfront payment).
+        Commitment3YearUpfrontPayment,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CommitmentPlan::value] or
+        /// [CommitmentPlan::name].
+        UnknownValue(commitment_plan::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod commitment_plan {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CommitmentPlan {
-        /// Unspecified commitment plan.
-        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
-
-        /// No commitment plan (on-demand usage).
-        pub const ON_DEMAND: CommitmentPlan = CommitmentPlan::new(1);
-
-        /// 1 year commitment (monthly payments).
-        pub const COMMITMENT_1_YEAR_MONTHLY_PAYMENTS: CommitmentPlan = CommitmentPlan::new(2);
-
-        /// 3 year commitment (monthly payments).
-        pub const COMMITMENT_3_YEAR_MONTHLY_PAYMENTS: CommitmentPlan = CommitmentPlan::new(3);
-
-        /// 1 year commitment (upfront payment).
-        pub const COMMITMENT_1_YEAR_UPFRONT_PAYMENT: CommitmentPlan = CommitmentPlan::new(4);
-
-        /// 3 years commitment (upfront payment).
-        pub const COMMITMENT_3_YEAR_UPFRONT_PAYMENT: CommitmentPlan = CommitmentPlan::new(5);
-
-        /// Creates a new CommitmentPlan instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OnDemand => std::option::Option::Some(1),
+                Self::Commitment1YearMonthlyPayments => std::option::Option::Some(2),
+                Self::Commitment3YearMonthlyPayments => std::option::Option::Some(3),
+                Self::Commitment1YearUpfrontPayment => std::option::Option::Some(4),
+                Self::Commitment3YearUpfrontPayment => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                2 => std::borrow::Cow::Borrowed("COMMITMENT_1_YEAR_MONTHLY_PAYMENTS"),
-                3 => std::borrow::Cow::Borrowed("COMMITMENT_3_YEAR_MONTHLY_PAYMENTS"),
-                4 => std::borrow::Cow::Borrowed("COMMITMENT_1_YEAR_UPFRONT_PAYMENT"),
-                5 => std::borrow::Cow::Borrowed("COMMITMENT_3_YEAR_UPFRONT_PAYMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMMITMENT_PLAN_UNSPECIFIED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::Commitment1YearMonthlyPayments => {
+                    std::option::Option::Some("COMMITMENT_1_YEAR_MONTHLY_PAYMENTS")
+                }
+                Self::Commitment3YearMonthlyPayments => {
+                    std::option::Option::Some("COMMITMENT_3_YEAR_MONTHLY_PAYMENTS")
+                }
+                Self::Commitment1YearUpfrontPayment => {
+                    std::option::Option::Some("COMMITMENT_1_YEAR_UPFRONT_PAYMENT")
+                }
+                Self::Commitment3YearUpfrontPayment => {
+                    std::option::Option::Some("COMMITMENT_3_YEAR_UPFRONT_PAYMENT")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMMITMENT_PLAN_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
-                }
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                "COMMITMENT_1_YEAR_MONTHLY_PAYMENTS" => {
-                    std::option::Option::Some(Self::COMMITMENT_1_YEAR_MONTHLY_PAYMENTS)
-                }
-                "COMMITMENT_3_YEAR_MONTHLY_PAYMENTS" => {
-                    std::option::Option::Some(Self::COMMITMENT_3_YEAR_MONTHLY_PAYMENTS)
-                }
-                "COMMITMENT_1_YEAR_UPFRONT_PAYMENT" => {
-                    std::option::Option::Some(Self::COMMITMENT_1_YEAR_UPFRONT_PAYMENT)
-                }
-                "COMMITMENT_3_YEAR_UPFRONT_PAYMENT" => {
-                    std::option::Option::Some(Self::COMMITMENT_3_YEAR_UPFRONT_PAYMENT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CommitmentPlan {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CommitmentPlan {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CommitmentPlan {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CommitmentPlan {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OnDemand,
+                2 => Self::Commitment1YearMonthlyPayments,
+                3 => Self::Commitment3YearMonthlyPayments,
+                4 => Self::Commitment1YearUpfrontPayment,
+                5 => Self::Commitment3YearUpfrontPayment,
+                _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CommitmentPlan {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMMITMENT_PLAN_UNSPECIFIED" => Self::Unspecified,
+                "ON_DEMAND" => Self::OnDemand,
+                "COMMITMENT_1_YEAR_MONTHLY_PAYMENTS" => Self::Commitment1YearMonthlyPayments,
+                "COMMITMENT_3_YEAR_MONTHLY_PAYMENTS" => Self::Commitment3YearMonthlyPayments,
+                "COMMITMENT_1_YEAR_UPFRONT_PAYMENT" => Self::Commitment1YearUpfrontPayment,
+                "COMMITMENT_3_YEAR_UPFRONT_PAYMENT" => Self::Commitment3YearUpfrontPayment,
+                _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CommitmentPlan {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OnDemand => serializer.serialize_i32(1),
+                Self::Commitment1YearMonthlyPayments => serializer.serialize_i32(2),
+                Self::Commitment3YearMonthlyPayments => serializer.serialize_i32(3),
+                Self::Commitment1YearUpfrontPayment => serializer.serialize_i32(4),
+                Self::Commitment3YearUpfrontPayment => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CommitmentPlan {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommitmentPlan>::new(
+                ".google.cloud.migrationcenter.v1.VmwareEnginePreferences.CommitmentPlan",
+            ))
         }
     }
 }
@@ -12399,142 +13706,258 @@ pub mod sole_tenancy_preferences {
     use super::*;
 
     /// Sole Tenancy nodes maintenance policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HostMaintenancePolicy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HostMaintenancePolicy {
+        /// Unspecified host maintenance policy.
+        Unspecified,
+        /// Default host maintenance policy.
+        Default,
+        /// Restart in place host maintenance policy.
+        RestartInPlace,
+        /// Migrate within node group host maintenance policy.
+        MigrateWithinNodeGroup,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HostMaintenancePolicy::value] or
+        /// [HostMaintenancePolicy::name].
+        UnknownValue(host_maintenance_policy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod host_maintenance_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HostMaintenancePolicy {
-        /// Unspecified host maintenance policy.
-        pub const HOST_MAINTENANCE_POLICY_UNSPECIFIED: HostMaintenancePolicy =
-            HostMaintenancePolicy::new(0);
-
-        /// Default host maintenance policy.
-        pub const HOST_MAINTENANCE_POLICY_DEFAULT: HostMaintenancePolicy =
-            HostMaintenancePolicy::new(1);
-
-        /// Restart in place host maintenance policy.
-        pub const HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE: HostMaintenancePolicy =
-            HostMaintenancePolicy::new(2);
-
-        /// Migrate within node group host maintenance policy.
-        pub const HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP: HostMaintenancePolicy =
-            HostMaintenancePolicy::new(3);
-
-        /// Creates a new HostMaintenancePolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::RestartInPlace => std::option::Option::Some(2),
+                Self::MigrateWithinNodeGroup => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE"),
-                3 => {
-                    std::borrow::Cow::Borrowed("HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP")
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("HOST_MAINTENANCE_POLICY_UNSPECIFIED")
                 }
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                Self::Default => std::option::Option::Some("HOST_MAINTENANCE_POLICY_DEFAULT"),
+                Self::RestartInPlace => {
+                    std::option::Option::Some("HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE")
+                }
+                Self::MigrateWithinNodeGroup => {
+                    std::option::Option::Some("HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HOST_MAINTENANCE_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HOST_MAINTENANCE_POLICY_UNSPECIFIED)
-                }
-                "HOST_MAINTENANCE_POLICY_DEFAULT" => {
-                    std::option::Option::Some(Self::HOST_MAINTENANCE_POLICY_DEFAULT)
-                }
-                "HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE" => {
-                    std::option::Option::Some(Self::HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE)
-                }
-                "HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP" => std::option::Option::Some(
-                    Self::HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP,
-                ),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HostMaintenancePolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HostMaintenancePolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HostMaintenancePolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HostMaintenancePolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::RestartInPlace,
+                3 => Self::MigrateWithinNodeGroup,
+                _ => Self::UnknownValue(host_maintenance_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HostMaintenancePolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HOST_MAINTENANCE_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "HOST_MAINTENANCE_POLICY_DEFAULT" => Self::Default,
+                "HOST_MAINTENANCE_POLICY_RESTART_IN_PLACE" => Self::RestartInPlace,
+                "HOST_MAINTENANCE_POLICY_MIGRATE_WITHIN_NODE_GROUP" => Self::MigrateWithinNodeGroup,
+                _ => Self::UnknownValue(host_maintenance_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HostMaintenancePolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::RestartInPlace => serializer.serialize_i32(2),
+                Self::MigrateWithinNodeGroup => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HostMaintenancePolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HostMaintenancePolicy>::new(
+                ".google.cloud.migrationcenter.v1.SoleTenancyPreferences.HostMaintenancePolicy",
+            ))
         }
     }
 
     /// Type of committed use discount.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommitmentPlan(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CommitmentPlan {
+        /// Unspecified commitment plan.
+        Unspecified,
+        /// No commitment plan (on-demand usage).
+        OnDemand,
+        /// 1 year commitment.
+        Commitment1Year,
+        /// 3 years commitment.
+        Commitment3Year,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CommitmentPlan::value] or
+        /// [CommitmentPlan::name].
+        UnknownValue(commitment_plan::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod commitment_plan {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CommitmentPlan {
-        /// Unspecified commitment plan.
-        pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
-
-        /// No commitment plan (on-demand usage).
-        pub const ON_DEMAND: CommitmentPlan = CommitmentPlan::new(1);
-
-        /// 1 year commitment.
-        pub const COMMITMENT_1_YEAR: CommitmentPlan = CommitmentPlan::new(2);
-
-        /// 3 years commitment.
-        pub const COMMITMENT_3_YEAR: CommitmentPlan = CommitmentPlan::new(3);
-
-        /// Creates a new CommitmentPlan instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OnDemand => std::option::Option::Some(1),
+                Self::Commitment1Year => std::option::Option::Some(2),
+                Self::Commitment3Year => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                2 => std::borrow::Cow::Borrowed("COMMITMENT_1_YEAR"),
-                3 => std::borrow::Cow::Borrowed("COMMITMENT_3_YEAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMMITMENT_PLAN_UNSPECIFIED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::Commitment1Year => std::option::Option::Some("COMMITMENT_1_YEAR"),
+                Self::Commitment3Year => std::option::Option::Some("COMMITMENT_3_YEAR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMMITMENT_PLAN_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
-                }
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                "COMMITMENT_1_YEAR" => std::option::Option::Some(Self::COMMITMENT_1_YEAR),
-                "COMMITMENT_3_YEAR" => std::option::Option::Some(Self::COMMITMENT_3_YEAR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CommitmentPlan {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CommitmentPlan {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CommitmentPlan {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CommitmentPlan {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OnDemand,
+                2 => Self::Commitment1Year,
+                3 => Self::Commitment3Year,
+                _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CommitmentPlan {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMMITMENT_PLAN_UNSPECIFIED" => Self::Unspecified,
+                "ON_DEMAND" => Self::OnDemand,
+                "COMMITMENT_1_YEAR" => Self::Commitment1Year,
+                "COMMITMENT_3_YEAR" => Self::Commitment3Year,
+                _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CommitmentPlan {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OnDemand => serializer.serialize_i32(1),
+                Self::Commitment1Year => serializer.serialize_i32(2),
+                Self::Commitment3Year => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CommitmentPlan {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommitmentPlan>::new(
+                ".google.cloud.migrationcenter.v1.SoleTenancyPreferences.CommitmentPlan",
+            ))
         }
     }
 }
@@ -13825,750 +15248,1409 @@ pub mod report_summary {
 
 /// Specifies the types of asset views that provide complete or partial details
 /// of an asset.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AssetView(i32);
-
-impl AssetView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AssetView {
     /// The asset view is not specified. The API displays the basic view by
     /// default.
-    pub const ASSET_VIEW_UNSPECIFIED: AssetView = AssetView::new(0);
-
+    Unspecified,
     /// The asset view includes only basic metadata of the asset.
-    pub const ASSET_VIEW_BASIC: AssetView = AssetView::new(1);
-
+    Basic,
     /// The asset view includes all the metadata of an asset and performance data.
-    pub const ASSET_VIEW_FULL: AssetView = AssetView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AssetView::value] or
+    /// [AssetView::name].
+    UnknownValue(asset_view::UnknownValue),
+}
 
-    /// Creates a new AssetView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod asset_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AssetView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ASSET_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ASSET_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("ASSET_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ASSET_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("ASSET_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("ASSET_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ASSET_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::ASSET_VIEW_UNSPECIFIED),
-            "ASSET_VIEW_BASIC" => std::option::Option::Some(Self::ASSET_VIEW_BASIC),
-            "ASSET_VIEW_FULL" => std::option::Option::Some(Self::ASSET_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AssetView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AssetView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AssetView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AssetView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(asset_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AssetView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ASSET_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "ASSET_VIEW_BASIC" => Self::Basic,
+            "ASSET_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(asset_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AssetView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AssetView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AssetView>::new(
+            ".google.cloud.migrationcenter.v1.AssetView",
+        ))
     }
 }
 
 /// Known categories of operating systems.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperatingSystemFamily(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperatingSystemFamily {
+    OsFamilyUnknown,
+    /// Microsoft Windows Server and Desktop.
+    OsFamilyWindows,
+    /// Various Linux flavors.
+    OsFamilyLinux,
+    /// Non-Linux Unix flavors.
+    OsFamilyUnix,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperatingSystemFamily::value] or
+    /// [OperatingSystemFamily::name].
+    UnknownValue(operating_system_family::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod operating_system_family {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl OperatingSystemFamily {
-    pub const OS_FAMILY_UNKNOWN: OperatingSystemFamily = OperatingSystemFamily::new(0);
-
-    /// Microsoft Windows Server and Desktop.
-    pub const OS_FAMILY_WINDOWS: OperatingSystemFamily = OperatingSystemFamily::new(1);
-
-    /// Various Linux flavors.
-    pub const OS_FAMILY_LINUX: OperatingSystemFamily = OperatingSystemFamily::new(2);
-
-    /// Non-Linux Unix flavors.
-    pub const OS_FAMILY_UNIX: OperatingSystemFamily = OperatingSystemFamily::new(3);
-
-    /// Creates a new OperatingSystemFamily instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::OsFamilyUnknown => std::option::Option::Some(0),
+            Self::OsFamilyWindows => std::option::Option::Some(1),
+            Self::OsFamilyLinux => std::option::Option::Some(2),
+            Self::OsFamilyUnix => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OS_FAMILY_UNKNOWN"),
-            1 => std::borrow::Cow::Borrowed("OS_FAMILY_WINDOWS"),
-            2 => std::borrow::Cow::Borrowed("OS_FAMILY_LINUX"),
-            3 => std::borrow::Cow::Borrowed("OS_FAMILY_UNIX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::OsFamilyUnknown => std::option::Option::Some("OS_FAMILY_UNKNOWN"),
+            Self::OsFamilyWindows => std::option::Option::Some("OS_FAMILY_WINDOWS"),
+            Self::OsFamilyLinux => std::option::Option::Some("OS_FAMILY_LINUX"),
+            Self::OsFamilyUnix => std::option::Option::Some("OS_FAMILY_UNIX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OS_FAMILY_UNKNOWN" => std::option::Option::Some(Self::OS_FAMILY_UNKNOWN),
-            "OS_FAMILY_WINDOWS" => std::option::Option::Some(Self::OS_FAMILY_WINDOWS),
-            "OS_FAMILY_LINUX" => std::option::Option::Some(Self::OS_FAMILY_LINUX),
-            "OS_FAMILY_UNIX" => std::option::Option::Some(Self::OS_FAMILY_UNIX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperatingSystemFamily {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperatingSystemFamily {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperatingSystemFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperatingSystemFamily {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::OsFamilyUnknown,
+            1 => Self::OsFamilyWindows,
+            2 => Self::OsFamilyLinux,
+            3 => Self::OsFamilyUnix,
+            _ => Self::UnknownValue(operating_system_family::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperatingSystemFamily {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OS_FAMILY_UNKNOWN" => Self::OsFamilyUnknown,
+            "OS_FAMILY_WINDOWS" => Self::OsFamilyWindows,
+            "OS_FAMILY_LINUX" => Self::OsFamilyLinux,
+            "OS_FAMILY_UNIX" => Self::OsFamilyUnix,
+            _ => Self::UnknownValue(operating_system_family::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperatingSystemFamily {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::OsFamilyUnknown => serializer.serialize_i32(0),
+            Self::OsFamilyWindows => serializer.serialize_i32(1),
+            Self::OsFamilyLinux => serializer.serialize_i32(2),
+            Self::OsFamilyUnix => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperatingSystemFamily {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperatingSystemFamily>::new(
+            ".google.cloud.migrationcenter.v1.OperatingSystemFamily",
+        ))
     }
 }
 
 /// Specifies the data formats supported by Migration Center.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportJobFormat(i32);
-
-impl ImportJobFormat {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ImportJobFormat {
     /// Default value.
-    pub const IMPORT_JOB_FORMAT_UNSPECIFIED: ImportJobFormat = ImportJobFormat::new(0);
-
+    Unspecified,
     /// RVTools format (XLSX).
-    pub const IMPORT_JOB_FORMAT_RVTOOLS_XLSX: ImportJobFormat = ImportJobFormat::new(1);
-
+    RvtoolsXlsx,
     /// RVTools format (CSV).
-    pub const IMPORT_JOB_FORMAT_RVTOOLS_CSV: ImportJobFormat = ImportJobFormat::new(2);
-
+    RvtoolsCsv,
     /// CSV format exported from AWS using the
     /// [AWS collection
     /// script][<https://github.com/GoogleCloudPlatform/aws-to-stratozone-export>].
-    pub const IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV: ImportJobFormat = ImportJobFormat::new(4);
-
+    ExportedAwsCsv,
     /// CSV format exported from Azure using the
     /// [Azure collection
     /// script][<https://github.com/GoogleCloudPlatform/azure-to-stratozone-export>].
-    pub const IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV: ImportJobFormat = ImportJobFormat::new(5);
-
+    ExportedAzureCsv,
     /// CSV format created manually and following the StratoZone format. For more
     /// information, see [Manually create and upload data
     /// tables][<https://cloud.google.com/migrate/stratozone/docs/import-data-portal>].
-    pub const IMPORT_JOB_FORMAT_STRATOZONE_CSV: ImportJobFormat = ImportJobFormat::new(6);
+    StratozoneCsv,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ImportJobFormat::value] or
+    /// [ImportJobFormat::name].
+    UnknownValue(import_job_format::UnknownValue),
+}
 
-    /// Creates a new ImportJobFormat instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod import_job_format {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ImportJobFormat {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RvtoolsXlsx => std::option::Option::Some(1),
+            Self::RvtoolsCsv => std::option::Option::Some(2),
+            Self::ExportedAwsCsv => std::option::Option::Some(4),
+            Self::ExportedAzureCsv => std::option::Option::Some(5),
+            Self::StratozoneCsv => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_RVTOOLS_XLSX"),
-            2 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_RVTOOLS_CSV"),
-            4 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV"),
-            5 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV"),
-            6 => std::borrow::Cow::Borrowed("IMPORT_JOB_FORMAT_STRATOZONE_CSV"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("IMPORT_JOB_FORMAT_UNSPECIFIED"),
+            Self::RvtoolsXlsx => std::option::Option::Some("IMPORT_JOB_FORMAT_RVTOOLS_XLSX"),
+            Self::RvtoolsCsv => std::option::Option::Some("IMPORT_JOB_FORMAT_RVTOOLS_CSV"),
+            Self::ExportedAwsCsv => std::option::Option::Some("IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV"),
+            Self::ExportedAzureCsv => {
+                std::option::Option::Some("IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV")
+            }
+            Self::StratozoneCsv => std::option::Option::Some("IMPORT_JOB_FORMAT_STRATOZONE_CSV"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IMPORT_JOB_FORMAT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_UNSPECIFIED)
-            }
-            "IMPORT_JOB_FORMAT_RVTOOLS_XLSX" => {
-                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_RVTOOLS_XLSX)
-            }
-            "IMPORT_JOB_FORMAT_RVTOOLS_CSV" => {
-                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_RVTOOLS_CSV)
-            }
-            "IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV" => {
-                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV)
-            }
-            "IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV" => {
-                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV)
-            }
-            "IMPORT_JOB_FORMAT_STRATOZONE_CSV" => {
-                std::option::Option::Some(Self::IMPORT_JOB_FORMAT_STRATOZONE_CSV)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ImportJobFormat {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportJobFormat {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ImportJobFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ImportJobFormat {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RvtoolsXlsx,
+            2 => Self::RvtoolsCsv,
+            4 => Self::ExportedAwsCsv,
+            5 => Self::ExportedAzureCsv,
+            6 => Self::StratozoneCsv,
+            _ => Self::UnknownValue(import_job_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ImportJobFormat {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IMPORT_JOB_FORMAT_UNSPECIFIED" => Self::Unspecified,
+            "IMPORT_JOB_FORMAT_RVTOOLS_XLSX" => Self::RvtoolsXlsx,
+            "IMPORT_JOB_FORMAT_RVTOOLS_CSV" => Self::RvtoolsCsv,
+            "IMPORT_JOB_FORMAT_EXPORTED_AWS_CSV" => Self::ExportedAwsCsv,
+            "IMPORT_JOB_FORMAT_EXPORTED_AZURE_CSV" => Self::ExportedAzureCsv,
+            "IMPORT_JOB_FORMAT_STRATOZONE_CSV" => Self::StratozoneCsv,
+            _ => Self::UnknownValue(import_job_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ImportJobFormat {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RvtoolsXlsx => serializer.serialize_i32(1),
+            Self::RvtoolsCsv => serializer.serialize_i32(2),
+            Self::ExportedAwsCsv => serializer.serialize_i32(4),
+            Self::ExportedAzureCsv => serializer.serialize_i32(5),
+            Self::StratozoneCsv => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ImportJobFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportJobFormat>::new(
+            ".google.cloud.migrationcenter.v1.ImportJobFormat",
+        ))
     }
 }
 
 /// Specifies the types of import job views that provide complete or partial
 /// details of an import job.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ImportJobView(i32);
-
-impl ImportJobView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ImportJobView {
     /// The import job view is not specified. The API displays the basic view by
     /// default.
-    pub const IMPORT_JOB_VIEW_UNSPECIFIED: ImportJobView = ImportJobView::new(0);
-
+    Unspecified,
     /// The import job view includes basic metadata of an import job.
     /// This view does not include payload information.
-    pub const IMPORT_JOB_VIEW_BASIC: ImportJobView = ImportJobView::new(1);
-
+    Basic,
     /// The import job view includes all metadata of an import job.
-    pub const IMPORT_JOB_VIEW_FULL: ImportJobView = ImportJobView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ImportJobView::value] or
+    /// [ImportJobView::name].
+    UnknownValue(import_job_view::UnknownValue),
+}
 
-    /// Creates a new ImportJobView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod import_job_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ImportJobView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IMPORT_JOB_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IMPORT_JOB_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("IMPORT_JOB_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("IMPORT_JOB_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("IMPORT_JOB_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("IMPORT_JOB_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IMPORT_JOB_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::IMPORT_JOB_VIEW_UNSPECIFIED)
-            }
-            "IMPORT_JOB_VIEW_BASIC" => std::option::Option::Some(Self::IMPORT_JOB_VIEW_BASIC),
-            "IMPORT_JOB_VIEW_FULL" => std::option::Option::Some(Self::IMPORT_JOB_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ImportJobView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ImportJobView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ImportJobView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ImportJobView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(import_job_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ImportJobView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IMPORT_JOB_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "IMPORT_JOB_VIEW_BASIC" => Self::Basic,
+            "IMPORT_JOB_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(import_job_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ImportJobView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ImportJobView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportJobView>::new(
+            ".google.cloud.migrationcenter.v1.ImportJobView",
+        ))
     }
 }
 
 /// ErrorFrameView can be specified in ErrorFrames List and Get requests to
 /// control the level of details that is returned for the original frame.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ErrorFrameView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorFrameView {
+    /// Value is unset. The system will fallback to the default value.
+    Unspecified,
+    /// Include basic frame data, but not the full contents.
+    Basic,
+    /// Include everything.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ErrorFrameView::value] or
+    /// [ErrorFrameView::name].
+    UnknownValue(error_frame_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod error_frame_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ErrorFrameView {
-    /// Value is unset. The system will fallback to the default value.
-    pub const ERROR_FRAME_VIEW_UNSPECIFIED: ErrorFrameView = ErrorFrameView::new(0);
-
-    /// Include basic frame data, but not the full contents.
-    pub const ERROR_FRAME_VIEW_BASIC: ErrorFrameView = ErrorFrameView::new(1);
-
-    /// Include everything.
-    pub const ERROR_FRAME_VIEW_FULL: ErrorFrameView = ErrorFrameView::new(2);
-
-    /// Creates a new ErrorFrameView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ERROR_FRAME_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ERROR_FRAME_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("ERROR_FRAME_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ERROR_FRAME_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("ERROR_FRAME_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("ERROR_FRAME_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ERROR_FRAME_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ERROR_FRAME_VIEW_UNSPECIFIED)
-            }
-            "ERROR_FRAME_VIEW_BASIC" => std::option::Option::Some(Self::ERROR_FRAME_VIEW_BASIC),
-            "ERROR_FRAME_VIEW_FULL" => std::option::Option::Some(Self::ERROR_FRAME_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ErrorFrameView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ErrorFrameView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ErrorFrameView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ErrorFrameView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(error_frame_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ErrorFrameView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ERROR_FRAME_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "ERROR_FRAME_VIEW_BASIC" => Self::Basic,
+            "ERROR_FRAME_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(error_frame_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ErrorFrameView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ErrorFrameView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorFrameView>::new(
+            ".google.cloud.migrationcenter.v1.ErrorFrameView",
+        ))
     }
 }
 
 /// The persistent disk (PD) types of Compute Engine virtual machines.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PersistentDiskType(i32);
-
-impl PersistentDiskType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PersistentDiskType {
     /// Unspecified (default value).
     /// Selecting this value allows the system to use any disk type according
     /// to reported usage. This a good value to start with.
-    pub const PERSISTENT_DISK_TYPE_UNSPECIFIED: PersistentDiskType = PersistentDiskType::new(0);
-
+    Unspecified,
     /// Standard HDD Persistent Disk.
-    pub const PERSISTENT_DISK_TYPE_STANDARD: PersistentDiskType = PersistentDiskType::new(1);
-
+    Standard,
     /// Balanced Persistent Disk.
-    pub const PERSISTENT_DISK_TYPE_BALANCED: PersistentDiskType = PersistentDiskType::new(2);
-
+    Balanced,
     /// SSD Persistent Disk.
-    pub const PERSISTENT_DISK_TYPE_SSD: PersistentDiskType = PersistentDiskType::new(3);
+    Ssd,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PersistentDiskType::value] or
+    /// [PersistentDiskType::name].
+    UnknownValue(persistent_disk_type::UnknownValue),
+}
 
-    /// Creates a new PersistentDiskType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod persistent_disk_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl PersistentDiskType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Standard => std::option::Option::Some(1),
+            Self::Balanced => std::option::Option::Some(2),
+            Self::Ssd => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_STANDARD"),
-            2 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_BALANCED"),
-            3 => std::borrow::Cow::Borrowed("PERSISTENT_DISK_TYPE_SSD"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PERSISTENT_DISK_TYPE_UNSPECIFIED"),
+            Self::Standard => std::option::Option::Some("PERSISTENT_DISK_TYPE_STANDARD"),
+            Self::Balanced => std::option::Option::Some("PERSISTENT_DISK_TYPE_BALANCED"),
+            Self::Ssd => std::option::Option::Some("PERSISTENT_DISK_TYPE_SSD"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PERSISTENT_DISK_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_UNSPECIFIED)
-            }
-            "PERSISTENT_DISK_TYPE_STANDARD" => {
-                std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_STANDARD)
-            }
-            "PERSISTENT_DISK_TYPE_BALANCED" => {
-                std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_BALANCED)
-            }
-            "PERSISTENT_DISK_TYPE_SSD" => std::option::Option::Some(Self::PERSISTENT_DISK_TYPE_SSD),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PersistentDiskType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PersistentDiskType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PersistentDiskType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PersistentDiskType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Standard,
+            2 => Self::Balanced,
+            3 => Self::Ssd,
+            _ => Self::UnknownValue(persistent_disk_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PersistentDiskType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PERSISTENT_DISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PERSISTENT_DISK_TYPE_STANDARD" => Self::Standard,
+            "PERSISTENT_DISK_TYPE_BALANCED" => Self::Balanced,
+            "PERSISTENT_DISK_TYPE_SSD" => Self::Ssd,
+            _ => Self::UnknownValue(persistent_disk_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PersistentDiskType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Standard => serializer.serialize_i32(1),
+            Self::Balanced => serializer.serialize_i32(2),
+            Self::Ssd => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PersistentDiskType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PersistentDiskType>::new(
+            ".google.cloud.migrationcenter.v1.PersistentDiskType",
+        ))
     }
 }
 
 /// The License type for premium images (RHEL, RHEL for SAP, SLES, SLES for SAP,
 /// Windows Server).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LicenseType(i32);
-
-impl LicenseType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LicenseType {
     /// Unspecified (default value).
-    pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
-
+    Unspecified,
     /// Default Google Cloud licensing plan. Licensing is charged per usage.
     /// This a good value to start with.
-    pub const LICENSE_TYPE_DEFAULT: LicenseType = LicenseType::new(1);
-
+    Default,
     /// Bring-your-own-license (BYOL) plan. User provides the OS license.
-    pub const LICENSE_TYPE_BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
+    BringYourOwnLicense,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LicenseType::value] or
+    /// [LicenseType::name].
+    UnknownValue(license_type::UnknownValue),
+}
 
-    /// Creates a new LicenseType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod license_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LicenseType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Default => std::option::Option::Some(1),
+            Self::BringYourOwnLicense => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LICENSE_TYPE_DEFAULT"),
-            2 => std::borrow::Cow::Borrowed("LICENSE_TYPE_BRING_YOUR_OWN_LICENSE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LICENSE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED),
-            "LICENSE_TYPE_DEFAULT" => std::option::Option::Some(Self::LICENSE_TYPE_DEFAULT),
-            "LICENSE_TYPE_BRING_YOUR_OWN_LICENSE" => {
-                std::option::Option::Some(Self::LICENSE_TYPE_BRING_YOUR_OWN_LICENSE)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LICENSE_TYPE_UNSPECIFIED"),
+            Self::Default => std::option::Option::Some("LICENSE_TYPE_DEFAULT"),
+            Self::BringYourOwnLicense => {
+                std::option::Option::Some("LICENSE_TYPE_BRING_YOUR_OWN_LICENSE")
             }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for LicenseType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LicenseType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LicenseType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LicenseType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Default,
+            2 => Self::BringYourOwnLicense,
+            _ => Self::UnknownValue(license_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LicenseType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LICENSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "LICENSE_TYPE_DEFAULT" => Self::Default,
+            "LICENSE_TYPE_BRING_YOUR_OWN_LICENSE" => Self::BringYourOwnLicense,
+            _ => Self::UnknownValue(license_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LicenseType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Default => serializer.serialize_i32(1),
+            Self::BringYourOwnLicense => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LicenseType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LicenseType>::new(
+            ".google.cloud.migrationcenter.v1.LicenseType",
+        ))
     }
 }
 
 /// The sizing optimization strategy preferences of a virtual machine. This
 /// strategy, in addition to actual usage data of the virtual machine, can help
 /// determine the recommended shape on the target platform.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SizingOptimizationStrategy(i32);
-
-impl SizingOptimizationStrategy {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SizingOptimizationStrategy {
     /// Unspecified (default value).
-    pub const SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new(0);
-
+    Unspecified,
     /// No optimization applied. Virtual machine sizing matches as closely as
     /// possible the machine shape on the source site, not considering any actual
     /// performance data.
-    pub const SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new(1);
-
+    SameAsSource,
     /// Virtual machine sizing will match the reported usage and shape, with some
     /// slack. This a good value to start with.
-    pub const SIZING_OPTIMIZATION_STRATEGY_MODERATE: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new(2);
-
+    Moderate,
     /// Virtual machine sizing will match the reported usage, with little slack.
     /// Using this option can help reduce costs.
-    pub const SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE: SizingOptimizationStrategy =
-        SizingOptimizationStrategy::new(3);
+    Aggressive,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SizingOptimizationStrategy::value] or
+    /// [SizingOptimizationStrategy::name].
+    UnknownValue(sizing_optimization_strategy::UnknownValue),
+}
 
-    /// Creates a new SizingOptimizationStrategy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod sizing_optimization_strategy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SizingOptimizationStrategy {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SameAsSource => std::option::Option::Some(1),
+            Self::Moderate => std::option::Option::Some(2),
+            Self::Aggressive => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE"),
-            2 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_MODERATE"),
-            3 => std::borrow::Cow::Borrowed("SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED")
+            }
+            Self::SameAsSource => {
+                std::option::Option::Some("SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE")
+            }
+            Self::Moderate => std::option::Option::Some("SIZING_OPTIMIZATION_STRATEGY_MODERATE"),
+            Self::Aggressive => {
+                std::option::Option::Some("SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED)
-            }
-            "SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE" => {
-                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE)
-            }
-            "SIZING_OPTIMIZATION_STRATEGY_MODERATE" => {
-                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_MODERATE)
-            }
-            "SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE" => {
-                std::option::Option::Some(Self::SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SizingOptimizationStrategy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SizingOptimizationStrategy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SizingOptimizationStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SizingOptimizationStrategy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::SameAsSource,
+            2 => Self::Moderate,
+            3 => Self::Aggressive,
+            _ => Self::UnknownValue(sizing_optimization_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SizingOptimizationStrategy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SIZING_OPTIMIZATION_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+            "SIZING_OPTIMIZATION_STRATEGY_SAME_AS_SOURCE" => Self::SameAsSource,
+            "SIZING_OPTIMIZATION_STRATEGY_MODERATE" => Self::Moderate,
+            "SIZING_OPTIMIZATION_STRATEGY_AGGRESSIVE" => Self::Aggressive,
+            _ => Self::UnknownValue(sizing_optimization_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SizingOptimizationStrategy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SameAsSource => serializer.serialize_i32(1),
+            Self::Moderate => serializer.serialize_i32(2),
+            Self::Aggressive => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SizingOptimizationStrategy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<SizingOptimizationStrategy>::new(
+                ".google.cloud.migrationcenter.v1.SizingOptimizationStrategy",
+            ),
+        )
     }
 }
 
 /// The plan of commitments for VM resource-based committed use discount (CUD).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CommitmentPlan(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CommitmentPlan {
+    /// Unspecified commitment plan.
+    Unspecified,
+    /// No commitment plan.
+    None,
+    /// 1 year commitment.
+    OneYear,
+    /// 3 years commitment.
+    ThreeYears,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CommitmentPlan::value] or
+    /// [CommitmentPlan::name].
+    UnknownValue(commitment_plan::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod commitment_plan {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CommitmentPlan {
-    /// Unspecified commitment plan.
-    pub const COMMITMENT_PLAN_UNSPECIFIED: CommitmentPlan = CommitmentPlan::new(0);
-
-    /// No commitment plan.
-    pub const COMMITMENT_PLAN_NONE: CommitmentPlan = CommitmentPlan::new(1);
-
-    /// 1 year commitment.
-    pub const COMMITMENT_PLAN_ONE_YEAR: CommitmentPlan = CommitmentPlan::new(2);
-
-    /// 3 years commitment.
-    pub const COMMITMENT_PLAN_THREE_YEARS: CommitmentPlan = CommitmentPlan::new(3);
-
-    /// Creates a new CommitmentPlan instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::None => std::option::Option::Some(1),
+            Self::OneYear => std::option::Option::Some(2),
+            Self::ThreeYears => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_NONE"),
-            2 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_ONE_YEAR"),
-            3 => std::borrow::Cow::Borrowed("COMMITMENT_PLAN_THREE_YEARS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMMITMENT_PLAN_UNSPECIFIED"),
+            Self::None => std::option::Option::Some("COMMITMENT_PLAN_NONE"),
+            Self::OneYear => std::option::Option::Some("COMMITMENT_PLAN_ONE_YEAR"),
+            Self::ThreeYears => std::option::Option::Some("COMMITMENT_PLAN_THREE_YEARS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMMITMENT_PLAN_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMMITMENT_PLAN_UNSPECIFIED)
-            }
-            "COMMITMENT_PLAN_NONE" => std::option::Option::Some(Self::COMMITMENT_PLAN_NONE),
-            "COMMITMENT_PLAN_ONE_YEAR" => std::option::Option::Some(Self::COMMITMENT_PLAN_ONE_YEAR),
-            "COMMITMENT_PLAN_THREE_YEARS" => {
-                std::option::Option::Some(Self::COMMITMENT_PLAN_THREE_YEARS)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CommitmentPlan {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CommitmentPlan {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CommitmentPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CommitmentPlan {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::None,
+            2 => Self::OneYear,
+            3 => Self::ThreeYears,
+            _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CommitmentPlan {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMMITMENT_PLAN_UNSPECIFIED" => Self::Unspecified,
+            "COMMITMENT_PLAN_NONE" => Self::None,
+            "COMMITMENT_PLAN_ONE_YEAR" => Self::OneYear,
+            "COMMITMENT_PLAN_THREE_YEARS" => Self::ThreeYears,
+            _ => Self::UnknownValue(commitment_plan::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CommitmentPlan {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::None => serializer.serialize_i32(1),
+            Self::OneYear => serializer.serialize_i32(2),
+            Self::ThreeYears => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CommitmentPlan {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommitmentPlan>::new(
+            ".google.cloud.migrationcenter.v1.CommitmentPlan",
+        ))
     }
 }
 
 /// The preference for a specific Google Cloud product platform.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComputeMigrationTargetProduct(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ComputeMigrationTargetProduct {
+    /// Unspecified (default value).
+    Unspecified,
+    /// Prefer to migrate to Google Cloud Compute Engine.
+    ComputeEngine,
+    /// Prefer to migrate to Google Cloud VMware Engine.
+    VmwareEngine,
+    /// Prefer to migrate to Google Cloud Sole Tenant Nodes.
+    SoleTenancy,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ComputeMigrationTargetProduct::value] or
+    /// [ComputeMigrationTargetProduct::name].
+    UnknownValue(compute_migration_target_product::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod compute_migration_target_product {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ComputeMigrationTargetProduct {
-    /// Unspecified (default value).
-    pub const COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new(0);
-
-    /// Prefer to migrate to Google Cloud Compute Engine.
-    pub const COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new(1);
-
-    /// Prefer to migrate to Google Cloud VMware Engine.
-    pub const COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new(2);
-
-    /// Prefer to migrate to Google Cloud Sole Tenant Nodes.
-    pub const COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY: ComputeMigrationTargetProduct =
-        ComputeMigrationTargetProduct::new(3);
-
-    /// Creates a new ComputeMigrationTargetProduct instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ComputeEngine => std::option::Option::Some(1),
+            Self::VmwareEngine => std::option::Option::Some(2),
+            Self::SoleTenancy => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE"),
-            2 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE"),
-            3 => std::borrow::Cow::Borrowed("COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED")
+            }
+            Self::ComputeEngine => {
+                std::option::Option::Some("COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE")
+            }
+            Self::VmwareEngine => {
+                std::option::Option::Some("COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE")
+            }
+            Self::SoleTenancy => {
+                std::option::Option::Some("COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED)
-            }
-            "COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE" => {
-                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE)
-            }
-            "COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE" => {
-                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE)
-            }
-            "COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY" => {
-                std::option::Option::Some(Self::COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ComputeMigrationTargetProduct {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ComputeMigrationTargetProduct {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ComputeMigrationTargetProduct {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ComputeMigrationTargetProduct {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ComputeEngine,
+            2 => Self::VmwareEngine,
+            3 => Self::SoleTenancy,
+            _ => Self::UnknownValue(compute_migration_target_product::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ComputeMigrationTargetProduct {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_UNSPECIFIED" => Self::Unspecified,
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_COMPUTE_ENGINE" => Self::ComputeEngine,
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_VMWARE_ENGINE" => Self::VmwareEngine,
+            "COMPUTE_MIGRATION_TARGET_PRODUCT_SOLE_TENANCY" => Self::SoleTenancy,
+            _ => Self::UnknownValue(compute_migration_target_product::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ComputeMigrationTargetProduct {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ComputeEngine => serializer.serialize_i32(1),
+            Self::VmwareEngine => serializer.serialize_i32(2),
+            Self::SoleTenancy => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ComputeMigrationTargetProduct {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<ComputeMigrationTargetProduct>::new(
+                ".google.cloud.migrationcenter.v1.ComputeMigrationTargetProduct",
+            ),
+        )
     }
 }
 
 /// Specifies the types of views that provide complete or partial details
 /// of a Report.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ReportView(i32);
-
-impl ReportView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ReportView {
     /// The report view is not specified. The API displays the basic view by
     /// default.
-    pub const REPORT_VIEW_UNSPECIFIED: ReportView = ReportView::new(0);
-
+    Unspecified,
     /// The report view includes only basic metadata of the Report. Useful for
     /// list views.
-    pub const REPORT_VIEW_BASIC: ReportView = ReportView::new(1);
-
+    Basic,
     /// The report view includes all the metadata of the Report. Useful for
     /// preview.
-    pub const REPORT_VIEW_FULL: ReportView = ReportView::new(2);
-
+    Full,
     /// The report view includes the standard metadata of an report. Useful for
     /// detail view.
-    pub const REPORT_VIEW_STANDARD: ReportView = ReportView::new(3);
+    Standard,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ReportView::value] or
+    /// [ReportView::name].
+    UnknownValue(report_view::UnknownValue),
+}
 
-    /// Creates a new ReportView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod report_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ReportView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::Standard => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REPORT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("REPORT_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("REPORT_VIEW_FULL"),
-            3 => std::borrow::Cow::Borrowed("REPORT_VIEW_STANDARD"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("REPORT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("REPORT_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("REPORT_VIEW_FULL"),
+            Self::Standard => std::option::Option::Some("REPORT_VIEW_STANDARD"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REPORT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::REPORT_VIEW_UNSPECIFIED),
-            "REPORT_VIEW_BASIC" => std::option::Option::Some(Self::REPORT_VIEW_BASIC),
-            "REPORT_VIEW_FULL" => std::option::Option::Some(Self::REPORT_VIEW_FULL),
-            "REPORT_VIEW_STANDARD" => std::option::Option::Some(Self::REPORT_VIEW_STANDARD),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ReportView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ReportView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ReportView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ReportView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            3 => Self::Standard,
+            _ => Self::UnknownValue(report_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ReportView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REPORT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "REPORT_VIEW_BASIC" => Self::Basic,
+            "REPORT_VIEW_FULL" => Self::Full,
+            "REPORT_VIEW_STANDARD" => Self::Standard,
+            _ => Self::UnknownValue(report_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ReportView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::Standard => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ReportView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReportView>::new(
+            ".google.cloud.migrationcenter.v1.ReportView",
+        ))
     }
 }

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -58,7 +58,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -78,7 +78,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -272,7 +272,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -292,7 +292,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -650,7 +650,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -670,7 +670,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1090,7 +1090,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1114,7 +1114,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -967,64 +967,121 @@ pub mod pi_and_jailbreak_filter_settings {
 
     /// Option to specify the state of Prompt Injection and Jailbreak filter
     /// (ENABLED/DISABLED).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PiAndJailbreakFilterEnforcement(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PiAndJailbreakFilterEnforcement {
+        /// Same as Disabled
+        Unspecified,
+        /// Enabled
+        Enabled,
+        /// Enabled
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PiAndJailbreakFilterEnforcement::value] or
+        /// [PiAndJailbreakFilterEnforcement::name].
+        UnknownValue(pi_and_jailbreak_filter_enforcement::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod pi_and_jailbreak_filter_enforcement {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PiAndJailbreakFilterEnforcement {
-        /// Same as Disabled
-        pub const PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED: PiAndJailbreakFilterEnforcement =
-            PiAndJailbreakFilterEnforcement::new(0);
-
-        /// Enabled
-        pub const ENABLED: PiAndJailbreakFilterEnforcement =
-            PiAndJailbreakFilterEnforcement::new(1);
-
-        /// Enabled
-        pub const DISABLED: PiAndJailbreakFilterEnforcement =
-            PiAndJailbreakFilterEnforcement::new(2);
-
-        /// Creates a new PiAndJailbreakFilterEnforcement instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED")
                 }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PiAndJailbreakFilterEnforcement {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PiAndJailbreakFilterEnforcement {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PiAndJailbreakFilterEnforcement {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PiAndJailbreakFilterEnforcement {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(pi_and_jailbreak_filter_enforcement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PiAndJailbreakFilterEnforcement {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PI_AND_JAILBREAK_FILTER_ENFORCEMENT_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(pi_and_jailbreak_filter_enforcement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PiAndJailbreakFilterEnforcement {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PiAndJailbreakFilterEnforcement {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PiAndJailbreakFilterEnforcement>::new(
+                ".google.cloud.modelarmor.v1.PiAndJailbreakFilterSettings.PiAndJailbreakFilterEnforcement"))
         }
     }
 }
@@ -1074,62 +1131,121 @@ pub mod malicious_uri_filter_settings {
     use super::*;
 
     /// Option to specify the state of Malicious URI filter (ENABLED/DISABLED).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MaliciousUriFilterEnforcement(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MaliciousUriFilterEnforcement {
+        /// Same as Disabled
+        Unspecified,
+        /// Enabled
+        Enabled,
+        /// Disabled
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MaliciousUriFilterEnforcement::value] or
+        /// [MaliciousUriFilterEnforcement::name].
+        UnknownValue(malicious_uri_filter_enforcement::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod malicious_uri_filter_enforcement {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MaliciousUriFilterEnforcement {
-        /// Same as Disabled
-        pub const MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED: MaliciousUriFilterEnforcement =
-            MaliciousUriFilterEnforcement::new(0);
-
-        /// Enabled
-        pub const ENABLED: MaliciousUriFilterEnforcement = MaliciousUriFilterEnforcement::new(1);
-
-        /// Disabled
-        pub const DISABLED: MaliciousUriFilterEnforcement = MaliciousUriFilterEnforcement::new(2);
-
-        /// Creates a new MaliciousUriFilterEnforcement instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED")
                 }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for MaliciousUriFilterEnforcement {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MaliciousUriFilterEnforcement {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MaliciousUriFilterEnforcement {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MaliciousUriFilterEnforcement {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(malicious_uri_filter_enforcement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MaliciousUriFilterEnforcement {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MALICIOUS_URI_FILTER_ENFORCEMENT_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(malicious_uri_filter_enforcement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MaliciousUriFilterEnforcement {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MaliciousUriFilterEnforcement {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MaliciousUriFilterEnforcement>::new(
+                ".google.cloud.modelarmor.v1.MaliciousUriFilterSettings.MaliciousUriFilterEnforcement"))
         }
     }
 }
@@ -1402,62 +1518,124 @@ pub mod sdp_basic_config {
 
     /// Option to specify the state of Sensitive Data Protection basic config
     /// (ENABLED/DISABLED).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SdpBasicConfigEnforcement(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SdpBasicConfigEnforcement {
+        /// Same as Disabled
+        Unspecified,
+        /// Enabled
+        Enabled,
+        /// Disabled
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SdpBasicConfigEnforcement::value] or
+        /// [SdpBasicConfigEnforcement::name].
+        UnknownValue(sdp_basic_config_enforcement::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sdp_basic_config_enforcement {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SdpBasicConfigEnforcement {
-        /// Same as Disabled
-        pub const SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED: SdpBasicConfigEnforcement =
-            SdpBasicConfigEnforcement::new(0);
-
-        /// Enabled
-        pub const ENABLED: SdpBasicConfigEnforcement = SdpBasicConfigEnforcement::new(1);
-
-        /// Disabled
-        pub const DISABLED: SdpBasicConfigEnforcement = SdpBasicConfigEnforcement::new(2);
-
-        /// Creates a new SdpBasicConfigEnforcement instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED")
                 }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SdpBasicConfigEnforcement {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SdpBasicConfigEnforcement {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SdpBasicConfigEnforcement {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SdpBasicConfigEnforcement {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(sdp_basic_config_enforcement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SdpBasicConfigEnforcement {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SDP_BASIC_CONFIG_ENFORCEMENT_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(sdp_basic_config_enforcement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SdpBasicConfigEnforcement {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SdpBasicConfigEnforcement {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<SdpBasicConfigEnforcement>::new(
+                    ".google.cloud.modelarmor.v1.SdpBasicConfig.SdpBasicConfigEnforcement",
+                ),
+            )
         }
     }
 }
@@ -2639,61 +2817,120 @@ pub mod byte_data_item {
     use super::*;
 
     /// Option to specify the type of byte data.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ByteItemType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ByteItemType {
+        /// Unused
+        Unspecified,
+        /// plain text
+        PlaintextUtf8,
+        /// PDF
+        Pdf,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ByteItemType::value] or
+        /// [ByteItemType::name].
+        UnknownValue(byte_item_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod byte_item_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ByteItemType {
-        /// Unused
-        pub const BYTE_ITEM_TYPE_UNSPECIFIED: ByteItemType = ByteItemType::new(0);
-
-        /// plain text
-        pub const PLAINTEXT_UTF8: ByteItemType = ByteItemType::new(1);
-
-        /// PDF
-        pub const PDF: ByteItemType = ByteItemType::new(2);
-
-        /// Creates a new ByteItemType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PlaintextUtf8 => std::option::Option::Some(1),
+                Self::Pdf => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BYTE_ITEM_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PLAINTEXT_UTF8"),
-                2 => std::borrow::Cow::Borrowed("PDF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BYTE_ITEM_TYPE_UNSPECIFIED"),
+                Self::PlaintextUtf8 => std::option::Option::Some("PLAINTEXT_UTF8"),
+                Self::Pdf => std::option::Option::Some("PDF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BYTE_ITEM_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BYTE_ITEM_TYPE_UNSPECIFIED)
-                }
-                "PLAINTEXT_UTF8" => std::option::Option::Some(Self::PLAINTEXT_UTF8),
-                "PDF" => std::option::Option::Some(Self::PDF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ByteItemType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ByteItemType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ByteItemType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ByteItemType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PlaintextUtf8,
+                2 => Self::Pdf,
+                _ => Self::UnknownValue(byte_item_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ByteItemType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BYTE_ITEM_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PLAINTEXT_UTF8" => Self::PlaintextUtf8,
+                "PDF" => Self::Pdf,
+                _ => Self::UnknownValue(byte_item_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ByteItemType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PlaintextUtf8 => serializer.serialize_i32(1),
+                Self::Pdf => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ByteItemType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ByteItemType>::new(
+                ".google.cloud.modelarmor.v1.ByteDataItem.ByteItemType",
+            ))
         }
     }
 }
@@ -3255,67 +3492,128 @@ pub mod virus_scan_filter_result {
     use super::*;
 
     /// Type of content scanned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ScannedContentType(i32);
-
-    impl ScannedContentType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ScannedContentType {
         /// Unused
-        pub const SCANNED_CONTENT_TYPE_UNSPECIFIED: ScannedContentType = ScannedContentType::new(0);
-
+        Unspecified,
         /// Unknown content
-        pub const UNKNOWN: ScannedContentType = ScannedContentType::new(1);
-
+        Unknown,
         /// Plaintext
-        pub const PLAINTEXT: ScannedContentType = ScannedContentType::new(2);
-
+        Plaintext,
         /// PDF
         /// Scanning for only PDF is supported.
-        pub const PDF: ScannedContentType = ScannedContentType::new(3);
+        Pdf,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ScannedContentType::value] or
+        /// [ScannedContentType::name].
+        UnknownValue(scanned_content_type::UnknownValue),
+    }
 
-        /// Creates a new ScannedContentType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod scanned_content_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ScannedContentType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unknown => std::option::Option::Some(1),
+                Self::Plaintext => std::option::Option::Some(2),
+                Self::Pdf => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCANNED_CONTENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                2 => std::borrow::Cow::Borrowed("PLAINTEXT"),
-                3 => std::borrow::Cow::Borrowed("PDF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCANNED_CONTENT_TYPE_UNSPECIFIED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Plaintext => std::option::Option::Some("PLAINTEXT"),
+                Self::Pdf => std::option::Option::Some("PDF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCANNED_CONTENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SCANNED_CONTENT_TYPE_UNSPECIFIED)
-                }
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "PLAINTEXT" => std::option::Option::Some(Self::PLAINTEXT),
-                "PDF" => std::option::Option::Some(Self::PDF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ScannedContentType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ScannedContentType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ScannedContentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ScannedContentType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unknown,
+                2 => Self::Plaintext,
+                3 => Self::Pdf,
+                _ => Self::UnknownValue(scanned_content_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ScannedContentType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCANNED_CONTENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN" => Self::Unknown,
+                "PLAINTEXT" => Self::Plaintext,
+                "PDF" => Self::Pdf,
+                _ => Self::UnknownValue(scanned_content_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ScannedContentType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unknown => serializer.serialize_i32(1),
+                Self::Plaintext => serializer.serialize_i32(2),
+                Self::Pdf => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ScannedContentType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ScannedContentType>::new(
+                ".google.cloud.modelarmor.v1.VirusScanFilterResult.ScannedContentType",
+            ))
         }
     }
 }
@@ -3385,80 +3683,145 @@ pub mod virus_detail {
     use super::*;
 
     /// Defines all the threat types of a virus
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ThreatType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ThreatType {
+        /// Unused
+        Unspecified,
+        /// Unable to categorize threat
+        Unknown,
+        /// Virus or Worm threat.
+        VirusOrWorm,
+        /// Malicious program. E.g. Spyware, Trojan.
+        MaliciousProgram,
+        /// Potentially harmful content. E.g. Injected code, Macro
+        PotentiallyHarmfulContent,
+        /// Potentially unwanted content. E.g. Adware.
+        PotentiallyUnwantedContent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ThreatType::value] or
+        /// [ThreatType::name].
+        UnknownValue(threat_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod threat_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ThreatType {
-        /// Unused
-        pub const THREAT_TYPE_UNSPECIFIED: ThreatType = ThreatType::new(0);
-
-        /// Unable to categorize threat
-        pub const UNKNOWN: ThreatType = ThreatType::new(1);
-
-        /// Virus or Worm threat.
-        pub const VIRUS_OR_WORM: ThreatType = ThreatType::new(2);
-
-        /// Malicious program. E.g. Spyware, Trojan.
-        pub const MALICIOUS_PROGRAM: ThreatType = ThreatType::new(3);
-
-        /// Potentially harmful content. E.g. Injected code, Macro
-        pub const POTENTIALLY_HARMFUL_CONTENT: ThreatType = ThreatType::new(4);
-
-        /// Potentially unwanted content. E.g. Adware.
-        pub const POTENTIALLY_UNWANTED_CONTENT: ThreatType = ThreatType::new(5);
-
-        /// Creates a new ThreatType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unknown => std::option::Option::Some(1),
+                Self::VirusOrWorm => std::option::Option::Some(2),
+                Self::MaliciousProgram => std::option::Option::Some(3),
+                Self::PotentiallyHarmfulContent => std::option::Option::Some(4),
+                Self::PotentiallyUnwantedContent => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("THREAT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                2 => std::borrow::Cow::Borrowed("VIRUS_OR_WORM"),
-                3 => std::borrow::Cow::Borrowed("MALICIOUS_PROGRAM"),
-                4 => std::borrow::Cow::Borrowed("POTENTIALLY_HARMFUL_CONTENT"),
-                5 => std::borrow::Cow::Borrowed("POTENTIALLY_UNWANTED_CONTENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("THREAT_TYPE_UNSPECIFIED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::VirusOrWorm => std::option::Option::Some("VIRUS_OR_WORM"),
+                Self::MaliciousProgram => std::option::Option::Some("MALICIOUS_PROGRAM"),
+                Self::PotentiallyHarmfulContent => {
+                    std::option::Option::Some("POTENTIALLY_HARMFUL_CONTENT")
+                }
+                Self::PotentiallyUnwantedContent => {
+                    std::option::Option::Some("POTENTIALLY_UNWANTED_CONTENT")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "THREAT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::THREAT_TYPE_UNSPECIFIED)
-                }
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "VIRUS_OR_WORM" => std::option::Option::Some(Self::VIRUS_OR_WORM),
-                "MALICIOUS_PROGRAM" => std::option::Option::Some(Self::MALICIOUS_PROGRAM),
-                "POTENTIALLY_HARMFUL_CONTENT" => {
-                    std::option::Option::Some(Self::POTENTIALLY_HARMFUL_CONTENT)
-                }
-                "POTENTIALLY_UNWANTED_CONTENT" => {
-                    std::option::Option::Some(Self::POTENTIALLY_UNWANTED_CONTENT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ThreatType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ThreatType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ThreatType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ThreatType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unknown,
+                2 => Self::VirusOrWorm,
+                3 => Self::MaliciousProgram,
+                4 => Self::PotentiallyHarmfulContent,
+                5 => Self::PotentiallyUnwantedContent,
+                _ => Self::UnknownValue(threat_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ThreatType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "THREAT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN" => Self::Unknown,
+                "VIRUS_OR_WORM" => Self::VirusOrWorm,
+                "MALICIOUS_PROGRAM" => Self::MaliciousProgram,
+                "POTENTIALLY_HARMFUL_CONTENT" => Self::PotentiallyHarmfulContent,
+                "POTENTIALLY_UNWANTED_CONTENT" => Self::PotentiallyUnwantedContent,
+                _ => Self::UnknownValue(threat_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ThreatType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unknown => serializer.serialize_i32(1),
+                Self::VirusOrWorm => serializer.serialize_i32(2),
+                Self::MaliciousProgram => serializer.serialize_i32(3),
+                Self::PotentiallyHarmfulContent => serializer.serialize_i32(4),
+                Self::PotentiallyUnwantedContent => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ThreatType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ThreatType>::new(
+                ".google.cloud.modelarmor.v1.VirusDetail.ThreatType",
+            ))
         }
     }
 }
@@ -3578,66 +3941,127 @@ pub mod message_item {
     use super::*;
 
     /// Option to specify the type of message.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MessageType {
+        /// Unused
+        Unspecified,
+        /// Information related message.
+        Info,
+        /// Warning related message.
+        Warning,
+        /// Error message.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MessageType::value] or
+        /// [MessageType::name].
+        UnknownValue(message_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod message_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MessageType {
-        /// Unused
-        pub const MESSAGE_TYPE_UNSPECIFIED: MessageType = MessageType::new(0);
-
-        /// Information related message.
-        pub const INFO: MessageType = MessageType::new(1);
-
-        /// Warning related message.
-        pub const WARNING: MessageType = MessageType::new(2);
-
-        /// Error message.
-        pub const ERROR: MessageType = MessageType::new(3);
-
-        /// Creates a new MessageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Info => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Error => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MESSAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INFO"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MESSAGE_TYPE_UNSPECIFIED"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MESSAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MESSAGE_TYPE_UNSPECIFIED)
-                }
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MessageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MessageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MessageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Info,
+                2 => Self::Warning,
+                3 => Self::Error,
+                _ => Self::UnknownValue(message_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MessageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MESSAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INFO" => Self::Info,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(message_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MessageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Info => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Error => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MessageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MessageType>::new(
+                ".google.cloud.modelarmor.v1.MessageItem.MessageType",
+            ))
         }
     }
 }
@@ -3689,398 +4113,765 @@ impl wkt::message::Message for RangeInfo {
 }
 
 /// Option to specify filter match state.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FilterMatchState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FilterMatchState {
+    /// Unused
+    Unspecified,
+    /// Matching criteria is not achieved for filters.
+    NoMatchFound,
+    /// Matching criteria is achieved for the filter.
+    MatchFound,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FilterMatchState::value] or
+    /// [FilterMatchState::name].
+    UnknownValue(filter_match_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod filter_match_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl FilterMatchState {
-    /// Unused
-    pub const FILTER_MATCH_STATE_UNSPECIFIED: FilterMatchState = FilterMatchState::new(0);
-
-    /// Matching criteria is not achieved for filters.
-    pub const NO_MATCH_FOUND: FilterMatchState = FilterMatchState::new(1);
-
-    /// Matching criteria is achieved for the filter.
-    pub const MATCH_FOUND: FilterMatchState = FilterMatchState::new(2);
-
-    /// Creates a new FilterMatchState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NoMatchFound => std::option::Option::Some(1),
+            Self::MatchFound => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FILTER_MATCH_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NO_MATCH_FOUND"),
-            2 => std::borrow::Cow::Borrowed("MATCH_FOUND"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FILTER_MATCH_STATE_UNSPECIFIED"),
+            Self::NoMatchFound => std::option::Option::Some("NO_MATCH_FOUND"),
+            Self::MatchFound => std::option::Option::Some("MATCH_FOUND"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FILTER_MATCH_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FILTER_MATCH_STATE_UNSPECIFIED)
-            }
-            "NO_MATCH_FOUND" => std::option::Option::Some(Self::NO_MATCH_FOUND),
-            "MATCH_FOUND" => std::option::Option::Some(Self::MATCH_FOUND),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FilterMatchState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FilterMatchState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FilterMatchState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FilterMatchState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NoMatchFound,
+            2 => Self::MatchFound,
+            _ => Self::UnknownValue(filter_match_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FilterMatchState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FILTER_MATCH_STATE_UNSPECIFIED" => Self::Unspecified,
+            "NO_MATCH_FOUND" => Self::NoMatchFound,
+            "MATCH_FOUND" => Self::MatchFound,
+            _ => Self::UnknownValue(filter_match_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FilterMatchState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NoMatchFound => serializer.serialize_i32(1),
+            Self::MatchFound => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FilterMatchState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FilterMatchState>::new(
+            ".google.cloud.modelarmor.v1.FilterMatchState",
+        ))
     }
 }
 
 /// Enum which reports whether a specific filter executed successfully or not.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FilterExecutionState(i32);
-
-impl FilterExecutionState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FilterExecutionState {
     /// Unused
-    pub const FILTER_EXECUTION_STATE_UNSPECIFIED: FilterExecutionState =
-        FilterExecutionState::new(0);
-
+    Unspecified,
     /// Filter executed successfully
-    pub const EXECUTION_SUCCESS: FilterExecutionState = FilterExecutionState::new(1);
-
+    ExecutionSuccess,
     /// Filter execution was skipped. This can happen due to server-side error
     /// or permission issue.
-    pub const EXECUTION_SKIPPED: FilterExecutionState = FilterExecutionState::new(2);
+    ExecutionSkipped,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FilterExecutionState::value] or
+    /// [FilterExecutionState::name].
+    UnknownValue(filter_execution_state::UnknownValue),
+}
 
-    /// Creates a new FilterExecutionState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod filter_execution_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl FilterExecutionState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ExecutionSuccess => std::option::Option::Some(1),
+            Self::ExecutionSkipped => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FILTER_EXECUTION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EXECUTION_SUCCESS"),
-            2 => std::borrow::Cow::Borrowed("EXECUTION_SKIPPED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FILTER_EXECUTION_STATE_UNSPECIFIED"),
+            Self::ExecutionSuccess => std::option::Option::Some("EXECUTION_SUCCESS"),
+            Self::ExecutionSkipped => std::option::Option::Some("EXECUTION_SKIPPED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FILTER_EXECUTION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FILTER_EXECUTION_STATE_UNSPECIFIED)
-            }
-            "EXECUTION_SUCCESS" => std::option::Option::Some(Self::EXECUTION_SUCCESS),
-            "EXECUTION_SKIPPED" => std::option::Option::Some(Self::EXECUTION_SKIPPED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FilterExecutionState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FilterExecutionState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FilterExecutionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FilterExecutionState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ExecutionSuccess,
+            2 => Self::ExecutionSkipped,
+            _ => Self::UnknownValue(filter_execution_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FilterExecutionState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FILTER_EXECUTION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "EXECUTION_SUCCESS" => Self::ExecutionSuccess,
+            "EXECUTION_SKIPPED" => Self::ExecutionSkipped,
+            _ => Self::UnknownValue(filter_execution_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FilterExecutionState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ExecutionSuccess => serializer.serialize_i32(1),
+            Self::ExecutionSkipped => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FilterExecutionState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FilterExecutionState>::new(
+            ".google.cloud.modelarmor.v1.FilterExecutionState",
+        ))
     }
 }
 
 /// Options for responsible AI Filter Types.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RaiFilterType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RaiFilterType {
+    /// Unspecified filter type.
+    Unspecified,
+    /// Sexually Explicit.
+    SexuallyExplicit,
+    /// Hate Speech.
+    HateSpeech,
+    /// Harassment.
+    Harassment,
+    /// Danger
+    Dangerous,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RaiFilterType::value] or
+    /// [RaiFilterType::name].
+    UnknownValue(rai_filter_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod rai_filter_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RaiFilterType {
-    /// Unspecified filter type.
-    pub const RAI_FILTER_TYPE_UNSPECIFIED: RaiFilterType = RaiFilterType::new(0);
-
-    /// Sexually Explicit.
-    pub const SEXUALLY_EXPLICIT: RaiFilterType = RaiFilterType::new(2);
-
-    /// Hate Speech.
-    pub const HATE_SPEECH: RaiFilterType = RaiFilterType::new(3);
-
-    /// Harassment.
-    pub const HARASSMENT: RaiFilterType = RaiFilterType::new(6);
-
-    /// Danger
-    pub const DANGEROUS: RaiFilterType = RaiFilterType::new(17);
-
-    /// Creates a new RaiFilterType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SexuallyExplicit => std::option::Option::Some(2),
+            Self::HateSpeech => std::option::Option::Some(3),
+            Self::Harassment => std::option::Option::Some(6),
+            Self::Dangerous => std::option::Option::Some(17),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RAI_FILTER_TYPE_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("SEXUALLY_EXPLICIT"),
-            3 => std::borrow::Cow::Borrowed("HATE_SPEECH"),
-            6 => std::borrow::Cow::Borrowed("HARASSMENT"),
-            17 => std::borrow::Cow::Borrowed("DANGEROUS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RAI_FILTER_TYPE_UNSPECIFIED"),
+            Self::SexuallyExplicit => std::option::Option::Some("SEXUALLY_EXPLICIT"),
+            Self::HateSpeech => std::option::Option::Some("HATE_SPEECH"),
+            Self::Harassment => std::option::Option::Some("HARASSMENT"),
+            Self::Dangerous => std::option::Option::Some("DANGEROUS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RAI_FILTER_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RAI_FILTER_TYPE_UNSPECIFIED)
-            }
-            "SEXUALLY_EXPLICIT" => std::option::Option::Some(Self::SEXUALLY_EXPLICIT),
-            "HATE_SPEECH" => std::option::Option::Some(Self::HATE_SPEECH),
-            "HARASSMENT" => std::option::Option::Some(Self::HARASSMENT),
-            "DANGEROUS" => std::option::Option::Some(Self::DANGEROUS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RaiFilterType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RaiFilterType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RaiFilterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RaiFilterType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::SexuallyExplicit,
+            3 => Self::HateSpeech,
+            6 => Self::Harassment,
+            17 => Self::Dangerous,
+            _ => Self::UnknownValue(rai_filter_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RaiFilterType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RAI_FILTER_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SEXUALLY_EXPLICIT" => Self::SexuallyExplicit,
+            "HATE_SPEECH" => Self::HateSpeech,
+            "HARASSMENT" => Self::Harassment,
+            "DANGEROUS" => Self::Dangerous,
+            _ => Self::UnknownValue(rai_filter_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RaiFilterType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SexuallyExplicit => serializer.serialize_i32(2),
+            Self::HateSpeech => serializer.serialize_i32(3),
+            Self::Harassment => serializer.serialize_i32(6),
+            Self::Dangerous => serializer.serialize_i32(17),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RaiFilterType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RaiFilterType>::new(
+            ".google.cloud.modelarmor.v1.RaiFilterType",
+        ))
     }
 }
 
 /// Confidence levels for detectors.
 /// Higher value maps to a greater confidence level. To enforce stricter level a
 /// lower value should be used.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DetectionConfidenceLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DetectionConfidenceLevel {
+    /// Same as MEDIUM_AND_ABOVE.
+    Unspecified,
+    /// Highest chance of a false positive.
+    LowAndAbove,
+    /// Some chance of false positives.
+    MediumAndAbove,
+    /// Low chance of false positives.
+    High,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DetectionConfidenceLevel::value] or
+    /// [DetectionConfidenceLevel::name].
+    UnknownValue(detection_confidence_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod detection_confidence_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DetectionConfidenceLevel {
-    /// Same as MEDIUM_AND_ABOVE.
-    pub const DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED: DetectionConfidenceLevel =
-        DetectionConfidenceLevel::new(0);
-
-    /// Highest chance of a false positive.
-    pub const LOW_AND_ABOVE: DetectionConfidenceLevel = DetectionConfidenceLevel::new(1);
-
-    /// Some chance of false positives.
-    pub const MEDIUM_AND_ABOVE: DetectionConfidenceLevel = DetectionConfidenceLevel::new(2);
-
-    /// Low chance of false positives.
-    pub const HIGH: DetectionConfidenceLevel = DetectionConfidenceLevel::new(3);
-
-    /// Creates a new DetectionConfidenceLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::LowAndAbove => std::option::Option::Some(1),
+            Self::MediumAndAbove => std::option::Option::Some(2),
+            Self::High => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LOW_AND_ABOVE"),
-            2 => std::borrow::Cow::Borrowed("MEDIUM_AND_ABOVE"),
-            3 => std::borrow::Cow::Borrowed("HIGH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED")
             }
-            "LOW_AND_ABOVE" => std::option::Option::Some(Self::LOW_AND_ABOVE),
-            "MEDIUM_AND_ABOVE" => std::option::Option::Some(Self::MEDIUM_AND_ABOVE),
-            "HIGH" => std::option::Option::Some(Self::HIGH),
-            _ => std::option::Option::None,
+            Self::LowAndAbove => std::option::Option::Some("LOW_AND_ABOVE"),
+            Self::MediumAndAbove => std::option::Option::Some("MEDIUM_AND_ABOVE"),
+            Self::High => std::option::Option::Some("HIGH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for DetectionConfidenceLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DetectionConfidenceLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DetectionConfidenceLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DetectionConfidenceLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::LowAndAbove,
+            2 => Self::MediumAndAbove,
+            3 => Self::High,
+            _ => Self::UnknownValue(detection_confidence_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DetectionConfidenceLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DETECTION_CONFIDENCE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "LOW_AND_ABOVE" => Self::LowAndAbove,
+            "MEDIUM_AND_ABOVE" => Self::MediumAndAbove,
+            "HIGH" => Self::High,
+            _ => Self::UnknownValue(detection_confidence_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DetectionConfidenceLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::LowAndAbove => serializer.serialize_i32(1),
+            Self::MediumAndAbove => serializer.serialize_i32(2),
+            Self::High => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DetectionConfidenceLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DetectionConfidenceLevel>::new(
+            ".google.cloud.modelarmor.v1.DetectionConfidenceLevel",
+        ))
     }
 }
 
 /// For more information about each Sensitive Data Protection likelihood level,
 /// see <https://cloud.google.com/sensitive-data-protection/docs/likelihood>.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SdpFindingLikelihood(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SdpFindingLikelihood {
+    /// Default value; same as POSSIBLE.
+    Unspecified,
+    /// Highest chance of a false positive.
+    VeryUnlikely,
+    /// High chance of a false positive.
+    Unlikely,
+    /// Some matching signals. The default value.
+    Possible,
+    /// Low chance of a false positive.
+    Likely,
+    /// Confidence level is high. Lowest chance of a false positive.
+    VeryLikely,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SdpFindingLikelihood::value] or
+    /// [SdpFindingLikelihood::name].
+    UnknownValue(sdp_finding_likelihood::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod sdp_finding_likelihood {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SdpFindingLikelihood {
-    /// Default value; same as POSSIBLE.
-    pub const SDP_FINDING_LIKELIHOOD_UNSPECIFIED: SdpFindingLikelihood =
-        SdpFindingLikelihood::new(0);
-
-    /// Highest chance of a false positive.
-    pub const VERY_UNLIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(1);
-
-    /// High chance of a false positive.
-    pub const UNLIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(2);
-
-    /// Some matching signals. The default value.
-    pub const POSSIBLE: SdpFindingLikelihood = SdpFindingLikelihood::new(3);
-
-    /// Low chance of a false positive.
-    pub const LIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(4);
-
-    /// Confidence level is high. Lowest chance of a false positive.
-    pub const VERY_LIKELY: SdpFindingLikelihood = SdpFindingLikelihood::new(5);
-
-    /// Creates a new SdpFindingLikelihood instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::VeryUnlikely => std::option::Option::Some(1),
+            Self::Unlikely => std::option::Option::Some(2),
+            Self::Possible => std::option::Option::Some(3),
+            Self::Likely => std::option::Option::Some(4),
+            Self::VeryLikely => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SDP_FINDING_LIKELIHOOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
-            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
-            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
-            4 => std::borrow::Cow::Borrowed("LIKELY"),
-            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SDP_FINDING_LIKELIHOOD_UNSPECIFIED"),
+            Self::VeryUnlikely => std::option::Option::Some("VERY_UNLIKELY"),
+            Self::Unlikely => std::option::Option::Some("UNLIKELY"),
+            Self::Possible => std::option::Option::Some("POSSIBLE"),
+            Self::Likely => std::option::Option::Some("LIKELY"),
+            Self::VeryLikely => std::option::Option::Some("VERY_LIKELY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SDP_FINDING_LIKELIHOOD_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SDP_FINDING_LIKELIHOOD_UNSPECIFIED)
-            }
-            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
-            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
-            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
-            "LIKELY" => std::option::Option::Some(Self::LIKELY),
-            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SdpFindingLikelihood {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SdpFindingLikelihood {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SdpFindingLikelihood {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SdpFindingLikelihood {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::VeryUnlikely,
+            2 => Self::Unlikely,
+            3 => Self::Possible,
+            4 => Self::Likely,
+            5 => Self::VeryLikely,
+            _ => Self::UnknownValue(sdp_finding_likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SdpFindingLikelihood {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SDP_FINDING_LIKELIHOOD_UNSPECIFIED" => Self::Unspecified,
+            "VERY_UNLIKELY" => Self::VeryUnlikely,
+            "UNLIKELY" => Self::Unlikely,
+            "POSSIBLE" => Self::Possible,
+            "LIKELY" => Self::Likely,
+            "VERY_LIKELY" => Self::VeryLikely,
+            _ => Self::UnknownValue(sdp_finding_likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SdpFindingLikelihood {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::VeryUnlikely => serializer.serialize_i32(1),
+            Self::Unlikely => serializer.serialize_i32(2),
+            Self::Possible => serializer.serialize_i32(3),
+            Self::Likely => serializer.serialize_i32(4),
+            Self::VeryLikely => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SdpFindingLikelihood {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SdpFindingLikelihood>::new(
+            ".google.cloud.modelarmor.v1.SdpFindingLikelihood",
+        ))
     }
 }
 
 /// A field indicating the outcome of the invocation, irrespective of match
 /// status.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InvocationResult(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum InvocationResult {
+    /// Unused. Default value.
+    Unspecified,
+    /// All filters were invoked successfully.
+    Success,
+    /// Some filters were skipped or failed.
+    Partial,
+    /// All filters were skipped or failed.
+    Failure,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [InvocationResult::value] or
+    /// [InvocationResult::name].
+    UnknownValue(invocation_result::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod invocation_result {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl InvocationResult {
-    /// Unused. Default value.
-    pub const INVOCATION_RESULT_UNSPECIFIED: InvocationResult = InvocationResult::new(0);
-
-    /// All filters were invoked successfully.
-    pub const SUCCESS: InvocationResult = InvocationResult::new(1);
-
-    /// Some filters were skipped or failed.
-    pub const PARTIAL: InvocationResult = InvocationResult::new(2);
-
-    /// All filters were skipped or failed.
-    pub const FAILURE: InvocationResult = InvocationResult::new(3);
-
-    /// Creates a new InvocationResult instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Success => std::option::Option::Some(1),
+            Self::Partial => std::option::Option::Some(2),
+            Self::Failure => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INVOCATION_RESULT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SUCCESS"),
-            2 => std::borrow::Cow::Borrowed("PARTIAL"),
-            3 => std::borrow::Cow::Borrowed("FAILURE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INVOCATION_RESULT_UNSPECIFIED"),
+            Self::Success => std::option::Option::Some("SUCCESS"),
+            Self::Partial => std::option::Option::Some("PARTIAL"),
+            Self::Failure => std::option::Option::Some("FAILURE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INVOCATION_RESULT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INVOCATION_RESULT_UNSPECIFIED)
-            }
-            "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-            "PARTIAL" => std::option::Option::Some(Self::PARTIAL),
-            "FAILURE" => std::option::Option::Some(Self::FAILURE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for InvocationResult {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for InvocationResult {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for InvocationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for InvocationResult {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Success,
+            2 => Self::Partial,
+            3 => Self::Failure,
+            _ => Self::UnknownValue(invocation_result::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for InvocationResult {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INVOCATION_RESULT_UNSPECIFIED" => Self::Unspecified,
+            "SUCCESS" => Self::Success,
+            "PARTIAL" => Self::Partial,
+            "FAILURE" => Self::Failure,
+            _ => Self::UnknownValue(invocation_result::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for InvocationResult {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Success => serializer.serialize_i32(1),
+            Self::Partial => serializer.serialize_i32(2),
+            Self::Failure => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for InvocationResult {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<InvocationResult>::new(
+            ".google.cloud.modelarmor.v1.InvocationResult",
+        ))
     }
 }

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -649,84 +649,155 @@ pub mod active_directory {
     use super::*;
 
     /// The Active Directory States
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified Active Directory State
+        Unspecified,
+        /// Active Directory State is Creating
+        Creating,
+        /// Active Directory State is Ready
+        Ready,
+        /// Active Directory State is Updating
+        Updating,
+        /// Active Directory State is In use
+        InUse,
+        /// Active Directory State is Deleting
+        Deleting,
+        /// Active Directory State is Error
+        Error,
+        /// Active Directory State is Diagnosing.
+        Diagnosing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified Active Directory State
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Active Directory State is Creating
-        pub const CREATING: State = State::new(1);
-
-        /// Active Directory State is Ready
-        pub const READY: State = State::new(2);
-
-        /// Active Directory State is Updating
-        pub const UPDATING: State = State::new(3);
-
-        /// Active Directory State is In use
-        pub const IN_USE: State = State::new(4);
-
-        /// Active Directory State is Deleting
-        pub const DELETING: State = State::new(5);
-
-        /// Active Directory State is Error
-        pub const ERROR: State = State::new(6);
-
-        /// Active Directory State is Diagnosing.
-        pub const DIAGNOSING: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::InUse => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::Diagnosing => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("IN_USE"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("DIAGNOSING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::InUse => std::option::Option::Some("IN_USE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Diagnosing => std::option::Option::Some("DIAGNOSING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "IN_USE" => std::option::Option::Some(Self::IN_USE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DIAGNOSING" => std::option::Option::Some(Self::DIAGNOSING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Updating,
+                4 => Self::InUse,
+                5 => Self::Deleting,
+                6 => Self::Error,
+                7 => Self::Diagnosing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "IN_USE" => Self::InUse,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "DIAGNOSING" => Self::Diagnosing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::InUse => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::Diagnosing => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.ActiveDirectory.State",
+            ))
         }
     }
 }
@@ -906,140 +977,270 @@ pub mod backup {
     use super::*;
 
     /// The Backup States
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Backup is being created. While in this state, the snapshot for the backup
         /// point-in-time may not have been created yet, and so the point-in-time may
         /// not have been fixed.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Backup is being uploaded. While in this state, none of the writes to the
         /// volume will be included in the backup.
-        pub const UPLOADING: State = State::new(2);
-
+        Uploading,
         /// Backup is available for use.
-        pub const READY: State = State::new(3);
-
+        Ready,
         /// Backup is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Backup is not valid and cannot be used for creating new volumes or
         /// restoring existing volumes.
-        pub const ERROR: State = State::new(5);
-
+        Error,
         /// Backup is being updated.
-        pub const UPDATING: State = State::new(6);
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Uploading => std::option::Option::Some(2),
+                Self::Ready => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Updating => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UPLOADING"),
-                3 => std::borrow::Cow::Borrowed("READY"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Uploading => std::option::Option::Some("UPLOADING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPLOADING" => std::option::Option::Some(Self::UPLOADING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Uploading,
+                3 => Self::Ready,
+                4 => Self::Deleting,
+                5 => Self::Error,
+                6 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UPLOADING" => Self::Uploading,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Uploading => serializer.serialize_i32(2),
+                Self::Ready => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Updating => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.Backup.State",
+            ))
         }
     }
 
     /// Backup types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified backup type.
+        Unspecified,
+        /// Manual backup type.
+        Manual,
+        /// Scheduled backup type.
+        Scheduled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified backup type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Manual backup type.
-        pub const MANUAL: Type = Type::new(1);
-
-        /// Scheduled backup type.
-        pub const SCHEDULED: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Manual => std::option::Option::Some(1),
+                Self::Scheduled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MANUAL"),
-                2 => std::borrow::Cow::Borrowed("SCHEDULED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::Scheduled => std::option::Option::Some("SCHEDULED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Manual,
+                2 => Self::Scheduled,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MANUAL" => Self::Manual,
+                "SCHEDULED" => Self::Scheduled,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Manual => serializer.serialize_i32(1),
+                Self::Scheduled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.netapp.v1.Backup.Type",
+            ))
         }
     }
 }
@@ -1545,74 +1746,141 @@ pub mod backup_policy {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// BackupPolicy is being created.
+        Creating,
+        /// BackupPolicy is available for use.
+        Ready,
+        /// BackupPolicy is being deleted.
+        Deleting,
+        /// BackupPolicy is not valid and cannot be used.
+        Error,
+        /// BackupPolicy is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// BackupPolicy is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// BackupPolicy is available for use.
-        pub const READY: State = State::new(2);
-
-        /// BackupPolicy is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// BackupPolicy is not valid and cannot be used.
-        pub const ERROR: State = State::new(4);
-
-        /// BackupPolicy is being updated.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.BackupPolicy.State",
+            ))
         }
     }
 }
@@ -2042,74 +2310,141 @@ pub mod backup_vault {
     use super::*;
 
     /// The Backup Vault States
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State not set.
+        Unspecified,
+        /// BackupVault is being created.
+        Creating,
+        /// BackupVault is available for use.
+        Ready,
+        /// BackupVault is being deleted.
+        Deleting,
+        /// BackupVault is not valid and cannot be used.
+        Error,
+        /// BackupVault is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// BackupVault is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// BackupVault is available for use.
-        pub const READY: State = State::new(2);
-
-        /// BackupVault is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// BackupVault is not valid and cannot be used.
-        pub const ERROR: State = State::new(4);
-
-        /// BackupVault is being updated.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.BackupVault.State",
+            ))
         }
     }
 }
@@ -3181,106 +3516,185 @@ pub mod kms_config {
     use super::*;
 
     /// The KmsConfig States
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified KmsConfig State
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// KmsConfig State is Ready
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// KmsConfig State is Creating
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// KmsConfig State is Deleting
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// KmsConfig State is Updating
-        pub const UPDATING: State = State::new(4);
-
+        Updating,
         /// KmsConfig State is In Use.
-        pub const IN_USE: State = State::new(5);
-
+        InUse,
         /// KmsConfig State is Error
-        pub const ERROR: State = State::new(6);
-
+        Error,
         /// KmsConfig State is Pending to verify crypto key access.
-        pub const KEY_CHECK_PENDING: State = State::new(7);
-
+        KeyCheckPending,
         /// KmsConfig State is Not accessbile by the SDE service account to the
         /// crypto key.
-        pub const KEY_NOT_REACHABLE: State = State::new(8);
-
+        KeyNotReachable,
         /// KmsConfig State is Disabling.
-        pub const DISABLING: State = State::new(9);
-
+        Disabling,
         /// KmsConfig State is Disabled.
-        pub const DISABLED: State = State::new(10);
-
+        Disabled,
         /// KmsConfig State is Migrating.
         /// The existing volumes are migrating from SMEK to CMEK.
-        pub const MIGRATING: State = State::new(11);
+        Migrating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::InUse => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::KeyCheckPending => std::option::Option::Some(7),
+                Self::KeyNotReachable => std::option::Option::Some(8),
+                Self::Disabling => std::option::Option::Some(9),
+                Self::Disabled => std::option::Option::Some(10),
+                Self::Migrating => std::option::Option::Some(11),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("IN_USE"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                7 => std::borrow::Cow::Borrowed("KEY_CHECK_PENDING"),
-                8 => std::borrow::Cow::Borrowed("KEY_NOT_REACHABLE"),
-                9 => std::borrow::Cow::Borrowed("DISABLING"),
-                10 => std::borrow::Cow::Borrowed("DISABLED"),
-                11 => std::borrow::Cow::Borrowed("MIGRATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::InUse => std::option::Option::Some("IN_USE"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::KeyCheckPending => std::option::Option::Some("KEY_CHECK_PENDING"),
+                Self::KeyNotReachable => std::option::Option::Some("KEY_NOT_REACHABLE"),
+                Self::Disabling => std::option::Option::Some("DISABLING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Migrating => std::option::Option::Some("MIGRATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "IN_USE" => std::option::Option::Some(Self::IN_USE),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "KEY_CHECK_PENDING" => std::option::Option::Some(Self::KEY_CHECK_PENDING),
-                "KEY_NOT_REACHABLE" => std::option::Option::Some(Self::KEY_NOT_REACHABLE),
-                "DISABLING" => std::option::Option::Some(Self::DISABLING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "MIGRATING" => std::option::Option::Some(Self::MIGRATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Deleting,
+                4 => Self::Updating,
+                5 => Self::InUse,
+                6 => Self::Error,
+                7 => Self::KeyCheckPending,
+                8 => Self::KeyNotReachable,
+                9 => Self::Disabling,
+                10 => Self::Disabled,
+                11 => Self::Migrating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "IN_USE" => Self::InUse,
+                "ERROR" => Self::Error,
+                "KEY_CHECK_PENDING" => Self::KeyCheckPending,
+                "KEY_NOT_REACHABLE" => Self::KeyNotReachable,
+                "DISABLING" => Self::Disabling,
+                "DISABLED" => Self::Disabled,
+                "MIGRATING" => Self::Migrating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::InUse => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::KeyCheckPending => serializer.serialize_i32(7),
+                Self::KeyNotReachable => serializer.serialize_i32(8),
+                Self::Disabling => serializer.serialize_i32(9),
+                Self::Disabled => serializer.serialize_i32(10),
+                Self::Migrating => serializer.serialize_i32(11),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.KmsConfig.State",
+            ))
         }
     }
 }
@@ -3741,141 +4155,273 @@ pub mod quota_rule {
     use super::*;
 
     /// Types of Quota Rule
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified type for quota rule
+        Unspecified,
+        /// Individual user quota rule
+        IndividualUserQuota,
+        /// Individual group quota rule
+        IndividualGroupQuota,
+        /// Default user quota rule
+        DefaultUserQuota,
+        /// Default group quota rule
+        DefaultGroupQuota,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified type for quota rule
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Individual user quota rule
-        pub const INDIVIDUAL_USER_QUOTA: Type = Type::new(1);
-
-        /// Individual group quota rule
-        pub const INDIVIDUAL_GROUP_QUOTA: Type = Type::new(2);
-
-        /// Default user quota rule
-        pub const DEFAULT_USER_QUOTA: Type = Type::new(3);
-
-        /// Default group quota rule
-        pub const DEFAULT_GROUP_QUOTA: Type = Type::new(4);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::IndividualUserQuota => std::option::Option::Some(1),
+                Self::IndividualGroupQuota => std::option::Option::Some(2),
+                Self::DefaultUserQuota => std::option::Option::Some(3),
+                Self::DefaultGroupQuota => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INDIVIDUAL_USER_QUOTA"),
-                2 => std::borrow::Cow::Borrowed("INDIVIDUAL_GROUP_QUOTA"),
-                3 => std::borrow::Cow::Borrowed("DEFAULT_USER_QUOTA"),
-                4 => std::borrow::Cow::Borrowed("DEFAULT_GROUP_QUOTA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::IndividualUserQuota => std::option::Option::Some("INDIVIDUAL_USER_QUOTA"),
+                Self::IndividualGroupQuota => std::option::Option::Some("INDIVIDUAL_GROUP_QUOTA"),
+                Self::DefaultUserQuota => std::option::Option::Some("DEFAULT_USER_QUOTA"),
+                Self::DefaultGroupQuota => std::option::Option::Some("DEFAULT_GROUP_QUOTA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "INDIVIDUAL_USER_QUOTA" => std::option::Option::Some(Self::INDIVIDUAL_USER_QUOTA),
-                "INDIVIDUAL_GROUP_QUOTA" => std::option::Option::Some(Self::INDIVIDUAL_GROUP_QUOTA),
-                "DEFAULT_USER_QUOTA" => std::option::Option::Some(Self::DEFAULT_USER_QUOTA),
-                "DEFAULT_GROUP_QUOTA" => std::option::Option::Some(Self::DEFAULT_GROUP_QUOTA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::IndividualUserQuota,
+                2 => Self::IndividualGroupQuota,
+                3 => Self::DefaultUserQuota,
+                4 => Self::DefaultGroupQuota,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INDIVIDUAL_USER_QUOTA" => Self::IndividualUserQuota,
+                "INDIVIDUAL_GROUP_QUOTA" => Self::IndividualGroupQuota,
+                "DEFAULT_USER_QUOTA" => Self::DefaultUserQuota,
+                "DEFAULT_GROUP_QUOTA" => Self::DefaultGroupQuota,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::IndividualUserQuota => serializer.serialize_i32(1),
+                Self::IndividualGroupQuota => serializer.serialize_i32(2),
+                Self::DefaultUserQuota => serializer.serialize_i32(3),
+                Self::DefaultGroupQuota => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.netapp.v1.QuotaRule.Type",
+            ))
         }
     }
 
     /// Quota Rule states
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state for quota rule
+        Unspecified,
+        /// Quota rule is creating
+        Creating,
+        /// Quota rule is updating
+        Updating,
+        /// Quota rule is deleting
+        Deleting,
+        /// Quota rule is ready
+        Ready,
+        /// Quota rule is in error state.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state for quota rule
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Quota rule is creating
-        pub const CREATING: State = State::new(1);
-
-        /// Quota rule is updating
-        pub const UPDATING: State = State::new(2);
-
-        /// Quota rule is deleting
-        pub const DELETING: State = State::new(3);
-
-        /// Quota rule is ready
-        pub const READY: State = State::new(4);
-
-        /// Quota rule is in error state.
-        pub const ERROR: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Updating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Ready => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("UPDATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("READY"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Updating,
+                3 => Self::Deleting,
+                4 => Self::Ready,
+                5 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "READY" => Self::Ready,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Updating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Ready => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.QuotaRule.State",
+            ))
         }
     }
 }
@@ -4274,354 +4820,669 @@ pub mod replication {
 
     /// The replication states
     /// New enum values may be added in future to indicate possible new states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified replication State
+        Unspecified,
+        /// Replication is creating.
+        Creating,
+        /// Replication is ready.
+        Ready,
+        /// Replication is updating.
+        Updating,
+        /// Replication is deleting.
+        Deleting,
+        /// Replication is in error state.
+        Error,
+        /// Replication is waiting for cluster peering to be established.
+        PendingClusterPeering,
+        /// Replication is waiting for SVM peering to be established.
+        PendingSvmPeering,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified replication State
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Replication is creating.
-        pub const CREATING: State = State::new(1);
-
-        /// Replication is ready.
-        pub const READY: State = State::new(2);
-
-        /// Replication is updating.
-        pub const UPDATING: State = State::new(3);
-
-        /// Replication is deleting.
-        pub const DELETING: State = State::new(5);
-
-        /// Replication is in error state.
-        pub const ERROR: State = State::new(6);
-
-        /// Replication is waiting for cluster peering to be established.
-        pub const PENDING_CLUSTER_PEERING: State = State::new(8);
-
-        /// Replication is waiting for SVM peering to be established.
-        pub const PENDING_SVM_PEERING: State = State::new(9);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::PendingClusterPeering => std::option::Option::Some(8),
+                Self::PendingSvmPeering => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                8 => std::borrow::Cow::Borrowed("PENDING_CLUSTER_PEERING"),
-                9 => std::borrow::Cow::Borrowed("PENDING_SVM_PEERING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::PendingClusterPeering => std::option::Option::Some("PENDING_CLUSTER_PEERING"),
+                Self::PendingSvmPeering => std::option::Option::Some("PENDING_SVM_PEERING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "PENDING_CLUSTER_PEERING" => {
-                    std::option::Option::Some(Self::PENDING_CLUSTER_PEERING)
-                }
-                "PENDING_SVM_PEERING" => std::option::Option::Some(Self::PENDING_SVM_PEERING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Updating,
+                5 => Self::Deleting,
+                6 => Self::Error,
+                8 => Self::PendingClusterPeering,
+                9 => Self::PendingSvmPeering,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "PENDING_CLUSTER_PEERING" => Self::PendingClusterPeering,
+                "PENDING_SVM_PEERING" => Self::PendingSvmPeering,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::PendingClusterPeering => serializer.serialize_i32(8),
+                Self::PendingSvmPeering => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.Replication.State",
+            ))
         }
     }
 
     /// New enum values may be added in future to support different replication
     /// topology.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicationRole(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReplicationRole {
+        /// Unspecified replication role
+        Unspecified,
+        /// Indicates Source volume.
+        Source,
+        /// Indicates Destination volume.
+        Destination,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReplicationRole::value] or
+        /// [ReplicationRole::name].
+        UnknownValue(replication_role::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod replication_role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ReplicationRole {
-        /// Unspecified replication role
-        pub const REPLICATION_ROLE_UNSPECIFIED: ReplicationRole = ReplicationRole::new(0);
-
-        /// Indicates Source volume.
-        pub const SOURCE: ReplicationRole = ReplicationRole::new(1);
-
-        /// Indicates Destination volume.
-        pub const DESTINATION: ReplicationRole = ReplicationRole::new(2);
-
-        /// Creates a new ReplicationRole instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Source => std::option::Option::Some(1),
+                Self::Destination => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REPLICATION_ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SOURCE"),
-                2 => std::borrow::Cow::Borrowed("DESTINATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REPLICATION_ROLE_UNSPECIFIED"),
+                Self::Source => std::option::Option::Some("SOURCE"),
+                Self::Destination => std::option::Option::Some("DESTINATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REPLICATION_ROLE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REPLICATION_ROLE_UNSPECIFIED)
-                }
-                "SOURCE" => std::option::Option::Some(Self::SOURCE),
-                "DESTINATION" => std::option::Option::Some(Self::DESTINATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReplicationRole {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicationRole {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReplicationRole {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReplicationRole {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Source,
+                2 => Self::Destination,
+                _ => Self::UnknownValue(replication_role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReplicationRole {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REPLICATION_ROLE_UNSPECIFIED" => Self::Unspecified,
+                "SOURCE" => Self::Source,
+                "DESTINATION" => Self::Destination,
+                _ => Self::UnknownValue(replication_role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReplicationRole {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Source => serializer.serialize_i32(1),
+                Self::Destination => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReplicationRole {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReplicationRole>::new(
+                ".google.cloud.netapp.v1.Replication.ReplicationRole",
+            ))
         }
     }
 
     /// Schedule for Replication.
     /// New enum values may be added in future to support different frequency of
     /// replication.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicationSchedule(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReplicationSchedule {
+        /// Unspecified ReplicationSchedule
+        Unspecified,
+        /// Replication happens once every 10 minutes.
+        Every10Minutes,
+        /// Replication happens once every hour.
+        Hourly,
+        /// Replication happens once every day.
+        Daily,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReplicationSchedule::value] or
+        /// [ReplicationSchedule::name].
+        UnknownValue(replication_schedule::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod replication_schedule {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ReplicationSchedule {
-        /// Unspecified ReplicationSchedule
-        pub const REPLICATION_SCHEDULE_UNSPECIFIED: ReplicationSchedule =
-            ReplicationSchedule::new(0);
-
-        /// Replication happens once every 10 minutes.
-        pub const EVERY_10_MINUTES: ReplicationSchedule = ReplicationSchedule::new(1);
-
-        /// Replication happens once every hour.
-        pub const HOURLY: ReplicationSchedule = ReplicationSchedule::new(2);
-
-        /// Replication happens once every day.
-        pub const DAILY: ReplicationSchedule = ReplicationSchedule::new(3);
-
-        /// Creates a new ReplicationSchedule instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Every10Minutes => std::option::Option::Some(1),
+                Self::Hourly => std::option::Option::Some(2),
+                Self::Daily => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REPLICATION_SCHEDULE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EVERY_10_MINUTES"),
-                2 => std::borrow::Cow::Borrowed("HOURLY"),
-                3 => std::borrow::Cow::Borrowed("DAILY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REPLICATION_SCHEDULE_UNSPECIFIED"),
+                Self::Every10Minutes => std::option::Option::Some("EVERY_10_MINUTES"),
+                Self::Hourly => std::option::Option::Some("HOURLY"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REPLICATION_SCHEDULE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REPLICATION_SCHEDULE_UNSPECIFIED)
-                }
-                "EVERY_10_MINUTES" => std::option::Option::Some(Self::EVERY_10_MINUTES),
-                "HOURLY" => std::option::Option::Some(Self::HOURLY),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReplicationSchedule {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicationSchedule {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReplicationSchedule {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReplicationSchedule {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Every10Minutes,
+                2 => Self::Hourly,
+                3 => Self::Daily,
+                _ => Self::UnknownValue(replication_schedule::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReplicationSchedule {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REPLICATION_SCHEDULE_UNSPECIFIED" => Self::Unspecified,
+                "EVERY_10_MINUTES" => Self::Every10Minutes,
+                "HOURLY" => Self::Hourly,
+                "DAILY" => Self::Daily,
+                _ => Self::UnknownValue(replication_schedule::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReplicationSchedule {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Every10Minutes => serializer.serialize_i32(1),
+                Self::Hourly => serializer.serialize_i32(2),
+                Self::Daily => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReplicationSchedule {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReplicationSchedule>::new(
+                ".google.cloud.netapp.v1.Replication.ReplicationSchedule",
+            ))
         }
     }
 
     /// Mirroring states.
     /// No new value is expected to be added in future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MirrorState(i32);
-
-    impl MirrorState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MirrorState {
         /// Unspecified MirrorState
-        pub const MIRROR_STATE_UNSPECIFIED: MirrorState = MirrorState::new(0);
-
+        Unspecified,
         /// Destination volume is being prepared.
-        pub const PREPARING: MirrorState = MirrorState::new(1);
-
+        Preparing,
         /// Destination volume has been initialized and is ready to receive
         /// replication transfers.
-        pub const MIRRORED: MirrorState = MirrorState::new(2);
-
+        Mirrored,
         /// Destination volume is not receiving replication transfers.
-        pub const STOPPED: MirrorState = MirrorState::new(3);
-
+        Stopped,
         /// Incremental replication is in progress.
-        pub const TRANSFERRING: MirrorState = MirrorState::new(4);
-
+        Transferring,
         /// Baseline replication is in progress.
-        pub const BASELINE_TRANSFERRING: MirrorState = MirrorState::new(5);
-
+        BaselineTransferring,
         /// Replication is aborted.
-        pub const ABORTED: MirrorState = MirrorState::new(6);
+        Aborted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MirrorState::value] or
+        /// [MirrorState::name].
+        UnknownValue(mirror_state::UnknownValue),
+    }
 
-        /// Creates a new MirrorState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod mirror_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MirrorState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Preparing => std::option::Option::Some(1),
+                Self::Mirrored => std::option::Option::Some(2),
+                Self::Stopped => std::option::Option::Some(3),
+                Self::Transferring => std::option::Option::Some(4),
+                Self::BaselineTransferring => std::option::Option::Some(5),
+                Self::Aborted => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MIRROR_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PREPARING"),
-                2 => std::borrow::Cow::Borrowed("MIRRORED"),
-                3 => std::borrow::Cow::Borrowed("STOPPED"),
-                4 => std::borrow::Cow::Borrowed("TRANSFERRING"),
-                5 => std::borrow::Cow::Borrowed("BASELINE_TRANSFERRING"),
-                6 => std::borrow::Cow::Borrowed("ABORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MIRROR_STATE_UNSPECIFIED"),
+                Self::Preparing => std::option::Option::Some("PREPARING"),
+                Self::Mirrored => std::option::Option::Some("MIRRORED"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Transferring => std::option::Option::Some("TRANSFERRING"),
+                Self::BaselineTransferring => std::option::Option::Some("BASELINE_TRANSFERRING"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MIRROR_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MIRROR_STATE_UNSPECIFIED)
-                }
-                "PREPARING" => std::option::Option::Some(Self::PREPARING),
-                "MIRRORED" => std::option::Option::Some(Self::MIRRORED),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "TRANSFERRING" => std::option::Option::Some(Self::TRANSFERRING),
-                "BASELINE_TRANSFERRING" => std::option::Option::Some(Self::BASELINE_TRANSFERRING),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MirrorState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MirrorState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MirrorState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MirrorState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Preparing,
+                2 => Self::Mirrored,
+                3 => Self::Stopped,
+                4 => Self::Transferring,
+                5 => Self::BaselineTransferring,
+                6 => Self::Aborted,
+                _ => Self::UnknownValue(mirror_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MirrorState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MIRROR_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PREPARING" => Self::Preparing,
+                "MIRRORED" => Self::Mirrored,
+                "STOPPED" => Self::Stopped,
+                "TRANSFERRING" => Self::Transferring,
+                "BASELINE_TRANSFERRING" => Self::BaselineTransferring,
+                "ABORTED" => Self::Aborted,
+                _ => Self::UnknownValue(mirror_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MirrorState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Preparing => serializer.serialize_i32(1),
+                Self::Mirrored => serializer.serialize_i32(2),
+                Self::Stopped => serializer.serialize_i32(3),
+                Self::Transferring => serializer.serialize_i32(4),
+                Self::BaselineTransferring => serializer.serialize_i32(5),
+                Self::Aborted => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MirrorState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MirrorState>::new(
+                ".google.cloud.netapp.v1.Replication.MirrorState",
+            ))
         }
     }
 
     /// Hybrid replication type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HybridReplicationType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HybridReplicationType {
+        /// Unspecified hybrid replication type.
+        Unspecified,
+        /// Hybrid replication type for migration.
+        Migration,
+        /// Hybrid replication type for continuous replication.
+        ContinuousReplication,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HybridReplicationType::value] or
+        /// [HybridReplicationType::name].
+        UnknownValue(hybrid_replication_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod hybrid_replication_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HybridReplicationType {
-        /// Unspecified hybrid replication type.
-        pub const HYBRID_REPLICATION_TYPE_UNSPECIFIED: HybridReplicationType =
-            HybridReplicationType::new(0);
-
-        /// Hybrid replication type for migration.
-        pub const MIGRATION: HybridReplicationType = HybridReplicationType::new(1);
-
-        /// Hybrid replication type for continuous replication.
-        pub const CONTINUOUS_REPLICATION: HybridReplicationType = HybridReplicationType::new(2);
-
-        /// Creates a new HybridReplicationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Migration => std::option::Option::Some(1),
+                Self::ContinuousReplication => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HYBRID_REPLICATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MIGRATION"),
-                2 => std::borrow::Cow::Borrowed("CONTINUOUS_REPLICATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HYBRID_REPLICATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HYBRID_REPLICATION_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("HYBRID_REPLICATION_TYPE_UNSPECIFIED")
                 }
-                "MIGRATION" => std::option::Option::Some(Self::MIGRATION),
-                "CONTINUOUS_REPLICATION" => std::option::Option::Some(Self::CONTINUOUS_REPLICATION),
-                _ => std::option::Option::None,
+                Self::Migration => std::option::Option::Some("MIGRATION"),
+                Self::ContinuousReplication => std::option::Option::Some("CONTINUOUS_REPLICATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for HybridReplicationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HybridReplicationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HybridReplicationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HybridReplicationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Migration,
+                2 => Self::ContinuousReplication,
+                _ => Self::UnknownValue(hybrid_replication_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HybridReplicationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HYBRID_REPLICATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MIGRATION" => Self::Migration,
+                "CONTINUOUS_REPLICATION" => Self::ContinuousReplication,
+                _ => Self::UnknownValue(hybrid_replication_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HybridReplicationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Migration => serializer.serialize_i32(1),
+                Self::ContinuousReplication => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HybridReplicationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HybridReplicationType>::new(
+                ".google.cloud.netapp.v1.Replication.HybridReplicationType",
+            ))
         }
     }
 }
@@ -5818,79 +6679,148 @@ pub mod snapshot {
     use super::*;
 
     /// The Snapshot States
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified Snapshot State
+        Unspecified,
+        /// Snapshot State is Ready
+        Ready,
+        /// Snapshot State is Creating
+        Creating,
+        /// Snapshot State is Deleting
+        Deleting,
+        /// Snapshot State is Updating
+        Updating,
+        /// Snapshot State is Disabled
+        Disabled,
+        /// Snapshot State is Error
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified Snapshot State
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Snapshot State is Ready
-        pub const READY: State = State::new(1);
-
-        /// Snapshot State is Creating
-        pub const CREATING: State = State::new(2);
-
-        /// Snapshot State is Deleting
-        pub const DELETING: State = State::new(3);
-
-        /// Snapshot State is Updating
-        pub const UPDATING: State = State::new(4);
-
-        /// Snapshot State is Disabled
-        pub const DISABLED: State = State::new(5);
-
-        /// Snapshot State is Error
-        pub const ERROR: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::Disabled => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("DISABLED"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Deleting,
+                4 => Self::Updating,
+                5 => Self::Disabled,
+                6 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "DISABLED" => Self::Disabled,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::Disabled => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.Snapshot.State",
+            ))
         }
     }
 }
@@ -6535,84 +7465,155 @@ pub mod storage_pool {
     use super::*;
 
     /// The Storage Pool States
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified Storage Pool State
+        Unspecified,
+        /// Storage Pool State is Ready
+        Ready,
+        /// Storage Pool State is Creating
+        Creating,
+        /// Storage Pool State is Deleting
+        Deleting,
+        /// Storage Pool State is Updating
+        Updating,
+        /// Storage Pool State is Restoring
+        Restoring,
+        /// Storage Pool State is Disabled
+        Disabled,
+        /// Storage Pool State is Error
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified Storage Pool State
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Storage Pool State is Ready
-        pub const READY: State = State::new(1);
-
-        /// Storage Pool State is Creating
-        pub const CREATING: State = State::new(2);
-
-        /// Storage Pool State is Deleting
-        pub const DELETING: State = State::new(3);
-
-        /// Storage Pool State is Updating
-        pub const UPDATING: State = State::new(4);
-
-        /// Storage Pool State is Restoring
-        pub const RESTORING: State = State::new(5);
-
-        /// Storage Pool State is Disabled
-        pub const DISABLED: State = State::new(6);
-
-        /// Storage Pool State is Error
-        pub const ERROR: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::Restoring => std::option::Option::Some(5),
+                Self::Disabled => std::option::Option::Some(6),
+                Self::Error => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("RESTORING"),
-                6 => std::borrow::Cow::Borrowed("DISABLED"),
-                7 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Restoring => std::option::Option::Some("RESTORING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "RESTORING" => std::option::Option::Some(Self::RESTORING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Deleting,
+                4 => Self::Updating,
+                5 => Self::Restoring,
+                6 => Self::Disabled,
+                7 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "RESTORING" => Self::Restoring,
+                "DISABLED" => Self::Disabled,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::Restoring => serializer.serialize_i32(5),
+                Self::Disabled => serializer.serialize_i32(6),
+                Self::Error => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.StoragePool.State",
+            ))
         }
     }
 }
@@ -7536,96 +8537,171 @@ pub mod volume {
     use super::*;
 
     /// The volume states
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified Volume State
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Volume State is Ready
-        pub const READY: State = State::new(1);
-
+        Ready,
         /// Volume State is Creating
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// Volume State is Deleting
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// Volume State is Updating
-        pub const UPDATING: State = State::new(4);
-
+        Updating,
         /// Volume State is Restoring
-        pub const RESTORING: State = State::new(5);
-
+        Restoring,
         /// Volume State is Disabled
-        pub const DISABLED: State = State::new(6);
-
+        Disabled,
         /// Volume State is Error
-        pub const ERROR: State = State::new(7);
-
+        Error,
         /// Volume State is Preparing. Note that this is different from CREATING
         /// where CREATING means the volume is being created, while PREPARING means
         /// the volume is created and now being prepared for the replication.
-        pub const PREPARING: State = State::new(8);
-
+        Preparing,
         /// Volume State is Read Only
-        pub const READ_ONLY: State = State::new(9);
+        ReadOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Updating => std::option::Option::Some(4),
+                Self::Restoring => std::option::Option::Some(5),
+                Self::Disabled => std::option::Option::Some(6),
+                Self::Error => std::option::Option::Some(7),
+                Self::Preparing => std::option::Option::Some(8),
+                Self::ReadOnly => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("RESTORING"),
-                6 => std::borrow::Cow::Borrowed("DISABLED"),
-                7 => std::borrow::Cow::Borrowed("ERROR"),
-                8 => std::borrow::Cow::Borrowed("PREPARING"),
-                9 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Restoring => std::option::Option::Some("RESTORING"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Preparing => std::option::Option::Some("PREPARING"),
+                Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "RESTORING" => std::option::Option::Some(Self::RESTORING),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "PREPARING" => std::option::Option::Some(Self::PREPARING),
-                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Deleting,
+                4 => Self::Updating,
+                5 => Self::Restoring,
+                6 => Self::Disabled,
+                7 => Self::Error,
+                8 => Self::Preparing,
+                9 => Self::ReadOnly,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "RESTORING" => Self::Restoring,
+                "DISABLED" => Self::Disabled,
+                "ERROR" => Self::Error,
+                "PREPARING" => Self::Preparing,
+                "READ_ONLY" => Self::ReadOnly,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Updating => serializer.serialize_i32(4),
+                Self::Restoring => serializer.serialize_i32(5),
+                Self::Disabled => serializer.serialize_i32(6),
+                Self::Error => serializer.serialize_i32(7),
+                Self::Preparing => serializer.serialize_i32(8),
+                Self::ReadOnly => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.netapp.v1.Volume.State",
+            ))
         }
     }
 }
@@ -8500,62 +9576,121 @@ pub mod tiering_policy {
     use super::*;
 
     /// Tier action for the volume.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TierAction(i32);
-
-    impl TierAction {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TierAction {
         /// Unspecified.
-        pub const TIER_ACTION_UNSPECIFIED: TierAction = TierAction::new(0);
-
+        Unspecified,
         /// When tiering is enabled, new cold data will be tiered.
-        pub const ENABLED: TierAction = TierAction::new(1);
-
+        Enabled,
         /// When paused, tiering won't be performed on new data. Existing data stays
         /// tiered until accessed.
-        pub const PAUSED: TierAction = TierAction::new(2);
+        Paused,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TierAction::value] or
+        /// [TierAction::name].
+        UnknownValue(tier_action::UnknownValue),
+    }
 
-        /// Creates a new TierAction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod tier_action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TierAction {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_ACTION_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_ACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TIER_ACTION_UNSPECIFIED)
-                }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TierAction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TierAction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TierAction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TierAction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Paused,
+                _ => Self::UnknownValue(tier_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TierAction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "PAUSED" => Self::Paused,
+                _ => Self::UnknownValue(tier_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TierAction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TierAction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TierAction>::new(
+                ".google.cloud.netapp.v1.TieringPolicy.TierAction",
+            ))
         }
     }
 }
@@ -8687,573 +9822,1127 @@ impl wkt::message::Message for HybridReplicationParameters {
 }
 
 /// The service level of a storage pool and its volumes.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceLevel {
+    /// Unspecified service level.
+    Unspecified,
+    /// Premium service level.
+    Premium,
+    /// Extreme service level.
+    Extreme,
+    /// Standard service level.
+    Standard,
+    /// Flex service level.
+    Flex,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServiceLevel::value] or
+    /// [ServiceLevel::name].
+    UnknownValue(service_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod service_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ServiceLevel {
-    /// Unspecified service level.
-    pub const SERVICE_LEVEL_UNSPECIFIED: ServiceLevel = ServiceLevel::new(0);
-
-    /// Premium service level.
-    pub const PREMIUM: ServiceLevel = ServiceLevel::new(1);
-
-    /// Extreme service level.
-    pub const EXTREME: ServiceLevel = ServiceLevel::new(2);
-
-    /// Standard service level.
-    pub const STANDARD: ServiceLevel = ServiceLevel::new(3);
-
-    /// Flex service level.
-    pub const FLEX: ServiceLevel = ServiceLevel::new(4);
-
-    /// Creates a new ServiceLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Premium => std::option::Option::Some(1),
+            Self::Extreme => std::option::Option::Some(2),
+            Self::Standard => std::option::Option::Some(3),
+            Self::Flex => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SERVICE_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PREMIUM"),
-            2 => std::borrow::Cow::Borrowed("EXTREME"),
-            3 => std::borrow::Cow::Borrowed("STANDARD"),
-            4 => std::borrow::Cow::Borrowed("FLEX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SERVICE_LEVEL_UNSPECIFIED"),
+            Self::Premium => std::option::Option::Some("PREMIUM"),
+            Self::Extreme => std::option::Option::Some("EXTREME"),
+            Self::Standard => std::option::Option::Some("STANDARD"),
+            Self::Flex => std::option::Option::Some("FLEX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SERVICE_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SERVICE_LEVEL_UNSPECIFIED)
-            }
-            "PREMIUM" => std::option::Option::Some(Self::PREMIUM),
-            "EXTREME" => std::option::Option::Some(Self::EXTREME),
-            "STANDARD" => std::option::Option::Some(Self::STANDARD),
-            "FLEX" => std::option::Option::Some(Self::FLEX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServiceLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServiceLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServiceLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Premium,
+            2 => Self::Extreme,
+            3 => Self::Standard,
+            4 => Self::Flex,
+            _ => Self::UnknownValue(service_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServiceLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SERVICE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "PREMIUM" => Self::Premium,
+            "EXTREME" => Self::Extreme,
+            "STANDARD" => Self::Standard,
+            "FLEX" => Self::Flex,
+            _ => Self::UnknownValue(service_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServiceLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Premium => serializer.serialize_i32(1),
+            Self::Extreme => serializer.serialize_i32(2),
+            Self::Standard => serializer.serialize_i32(3),
+            Self::Flex => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServiceLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceLevel>::new(
+            ".google.cloud.netapp.v1.ServiceLevel",
+        ))
     }
 }
 
 /// Flex Storage Pool performance.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FlexPerformance(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FlexPerformance {
+    /// Unspecified flex performance.
+    Unspecified,
+    /// Flex Storage Pool with default performance.
+    Default,
+    /// Flex Storage Pool with custom performance.
+    Custom,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FlexPerformance::value] or
+    /// [FlexPerformance::name].
+    UnknownValue(flex_performance::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod flex_performance {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl FlexPerformance {
-    /// Unspecified flex performance.
-    pub const FLEX_PERFORMANCE_UNSPECIFIED: FlexPerformance = FlexPerformance::new(0);
-
-    /// Flex Storage Pool with default performance.
-    pub const FLEX_PERFORMANCE_DEFAULT: FlexPerformance = FlexPerformance::new(1);
-
-    /// Flex Storage Pool with custom performance.
-    pub const FLEX_PERFORMANCE_CUSTOM: FlexPerformance = FlexPerformance::new(2);
-
-    /// Creates a new FlexPerformance instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Default => std::option::Option::Some(1),
+            Self::Custom => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FLEX_PERFORMANCE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("FLEX_PERFORMANCE_DEFAULT"),
-            2 => std::borrow::Cow::Borrowed("FLEX_PERFORMANCE_CUSTOM"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FLEX_PERFORMANCE_UNSPECIFIED"),
+            Self::Default => std::option::Option::Some("FLEX_PERFORMANCE_DEFAULT"),
+            Self::Custom => std::option::Option::Some("FLEX_PERFORMANCE_CUSTOM"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FLEX_PERFORMANCE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FLEX_PERFORMANCE_UNSPECIFIED)
-            }
-            "FLEX_PERFORMANCE_DEFAULT" => std::option::Option::Some(Self::FLEX_PERFORMANCE_DEFAULT),
-            "FLEX_PERFORMANCE_CUSTOM" => std::option::Option::Some(Self::FLEX_PERFORMANCE_CUSTOM),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FlexPerformance {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FlexPerformance {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FlexPerformance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FlexPerformance {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Default,
+            2 => Self::Custom,
+            _ => Self::UnknownValue(flex_performance::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FlexPerformance {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FLEX_PERFORMANCE_UNSPECIFIED" => Self::Unspecified,
+            "FLEX_PERFORMANCE_DEFAULT" => Self::Default,
+            "FLEX_PERFORMANCE_CUSTOM" => Self::Custom,
+            _ => Self::UnknownValue(flex_performance::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FlexPerformance {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Default => serializer.serialize_i32(1),
+            Self::Custom => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FlexPerformance {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FlexPerformance>::new(
+            ".google.cloud.netapp.v1.FlexPerformance",
+        ))
     }
 }
 
 /// The volume encryption key source.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncryptionType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EncryptionType {
+    /// The source of the encryption key is not specified.
+    Unspecified,
+    /// Google managed encryption key.
+    ServiceManaged,
+    /// Customer managed encryption key, which is stored in KMS.
+    CloudKms,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EncryptionType::value] or
+    /// [EncryptionType::name].
+    UnknownValue(encryption_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod encryption_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl EncryptionType {
-    /// The source of the encryption key is not specified.
-    pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
-
-    /// Google managed encryption key.
-    pub const SERVICE_MANAGED: EncryptionType = EncryptionType::new(1);
-
-    /// Customer managed encryption key, which is stored in KMS.
-    pub const CLOUD_KMS: EncryptionType = EncryptionType::new(2);
-
-    /// Creates a new EncryptionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ServiceManaged => std::option::Option::Some(1),
+            Self::CloudKms => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SERVICE_MANAGED"),
-            2 => std::borrow::Cow::Borrowed("CLOUD_KMS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENCRYPTION_TYPE_UNSPECIFIED"),
+            Self::ServiceManaged => std::option::Option::Some("SERVICE_MANAGED"),
+            Self::CloudKms => std::option::Option::Some("CLOUD_KMS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENCRYPTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
-            }
-            "SERVICE_MANAGED" => std::option::Option::Some(Self::SERVICE_MANAGED),
-            "CLOUD_KMS" => std::option::Option::Some(Self::CLOUD_KMS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EncryptionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EncryptionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EncryptionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EncryptionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ServiceManaged,
+            2 => Self::CloudKms,
+            _ => Self::UnknownValue(encryption_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EncryptionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENCRYPTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SERVICE_MANAGED" => Self::ServiceManaged,
+            "CLOUD_KMS" => Self::CloudKms,
+            _ => Self::UnknownValue(encryption_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EncryptionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ServiceManaged => serializer.serialize_i32(1),
+            Self::CloudKms => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EncryptionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionType>::new(
+            ".google.cloud.netapp.v1.EncryptionType",
+        ))
     }
 }
 
 /// Type of directory service
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DirectoryServiceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DirectoryServiceType {
+    /// Directory service type is not specified.
+    Unspecified,
+    /// Active directory policy attached to the storage pool.
+    ActiveDirectory,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DirectoryServiceType::value] or
+    /// [DirectoryServiceType::name].
+    UnknownValue(directory_service_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod directory_service_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DirectoryServiceType {
-    /// Directory service type is not specified.
-    pub const DIRECTORY_SERVICE_TYPE_UNSPECIFIED: DirectoryServiceType =
-        DirectoryServiceType::new(0);
-
-    /// Active directory policy attached to the storage pool.
-    pub const ACTIVE_DIRECTORY: DirectoryServiceType = DirectoryServiceType::new(1);
-
-    /// Creates a new DirectoryServiceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ActiveDirectory => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DIRECTORY_SERVICE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVE_DIRECTORY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DIRECTORY_SERVICE_TYPE_UNSPECIFIED"),
+            Self::ActiveDirectory => std::option::Option::Some("ACTIVE_DIRECTORY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DIRECTORY_SERVICE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DIRECTORY_SERVICE_TYPE_UNSPECIFIED)
-            }
-            "ACTIVE_DIRECTORY" => std::option::Option::Some(Self::ACTIVE_DIRECTORY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DirectoryServiceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DirectoryServiceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DirectoryServiceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DirectoryServiceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ActiveDirectory,
+            _ => Self::UnknownValue(directory_service_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DirectoryServiceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DIRECTORY_SERVICE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVE_DIRECTORY" => Self::ActiveDirectory,
+            _ => Self::UnknownValue(directory_service_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DirectoryServiceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ActiveDirectory => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DirectoryServiceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DirectoryServiceType>::new(
+            ".google.cloud.netapp.v1.DirectoryServiceType",
+        ))
     }
 }
 
 /// Protocols is an enum of all the supported network protocols for a volume.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Protocols(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Protocols {
+    /// Unspecified protocol
+    Unspecified,
+    /// NFS V3 protocol
+    Nfsv3,
+    /// NFS V4 protocol
+    Nfsv4,
+    /// SMB protocol
+    Smb,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Protocols::value] or
+    /// [Protocols::name].
+    UnknownValue(protocols::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod protocols {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Protocols {
-    /// Unspecified protocol
-    pub const PROTOCOLS_UNSPECIFIED: Protocols = Protocols::new(0);
-
-    /// NFS V3 protocol
-    pub const NFSV3: Protocols = Protocols::new(1);
-
-    /// NFS V4 protocol
-    pub const NFSV4: Protocols = Protocols::new(2);
-
-    /// SMB protocol
-    pub const SMB: Protocols = Protocols::new(3);
-
-    /// Creates a new Protocols instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Nfsv3 => std::option::Option::Some(1),
+            Self::Nfsv4 => std::option::Option::Some(2),
+            Self::Smb => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PROTOCOLS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NFSV3"),
-            2 => std::borrow::Cow::Borrowed("NFSV4"),
-            3 => std::borrow::Cow::Borrowed("SMB"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PROTOCOLS_UNSPECIFIED"),
+            Self::Nfsv3 => std::option::Option::Some("NFSV3"),
+            Self::Nfsv4 => std::option::Option::Some("NFSV4"),
+            Self::Smb => std::option::Option::Some("SMB"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PROTOCOLS_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOLS_UNSPECIFIED),
-            "NFSV3" => std::option::Option::Some(Self::NFSV3),
-            "NFSV4" => std::option::Option::Some(Self::NFSV4),
-            "SMB" => std::option::Option::Some(Self::SMB),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Protocols {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Protocols {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Protocols {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Protocols {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Nfsv3,
+            2 => Self::Nfsv4,
+            3 => Self::Smb,
+            _ => Self::UnknownValue(protocols::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Protocols {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PROTOCOLS_UNSPECIFIED" => Self::Unspecified,
+            "NFSV3" => Self::Nfsv3,
+            "NFSV4" => Self::Nfsv4,
+            "SMB" => Self::Smb,
+            _ => Self::UnknownValue(protocols::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Protocols {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Nfsv3 => serializer.serialize_i32(1),
+            Self::Nfsv4 => serializer.serialize_i32(2),
+            Self::Smb => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Protocols {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Protocols>::new(
+            ".google.cloud.netapp.v1.Protocols",
+        ))
     }
 }
 
 /// AccessType is an enum of all the supported access types for a volume.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AccessType {
+    /// Unspecified Access Type
+    Unspecified,
+    /// Read Only
+    ReadOnly,
+    /// Read Write
+    ReadWrite,
+    /// None
+    ReadNone,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AccessType::value] or
+    /// [AccessType::name].
+    UnknownValue(access_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod access_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl AccessType {
-    /// Unspecified Access Type
-    pub const ACCESS_TYPE_UNSPECIFIED: AccessType = AccessType::new(0);
-
-    /// Read Only
-    pub const READ_ONLY: AccessType = AccessType::new(1);
-
-    /// Read Write
-    pub const READ_WRITE: AccessType = AccessType::new(2);
-
-    /// None
-    pub const READ_NONE: AccessType = AccessType::new(3);
-
-    /// Creates a new AccessType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ReadOnly => std::option::Option::Some(1),
+            Self::ReadWrite => std::option::Option::Some(2),
+            Self::ReadNone => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ACCESS_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("READ_ONLY"),
-            2 => std::borrow::Cow::Borrowed("READ_WRITE"),
-            3 => std::borrow::Cow::Borrowed("READ_NONE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ACCESS_TYPE_UNSPECIFIED"),
+            Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+            Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+            Self::ReadNone => std::option::Option::Some("READ_NONE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ACCESS_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ACCESS_TYPE_UNSPECIFIED),
-            "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-            "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-            "READ_NONE" => std::option::Option::Some(Self::READ_NONE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AccessType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AccessType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AccessType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ReadOnly,
+            2 => Self::ReadWrite,
+            3 => Self::ReadNone,
+            _ => Self::UnknownValue(access_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AccessType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ACCESS_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "READ_ONLY" => Self::ReadOnly,
+            "READ_WRITE" => Self::ReadWrite,
+            "READ_NONE" => Self::ReadNone,
+            _ => Self::UnknownValue(access_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AccessType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ReadOnly => serializer.serialize_i32(1),
+            Self::ReadWrite => serializer.serialize_i32(2),
+            Self::ReadNone => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AccessType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessType>::new(
+            ".google.cloud.netapp.v1.AccessType",
+        ))
     }
 }
 
 /// SMBSettings
 /// Modifies the behaviour of a SMB volume.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SMBSettings(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SMBSettings {
+    /// Unspecified default option
+    Unspecified,
+    /// SMB setting encrypt data
+    EncryptData,
+    /// SMB setting browsable
+    Browsable,
+    /// SMB setting notify change
+    ChangeNotify,
+    /// SMB setting not to notify change
+    NonBrowsable,
+    /// SMB setting oplocks
+    Oplocks,
+    /// SMB setting to show snapshots
+    ShowSnapshot,
+    /// SMB setting to show previous versions
+    ShowPreviousVersions,
+    /// SMB setting to access volume based on enumerartion
+    AccessBasedEnumeration,
+    /// Continuously available enumeration
+    ContinuouslyAvailable,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SMBSettings::value] or
+    /// [SMBSettings::name].
+    UnknownValue(smb_settings::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod smb_settings {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SMBSettings {
-    /// Unspecified default option
-    pub const SMB_SETTINGS_UNSPECIFIED: SMBSettings = SMBSettings::new(0);
-
-    /// SMB setting encrypt data
-    pub const ENCRYPT_DATA: SMBSettings = SMBSettings::new(1);
-
-    /// SMB setting browsable
-    pub const BROWSABLE: SMBSettings = SMBSettings::new(2);
-
-    /// SMB setting notify change
-    pub const CHANGE_NOTIFY: SMBSettings = SMBSettings::new(3);
-
-    /// SMB setting not to notify change
-    pub const NON_BROWSABLE: SMBSettings = SMBSettings::new(4);
-
-    /// SMB setting oplocks
-    pub const OPLOCKS: SMBSettings = SMBSettings::new(5);
-
-    /// SMB setting to show snapshots
-    pub const SHOW_SNAPSHOT: SMBSettings = SMBSettings::new(6);
-
-    /// SMB setting to show previous versions
-    pub const SHOW_PREVIOUS_VERSIONS: SMBSettings = SMBSettings::new(7);
-
-    /// SMB setting to access volume based on enumerartion
-    pub const ACCESS_BASED_ENUMERATION: SMBSettings = SMBSettings::new(8);
-
-    /// Continuously available enumeration
-    pub const CONTINUOUSLY_AVAILABLE: SMBSettings = SMBSettings::new(9);
-
-    /// Creates a new SMBSettings instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::EncryptData => std::option::Option::Some(1),
+            Self::Browsable => std::option::Option::Some(2),
+            Self::ChangeNotify => std::option::Option::Some(3),
+            Self::NonBrowsable => std::option::Option::Some(4),
+            Self::Oplocks => std::option::Option::Some(5),
+            Self::ShowSnapshot => std::option::Option::Some(6),
+            Self::ShowPreviousVersions => std::option::Option::Some(7),
+            Self::AccessBasedEnumeration => std::option::Option::Some(8),
+            Self::ContinuouslyAvailable => std::option::Option::Some(9),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SMB_SETTINGS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENCRYPT_DATA"),
-            2 => std::borrow::Cow::Borrowed("BROWSABLE"),
-            3 => std::borrow::Cow::Borrowed("CHANGE_NOTIFY"),
-            4 => std::borrow::Cow::Borrowed("NON_BROWSABLE"),
-            5 => std::borrow::Cow::Borrowed("OPLOCKS"),
-            6 => std::borrow::Cow::Borrowed("SHOW_SNAPSHOT"),
-            7 => std::borrow::Cow::Borrowed("SHOW_PREVIOUS_VERSIONS"),
-            8 => std::borrow::Cow::Borrowed("ACCESS_BASED_ENUMERATION"),
-            9 => std::borrow::Cow::Borrowed("CONTINUOUSLY_AVAILABLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SMB_SETTINGS_UNSPECIFIED"),
+            Self::EncryptData => std::option::Option::Some("ENCRYPT_DATA"),
+            Self::Browsable => std::option::Option::Some("BROWSABLE"),
+            Self::ChangeNotify => std::option::Option::Some("CHANGE_NOTIFY"),
+            Self::NonBrowsable => std::option::Option::Some("NON_BROWSABLE"),
+            Self::Oplocks => std::option::Option::Some("OPLOCKS"),
+            Self::ShowSnapshot => std::option::Option::Some("SHOW_SNAPSHOT"),
+            Self::ShowPreviousVersions => std::option::Option::Some("SHOW_PREVIOUS_VERSIONS"),
+            Self::AccessBasedEnumeration => std::option::Option::Some("ACCESS_BASED_ENUMERATION"),
+            Self::ContinuouslyAvailable => std::option::Option::Some("CONTINUOUSLY_AVAILABLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SMB_SETTINGS_UNSPECIFIED" => std::option::Option::Some(Self::SMB_SETTINGS_UNSPECIFIED),
-            "ENCRYPT_DATA" => std::option::Option::Some(Self::ENCRYPT_DATA),
-            "BROWSABLE" => std::option::Option::Some(Self::BROWSABLE),
-            "CHANGE_NOTIFY" => std::option::Option::Some(Self::CHANGE_NOTIFY),
-            "NON_BROWSABLE" => std::option::Option::Some(Self::NON_BROWSABLE),
-            "OPLOCKS" => std::option::Option::Some(Self::OPLOCKS),
-            "SHOW_SNAPSHOT" => std::option::Option::Some(Self::SHOW_SNAPSHOT),
-            "SHOW_PREVIOUS_VERSIONS" => std::option::Option::Some(Self::SHOW_PREVIOUS_VERSIONS),
-            "ACCESS_BASED_ENUMERATION" => std::option::Option::Some(Self::ACCESS_BASED_ENUMERATION),
-            "CONTINUOUSLY_AVAILABLE" => std::option::Option::Some(Self::CONTINUOUSLY_AVAILABLE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SMBSettings {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SMBSettings {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SMBSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SMBSettings {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::EncryptData,
+            2 => Self::Browsable,
+            3 => Self::ChangeNotify,
+            4 => Self::NonBrowsable,
+            5 => Self::Oplocks,
+            6 => Self::ShowSnapshot,
+            7 => Self::ShowPreviousVersions,
+            8 => Self::AccessBasedEnumeration,
+            9 => Self::ContinuouslyAvailable,
+            _ => Self::UnknownValue(smb_settings::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SMBSettings {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SMB_SETTINGS_UNSPECIFIED" => Self::Unspecified,
+            "ENCRYPT_DATA" => Self::EncryptData,
+            "BROWSABLE" => Self::Browsable,
+            "CHANGE_NOTIFY" => Self::ChangeNotify,
+            "NON_BROWSABLE" => Self::NonBrowsable,
+            "OPLOCKS" => Self::Oplocks,
+            "SHOW_SNAPSHOT" => Self::ShowSnapshot,
+            "SHOW_PREVIOUS_VERSIONS" => Self::ShowPreviousVersions,
+            "ACCESS_BASED_ENUMERATION" => Self::AccessBasedEnumeration,
+            "CONTINUOUSLY_AVAILABLE" => Self::ContinuouslyAvailable,
+            _ => Self::UnknownValue(smb_settings::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SMBSettings {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::EncryptData => serializer.serialize_i32(1),
+            Self::Browsable => serializer.serialize_i32(2),
+            Self::ChangeNotify => serializer.serialize_i32(3),
+            Self::NonBrowsable => serializer.serialize_i32(4),
+            Self::Oplocks => serializer.serialize_i32(5),
+            Self::ShowSnapshot => serializer.serialize_i32(6),
+            Self::ShowPreviousVersions => serializer.serialize_i32(7),
+            Self::AccessBasedEnumeration => serializer.serialize_i32(8),
+            Self::ContinuouslyAvailable => serializer.serialize_i32(9),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SMBSettings {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SMBSettings>::new(
+            ".google.cloud.netapp.v1.SMBSettings",
+        ))
     }
 }
 
 /// The security style of the volume, can be either UNIX or NTFS.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SecurityStyle(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SecurityStyle {
+    /// SecurityStyle is unspecified
+    Unspecified,
+    /// SecurityStyle uses NTFS
+    Ntfs,
+    /// SecurityStyle uses UNIX
+    Unix,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SecurityStyle::value] or
+    /// [SecurityStyle::name].
+    UnknownValue(security_style::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod security_style {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SecurityStyle {
-    /// SecurityStyle is unspecified
-    pub const SECURITY_STYLE_UNSPECIFIED: SecurityStyle = SecurityStyle::new(0);
-
-    /// SecurityStyle uses NTFS
-    pub const NTFS: SecurityStyle = SecurityStyle::new(1);
-
-    /// SecurityStyle uses UNIX
-    pub const UNIX: SecurityStyle = SecurityStyle::new(2);
-
-    /// Creates a new SecurityStyle instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Ntfs => std::option::Option::Some(1),
+            Self::Unix => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SECURITY_STYLE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NTFS"),
-            2 => std::borrow::Cow::Borrowed("UNIX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SECURITY_STYLE_UNSPECIFIED"),
+            Self::Ntfs => std::option::Option::Some("NTFS"),
+            Self::Unix => std::option::Option::Some("UNIX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SECURITY_STYLE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SECURITY_STYLE_UNSPECIFIED)
-            }
-            "NTFS" => std::option::Option::Some(Self::NTFS),
-            "UNIX" => std::option::Option::Some(Self::UNIX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SecurityStyle {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SecurityStyle {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SecurityStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SecurityStyle {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Ntfs,
+            2 => Self::Unix,
+            _ => Self::UnknownValue(security_style::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SecurityStyle {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SECURITY_STYLE_UNSPECIFIED" => Self::Unspecified,
+            "NTFS" => Self::Ntfs,
+            "UNIX" => Self::Unix,
+            _ => Self::UnknownValue(security_style::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SecurityStyle {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Ntfs => serializer.serialize_i32(1),
+            Self::Unix => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SecurityStyle {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SecurityStyle>::new(
+            ".google.cloud.netapp.v1.SecurityStyle",
+        ))
     }
 }
 
 /// Actions to be restricted for a volume.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RestrictedAction(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RestrictedAction {
+    /// Unspecified restricted action
+    Unspecified,
+    /// Prevent volume from being deleted when mounted.
+    Delete,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RestrictedAction::value] or
+    /// [RestrictedAction::name].
+    UnknownValue(restricted_action::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod restricted_action {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RestrictedAction {
-    /// Unspecified restricted action
-    pub const RESTRICTED_ACTION_UNSPECIFIED: RestrictedAction = RestrictedAction::new(0);
-
-    /// Prevent volume from being deleted when mounted.
-    pub const DELETE: RestrictedAction = RestrictedAction::new(1);
-
-    /// Creates a new RestrictedAction instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Delete => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESTRICTED_ACTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DELETE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RESTRICTED_ACTION_UNSPECIFIED"),
+            Self::Delete => std::option::Option::Some("DELETE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESTRICTED_ACTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESTRICTED_ACTION_UNSPECIFIED)
-            }
-            "DELETE" => std::option::Option::Some(Self::DELETE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RestrictedAction {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RestrictedAction {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RestrictedAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RestrictedAction {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Delete,
+            _ => Self::UnknownValue(restricted_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RestrictedAction {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESTRICTED_ACTION_UNSPECIFIED" => Self::Unspecified,
+            "DELETE" => Self::Delete,
+            _ => Self::UnknownValue(restricted_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RestrictedAction {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Delete => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RestrictedAction {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestrictedAction>::new(
+            ".google.cloud.netapp.v1.RestrictedAction",
+        ))
     }
 }

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -546,79 +546,148 @@ pub mod service_connection_map {
         use super::*;
 
         /// PSC Consumer Config State.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// Default state, when Connection Map is created initially.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// Set when policy and map configuration is valid,
             /// and their matching can lead to allowing creation of PSC Connections
             /// subject to other constraints like connections limit.
-            pub const VALID: State = State::new(1);
-
+            Valid,
             /// No Service Connection Policy found for this network and Service
             /// Class
-            pub const CONNECTION_POLICY_MISSING: State = State::new(2);
-
+            ConnectionPolicyMissing,
             /// Service Connection Policy limit reached for this network and Service
             /// Class
-            pub const POLICY_LIMIT_REACHED: State = State::new(3);
-
+            PolicyLimitReached,
             /// The consumer instance project is not in
             /// AllowedGoogleProducersResourceHierarchyLevels of the matching
             /// ServiceConnectionPolicy.
-            pub const CONSUMER_INSTANCE_PROJECT_NOT_ALLOWLISTED: State = State::new(4);
+            ConsumerInstanceProjectNotAllowlisted,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Valid => std::option::Option::Some(1),
+                    Self::ConnectionPolicyMissing => std::option::Option::Some(2),
+                    Self::PolicyLimitReached => std::option::Option::Some(3),
+                    Self::ConsumerInstanceProjectNotAllowlisted => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("VALID"),
-                    2 => std::borrow::Cow::Borrowed("CONNECTION_POLICY_MISSING"),
-                    3 => std::borrow::Cow::Borrowed("POLICY_LIMIT_REACHED"),
-                    4 => std::borrow::Cow::Borrowed("CONSUMER_INSTANCE_PROJECT_NOT_ALLOWLISTED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "VALID" => std::option::Option::Some(Self::VALID),
-                    "CONNECTION_POLICY_MISSING" => {
-                        std::option::Option::Some(Self::CONNECTION_POLICY_MISSING)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Valid => std::option::Option::Some("VALID"),
+                    Self::ConnectionPolicyMissing => {
+                        std::option::Option::Some("CONNECTION_POLICY_MISSING")
                     }
-                    "POLICY_LIMIT_REACHED" => std::option::Option::Some(Self::POLICY_LIMIT_REACHED),
-                    "CONSUMER_INSTANCE_PROJECT_NOT_ALLOWLISTED" => {
-                        std::option::Option::Some(Self::CONSUMER_INSTANCE_PROJECT_NOT_ALLOWLISTED)
+                    Self::PolicyLimitReached => std::option::Option::Some("POLICY_LIMIT_REACHED"),
+                    Self::ConsumerInstanceProjectNotAllowlisted => {
+                        std::option::Option::Some("CONSUMER_INSTANCE_PROJECT_NOT_ALLOWLISTED")
                     }
-                    _ => std::option::Option::None,
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Valid,
+                    2 => Self::ConnectionPolicyMissing,
+                    3 => Self::PolicyLimitReached,
+                    4 => Self::ConsumerInstanceProjectNotAllowlisted,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "VALID" => Self::Valid,
+                    "CONNECTION_POLICY_MISSING" => Self::ConnectionPolicyMissing,
+                    "POLICY_LIMIT_REACHED" => Self::PolicyLimitReached,
+                    "CONSUMER_INSTANCE_PROJECT_NOT_ALLOWLISTED" => {
+                        Self::ConsumerInstanceProjectNotAllowlisted
+                    }
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Valid => serializer.serialize_i32(1),
+                    Self::ConnectionPolicyMissing => serializer.serialize_i32(2),
+                    Self::PolicyLimitReached => serializer.serialize_i32(3),
+                    Self::ConsumerInstanceProjectNotAllowlisted => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.networkconnectivity.v1.ServiceConnectionMap.ConsumerPscConfig.State"))
             }
         }
     }
@@ -862,82 +931,153 @@ pub mod service_connection_map {
         /// We reserve the right to add more states without notice in the future.
         /// Users should not use exhaustive switch statements on this enum.
         /// See <https://google.aip.dev/216>.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// An invalid state as the default case.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// The connection has been created successfully. However, for the
             /// up-to-date connection status, please use the service attachment's
             /// "ConnectedEndpoint.status" as the source of truth.
-            pub const ACTIVE: State = State::new(1);
-
+            Active,
             /// The connection is not functional since some resources on the connection
             /// fail to be created.
-            pub const FAILED: State = State::new(2);
-
+            Failed,
             /// The connection is being created.
-            pub const CREATING: State = State::new(3);
-
+            Creating,
             /// The connection is being deleted.
-            pub const DELETING: State = State::new(4);
-
+            Deleting,
             /// The connection is being repaired to complete creation.
-            pub const CREATE_REPAIRING: State = State::new(5);
-
+            CreateRepairing,
             /// The connection is being repaired to complete deletion.
-            pub const DELETE_REPAIRING: State = State::new(6);
+            DeleteRepairing,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Active => std::option::Option::Some(1),
+                    Self::Failed => std::option::Option::Some(2),
+                    Self::Creating => std::option::Option::Some(3),
+                    Self::Deleting => std::option::Option::Some(4),
+                    Self::CreateRepairing => std::option::Option::Some(5),
+                    Self::DeleteRepairing => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                    2 => std::borrow::Cow::Borrowed("FAILED"),
-                    3 => std::borrow::Cow::Borrowed("CREATING"),
-                    4 => std::borrow::Cow::Borrowed("DELETING"),
-                    5 => std::borrow::Cow::Borrowed("CREATE_REPAIRING"),
-                    6 => std::borrow::Cow::Borrowed("DELETE_REPAIRING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Active => std::option::Option::Some("ACTIVE"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::Creating => std::option::Option::Some("CREATING"),
+                    Self::Deleting => std::option::Option::Some("DELETING"),
+                    Self::CreateRepairing => std::option::Option::Some("CREATE_REPAIRING"),
+                    Self::DeleteRepairing => std::option::Option::Some("DELETE_REPAIRING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "CREATING" => std::option::Option::Some(Self::CREATING),
-                    "DELETING" => std::option::Option::Some(Self::DELETING),
-                    "CREATE_REPAIRING" => std::option::Option::Some(Self::CREATE_REPAIRING),
-                    "DELETE_REPAIRING" => std::option::Option::Some(Self::DELETE_REPAIRING),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Active,
+                    2 => Self::Failed,
+                    3 => Self::Creating,
+                    4 => Self::Deleting,
+                    5 => Self::CreateRepairing,
+                    6 => Self::DeleteRepairing,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "ACTIVE" => Self::Active,
+                    "FAILED" => Self::Failed,
+                    "CREATING" => Self::Creating,
+                    "DELETING" => Self::Deleting,
+                    "CREATE_REPAIRING" => Self::CreateRepairing,
+                    "DELETE_REPAIRING" => Self::DeleteRepairing,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Active => serializer.serialize_i32(1),
+                    Self::Failed => serializer.serialize_i32(2),
+                    Self::Creating => serializer.serialize_i32(3),
+                    Self::Deleting => serializer.serialize_i32(4),
+                    Self::CreateRepairing => serializer.serialize_i32(5),
+                    Self::DeleteRepairing => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.networkconnectivity.v1.ServiceConnectionMap.ConsumerPscConnection.State"))
             }
         }
     }
@@ -1643,66 +1783,125 @@ pub mod service_connection_policy {
 
         /// ProducerInstanceLocation is used to specify which authorization mechanism
         /// to use to determine which projects the Producer instance can be within.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ProducerInstanceLocation(i32);
-
-        impl ProducerInstanceLocation {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ProducerInstanceLocation {
             /// Producer instance location is not specified. When this option is
             /// chosen, then the PSC connections created by this
             /// ServiceConnectionPolicy must be within the same project as the Producer
             /// instance. This is the default ProducerInstanceLocation value.
             /// To allow for PSC connections from this network to other networks, use
             /// the CUSTOM_RESOURCE_HIERARCHY_LEVELS option.
-            pub const PRODUCER_INSTANCE_LOCATION_UNSPECIFIED: ProducerInstanceLocation =
-                ProducerInstanceLocation::new(0);
-
+            Unspecified,
             /// Producer instance must be within one of the values provided in
             /// allowed_google_producers_resource_hierarchy_level.
-            pub const CUSTOM_RESOURCE_HIERARCHY_LEVELS: ProducerInstanceLocation =
-                ProducerInstanceLocation::new(1);
+            CustomResourceHierarchyLevels,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ProducerInstanceLocation::value] or
+            /// [ProducerInstanceLocation::name].
+            UnknownValue(producer_instance_location::UnknownValue),
+        }
 
-            /// Creates a new ProducerInstanceLocation instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod producer_instance_location {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ProducerInstanceLocation {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::CustomResourceHierarchyLevels => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CUSTOM_RESOURCE_HIERARCHY_LEVELS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PRODUCER_INSTANCE_LOCATION_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("PRODUCER_INSTANCE_LOCATION_UNSPECIFIED")
                     }
-                    "CUSTOM_RESOURCE_HIERARCHY_LEVELS" => {
-                        std::option::Option::Some(Self::CUSTOM_RESOURCE_HIERARCHY_LEVELS)
+                    Self::CustomResourceHierarchyLevels => {
+                        std::option::Option::Some("CUSTOM_RESOURCE_HIERARCHY_LEVELS")
                     }
-                    _ => std::option::Option::None,
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ProducerInstanceLocation {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ProducerInstanceLocation {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ProducerInstanceLocation {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ProducerInstanceLocation {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::CustomResourceHierarchyLevels,
+                    _ => Self::UnknownValue(producer_instance_location::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ProducerInstanceLocation {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED" => Self::Unspecified,
+                    "CUSTOM_RESOURCE_HIERARCHY_LEVELS" => Self::CustomResourceHierarchyLevels,
+                    _ => Self::UnknownValue(producer_instance_location::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ProducerInstanceLocation {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::CustomResourceHierarchyLevels => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ProducerInstanceLocation {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProducerInstanceLocation>::new(
+                    ".google.cloud.networkconnectivity.v1.ServiceConnectionPolicy.PscConfig.ProducerInstanceLocation"))
             }
         }
     }
@@ -1928,82 +2127,151 @@ pub mod service_connection_policy {
     /// We reserve the right to add more states without notice in the future.
     /// Users should not use exhaustive switch statements on this enum.
     /// See <https://google.aip.dev/216>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// An invalid state as the default case.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The connection has been created successfully. However, for the
         /// up-to-date connection status, please use the created forwarding rule's
         /// "PscConnectionStatus" as the source of truth.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The connection is not functional since some resources on the connection
         /// fail to be created.
-        pub const FAILED: State = State::new(2);
-
+        Failed,
         /// The connection is being created.
-        pub const CREATING: State = State::new(3);
-
+        Creating,
         /// The connection is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The connection is being repaired to complete creation.
-        pub const CREATE_REPAIRING: State = State::new(5);
-
+        CreateRepairing,
         /// The connection is being repaired to complete deletion.
-        pub const DELETE_REPAIRING: State = State::new(6);
+        DeleteRepairing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Creating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::CreateRepairing => std::option::Option::Some(5),
+                Self::DeleteRepairing => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("CREATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("CREATE_REPAIRING"),
-                6 => std::borrow::Cow::Borrowed("DELETE_REPAIRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::CreateRepairing => std::option::Option::Some("CREATE_REPAIRING"),
+                Self::DeleteRepairing => std::option::Option::Some("DELETE_REPAIRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "CREATE_REPAIRING" => std::option::Option::Some(Self::CREATE_REPAIRING),
-                "DELETE_REPAIRING" => std::option::Option::Some(Self::DELETE_REPAIRING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Failed,
+                3 => Self::Creating,
+                4 => Self::Deleting,
+                5 => Self::CreateRepairing,
+                6 => Self::DeleteRepairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "CREATE_REPAIRING" => Self::CreateRepairing,
+                "DELETE_REPAIRING" => Self::DeleteRepairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Creating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::CreateRepairing => serializer.serialize_i32(5),
+                Self::DeleteRepairing => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.networkconnectivity.v1.ServiceConnectionPolicy.State",
+            ))
         }
     }
 }
@@ -3935,88 +4203,160 @@ pub mod spoke {
         use super::*;
 
         /// The Code enum represents the various reasons a state can be `INACTIVE`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(i32);
-
-        impl Code {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Code {
             /// No information available.
-            pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+            Unspecified,
             /// The proposed spoke is pending review.
-            pub const PENDING_REVIEW: Code = Code::new(1);
-
+            PendingReview,
             /// The proposed spoke has been rejected by the hub administrator.
-            pub const REJECTED: Code = Code::new(2);
-
+            Rejected,
             /// The spoke has been deactivated internally.
-            pub const PAUSED: Code = Code::new(3);
-
+            Paused,
             /// Network Connectivity Center encountered errors while accepting
             /// the spoke.
-            pub const FAILED: Code = Code::new(4);
-
+            Failed,
             /// The proposed spoke update is pending review.
-            pub const UPDATE_PENDING_REVIEW: Code = Code::new(5);
-
+            UpdatePendingReview,
             /// The proposed spoke update has been rejected by the hub administrator.
-            pub const UPDATE_REJECTED: Code = Code::new(6);
-
+            UpdateRejected,
             /// Network Connectivity Center encountered errors while accepting
             /// the spoke update.
-            pub const UPDATE_FAILED: Code = Code::new(7);
+            UpdateFailed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Code::value] or
+            /// [Code::name].
+            UnknownValue(code::UnknownValue),
+        }
 
-            /// Creates a new Code instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod code {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Code {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::PendingReview => std::option::Option::Some(1),
+                    Self::Rejected => std::option::Option::Some(2),
+                    Self::Paused => std::option::Option::Some(3),
+                    Self::Failed => std::option::Option::Some(4),
+                    Self::UpdatePendingReview => std::option::Option::Some(5),
+                    Self::UpdateRejected => std::option::Option::Some(6),
+                    Self::UpdateFailed => std::option::Option::Some(7),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PENDING_REVIEW"),
-                    2 => std::borrow::Cow::Borrowed("REJECTED"),
-                    3 => std::borrow::Cow::Borrowed("PAUSED"),
-                    4 => std::borrow::Cow::Borrowed("FAILED"),
-                    5 => std::borrow::Cow::Borrowed("UPDATE_PENDING_REVIEW"),
-                    6 => std::borrow::Cow::Borrowed("UPDATE_REJECTED"),
-                    7 => std::borrow::Cow::Borrowed("UPDATE_FAILED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                    Self::PendingReview => std::option::Option::Some("PENDING_REVIEW"),
+                    Self::Rejected => std::option::Option::Some("REJECTED"),
+                    Self::Paused => std::option::Option::Some("PAUSED"),
+                    Self::Failed => std::option::Option::Some("FAILED"),
+                    Self::UpdatePendingReview => std::option::Option::Some("UPDATE_PENDING_REVIEW"),
+                    Self::UpdateRejected => std::option::Option::Some("UPDATE_REJECTED"),
+                    Self::UpdateFailed => std::option::Option::Some("UPDATE_FAILED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                    "PENDING_REVIEW" => std::option::Option::Some(Self::PENDING_REVIEW),
-                    "REJECTED" => std::option::Option::Some(Self::REJECTED),
-                    "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                    "FAILED" => std::option::Option::Some(Self::FAILED),
-                    "UPDATE_PENDING_REVIEW" => {
-                        std::option::Option::Some(Self::UPDATE_PENDING_REVIEW)
-                    }
-                    "UPDATE_REJECTED" => std::option::Option::Some(Self::UPDATE_REJECTED),
-                    "UPDATE_FAILED" => std::option::Option::Some(Self::UPDATE_FAILED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Code {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Code {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::PendingReview,
+                    2 => Self::Rejected,
+                    3 => Self::Paused,
+                    4 => Self::Failed,
+                    5 => Self::UpdatePendingReview,
+                    6 => Self::UpdateRejected,
+                    7 => Self::UpdateFailed,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Code {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CODE_UNSPECIFIED" => Self::Unspecified,
+                    "PENDING_REVIEW" => Self::PendingReview,
+                    "REJECTED" => Self::Rejected,
+                    "PAUSED" => Self::Paused,
+                    "FAILED" => Self::Failed,
+                    "UPDATE_PENDING_REVIEW" => Self::UpdatePendingReview,
+                    "UPDATE_REJECTED" => Self::UpdateRejected,
+                    "UPDATE_FAILED" => Self::UpdateFailed,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Code {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::PendingReview => serializer.serialize_i32(1),
+                    Self::Rejected => serializer.serialize_i32(2),
+                    Self::Paused => serializer.serialize_i32(3),
+                    Self::Failed => serializer.serialize_i32(4),
+                    Self::UpdatePendingReview => serializer.serialize_i32(5),
+                    Self::UpdateRejected => serializer.serialize_i32(6),
+                    Self::UpdateFailed => serializer.serialize_i32(7),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Code {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                    ".google.cloud.networkconnectivity.v1.Spoke.StateReason.Code",
+                ))
             }
         }
     }
@@ -5072,63 +5412,124 @@ pub mod list_hub_spokes_request {
     use super::*;
 
     /// Enum that controls which spoke fields are included in the response.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SpokeView(i32);
-
-    impl SpokeView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SpokeView {
         /// The spoke view is unspecified. When the spoke view is unspecified, the
         /// API returns the same fields as the `BASIC` view.
-        pub const SPOKE_VIEW_UNSPECIFIED: SpokeView = SpokeView::new(0);
-
+        Unspecified,
         /// Includes `name`, `create_time`, `hub`, `unique_id`, `state`, `reasons`,
         /// and `spoke_type`. This is the default value.
-        pub const BASIC: SpokeView = SpokeView::new(1);
-
+        Basic,
         /// Includes all spoke fields except `labels`.
         /// You can use the `DETAILED` view only when you set the `spoke_locations`
         /// field to `[global]`.
-        pub const DETAILED: SpokeView = SpokeView::new(2);
+        Detailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SpokeView::value] or
+        /// [SpokeView::name].
+        UnknownValue(spoke_view::UnknownValue),
+    }
 
-        /// Creates a new SpokeView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod spoke_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SpokeView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Detailed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SPOKE_VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("DETAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SPOKE_VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Detailed => std::option::Option::Some("DETAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SPOKE_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::SPOKE_VIEW_UNSPECIFIED),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "DETAILED" => std::option::Option::Some(Self::DETAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SpokeView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SpokeView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SpokeView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SpokeView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Detailed,
+                _ => Self::UnknownValue(spoke_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SpokeView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SPOKE_VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "DETAILED" => Self::Detailed,
+                _ => Self::UnknownValue(spoke_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SpokeView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Detailed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SpokeView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SpokeView>::new(
+                ".google.cloud.networkconnectivity.v1.ListHubSpokesRequest.SpokeView",
+            ))
         }
     }
 }
@@ -5561,99 +5962,170 @@ pub mod psc_propagation_status {
 
     /// The Code enum represents the state of the Private Service Connect
     /// propagation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// The code is unspecified.
-        pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+        Unspecified,
         /// The propagated Private Service Connect connection is ready.
-        pub const READY: Code = Code::new(1);
-
+        Ready,
         /// The Private Service Connect connection is propagating. This is a
         /// transient state.
-        pub const PROPAGATING: Code = Code::new(2);
-
+        Propagating,
         /// The Private Service Connect connection propagation failed because the VPC
         /// network or the project of the target spoke has exceeded the connection
         /// limit set by the producer.
-        pub const ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED: Code = Code::new(3);
-
+        ErrorProducerPropagatedConnectionLimitExceeded,
         /// The Private Service Connect connection propagation failed because the NAT
         /// IP subnet space has been exhausted. It is equivalent to the `Needs
         /// attention` status of the Private Service Connect connection. See
         /// <https://cloud.google.com/vpc/docs/about-accessing-vpc-hosted-services-endpoints#connection-statuses>.
-        pub const ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED: Code = Code::new(4);
-
+        ErrorProducerNatIpSpaceExhausted,
         /// The Private Service Connect connection propagation failed because the
         /// `PSC_ILB_CONSUMER_FORWARDING_RULES_PER_PRODUCER_NETWORK` quota in the
         /// producer VPC network has been exceeded.
-        pub const ERROR_PRODUCER_QUOTA_EXCEEDED: Code = Code::new(5);
-
+        ErrorProducerQuotaExceeded,
         /// The Private Service Connect connection propagation failed because the
         /// `PSC_PROPAGATED_CONNECTIONS_PER_VPC_NETWORK` quota in the consumer
         /// VPC network has been exceeded.
-        pub const ERROR_CONSUMER_QUOTA_EXCEEDED: Code = Code::new(6);
+        ErrorConsumerQuotaExceeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Propagating => std::option::Option::Some(2),
+                Self::ErrorProducerPropagatedConnectionLimitExceeded => {
+                    std::option::Option::Some(3)
+                }
+                Self::ErrorProducerNatIpSpaceExhausted => std::option::Option::Some(4),
+                Self::ErrorProducerQuotaExceeded => std::option::Option::Some(5),
+                Self::ErrorConsumerQuotaExceeded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("PROPAGATING"),
-                3 => std::borrow::Cow::Borrowed(
-                    "ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED",
-                ),
-                4 => std::borrow::Cow::Borrowed("ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED"),
-                5 => std::borrow::Cow::Borrowed("ERROR_PRODUCER_QUOTA_EXCEEDED"),
-                6 => std::borrow::Cow::Borrowed("ERROR_CONSUMER_QUOTA_EXCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Propagating => std::option::Option::Some("PROPAGATING"),
+                Self::ErrorProducerPropagatedConnectionLimitExceeded => {
+                    std::option::Option::Some("ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED")
+                }
+                Self::ErrorProducerNatIpSpaceExhausted => {
+                    std::option::Option::Some("ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED")
+                }
+                Self::ErrorProducerQuotaExceeded => {
+                    std::option::Option::Some("ERROR_PRODUCER_QUOTA_EXCEEDED")
+                }
+                Self::ErrorConsumerQuotaExceeded => {
+                    std::option::Option::Some("ERROR_CONSUMER_QUOTA_EXCEEDED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "PROPAGATING" => std::option::Option::Some(Self::PROPAGATING),
-                "ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED" => std::option::Option::Some(
-                    Self::ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED,
-                ),
-                "ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED" => {
-                    std::option::Option::Some(Self::ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED)
-                }
-                "ERROR_PRODUCER_QUOTA_EXCEEDED" => {
-                    std::option::Option::Some(Self::ERROR_PRODUCER_QUOTA_EXCEEDED)
-                }
-                "ERROR_CONSUMER_QUOTA_EXCEEDED" => {
-                    std::option::Option::Some(Self::ERROR_CONSUMER_QUOTA_EXCEEDED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Propagating,
+                3 => Self::ErrorProducerPropagatedConnectionLimitExceeded,
+                4 => Self::ErrorProducerNatIpSpaceExhausted,
+                5 => Self::ErrorProducerQuotaExceeded,
+                6 => Self::ErrorConsumerQuotaExceeded,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CODE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "PROPAGATING" => Self::Propagating,
+                "ERROR_PRODUCER_PROPAGATED_CONNECTION_LIMIT_EXCEEDED" => {
+                    Self::ErrorProducerPropagatedConnectionLimitExceeded
+                }
+                "ERROR_PRODUCER_NAT_IP_SPACE_EXHAUSTED" => Self::ErrorProducerNatIpSpaceExhausted,
+                "ERROR_PRODUCER_QUOTA_EXCEEDED" => Self::ErrorProducerQuotaExceeded,
+                "ERROR_CONSUMER_QUOTA_EXCEEDED" => Self::ErrorConsumerQuotaExceeded,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Propagating => serializer.serialize_i32(2),
+                Self::ErrorProducerPropagatedConnectionLimitExceeded => serializer.serialize_i32(3),
+                Self::ErrorProducerNatIpSpaceExhausted => serializer.serialize_i32(4),
+                Self::ErrorProducerQuotaExceeded => serializer.serialize_i32(5),
+                Self::ErrorConsumerQuotaExceeded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.cloud.networkconnectivity.v1.PscPropagationStatus.Code",
+            ))
         }
     }
 }
@@ -8653,56 +9125,116 @@ pub mod policy_based_route {
         use super::*;
 
         /// The internet protocol version.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ProtocolVersion(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ProtocolVersion {
+            /// Default value.
+            Unspecified,
+            /// The PBR is for IPv4 internet protocol traffic.
+            Ipv4,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ProtocolVersion::value] or
+            /// [ProtocolVersion::name].
+            UnknownValue(protocol_version::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod protocol_version {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ProtocolVersion {
-            /// Default value.
-            pub const PROTOCOL_VERSION_UNSPECIFIED: ProtocolVersion = ProtocolVersion::new(0);
-
-            /// The PBR is for IPv4 internet protocol traffic.
-            pub const IPV4: ProtocolVersion = ProtocolVersion::new(1);
-
-            /// Creates a new ProtocolVersion instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Ipv4 => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PROTOCOL_VERSION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IPV4"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PROTOCOL_VERSION_UNSPECIFIED"),
+                    Self::Ipv4 => std::option::Option::Some("IPV4"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PROTOCOL_VERSION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PROTOCOL_VERSION_UNSPECIFIED)
-                    }
-                    "IPV4" => std::option::Option::Some(Self::IPV4),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ProtocolVersion {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ProtocolVersion {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ProtocolVersion {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ProtocolVersion {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Ipv4,
+                    _ => Self::UnknownValue(protocol_version::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ProtocolVersion {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PROTOCOL_VERSION_UNSPECIFIED" => Self::Unspecified,
+                    "IPV4" => Self::Ipv4,
+                    _ => Self::UnknownValue(protocol_version::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ProtocolVersion {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Ipv4 => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ProtocolVersion {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProtocolVersion>::new(
+                    ".google.cloud.networkconnectivity.v1.PolicyBasedRoute.Filter.ProtocolVersion",
+                ))
             }
         }
     }
@@ -8782,122 +9314,243 @@ pub mod policy_based_route {
 
         /// Warning code for policy-based routing. Expect to add values in the
         /// future.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(i32);
-
-        impl Code {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Code {
             /// Default value.
-            pub const WARNING_UNSPECIFIED: Code = Code::new(0);
-
+            WarningUnspecified,
             /// The policy-based route is not active and functioning. Common causes are
             /// that the dependent network was deleted or the resource project was
             /// turned off.
-            pub const RESOURCE_NOT_ACTIVE: Code = Code::new(1);
-
+            ResourceNotActive,
             /// The policy-based route is being modified (e.g. created/deleted) at this
             /// time.
-            pub const RESOURCE_BEING_MODIFIED: Code = Code::new(2);
+            ResourceBeingModified,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Code::value] or
+            /// [Code::name].
+            UnknownValue(code::UnknownValue),
+        }
 
-            /// Creates a new Code instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod code {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Code {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::WarningUnspecified => std::option::Option::Some(0),
+                    Self::ResourceNotActive => std::option::Option::Some(1),
+                    Self::ResourceBeingModified => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("WARNING_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RESOURCE_NOT_ACTIVE"),
-                    2 => std::borrow::Cow::Borrowed("RESOURCE_BEING_MODIFIED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "WARNING_UNSPECIFIED" => std::option::Option::Some(Self::WARNING_UNSPECIFIED),
-                    "RESOURCE_NOT_ACTIVE" => std::option::Option::Some(Self::RESOURCE_NOT_ACTIVE),
-                    "RESOURCE_BEING_MODIFIED" => {
-                        std::option::Option::Some(Self::RESOURCE_BEING_MODIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::WarningUnspecified => std::option::Option::Some("WARNING_UNSPECIFIED"),
+                    Self::ResourceNotActive => std::option::Option::Some("RESOURCE_NOT_ACTIVE"),
+                    Self::ResourceBeingModified => {
+                        std::option::Option::Some("RESOURCE_BEING_MODIFIED")
                     }
-                    _ => std::option::Option::None,
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for Code {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Code {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::WarningUnspecified,
+                    1 => Self::ResourceNotActive,
+                    2 => Self::ResourceBeingModified,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Code {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "WARNING_UNSPECIFIED" => Self::WarningUnspecified,
+                    "RESOURCE_NOT_ACTIVE" => Self::ResourceNotActive,
+                    "RESOURCE_BEING_MODIFIED" => Self::ResourceBeingModified,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Code {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::WarningUnspecified => serializer.serialize_i32(0),
+                    Self::ResourceNotActive => serializer.serialize_i32(1),
+                    Self::ResourceBeingModified => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Code {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                    ".google.cloud.networkconnectivity.v1.PolicyBasedRoute.Warnings.Code",
+                ))
             }
         }
     }
 
     /// The other routing cases.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OtherRoutes(i32);
-
-    impl OtherRoutes {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OtherRoutes {
         /// Default value.
-        pub const OTHER_ROUTES_UNSPECIFIED: OtherRoutes = OtherRoutes::new(0);
-
+        Unspecified,
         /// Use the routes from the default routing tables (system-generated routes,
         /// custom routes, peering route) to determine the next hop. This effectively
         /// excludes matching packets being applied on other PBRs with a lower
         /// priority.
-        pub const DEFAULT_ROUTING: OtherRoutes = OtherRoutes::new(1);
+        DefaultRouting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OtherRoutes::value] or
+        /// [OtherRoutes::name].
+        UnknownValue(other_routes::UnknownValue),
+    }
 
-        /// Creates a new OtherRoutes instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod other_routes {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OtherRoutes {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DefaultRouting => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OTHER_ROUTES_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT_ROUTING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OTHER_ROUTES_UNSPECIFIED"),
+                Self::DefaultRouting => std::option::Option::Some("DEFAULT_ROUTING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OTHER_ROUTES_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OTHER_ROUTES_UNSPECIFIED)
-                }
-                "DEFAULT_ROUTING" => std::option::Option::Some(Self::DEFAULT_ROUTING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OtherRoutes {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OtherRoutes {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OtherRoutes {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OtherRoutes {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DefaultRouting,
+                _ => Self::UnknownValue(other_routes::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OtherRoutes {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OTHER_ROUTES_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT_ROUTING" => Self::DefaultRouting,
+                _ => Self::UnknownValue(other_routes::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OtherRoutes {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DefaultRouting => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OtherRoutes {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OtherRoutes>::new(
+                ".google.cloud.networkconnectivity.v1.PolicyBasedRoute.OtherRoutes",
+            ))
         }
     }
 
@@ -9276,588 +9929,1149 @@ impl wkt::message::Message for DeletePolicyBasedRouteRequest {
 }
 
 /// The infrastructure used for connections between consumers/producers.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Infrastructure(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Infrastructure {
+    /// An invalid infrastructure as the default case.
+    Unspecified,
+    /// Private Service Connect is used for connections.
+    Psc,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Infrastructure::value] or
+    /// [Infrastructure::name].
+    UnknownValue(infrastructure::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod infrastructure {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Infrastructure {
-    /// An invalid infrastructure as the default case.
-    pub const INFRASTRUCTURE_UNSPECIFIED: Infrastructure = Infrastructure::new(0);
-
-    /// Private Service Connect is used for connections.
-    pub const PSC: Infrastructure = Infrastructure::new(1);
-
-    /// Creates a new Infrastructure instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Psc => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INFRASTRUCTURE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PSC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INFRASTRUCTURE_UNSPECIFIED"),
+            Self::Psc => std::option::Option::Some("PSC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INFRASTRUCTURE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INFRASTRUCTURE_UNSPECIFIED)
-            }
-            "PSC" => std::option::Option::Some(Self::PSC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Infrastructure {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Infrastructure {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Infrastructure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Infrastructure {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Psc,
+            _ => Self::UnknownValue(infrastructure::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Infrastructure {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INFRASTRUCTURE_UNSPECIFIED" => Self::Unspecified,
+            "PSC" => Self::Psc,
+            _ => Self::UnknownValue(infrastructure::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Infrastructure {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Psc => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Infrastructure {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Infrastructure>::new(
+            ".google.cloud.networkconnectivity.v1.Infrastructure",
+        ))
     }
 }
 
 /// The error type indicates whether a connection error is consumer facing,
 /// producer facing or system internal.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionErrorType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectionErrorType {
+    /// An invalid error type as the default case.
+    Unspecified,
+    /// The error is due to Service Automation system internal.
+    ErrorInternal,
+    /// The error is due to the setup on consumer side.
+    ErrorConsumerSide,
+    /// The error is due to the setup on producer side.
+    ErrorProducerSide,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConnectionErrorType::value] or
+    /// [ConnectionErrorType::name].
+    UnknownValue(connection_error_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod connection_error_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ConnectionErrorType {
-    /// An invalid error type as the default case.
-    pub const CONNECTION_ERROR_TYPE_UNSPECIFIED: ConnectionErrorType = ConnectionErrorType::new(0);
-
-    /// The error is due to Service Automation system internal.
-    pub const ERROR_INTERNAL: ConnectionErrorType = ConnectionErrorType::new(1);
-
-    /// The error is due to the setup on consumer side.
-    pub const ERROR_CONSUMER_SIDE: ConnectionErrorType = ConnectionErrorType::new(2);
-
-    /// The error is due to the setup on producer side.
-    pub const ERROR_PRODUCER_SIDE: ConnectionErrorType = ConnectionErrorType::new(3);
-
-    /// Creates a new ConnectionErrorType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ErrorInternal => std::option::Option::Some(1),
+            Self::ErrorConsumerSide => std::option::Option::Some(2),
+            Self::ErrorProducerSide => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONNECTION_ERROR_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ERROR_INTERNAL"),
-            2 => std::borrow::Cow::Borrowed("ERROR_CONSUMER_SIDE"),
-            3 => std::borrow::Cow::Borrowed("ERROR_PRODUCER_SIDE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONNECTION_ERROR_TYPE_UNSPECIFIED"),
+            Self::ErrorInternal => std::option::Option::Some("ERROR_INTERNAL"),
+            Self::ErrorConsumerSide => std::option::Option::Some("ERROR_CONSUMER_SIDE"),
+            Self::ErrorProducerSide => std::option::Option::Some("ERROR_PRODUCER_SIDE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONNECTION_ERROR_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONNECTION_ERROR_TYPE_UNSPECIFIED)
-            }
-            "ERROR_INTERNAL" => std::option::Option::Some(Self::ERROR_INTERNAL),
-            "ERROR_CONSUMER_SIDE" => std::option::Option::Some(Self::ERROR_CONSUMER_SIDE),
-            "ERROR_PRODUCER_SIDE" => std::option::Option::Some(Self::ERROR_PRODUCER_SIDE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConnectionErrorType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionErrorType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConnectionErrorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConnectionErrorType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ErrorInternal,
+            2 => Self::ErrorConsumerSide,
+            3 => Self::ErrorProducerSide,
+            _ => Self::UnknownValue(connection_error_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConnectionErrorType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONNECTION_ERROR_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ERROR_INTERNAL" => Self::ErrorInternal,
+            "ERROR_CONSUMER_SIDE" => Self::ErrorConsumerSide,
+            "ERROR_PRODUCER_SIDE" => Self::ErrorProducerSide,
+            _ => Self::UnknownValue(connection_error_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConnectionErrorType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ErrorInternal => serializer.serialize_i32(1),
+            Self::ErrorConsumerSide => serializer.serialize_i32(2),
+            Self::ErrorProducerSide => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConnectionErrorType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionErrorType>::new(
+            ".google.cloud.networkconnectivity.v1.ConnectionErrorType",
+        ))
     }
 }
 
 /// The requested IP version for the PSC connection.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IPVersion(i32);
-
-impl IPVersion {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IPVersion {
     /// Default value. We will use IPv4 or IPv6 depending on the IP version of
     /// first available subnetwork.
-    pub const IP_VERSION_UNSPECIFIED: IPVersion = IPVersion::new(0);
-
+    Unspecified,
     /// Will use IPv4 only.
-    pub const IPV4: IPVersion = IPVersion::new(1);
-
+    Ipv4,
     /// Will use IPv6 only.
-    pub const IPV6: IPVersion = IPVersion::new(2);
+    Ipv6,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IPVersion::value] or
+    /// [IPVersion::name].
+    UnknownValue(ip_version::UnknownValue),
+}
 
-    /// Creates a new IPVersion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod ip_version {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl IPVersion {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Ipv4 => std::option::Option::Some(1),
+            Self::Ipv6 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IP_VERSION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IPV4"),
-            2 => std::borrow::Cow::Borrowed("IPV6"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("IP_VERSION_UNSPECIFIED"),
+            Self::Ipv4 => std::option::Option::Some("IPV4"),
+            Self::Ipv6 => std::option::Option::Some("IPV6"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IP_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::IP_VERSION_UNSPECIFIED),
-            "IPV4" => std::option::Option::Some(Self::IPV4),
-            "IPV6" => std::option::Option::Some(Self::IPV6),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IPVersion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IPVersion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IPVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IPVersion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Ipv4,
+            2 => Self::Ipv6,
+            _ => Self::UnknownValue(ip_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IPVersion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IP_VERSION_UNSPECIFIED" => Self::Unspecified,
+            "IPV4" => Self::Ipv4,
+            "IPV6" => Self::Ipv6,
+            _ => Self::UnknownValue(ip_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IPVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Ipv4 => serializer.serialize_i32(1),
+            Self::Ipv6 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IPVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IPVersion>::new(
+            ".google.cloud.networkconnectivity.v1.IPVersion",
+        ))
     }
 }
 
 /// Supported features for a location
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LocationFeature(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LocationFeature {
+    /// No publicly supported feature in this location
+    Unspecified,
+    /// Site-to-cloud spokes are supported in this location
+    SiteToCloudSpokes,
+    /// Site-to-site spokes are supported in this location
+    SiteToSiteSpokes,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LocationFeature::value] or
+    /// [LocationFeature::name].
+    UnknownValue(location_feature::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod location_feature {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LocationFeature {
-    /// No publicly supported feature in this location
-    pub const LOCATION_FEATURE_UNSPECIFIED: LocationFeature = LocationFeature::new(0);
-
-    /// Site-to-cloud spokes are supported in this location
-    pub const SITE_TO_CLOUD_SPOKES: LocationFeature = LocationFeature::new(1);
-
-    /// Site-to-site spokes are supported in this location
-    pub const SITE_TO_SITE_SPOKES: LocationFeature = LocationFeature::new(2);
-
-    /// Creates a new LocationFeature instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::SiteToCloudSpokes => std::option::Option::Some(1),
+            Self::SiteToSiteSpokes => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LOCATION_FEATURE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SITE_TO_CLOUD_SPOKES"),
-            2 => std::borrow::Cow::Borrowed("SITE_TO_SITE_SPOKES"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LOCATION_FEATURE_UNSPECIFIED"),
+            Self::SiteToCloudSpokes => std::option::Option::Some("SITE_TO_CLOUD_SPOKES"),
+            Self::SiteToSiteSpokes => std::option::Option::Some("SITE_TO_SITE_SPOKES"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LOCATION_FEATURE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LOCATION_FEATURE_UNSPECIFIED)
-            }
-            "SITE_TO_CLOUD_SPOKES" => std::option::Option::Some(Self::SITE_TO_CLOUD_SPOKES),
-            "SITE_TO_SITE_SPOKES" => std::option::Option::Some(Self::SITE_TO_SITE_SPOKES),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LocationFeature {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LocationFeature {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LocationFeature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LocationFeature {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::SiteToCloudSpokes,
+            2 => Self::SiteToSiteSpokes,
+            _ => Self::UnknownValue(location_feature::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LocationFeature {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LOCATION_FEATURE_UNSPECIFIED" => Self::Unspecified,
+            "SITE_TO_CLOUD_SPOKES" => Self::SiteToCloudSpokes,
+            "SITE_TO_SITE_SPOKES" => Self::SiteToSiteSpokes,
+            _ => Self::UnknownValue(location_feature::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LocationFeature {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::SiteToCloudSpokes => serializer.serialize_i32(1),
+            Self::SiteToSiteSpokes => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LocationFeature {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocationFeature>::new(
+            ".google.cloud.networkconnectivity.v1.LocationFeature",
+        ))
     }
 }
 
 /// The route's type
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RouteType(i32);
-
-impl RouteType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RouteType {
     /// No route type information specified
-    pub const ROUTE_TYPE_UNSPECIFIED: RouteType = RouteType::new(0);
-
+    Unspecified,
     /// The route leads to a destination within the primary address range of the
     /// VPC network's subnet.
-    pub const VPC_PRIMARY_SUBNET: RouteType = RouteType::new(1);
-
+    VpcPrimarySubnet,
     /// The route leads to a destination within the secondary address range of the
     /// VPC network's subnet.
-    pub const VPC_SECONDARY_SUBNET: RouteType = RouteType::new(2);
-
+    VpcSecondarySubnet,
     /// The route leads to a destination in a dynamic route. Dynamic routes are
     /// derived from Border Gateway Protocol (BGP) advertisements received from an
     /// NCC hybrid spoke.
-    pub const DYNAMIC_ROUTE: RouteType = RouteType::new(3);
+    DynamicRoute,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RouteType::value] or
+    /// [RouteType::name].
+    UnknownValue(route_type::UnknownValue),
+}
 
-    /// Creates a new RouteType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod route_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl RouteType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::VpcPrimarySubnet => std::option::Option::Some(1),
+            Self::VpcSecondarySubnet => std::option::Option::Some(2),
+            Self::DynamicRoute => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ROUTE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VPC_PRIMARY_SUBNET"),
-            2 => std::borrow::Cow::Borrowed("VPC_SECONDARY_SUBNET"),
-            3 => std::borrow::Cow::Borrowed("DYNAMIC_ROUTE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ROUTE_TYPE_UNSPECIFIED"),
+            Self::VpcPrimarySubnet => std::option::Option::Some("VPC_PRIMARY_SUBNET"),
+            Self::VpcSecondarySubnet => std::option::Option::Some("VPC_SECONDARY_SUBNET"),
+            Self::DynamicRoute => std::option::Option::Some("DYNAMIC_ROUTE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ROUTE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ROUTE_TYPE_UNSPECIFIED),
-            "VPC_PRIMARY_SUBNET" => std::option::Option::Some(Self::VPC_PRIMARY_SUBNET),
-            "VPC_SECONDARY_SUBNET" => std::option::Option::Some(Self::VPC_SECONDARY_SUBNET),
-            "DYNAMIC_ROUTE" => std::option::Option::Some(Self::DYNAMIC_ROUTE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RouteType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RouteType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RouteType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RouteType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::VpcPrimarySubnet,
+            2 => Self::VpcSecondarySubnet,
+            3 => Self::DynamicRoute,
+            _ => Self::UnknownValue(route_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RouteType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ROUTE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "VPC_PRIMARY_SUBNET" => Self::VpcPrimarySubnet,
+            "VPC_SECONDARY_SUBNET" => Self::VpcSecondarySubnet,
+            "DYNAMIC_ROUTE" => Self::DynamicRoute,
+            _ => Self::UnknownValue(route_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RouteType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::VpcPrimarySubnet => serializer.serialize_i32(1),
+            Self::VpcSecondarySubnet => serializer.serialize_i32(2),
+            Self::DynamicRoute => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RouteType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RouteType>::new(
+            ".google.cloud.networkconnectivity.v1.RouteType",
+        ))
     }
 }
 
 /// The State enum represents the lifecycle stage of a Network Connectivity
 /// Center resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(i32);
-
-impl State {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum State {
     /// No state information available
-    pub const STATE_UNSPECIFIED: State = State::new(0);
-
+    Unspecified,
     /// The resource's create operation is in progress.
-    pub const CREATING: State = State::new(1);
-
+    Creating,
     /// The resource is active
-    pub const ACTIVE: State = State::new(2);
-
+    Active,
     /// The resource's delete operation is in progress.
-    pub const DELETING: State = State::new(3);
-
+    Deleting,
     /// The resource's accept operation is in progress.
-    pub const ACCEPTING: State = State::new(8);
-
+    Accepting,
     /// The resource's reject operation is in progress.
-    pub const REJECTING: State = State::new(9);
-
+    Rejecting,
     /// The resource's update operation is in progress.
-    pub const UPDATING: State = State::new(6);
-
+    Updating,
     /// The resource is inactive.
-    pub const INACTIVE: State = State::new(7);
-
+    Inactive,
     /// The hub associated with this spoke resource has been deleted.
     /// This state applies to spoke resources only.
-    pub const OBSOLETE: State = State::new(10);
-
+    Obsolete,
     /// The resource is in an undefined state due to resource creation or deletion
     /// failure. You can try to delete the resource later or contact support for
     /// help.
-    pub const FAILED: State = State::new(11);
+    Failed,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [State::value] or
+    /// [State::name].
+    UnknownValue(state::UnknownValue),
+}
 
-    /// Creates a new State instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl State {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Creating => std::option::Option::Some(1),
+            Self::Active => std::option::Option::Some(2),
+            Self::Deleting => std::option::Option::Some(3),
+            Self::Accepting => std::option::Option::Some(8),
+            Self::Rejecting => std::option::Option::Some(9),
+            Self::Updating => std::option::Option::Some(6),
+            Self::Inactive => std::option::Option::Some(7),
+            Self::Obsolete => std::option::Option::Some(10),
+            Self::Failed => std::option::Option::Some(11),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CREATING"),
-            2 => std::borrow::Cow::Borrowed("ACTIVE"),
-            3 => std::borrow::Cow::Borrowed("DELETING"),
-            6 => std::borrow::Cow::Borrowed("UPDATING"),
-            7 => std::borrow::Cow::Borrowed("INACTIVE"),
-            8 => std::borrow::Cow::Borrowed("ACCEPTING"),
-            9 => std::borrow::Cow::Borrowed("REJECTING"),
-            10 => std::borrow::Cow::Borrowed("OBSOLETE"),
-            11 => std::borrow::Cow::Borrowed("FAILED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+            Self::Creating => std::option::Option::Some("CREATING"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::Deleting => std::option::Option::Some("DELETING"),
+            Self::Accepting => std::option::Option::Some("ACCEPTING"),
+            Self::Rejecting => std::option::Option::Some("REJECTING"),
+            Self::Updating => std::option::Option::Some("UPDATING"),
+            Self::Inactive => std::option::Option::Some("INACTIVE"),
+            Self::Obsolete => std::option::Option::Some("OBSOLETE"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-            "CREATING" => std::option::Option::Some(Self::CREATING),
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "DELETING" => std::option::Option::Some(Self::DELETING),
-            "ACCEPTING" => std::option::Option::Some(Self::ACCEPTING),
-            "REJECTING" => std::option::Option::Some(Self::REJECTING),
-            "UPDATING" => std::option::Option::Some(Self::UPDATING),
-            "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-            "OBSOLETE" => std::option::Option::Some(Self::OBSOLETE),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for State {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Creating,
+            2 => Self::Active,
+            3 => Self::Deleting,
+            6 => Self::Updating,
+            7 => Self::Inactive,
+            8 => Self::Accepting,
+            9 => Self::Rejecting,
+            10 => Self::Obsolete,
+            11 => Self::Failed,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for State {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_UNSPECIFIED" => Self::Unspecified,
+            "CREATING" => Self::Creating,
+            "ACTIVE" => Self::Active,
+            "DELETING" => Self::Deleting,
+            "ACCEPTING" => Self::Accepting,
+            "REJECTING" => Self::Rejecting,
+            "UPDATING" => Self::Updating,
+            "INACTIVE" => Self::Inactive,
+            "OBSOLETE" => Self::Obsolete,
+            "FAILED" => Self::Failed,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Creating => serializer.serialize_i32(1),
+            Self::Active => serializer.serialize_i32(2),
+            Self::Deleting => serializer.serialize_i32(3),
+            Self::Accepting => serializer.serialize_i32(8),
+            Self::Rejecting => serializer.serialize_i32(9),
+            Self::Updating => serializer.serialize_i32(6),
+            Self::Inactive => serializer.serialize_i32(7),
+            Self::Obsolete => serializer.serialize_i32(10),
+            Self::Failed => serializer.serialize_i32(11),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+            ".google.cloud.networkconnectivity.v1.State",
+        ))
     }
 }
 
 /// The SpokeType enum represents the type of spoke. The type
 /// reflects the kind of resource that a spoke is associated with.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SpokeType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SpokeType {
+    /// Unspecified spoke type.
+    Unspecified,
+    /// Spokes associated with VPN tunnels.
+    VpnTunnel,
+    /// Spokes associated with VLAN attachments.
+    InterconnectAttachment,
+    /// Spokes associated with router appliance instances.
+    RouterAppliance,
+    /// Spokes associated with VPC networks.
+    VpcNetwork,
+    /// Spokes that are backed by a producer VPC network.
+    ProducerVpcNetwork,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SpokeType::value] or
+    /// [SpokeType::name].
+    UnknownValue(spoke_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod spoke_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SpokeType {
-    /// Unspecified spoke type.
-    pub const SPOKE_TYPE_UNSPECIFIED: SpokeType = SpokeType::new(0);
-
-    /// Spokes associated with VPN tunnels.
-    pub const VPN_TUNNEL: SpokeType = SpokeType::new(1);
-
-    /// Spokes associated with VLAN attachments.
-    pub const INTERCONNECT_ATTACHMENT: SpokeType = SpokeType::new(2);
-
-    /// Spokes associated with router appliance instances.
-    pub const ROUTER_APPLIANCE: SpokeType = SpokeType::new(3);
-
-    /// Spokes associated with VPC networks.
-    pub const VPC_NETWORK: SpokeType = SpokeType::new(4);
-
-    /// Spokes that are backed by a producer VPC network.
-    pub const PRODUCER_VPC_NETWORK: SpokeType = SpokeType::new(7);
-
-    /// Creates a new SpokeType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::VpnTunnel => std::option::Option::Some(1),
+            Self::InterconnectAttachment => std::option::Option::Some(2),
+            Self::RouterAppliance => std::option::Option::Some(3),
+            Self::VpcNetwork => std::option::Option::Some(4),
+            Self::ProducerVpcNetwork => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SPOKE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VPN_TUNNEL"),
-            2 => std::borrow::Cow::Borrowed("INTERCONNECT_ATTACHMENT"),
-            3 => std::borrow::Cow::Borrowed("ROUTER_APPLIANCE"),
-            4 => std::borrow::Cow::Borrowed("VPC_NETWORK"),
-            7 => std::borrow::Cow::Borrowed("PRODUCER_VPC_NETWORK"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SPOKE_TYPE_UNSPECIFIED"),
+            Self::VpnTunnel => std::option::Option::Some("VPN_TUNNEL"),
+            Self::InterconnectAttachment => std::option::Option::Some("INTERCONNECT_ATTACHMENT"),
+            Self::RouterAppliance => std::option::Option::Some("ROUTER_APPLIANCE"),
+            Self::VpcNetwork => std::option::Option::Some("VPC_NETWORK"),
+            Self::ProducerVpcNetwork => std::option::Option::Some("PRODUCER_VPC_NETWORK"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SPOKE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SPOKE_TYPE_UNSPECIFIED),
-            "VPN_TUNNEL" => std::option::Option::Some(Self::VPN_TUNNEL),
-            "INTERCONNECT_ATTACHMENT" => std::option::Option::Some(Self::INTERCONNECT_ATTACHMENT),
-            "ROUTER_APPLIANCE" => std::option::Option::Some(Self::ROUTER_APPLIANCE),
-            "VPC_NETWORK" => std::option::Option::Some(Self::VPC_NETWORK),
-            "PRODUCER_VPC_NETWORK" => std::option::Option::Some(Self::PRODUCER_VPC_NETWORK),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SpokeType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SpokeType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SpokeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SpokeType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::VpnTunnel,
+            2 => Self::InterconnectAttachment,
+            3 => Self::RouterAppliance,
+            4 => Self::VpcNetwork,
+            7 => Self::ProducerVpcNetwork,
+            _ => Self::UnknownValue(spoke_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SpokeType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SPOKE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "VPN_TUNNEL" => Self::VpnTunnel,
+            "INTERCONNECT_ATTACHMENT" => Self::InterconnectAttachment,
+            "ROUTER_APPLIANCE" => Self::RouterAppliance,
+            "VPC_NETWORK" => Self::VpcNetwork,
+            "PRODUCER_VPC_NETWORK" => Self::ProducerVpcNetwork,
+            _ => Self::UnknownValue(spoke_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SpokeType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::VpnTunnel => serializer.serialize_i32(1),
+            Self::InterconnectAttachment => serializer.serialize_i32(2),
+            Self::RouterAppliance => serializer.serialize_i32(3),
+            Self::VpcNetwork => serializer.serialize_i32(4),
+            Self::ProducerVpcNetwork => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SpokeType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SpokeType>::new(
+            ".google.cloud.networkconnectivity.v1.SpokeType",
+        ))
     }
 }
 
 /// This enum controls the policy mode used in a hub.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PolicyMode(i32);
-
-impl PolicyMode {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PolicyMode {
     /// Policy mode is unspecified. It defaults to PRESET
     /// with preset_topology = MESH.
-    pub const POLICY_MODE_UNSPECIFIED: PolicyMode = PolicyMode::new(0);
-
+    Unspecified,
     /// Hub uses one of the preset topologies.
-    pub const PRESET: PolicyMode = PolicyMode::new(1);
+    Preset,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PolicyMode::value] or
+    /// [PolicyMode::name].
+    UnknownValue(policy_mode::UnknownValue),
+}
 
-    /// Creates a new PolicyMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod policy_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl PolicyMode {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Preset => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("POLICY_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PRESET"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("POLICY_MODE_UNSPECIFIED"),
+            Self::Preset => std::option::Option::Some("PRESET"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "POLICY_MODE_UNSPECIFIED" => std::option::Option::Some(Self::POLICY_MODE_UNSPECIFIED),
-            "PRESET" => std::option::Option::Some(Self::PRESET),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PolicyMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PolicyMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PolicyMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PolicyMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Preset,
+            _ => Self::UnknownValue(policy_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PolicyMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "POLICY_MODE_UNSPECIFIED" => Self::Unspecified,
+            "PRESET" => Self::Preset,
+            _ => Self::UnknownValue(policy_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PolicyMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Preset => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PolicyMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PolicyMode>::new(
+            ".google.cloud.networkconnectivity.v1.PolicyMode",
+        ))
     }
 }
 
 /// The list of available preset topologies.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PresetTopology(i32);
-
-impl PresetTopology {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PresetTopology {
     /// Preset topology is unspecified. When policy_mode = PRESET,
     /// it defaults to MESH.
-    pub const PRESET_TOPOLOGY_UNSPECIFIED: PresetTopology = PresetTopology::new(0);
-
+    Unspecified,
     /// Mesh topology is implemented. Group `default` is automatically created.
     /// All spokes in the hub are added to group `default`.
-    pub const MESH: PresetTopology = PresetTopology::new(2);
-
+    Mesh,
     /// Star topology is implemented. Two groups, `center` and `edge`, are
     /// automatically created along with hub creation. Spokes have to join one of
     /// the groups during creation.
-    pub const STAR: PresetTopology = PresetTopology::new(3);
+    Star,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PresetTopology::value] or
+    /// [PresetTopology::name].
+    UnknownValue(preset_topology::UnknownValue),
+}
 
-    /// Creates a new PresetTopology instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod preset_topology {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl PresetTopology {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Mesh => std::option::Option::Some(2),
+            Self::Star => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PRESET_TOPOLOGY_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("MESH"),
-            3 => std::borrow::Cow::Borrowed("STAR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PRESET_TOPOLOGY_UNSPECIFIED"),
+            Self::Mesh => std::option::Option::Some("MESH"),
+            Self::Star => std::option::Option::Some("STAR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PRESET_TOPOLOGY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PRESET_TOPOLOGY_UNSPECIFIED)
-            }
-            "MESH" => std::option::Option::Some(Self::MESH),
-            "STAR" => std::option::Option::Some(Self::STAR),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PresetTopology {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PresetTopology {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PresetTopology {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PresetTopology {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::Mesh,
+            3 => Self::Star,
+            _ => Self::UnknownValue(preset_topology::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PresetTopology {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PRESET_TOPOLOGY_UNSPECIFIED" => Self::Unspecified,
+            "MESH" => Self::Mesh,
+            "STAR" => Self::Star,
+            _ => Self::UnknownValue(preset_topology::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PresetTopology {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Mesh => serializer.serialize_i32(2),
+            Self::Star => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PresetTopology {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PresetTopology>::new(
+            ".google.cloud.networkconnectivity.v1.PresetTopology",
+        ))
     }
 }

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -868,7 +868,7 @@ impl super::stub::HubService for HubService {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -647,136 +647,259 @@ pub mod endpoint {
 
     /// The type definition of an endpoint's network. Use one of the
     /// following choices:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkType(i32);
-
-    impl NetworkType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NetworkType {
         /// Default type if unspecified.
-        pub const NETWORK_TYPE_UNSPECIFIED: NetworkType = NetworkType::new(0);
-
+        Unspecified,
         /// A network hosted within Google Cloud.
         /// To receive more detailed output, specify the URI for the source or
         /// destination network.
-        pub const GCP_NETWORK: NetworkType = NetworkType::new(1);
-
+        GcpNetwork,
         /// A network hosted outside of Google Cloud.
         /// This can be an on-premises network, an internet resource or a network
         /// hosted by another cloud provider.
-        pub const NON_GCP_NETWORK: NetworkType = NetworkType::new(2);
+        NonGcpNetwork,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NetworkType::value] or
+        /// [NetworkType::name].
+        UnknownValue(network_type::UnknownValue),
+    }
 
-        /// Creates a new NetworkType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod network_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NetworkType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GcpNetwork => std::option::Option::Some(1),
+                Self::NonGcpNetwork => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NETWORK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCP_NETWORK"),
-                2 => std::borrow::Cow::Borrowed("NON_GCP_NETWORK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NETWORK_TYPE_UNSPECIFIED"),
+                Self::GcpNetwork => std::option::Option::Some("GCP_NETWORK"),
+                Self::NonGcpNetwork => std::option::Option::Some("NON_GCP_NETWORK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NETWORK_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NETWORK_TYPE_UNSPECIFIED)
-                }
-                "GCP_NETWORK" => std::option::Option::Some(Self::GCP_NETWORK),
-                "NON_GCP_NETWORK" => std::option::Option::Some(Self::NON_GCP_NETWORK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NetworkType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NetworkType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NetworkType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GcpNetwork,
+                2 => Self::NonGcpNetwork,
+                _ => Self::UnknownValue(network_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NetworkType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NETWORK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GCP_NETWORK" => Self::GcpNetwork,
+                "NON_GCP_NETWORK" => Self::NonGcpNetwork,
+                _ => Self::UnknownValue(network_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NetworkType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GcpNetwork => serializer.serialize_i32(1),
+                Self::NonGcpNetwork => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NetworkType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NetworkType>::new(
+                ".google.cloud.networkmanagement.v1.Endpoint.NetworkType",
+            ))
         }
     }
 
     /// Type of the target of a forwarding rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ForwardingRuleTarget(i32);
-
-    impl ForwardingRuleTarget {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ForwardingRuleTarget {
         /// Forwarding rule target is unknown.
-        pub const FORWARDING_RULE_TARGET_UNSPECIFIED: ForwardingRuleTarget =
-            ForwardingRuleTarget::new(0);
-
+        Unspecified,
         /// Compute Engine instance for protocol forwarding.
-        pub const INSTANCE: ForwardingRuleTarget = ForwardingRuleTarget::new(1);
-
+        Instance,
         /// Load Balancer. The specific type can be found from [load_balancer_type]
         /// [google.cloud.networkmanagement.v1.Endpoint.load_balancer_type].
-        pub const LOAD_BALANCER: ForwardingRuleTarget = ForwardingRuleTarget::new(2);
-
+        LoadBalancer,
         /// Classic Cloud VPN Gateway.
-        pub const VPN_GATEWAY: ForwardingRuleTarget = ForwardingRuleTarget::new(3);
-
+        VpnGateway,
         /// Forwarding Rule is a Private Service Connect endpoint.
-        pub const PSC: ForwardingRuleTarget = ForwardingRuleTarget::new(4);
+        Psc,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ForwardingRuleTarget::value] or
+        /// [ForwardingRuleTarget::name].
+        UnknownValue(forwarding_rule_target::UnknownValue),
+    }
 
-        /// Creates a new ForwardingRuleTarget instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod forwarding_rule_target {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ForwardingRuleTarget {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Instance => std::option::Option::Some(1),
+                Self::LoadBalancer => std::option::Option::Some(2),
+                Self::VpnGateway => std::option::Option::Some(3),
+                Self::Psc => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FORWARDING_RULE_TARGET_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INSTANCE"),
-                2 => std::borrow::Cow::Borrowed("LOAD_BALANCER"),
-                3 => std::borrow::Cow::Borrowed("VPN_GATEWAY"),
-                4 => std::borrow::Cow::Borrowed("PSC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FORWARDING_RULE_TARGET_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FORWARDING_RULE_TARGET_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("FORWARDING_RULE_TARGET_UNSPECIFIED")
                 }
-                "INSTANCE" => std::option::Option::Some(Self::INSTANCE),
-                "LOAD_BALANCER" => std::option::Option::Some(Self::LOAD_BALANCER),
-                "VPN_GATEWAY" => std::option::Option::Some(Self::VPN_GATEWAY),
-                "PSC" => std::option::Option::Some(Self::PSC),
-                _ => std::option::Option::None,
+                Self::Instance => std::option::Option::Some("INSTANCE"),
+                Self::LoadBalancer => std::option::Option::Some("LOAD_BALANCER"),
+                Self::VpnGateway => std::option::Option::Some("VPN_GATEWAY"),
+                Self::Psc => std::option::Option::Some("PSC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ForwardingRuleTarget {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ForwardingRuleTarget {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ForwardingRuleTarget {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ForwardingRuleTarget {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Instance,
+                2 => Self::LoadBalancer,
+                3 => Self::VpnGateway,
+                4 => Self::Psc,
+                _ => Self::UnknownValue(forwarding_rule_target::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ForwardingRuleTarget {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FORWARDING_RULE_TARGET_UNSPECIFIED" => Self::Unspecified,
+                "INSTANCE" => Self::Instance,
+                "LOAD_BALANCER" => Self::LoadBalancer,
+                "VPN_GATEWAY" => Self::VpnGateway,
+                "PSC" => Self::Psc,
+                _ => Self::UnknownValue(forwarding_rule_target::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ForwardingRuleTarget {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Instance => serializer.serialize_i32(1),
+                Self::LoadBalancer => serializer.serialize_i32(2),
+                Self::VpnGateway => serializer.serialize_i32(3),
+                Self::Psc => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ForwardingRuleTarget {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ForwardingRuleTarget>::new(
+                ".google.cloud.networkmanagement.v1.Endpoint.ForwardingRuleTarget",
+            ))
         }
     }
 }
@@ -864,13 +987,11 @@ pub mod reachability_details {
     use super::*;
 
     /// The overall result of the test's configuration analysis.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(i32);
-
-    impl Result {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Result {
         /// No result was specified.
-        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
-
+        Unspecified,
         /// Possible scenarios are:
         ///
         /// * The configuration analysis determined that a packet originating from
@@ -878,20 +999,17 @@ pub mod reachability_details {
         /// * The analysis didn't complete because the user lacks permission for
         ///   some of the resources in the trace. However, at the time the user's
         ///   permission became insufficient, the trace had been successful so far.
-        pub const REACHABLE: Result = Result::new(1);
-
+        Reachable,
         /// A packet originating from the source is expected to be dropped before
         /// reaching the destination.
-        pub const UNREACHABLE: Result = Result::new(2);
-
+        Unreachable,
         /// The source and destination endpoints do not uniquely identify
         /// the test location in the network, and the reachability result contains
         /// multiple traces. For some traces, a packet could be delivered, and for
         /// others, it would not be. This result is also assigned to
         /// configuration analysis of return path if on its own it should be
         /// REACHABLE, but configuration analysis of forward path is AMBIGUOUS.
-        pub const AMBIGUOUS: Result = Result::new(4);
-
+        Ambiguous,
         /// The configuration analysis did not complete. Possible reasons are:
         ///
         /// * A permissions error occurred--for example, the user might not have
@@ -899,52 +1017,122 @@ pub mod reachability_details {
         /// * An internal error occurred.
         /// * The analyzer received an invalid or unsupported argument or was unable
         ///   to identify a known endpoint.
-        pub const UNDETERMINED: Result = Result::new(5);
+        Undetermined,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Result::value] or
+        /// [Result::name].
+        UnknownValue(result::UnknownValue),
+    }
 
-        /// Creates a new Result instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Result {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Reachable => std::option::Option::Some(1),
+                Self::Unreachable => std::option::Option::Some(2),
+                Self::Ambiguous => std::option::Option::Some(4),
+                Self::Undetermined => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REACHABLE"),
-                2 => std::borrow::Cow::Borrowed("UNREACHABLE"),
-                4 => std::borrow::Cow::Borrowed("AMBIGUOUS"),
-                5 => std::borrow::Cow::Borrowed("UNDETERMINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESULT_UNSPECIFIED"),
+                Self::Reachable => std::option::Option::Some("REACHABLE"),
+                Self::Unreachable => std::option::Option::Some("UNREACHABLE"),
+                Self::Ambiguous => std::option::Option::Some("AMBIGUOUS"),
+                Self::Undetermined => std::option::Option::Some("UNDETERMINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
-                "REACHABLE" => std::option::Option::Some(Self::REACHABLE),
-                "UNREACHABLE" => std::option::Option::Some(Self::UNREACHABLE),
-                "AMBIGUOUS" => std::option::Option::Some(Self::AMBIGUOUS),
-                "UNDETERMINED" => std::option::Option::Some(Self::UNDETERMINED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Result {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Reachable,
+                2 => Self::Unreachable,
+                4 => Self::Ambiguous,
+                5 => Self::Undetermined,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Result {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESULT_UNSPECIFIED" => Self::Unspecified,
+                "REACHABLE" => Self::Reachable,
+                "UNREACHABLE" => Self::Unreachable,
+                "AMBIGUOUS" => Self::Ambiguous,
+                "UNDETERMINED" => Self::Undetermined,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Result {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Reachable => serializer.serialize_i32(1),
+                Self::Unreachable => serializer.serialize_i32(2),
+                Self::Ambiguous => serializer.serialize_i32(4),
+                Self::Undetermined => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Result {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Result>::new(
+                ".google.cloud.networkmanagement.v1.ReachabilityDetails.Result",
+            ))
         }
     }
 }
@@ -1220,138 +1408,260 @@ pub mod probing_details {
     }
 
     /// Overall probing result of the test.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProbingResult(i32);
-
-    impl ProbingResult {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProbingResult {
         /// No result was specified.
-        pub const PROBING_RESULT_UNSPECIFIED: ProbingResult = ProbingResult::new(0);
-
+        Unspecified,
         /// At least 95% of packets reached the destination.
-        pub const REACHABLE: ProbingResult = ProbingResult::new(1);
-
+        Reachable,
         /// No packets reached the destination.
-        pub const UNREACHABLE: ProbingResult = ProbingResult::new(2);
-
+        Unreachable,
         /// Less than 95% of packets reached the destination.
-        pub const REACHABILITY_INCONSISTENT: ProbingResult = ProbingResult::new(3);
-
+        ReachabilityInconsistent,
         /// Reachability could not be determined. Possible reasons are:
         ///
         /// * The user lacks permission to access some of the network resources
         ///   required to run the test.
         /// * No valid source endpoint could be derived from the request.
         /// * An internal error occurred.
-        pub const UNDETERMINED: ProbingResult = ProbingResult::new(4);
+        Undetermined,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProbingResult::value] or
+        /// [ProbingResult::name].
+        UnknownValue(probing_result::UnknownValue),
+    }
 
-        /// Creates a new ProbingResult instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod probing_result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ProbingResult {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Reachable => std::option::Option::Some(1),
+                Self::Unreachable => std::option::Option::Some(2),
+                Self::ReachabilityInconsistent => std::option::Option::Some(3),
+                Self::Undetermined => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROBING_RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REACHABLE"),
-                2 => std::borrow::Cow::Borrowed("UNREACHABLE"),
-                3 => std::borrow::Cow::Borrowed("REACHABILITY_INCONSISTENT"),
-                4 => std::borrow::Cow::Borrowed("UNDETERMINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROBING_RESULT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROBING_RESULT_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROBING_RESULT_UNSPECIFIED"),
+                Self::Reachable => std::option::Option::Some("REACHABLE"),
+                Self::Unreachable => std::option::Option::Some("UNREACHABLE"),
+                Self::ReachabilityInconsistent => {
+                    std::option::Option::Some("REACHABILITY_INCONSISTENT")
                 }
-                "REACHABLE" => std::option::Option::Some(Self::REACHABLE),
-                "UNREACHABLE" => std::option::Option::Some(Self::UNREACHABLE),
-                "REACHABILITY_INCONSISTENT" => {
-                    std::option::Option::Some(Self::REACHABILITY_INCONSISTENT)
-                }
-                "UNDETERMINED" => std::option::Option::Some(Self::UNDETERMINED),
-                _ => std::option::Option::None,
+                Self::Undetermined => std::option::Option::Some("UNDETERMINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ProbingResult {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProbingResult {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProbingResult {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProbingResult {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Reachable,
+                2 => Self::Unreachable,
+                3 => Self::ReachabilityInconsistent,
+                4 => Self::Undetermined,
+                _ => Self::UnknownValue(probing_result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProbingResult {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROBING_RESULT_UNSPECIFIED" => Self::Unspecified,
+                "REACHABLE" => Self::Reachable,
+                "UNREACHABLE" => Self::Unreachable,
+                "REACHABILITY_INCONSISTENT" => Self::ReachabilityInconsistent,
+                "UNDETERMINED" => Self::Undetermined,
+                _ => Self::UnknownValue(probing_result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProbingResult {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Reachable => serializer.serialize_i32(1),
+                Self::Unreachable => serializer.serialize_i32(2),
+                Self::ReachabilityInconsistent => serializer.serialize_i32(3),
+                Self::Undetermined => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProbingResult {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProbingResult>::new(
+                ".google.cloud.networkmanagement.v1.ProbingDetails.ProbingResult",
+            ))
         }
     }
 
     /// Abort cause types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProbingAbortCause(i32);
-
-    impl ProbingAbortCause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProbingAbortCause {
         /// No reason was specified.
-        pub const PROBING_ABORT_CAUSE_UNSPECIFIED: ProbingAbortCause = ProbingAbortCause::new(0);
-
+        Unspecified,
         /// The user lacks permission to access some of the
         /// network resources required to run the test.
-        pub const PERMISSION_DENIED: ProbingAbortCause = ProbingAbortCause::new(1);
-
+        PermissionDenied,
         /// No valid source endpoint could be derived from the request.
-        pub const NO_SOURCE_LOCATION: ProbingAbortCause = ProbingAbortCause::new(2);
+        NoSourceLocation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProbingAbortCause::value] or
+        /// [ProbingAbortCause::name].
+        UnknownValue(probing_abort_cause::UnknownValue),
+    }
 
-        /// Creates a new ProbingAbortCause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod probing_abort_cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ProbingAbortCause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PermissionDenied => std::option::Option::Some(1),
+                Self::NoSourceLocation => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROBING_ABORT_CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                2 => std::borrow::Cow::Borrowed("NO_SOURCE_LOCATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROBING_ABORT_CAUSE_UNSPECIFIED"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::NoSourceLocation => std::option::Option::Some("NO_SOURCE_LOCATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROBING_ABORT_CAUSE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROBING_ABORT_CAUSE_UNSPECIFIED)
-                }
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                "NO_SOURCE_LOCATION" => std::option::Option::Some(Self::NO_SOURCE_LOCATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ProbingAbortCause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProbingAbortCause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProbingAbortCause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProbingAbortCause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PermissionDenied,
+                2 => Self::NoSourceLocation,
+                _ => Self::UnknownValue(probing_abort_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProbingAbortCause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROBING_ABORT_CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                "NO_SOURCE_LOCATION" => Self::NoSourceLocation,
+                _ => Self::UnknownValue(probing_abort_cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProbingAbortCause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PermissionDenied => serializer.serialize_i32(1),
+                Self::NoSourceLocation => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProbingAbortCause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProbingAbortCause>::new(
+                ".google.cloud.networkmanagement.v1.ProbingDetails.ProbingAbortCause",
+            ))
         }
     }
 }
@@ -2807,292 +3117,417 @@ pub mod step {
 
     /// Type of states that are defined in the network state machine.
     /// Each step in the packet trace is in a specific state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Initial state: packet originating from a Compute Engine instance.
         /// An InstanceInfo is populated with starting instance information.
-        pub const START_FROM_INSTANCE: State = State::new(1);
-
+        StartFromInstance,
         /// Initial state: packet originating from the internet.
         /// The endpoint information is populated.
-        pub const START_FROM_INTERNET: State = State::new(2);
-
+        StartFromInternet,
         /// Initial state: packet originating from a Google service.
         /// The google_service information is populated.
-        pub const START_FROM_GOOGLE_SERVICE: State = State::new(27);
-
+        StartFromGoogleService,
         /// Initial state: packet originating from a VPC or on-premises network
         /// with internal source IP.
         /// If the source is a VPC network visible to the user, a NetworkInfo
         /// is populated with details of the network.
-        pub const START_FROM_PRIVATE_NETWORK: State = State::new(3);
-
+        StartFromPrivateNetwork,
         /// Initial state: packet originating from a Google Kubernetes Engine cluster
         /// master. A GKEMasterInfo is populated with starting instance information.
-        pub const START_FROM_GKE_MASTER: State = State::new(21);
-
+        StartFromGkeMaster,
         /// Initial state: packet originating from a Cloud SQL instance.
         /// A CloudSQLInstanceInfo is populated with starting instance information.
-        pub const START_FROM_CLOUD_SQL_INSTANCE: State = State::new(22);
-
+        StartFromCloudSqlInstance,
         /// Initial state: packet originating from a Redis instance.
         /// A RedisInstanceInfo is populated with starting instance information.
-        pub const START_FROM_REDIS_INSTANCE: State = State::new(32);
-
+        StartFromRedisInstance,
         /// Initial state: packet originating from a Redis Cluster.
         /// A RedisClusterInfo is populated with starting Cluster information.
-        pub const START_FROM_REDIS_CLUSTER: State = State::new(33);
-
+        StartFromRedisCluster,
         /// Initial state: packet originating from a Cloud Function.
         /// A CloudFunctionInfo is populated with starting function information.
-        pub const START_FROM_CLOUD_FUNCTION: State = State::new(23);
-
+        StartFromCloudFunction,
         /// Initial state: packet originating from an App Engine service version.
         /// An AppEngineVersionInfo is populated with starting version information.
-        pub const START_FROM_APP_ENGINE_VERSION: State = State::new(25);
-
+        StartFromAppEngineVersion,
         /// Initial state: packet originating from a Cloud Run revision.
         /// A CloudRunRevisionInfo is populated with starting revision information.
-        pub const START_FROM_CLOUD_RUN_REVISION: State = State::new(26);
-
+        StartFromCloudRunRevision,
         /// Initial state: packet originating from a Storage Bucket. Used only for
         /// return traces.
         /// The storage_bucket information is populated.
-        pub const START_FROM_STORAGE_BUCKET: State = State::new(29);
-
+        StartFromStorageBucket,
         /// Initial state: packet originating from a published service that uses
         /// Private Service Connect. Used only for return traces.
-        pub const START_FROM_PSC_PUBLISHED_SERVICE: State = State::new(30);
-
+        StartFromPscPublishedService,
         /// Initial state: packet originating from a serverless network endpoint
         /// group backend. Used only for return traces.
         /// The serverless_neg information is populated.
-        pub const START_FROM_SERVERLESS_NEG: State = State::new(31);
-
+        StartFromServerlessNeg,
         /// Config checking state: verify ingress firewall rule.
-        pub const APPLY_INGRESS_FIREWALL_RULE: State = State::new(4);
-
+        ApplyIngressFirewallRule,
         /// Config checking state: verify egress firewall rule.
-        pub const APPLY_EGRESS_FIREWALL_RULE: State = State::new(5);
-
+        ApplyEgressFirewallRule,
         /// Config checking state: verify route.
-        pub const APPLY_ROUTE: State = State::new(6);
-
+        ApplyRoute,
         /// Config checking state: match forwarding rule.
-        pub const APPLY_FORWARDING_RULE: State = State::new(7);
-
+        ApplyForwardingRule,
         /// Config checking state: verify load balancer backend configuration.
-        pub const ANALYZE_LOAD_BALANCER_BACKEND: State = State::new(28);
-
+        AnalyzeLoadBalancerBackend,
         /// Config checking state: packet sent or received under foreign IP
         /// address and allowed.
-        pub const SPOOFING_APPROVED: State = State::new(8);
-
+        SpoofingApproved,
         /// Forwarding state: arriving at a Compute Engine instance.
-        pub const ARRIVE_AT_INSTANCE: State = State::new(9);
-
+        ArriveAtInstance,
         /// Forwarding state: arriving at a Compute Engine internal load balancer.
         /// Deprecated in favor of the `ANALYZE_LOAD_BALANCER_BACKEND` state, not
         /// used in new tests.
-        pub const ARRIVE_AT_INTERNAL_LOAD_BALANCER: State = State::new(10);
-
+        ArriveAtInternalLoadBalancer,
         /// Forwarding state: arriving at a Compute Engine external load balancer.
         /// Deprecated in favor of the `ANALYZE_LOAD_BALANCER_BACKEND` state, not
         /// used in new tests.
-        pub const ARRIVE_AT_EXTERNAL_LOAD_BALANCER: State = State::new(11);
-
+        ArriveAtExternalLoadBalancer,
         /// Forwarding state: arriving at a Cloud VPN gateway.
-        pub const ARRIVE_AT_VPN_GATEWAY: State = State::new(12);
-
+        ArriveAtVpnGateway,
         /// Forwarding state: arriving at a Cloud VPN tunnel.
-        pub const ARRIVE_AT_VPN_TUNNEL: State = State::new(13);
-
+        ArriveAtVpnTunnel,
         /// Forwarding state: arriving at a VPC connector.
-        pub const ARRIVE_AT_VPC_CONNECTOR: State = State::new(24);
-
+        ArriveAtVpcConnector,
         /// Forwarding state: for packets originating from a serverless endpoint
         /// forwarded through Direct VPC egress.
-        pub const DIRECT_VPC_EGRESS_CONNECTION: State = State::new(35);
-
+        DirectVpcEgressConnection,
         /// Forwarding state: for packets originating from a serverless endpoint
         /// forwarded through public (external) connectivity.
-        pub const SERVERLESS_EXTERNAL_CONNECTION: State = State::new(36);
-
+        ServerlessExternalConnection,
         /// Transition state: packet header translated.
-        pub const NAT: State = State::new(14);
-
+        Nat,
         /// Transition state: original connection is terminated and a new proxied
         /// connection is initiated.
-        pub const PROXY_CONNECTION: State = State::new(15);
-
+        ProxyConnection,
         /// Final state: packet could be delivered.
-        pub const DELIVER: State = State::new(16);
-
+        Deliver,
         /// Final state: packet could be dropped.
-        pub const DROP: State = State::new(17);
-
+        Drop,
         /// Final state: packet could be forwarded to a network with an unknown
         /// configuration.
-        pub const FORWARD: State = State::new(18);
-
+        Forward,
         /// Final state: analysis is aborted.
-        pub const ABORT: State = State::new(19);
-
+        Abort,
         /// Special state: viewer of the test result does not have permission to
         /// see the configuration in this step.
-        pub const VIEWER_PERMISSION_MISSING: State = State::new(20);
+        ViewerPermissionMissing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StartFromInstance => std::option::Option::Some(1),
+                Self::StartFromInternet => std::option::Option::Some(2),
+                Self::StartFromGoogleService => std::option::Option::Some(27),
+                Self::StartFromPrivateNetwork => std::option::Option::Some(3),
+                Self::StartFromGkeMaster => std::option::Option::Some(21),
+                Self::StartFromCloudSqlInstance => std::option::Option::Some(22),
+                Self::StartFromRedisInstance => std::option::Option::Some(32),
+                Self::StartFromRedisCluster => std::option::Option::Some(33),
+                Self::StartFromCloudFunction => std::option::Option::Some(23),
+                Self::StartFromAppEngineVersion => std::option::Option::Some(25),
+                Self::StartFromCloudRunRevision => std::option::Option::Some(26),
+                Self::StartFromStorageBucket => std::option::Option::Some(29),
+                Self::StartFromPscPublishedService => std::option::Option::Some(30),
+                Self::StartFromServerlessNeg => std::option::Option::Some(31),
+                Self::ApplyIngressFirewallRule => std::option::Option::Some(4),
+                Self::ApplyEgressFirewallRule => std::option::Option::Some(5),
+                Self::ApplyRoute => std::option::Option::Some(6),
+                Self::ApplyForwardingRule => std::option::Option::Some(7),
+                Self::AnalyzeLoadBalancerBackend => std::option::Option::Some(28),
+                Self::SpoofingApproved => std::option::Option::Some(8),
+                Self::ArriveAtInstance => std::option::Option::Some(9),
+                Self::ArriveAtInternalLoadBalancer => std::option::Option::Some(10),
+                Self::ArriveAtExternalLoadBalancer => std::option::Option::Some(11),
+                Self::ArriveAtVpnGateway => std::option::Option::Some(12),
+                Self::ArriveAtVpnTunnel => std::option::Option::Some(13),
+                Self::ArriveAtVpcConnector => std::option::Option::Some(24),
+                Self::DirectVpcEgressConnection => std::option::Option::Some(35),
+                Self::ServerlessExternalConnection => std::option::Option::Some(36),
+                Self::Nat => std::option::Option::Some(14),
+                Self::ProxyConnection => std::option::Option::Some(15),
+                Self::Deliver => std::option::Option::Some(16),
+                Self::Drop => std::option::Option::Some(17),
+                Self::Forward => std::option::Option::Some(18),
+                Self::Abort => std::option::Option::Some(19),
+                Self::ViewerPermissionMissing => std::option::Option::Some(20),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("START_FROM_INSTANCE"),
-                2 => std::borrow::Cow::Borrowed("START_FROM_INTERNET"),
-                3 => std::borrow::Cow::Borrowed("START_FROM_PRIVATE_NETWORK"),
-                4 => std::borrow::Cow::Borrowed("APPLY_INGRESS_FIREWALL_RULE"),
-                5 => std::borrow::Cow::Borrowed("APPLY_EGRESS_FIREWALL_RULE"),
-                6 => std::borrow::Cow::Borrowed("APPLY_ROUTE"),
-                7 => std::borrow::Cow::Borrowed("APPLY_FORWARDING_RULE"),
-                8 => std::borrow::Cow::Borrowed("SPOOFING_APPROVED"),
-                9 => std::borrow::Cow::Borrowed("ARRIVE_AT_INSTANCE"),
-                10 => std::borrow::Cow::Borrowed("ARRIVE_AT_INTERNAL_LOAD_BALANCER"),
-                11 => std::borrow::Cow::Borrowed("ARRIVE_AT_EXTERNAL_LOAD_BALANCER"),
-                12 => std::borrow::Cow::Borrowed("ARRIVE_AT_VPN_GATEWAY"),
-                13 => std::borrow::Cow::Borrowed("ARRIVE_AT_VPN_TUNNEL"),
-                14 => std::borrow::Cow::Borrowed("NAT"),
-                15 => std::borrow::Cow::Borrowed("PROXY_CONNECTION"),
-                16 => std::borrow::Cow::Borrowed("DELIVER"),
-                17 => std::borrow::Cow::Borrowed("DROP"),
-                18 => std::borrow::Cow::Borrowed("FORWARD"),
-                19 => std::borrow::Cow::Borrowed("ABORT"),
-                20 => std::borrow::Cow::Borrowed("VIEWER_PERMISSION_MISSING"),
-                21 => std::borrow::Cow::Borrowed("START_FROM_GKE_MASTER"),
-                22 => std::borrow::Cow::Borrowed("START_FROM_CLOUD_SQL_INSTANCE"),
-                23 => std::borrow::Cow::Borrowed("START_FROM_CLOUD_FUNCTION"),
-                24 => std::borrow::Cow::Borrowed("ARRIVE_AT_VPC_CONNECTOR"),
-                25 => std::borrow::Cow::Borrowed("START_FROM_APP_ENGINE_VERSION"),
-                26 => std::borrow::Cow::Borrowed("START_FROM_CLOUD_RUN_REVISION"),
-                27 => std::borrow::Cow::Borrowed("START_FROM_GOOGLE_SERVICE"),
-                28 => std::borrow::Cow::Borrowed("ANALYZE_LOAD_BALANCER_BACKEND"),
-                29 => std::borrow::Cow::Borrowed("START_FROM_STORAGE_BUCKET"),
-                30 => std::borrow::Cow::Borrowed("START_FROM_PSC_PUBLISHED_SERVICE"),
-                31 => std::borrow::Cow::Borrowed("START_FROM_SERVERLESS_NEG"),
-                32 => std::borrow::Cow::Borrowed("START_FROM_REDIS_INSTANCE"),
-                33 => std::borrow::Cow::Borrowed("START_FROM_REDIS_CLUSTER"),
-                35 => std::borrow::Cow::Borrowed("DIRECT_VPC_EGRESS_CONNECTION"),
-                36 => std::borrow::Cow::Borrowed("SERVERLESS_EXTERNAL_CONNECTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::StartFromInstance => std::option::Option::Some("START_FROM_INSTANCE"),
+                Self::StartFromInternet => std::option::Option::Some("START_FROM_INTERNET"),
+                Self::StartFromGoogleService => {
+                    std::option::Option::Some("START_FROM_GOOGLE_SERVICE")
+                }
+                Self::StartFromPrivateNetwork => {
+                    std::option::Option::Some("START_FROM_PRIVATE_NETWORK")
+                }
+                Self::StartFromGkeMaster => std::option::Option::Some("START_FROM_GKE_MASTER"),
+                Self::StartFromCloudSqlInstance => {
+                    std::option::Option::Some("START_FROM_CLOUD_SQL_INSTANCE")
+                }
+                Self::StartFromRedisInstance => {
+                    std::option::Option::Some("START_FROM_REDIS_INSTANCE")
+                }
+                Self::StartFromRedisCluster => {
+                    std::option::Option::Some("START_FROM_REDIS_CLUSTER")
+                }
+                Self::StartFromCloudFunction => {
+                    std::option::Option::Some("START_FROM_CLOUD_FUNCTION")
+                }
+                Self::StartFromAppEngineVersion => {
+                    std::option::Option::Some("START_FROM_APP_ENGINE_VERSION")
+                }
+                Self::StartFromCloudRunRevision => {
+                    std::option::Option::Some("START_FROM_CLOUD_RUN_REVISION")
+                }
+                Self::StartFromStorageBucket => {
+                    std::option::Option::Some("START_FROM_STORAGE_BUCKET")
+                }
+                Self::StartFromPscPublishedService => {
+                    std::option::Option::Some("START_FROM_PSC_PUBLISHED_SERVICE")
+                }
+                Self::StartFromServerlessNeg => {
+                    std::option::Option::Some("START_FROM_SERVERLESS_NEG")
+                }
+                Self::ApplyIngressFirewallRule => {
+                    std::option::Option::Some("APPLY_INGRESS_FIREWALL_RULE")
+                }
+                Self::ApplyEgressFirewallRule => {
+                    std::option::Option::Some("APPLY_EGRESS_FIREWALL_RULE")
+                }
+                Self::ApplyRoute => std::option::Option::Some("APPLY_ROUTE"),
+                Self::ApplyForwardingRule => std::option::Option::Some("APPLY_FORWARDING_RULE"),
+                Self::AnalyzeLoadBalancerBackend => {
+                    std::option::Option::Some("ANALYZE_LOAD_BALANCER_BACKEND")
+                }
+                Self::SpoofingApproved => std::option::Option::Some("SPOOFING_APPROVED"),
+                Self::ArriveAtInstance => std::option::Option::Some("ARRIVE_AT_INSTANCE"),
+                Self::ArriveAtInternalLoadBalancer => {
+                    std::option::Option::Some("ARRIVE_AT_INTERNAL_LOAD_BALANCER")
+                }
+                Self::ArriveAtExternalLoadBalancer => {
+                    std::option::Option::Some("ARRIVE_AT_EXTERNAL_LOAD_BALANCER")
+                }
+                Self::ArriveAtVpnGateway => std::option::Option::Some("ARRIVE_AT_VPN_GATEWAY"),
+                Self::ArriveAtVpnTunnel => std::option::Option::Some("ARRIVE_AT_VPN_TUNNEL"),
+                Self::ArriveAtVpcConnector => std::option::Option::Some("ARRIVE_AT_VPC_CONNECTOR"),
+                Self::DirectVpcEgressConnection => {
+                    std::option::Option::Some("DIRECT_VPC_EGRESS_CONNECTION")
+                }
+                Self::ServerlessExternalConnection => {
+                    std::option::Option::Some("SERVERLESS_EXTERNAL_CONNECTION")
+                }
+                Self::Nat => std::option::Option::Some("NAT"),
+                Self::ProxyConnection => std::option::Option::Some("PROXY_CONNECTION"),
+                Self::Deliver => std::option::Option::Some("DELIVER"),
+                Self::Drop => std::option::Option::Some("DROP"),
+                Self::Forward => std::option::Option::Some("FORWARD"),
+                Self::Abort => std::option::Option::Some("ABORT"),
+                Self::ViewerPermissionMissing => {
+                    std::option::Option::Some("VIEWER_PERMISSION_MISSING")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "START_FROM_INSTANCE" => std::option::Option::Some(Self::START_FROM_INSTANCE),
-                "START_FROM_INTERNET" => std::option::Option::Some(Self::START_FROM_INTERNET),
-                "START_FROM_GOOGLE_SERVICE" => {
-                    std::option::Option::Some(Self::START_FROM_GOOGLE_SERVICE)
-                }
-                "START_FROM_PRIVATE_NETWORK" => {
-                    std::option::Option::Some(Self::START_FROM_PRIVATE_NETWORK)
-                }
-                "START_FROM_GKE_MASTER" => std::option::Option::Some(Self::START_FROM_GKE_MASTER),
-                "START_FROM_CLOUD_SQL_INSTANCE" => {
-                    std::option::Option::Some(Self::START_FROM_CLOUD_SQL_INSTANCE)
-                }
-                "START_FROM_REDIS_INSTANCE" => {
-                    std::option::Option::Some(Self::START_FROM_REDIS_INSTANCE)
-                }
-                "START_FROM_REDIS_CLUSTER" => {
-                    std::option::Option::Some(Self::START_FROM_REDIS_CLUSTER)
-                }
-                "START_FROM_CLOUD_FUNCTION" => {
-                    std::option::Option::Some(Self::START_FROM_CLOUD_FUNCTION)
-                }
-                "START_FROM_APP_ENGINE_VERSION" => {
-                    std::option::Option::Some(Self::START_FROM_APP_ENGINE_VERSION)
-                }
-                "START_FROM_CLOUD_RUN_REVISION" => {
-                    std::option::Option::Some(Self::START_FROM_CLOUD_RUN_REVISION)
-                }
-                "START_FROM_STORAGE_BUCKET" => {
-                    std::option::Option::Some(Self::START_FROM_STORAGE_BUCKET)
-                }
-                "START_FROM_PSC_PUBLISHED_SERVICE" => {
-                    std::option::Option::Some(Self::START_FROM_PSC_PUBLISHED_SERVICE)
-                }
-                "START_FROM_SERVERLESS_NEG" => {
-                    std::option::Option::Some(Self::START_FROM_SERVERLESS_NEG)
-                }
-                "APPLY_INGRESS_FIREWALL_RULE" => {
-                    std::option::Option::Some(Self::APPLY_INGRESS_FIREWALL_RULE)
-                }
-                "APPLY_EGRESS_FIREWALL_RULE" => {
-                    std::option::Option::Some(Self::APPLY_EGRESS_FIREWALL_RULE)
-                }
-                "APPLY_ROUTE" => std::option::Option::Some(Self::APPLY_ROUTE),
-                "APPLY_FORWARDING_RULE" => std::option::Option::Some(Self::APPLY_FORWARDING_RULE),
-                "ANALYZE_LOAD_BALANCER_BACKEND" => {
-                    std::option::Option::Some(Self::ANALYZE_LOAD_BALANCER_BACKEND)
-                }
-                "SPOOFING_APPROVED" => std::option::Option::Some(Self::SPOOFING_APPROVED),
-                "ARRIVE_AT_INSTANCE" => std::option::Option::Some(Self::ARRIVE_AT_INSTANCE),
-                "ARRIVE_AT_INTERNAL_LOAD_BALANCER" => {
-                    std::option::Option::Some(Self::ARRIVE_AT_INTERNAL_LOAD_BALANCER)
-                }
-                "ARRIVE_AT_EXTERNAL_LOAD_BALANCER" => {
-                    std::option::Option::Some(Self::ARRIVE_AT_EXTERNAL_LOAD_BALANCER)
-                }
-                "ARRIVE_AT_VPN_GATEWAY" => std::option::Option::Some(Self::ARRIVE_AT_VPN_GATEWAY),
-                "ARRIVE_AT_VPN_TUNNEL" => std::option::Option::Some(Self::ARRIVE_AT_VPN_TUNNEL),
-                "ARRIVE_AT_VPC_CONNECTOR" => {
-                    std::option::Option::Some(Self::ARRIVE_AT_VPC_CONNECTOR)
-                }
-                "DIRECT_VPC_EGRESS_CONNECTION" => {
-                    std::option::Option::Some(Self::DIRECT_VPC_EGRESS_CONNECTION)
-                }
-                "SERVERLESS_EXTERNAL_CONNECTION" => {
-                    std::option::Option::Some(Self::SERVERLESS_EXTERNAL_CONNECTION)
-                }
-                "NAT" => std::option::Option::Some(Self::NAT),
-                "PROXY_CONNECTION" => std::option::Option::Some(Self::PROXY_CONNECTION),
-                "DELIVER" => std::option::Option::Some(Self::DELIVER),
-                "DROP" => std::option::Option::Some(Self::DROP),
-                "FORWARD" => std::option::Option::Some(Self::FORWARD),
-                "ABORT" => std::option::Option::Some(Self::ABORT),
-                "VIEWER_PERMISSION_MISSING" => {
-                    std::option::Option::Some(Self::VIEWER_PERMISSION_MISSING)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StartFromInstance,
+                2 => Self::StartFromInternet,
+                3 => Self::StartFromPrivateNetwork,
+                4 => Self::ApplyIngressFirewallRule,
+                5 => Self::ApplyEgressFirewallRule,
+                6 => Self::ApplyRoute,
+                7 => Self::ApplyForwardingRule,
+                8 => Self::SpoofingApproved,
+                9 => Self::ArriveAtInstance,
+                10 => Self::ArriveAtInternalLoadBalancer,
+                11 => Self::ArriveAtExternalLoadBalancer,
+                12 => Self::ArriveAtVpnGateway,
+                13 => Self::ArriveAtVpnTunnel,
+                14 => Self::Nat,
+                15 => Self::ProxyConnection,
+                16 => Self::Deliver,
+                17 => Self::Drop,
+                18 => Self::Forward,
+                19 => Self::Abort,
+                20 => Self::ViewerPermissionMissing,
+                21 => Self::StartFromGkeMaster,
+                22 => Self::StartFromCloudSqlInstance,
+                23 => Self::StartFromCloudFunction,
+                24 => Self::ArriveAtVpcConnector,
+                25 => Self::StartFromAppEngineVersion,
+                26 => Self::StartFromCloudRunRevision,
+                27 => Self::StartFromGoogleService,
+                28 => Self::AnalyzeLoadBalancerBackend,
+                29 => Self::StartFromStorageBucket,
+                30 => Self::StartFromPscPublishedService,
+                31 => Self::StartFromServerlessNeg,
+                32 => Self::StartFromRedisInstance,
+                33 => Self::StartFromRedisCluster,
+                35 => Self::DirectVpcEgressConnection,
+                36 => Self::ServerlessExternalConnection,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "START_FROM_INSTANCE" => Self::StartFromInstance,
+                "START_FROM_INTERNET" => Self::StartFromInternet,
+                "START_FROM_GOOGLE_SERVICE" => Self::StartFromGoogleService,
+                "START_FROM_PRIVATE_NETWORK" => Self::StartFromPrivateNetwork,
+                "START_FROM_GKE_MASTER" => Self::StartFromGkeMaster,
+                "START_FROM_CLOUD_SQL_INSTANCE" => Self::StartFromCloudSqlInstance,
+                "START_FROM_REDIS_INSTANCE" => Self::StartFromRedisInstance,
+                "START_FROM_REDIS_CLUSTER" => Self::StartFromRedisCluster,
+                "START_FROM_CLOUD_FUNCTION" => Self::StartFromCloudFunction,
+                "START_FROM_APP_ENGINE_VERSION" => Self::StartFromAppEngineVersion,
+                "START_FROM_CLOUD_RUN_REVISION" => Self::StartFromCloudRunRevision,
+                "START_FROM_STORAGE_BUCKET" => Self::StartFromStorageBucket,
+                "START_FROM_PSC_PUBLISHED_SERVICE" => Self::StartFromPscPublishedService,
+                "START_FROM_SERVERLESS_NEG" => Self::StartFromServerlessNeg,
+                "APPLY_INGRESS_FIREWALL_RULE" => Self::ApplyIngressFirewallRule,
+                "APPLY_EGRESS_FIREWALL_RULE" => Self::ApplyEgressFirewallRule,
+                "APPLY_ROUTE" => Self::ApplyRoute,
+                "APPLY_FORWARDING_RULE" => Self::ApplyForwardingRule,
+                "ANALYZE_LOAD_BALANCER_BACKEND" => Self::AnalyzeLoadBalancerBackend,
+                "SPOOFING_APPROVED" => Self::SpoofingApproved,
+                "ARRIVE_AT_INSTANCE" => Self::ArriveAtInstance,
+                "ARRIVE_AT_INTERNAL_LOAD_BALANCER" => Self::ArriveAtInternalLoadBalancer,
+                "ARRIVE_AT_EXTERNAL_LOAD_BALANCER" => Self::ArriveAtExternalLoadBalancer,
+                "ARRIVE_AT_VPN_GATEWAY" => Self::ArriveAtVpnGateway,
+                "ARRIVE_AT_VPN_TUNNEL" => Self::ArriveAtVpnTunnel,
+                "ARRIVE_AT_VPC_CONNECTOR" => Self::ArriveAtVpcConnector,
+                "DIRECT_VPC_EGRESS_CONNECTION" => Self::DirectVpcEgressConnection,
+                "SERVERLESS_EXTERNAL_CONNECTION" => Self::ServerlessExternalConnection,
+                "NAT" => Self::Nat,
+                "PROXY_CONNECTION" => Self::ProxyConnection,
+                "DELIVER" => Self::Deliver,
+                "DROP" => Self::Drop,
+                "FORWARD" => Self::Forward,
+                "ABORT" => Self::Abort,
+                "VIEWER_PERMISSION_MISSING" => Self::ViewerPermissionMissing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StartFromInstance => serializer.serialize_i32(1),
+                Self::StartFromInternet => serializer.serialize_i32(2),
+                Self::StartFromGoogleService => serializer.serialize_i32(27),
+                Self::StartFromPrivateNetwork => serializer.serialize_i32(3),
+                Self::StartFromGkeMaster => serializer.serialize_i32(21),
+                Self::StartFromCloudSqlInstance => serializer.serialize_i32(22),
+                Self::StartFromRedisInstance => serializer.serialize_i32(32),
+                Self::StartFromRedisCluster => serializer.serialize_i32(33),
+                Self::StartFromCloudFunction => serializer.serialize_i32(23),
+                Self::StartFromAppEngineVersion => serializer.serialize_i32(25),
+                Self::StartFromCloudRunRevision => serializer.serialize_i32(26),
+                Self::StartFromStorageBucket => serializer.serialize_i32(29),
+                Self::StartFromPscPublishedService => serializer.serialize_i32(30),
+                Self::StartFromServerlessNeg => serializer.serialize_i32(31),
+                Self::ApplyIngressFirewallRule => serializer.serialize_i32(4),
+                Self::ApplyEgressFirewallRule => serializer.serialize_i32(5),
+                Self::ApplyRoute => serializer.serialize_i32(6),
+                Self::ApplyForwardingRule => serializer.serialize_i32(7),
+                Self::AnalyzeLoadBalancerBackend => serializer.serialize_i32(28),
+                Self::SpoofingApproved => serializer.serialize_i32(8),
+                Self::ArriveAtInstance => serializer.serialize_i32(9),
+                Self::ArriveAtInternalLoadBalancer => serializer.serialize_i32(10),
+                Self::ArriveAtExternalLoadBalancer => serializer.serialize_i32(11),
+                Self::ArriveAtVpnGateway => serializer.serialize_i32(12),
+                Self::ArriveAtVpnTunnel => serializer.serialize_i32(13),
+                Self::ArriveAtVpcConnector => serializer.serialize_i32(24),
+                Self::DirectVpcEgressConnection => serializer.serialize_i32(35),
+                Self::ServerlessExternalConnection => serializer.serialize_i32(36),
+                Self::Nat => serializer.serialize_i32(14),
+                Self::ProxyConnection => serializer.serialize_i32(15),
+                Self::Deliver => serializer.serialize_i32(16),
+                Self::Drop => serializer.serialize_i32(17),
+                Self::Forward => serializer.serialize_i32(18),
+                Self::Abort => serializer.serialize_i32(19),
+                Self::ViewerPermissionMissing => serializer.serialize_i32(20),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.networkmanagement.v1.Step.State",
+            ))
         }
     }
 
@@ -3533,130 +3968,203 @@ pub mod firewall_info {
     use super::*;
 
     /// The firewall rule's type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FirewallRuleType(i32);
-
-    impl FirewallRuleType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FirewallRuleType {
         /// Unspecified type.
-        pub const FIREWALL_RULE_TYPE_UNSPECIFIED: FirewallRuleType = FirewallRuleType::new(0);
-
+        Unspecified,
         /// Hierarchical firewall policy rule. For details, see
         /// [Hierarchical firewall policies
         /// overview](https://cloud.google.com/vpc/docs/firewall-policies).
-        pub const HIERARCHICAL_FIREWALL_POLICY_RULE: FirewallRuleType = FirewallRuleType::new(1);
-
+        HierarchicalFirewallPolicyRule,
         /// VPC firewall rule. For details, see
         /// [VPC firewall rules
         /// overview](https://cloud.google.com/vpc/docs/firewalls).
-        pub const VPC_FIREWALL_RULE: FirewallRuleType = FirewallRuleType::new(2);
-
+        VpcFirewallRule,
         /// Implied VPC firewall rule. For details, see
         /// [Implied
         /// rules](https://cloud.google.com/vpc/docs/firewalls#default_firewall_rules).
-        pub const IMPLIED_VPC_FIREWALL_RULE: FirewallRuleType = FirewallRuleType::new(3);
-
+        ImpliedVpcFirewallRule,
         /// Implicit firewall rules that are managed by serverless VPC access to
         /// allow ingress access. They are not visible in the Google Cloud console.
         /// For details, see [VPC connector's implicit
         /// rules](https://cloud.google.com/functions/docs/networking/connecting-vpc#restrict-access).
-        pub const SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE: FirewallRuleType =
-            FirewallRuleType::new(4);
-
+        ServerlessVpcAccessManagedFirewallRule,
         /// Global network firewall policy rule.
         /// For details, see [Network firewall
         /// policies](https://cloud.google.com/vpc/docs/network-firewall-policies).
-        pub const NETWORK_FIREWALL_POLICY_RULE: FirewallRuleType = FirewallRuleType::new(5);
-
+        NetworkFirewallPolicyRule,
         /// Regional network firewall policy rule.
         /// For details, see [Regional network firewall
         /// policies](https://cloud.google.com/firewall/docs/regional-firewall-policies).
-        pub const NETWORK_REGIONAL_FIREWALL_POLICY_RULE: FirewallRuleType =
-            FirewallRuleType::new(6);
-
+        NetworkRegionalFirewallPolicyRule,
         /// Firewall policy rule containing attributes not yet supported in
         /// Connectivity tests. Firewall analysis is skipped if such a rule can
         /// potentially be matched. Please see the [list of unsupported
         /// configurations](https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/concepts/overview#unsupported-configs).
-        pub const UNSUPPORTED_FIREWALL_POLICY_RULE: FirewallRuleType = FirewallRuleType::new(100);
-
+        UnsupportedFirewallPolicyRule,
         /// Tracking state for response traffic created when request traffic goes
         /// through allow firewall rule.
         /// For details, see [firewall rules
         /// specifications](https://cloud.google.com/firewall/docs/firewalls#specifications)
-        pub const TRACKING_STATE: FirewallRuleType = FirewallRuleType::new(101);
-
+        TrackingState,
         /// Firewall analysis was skipped due to executing Connectivity Test in the
         /// BypassFirewallChecks mode
-        pub const ANALYSIS_SKIPPED: FirewallRuleType = FirewallRuleType::new(102);
+        AnalysisSkipped,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FirewallRuleType::value] or
+        /// [FirewallRuleType::name].
+        UnknownValue(firewall_rule_type::UnknownValue),
+    }
 
-        /// Creates a new FirewallRuleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod firewall_rule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FirewallRuleType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HierarchicalFirewallPolicyRule => std::option::Option::Some(1),
+                Self::VpcFirewallRule => std::option::Option::Some(2),
+                Self::ImpliedVpcFirewallRule => std::option::Option::Some(3),
+                Self::ServerlessVpcAccessManagedFirewallRule => std::option::Option::Some(4),
+                Self::NetworkFirewallPolicyRule => std::option::Option::Some(5),
+                Self::NetworkRegionalFirewallPolicyRule => std::option::Option::Some(6),
+                Self::UnsupportedFirewallPolicyRule => std::option::Option::Some(100),
+                Self::TrackingState => std::option::Option::Some(101),
+                Self::AnalysisSkipped => std::option::Option::Some(102),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FIREWALL_RULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIERARCHICAL_FIREWALL_POLICY_RULE"),
-                2 => std::borrow::Cow::Borrowed("VPC_FIREWALL_RULE"),
-                3 => std::borrow::Cow::Borrowed("IMPLIED_VPC_FIREWALL_RULE"),
-                4 => std::borrow::Cow::Borrowed("SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE"),
-                5 => std::borrow::Cow::Borrowed("NETWORK_FIREWALL_POLICY_RULE"),
-                6 => std::borrow::Cow::Borrowed("NETWORK_REGIONAL_FIREWALL_POLICY_RULE"),
-                100 => std::borrow::Cow::Borrowed("UNSUPPORTED_FIREWALL_POLICY_RULE"),
-                101 => std::borrow::Cow::Borrowed("TRACKING_STATE"),
-                102 => std::borrow::Cow::Borrowed("ANALYSIS_SKIPPED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FIREWALL_RULE_TYPE_UNSPECIFIED"),
+                Self::HierarchicalFirewallPolicyRule => {
+                    std::option::Option::Some("HIERARCHICAL_FIREWALL_POLICY_RULE")
+                }
+                Self::VpcFirewallRule => std::option::Option::Some("VPC_FIREWALL_RULE"),
+                Self::ImpliedVpcFirewallRule => {
+                    std::option::Option::Some("IMPLIED_VPC_FIREWALL_RULE")
+                }
+                Self::ServerlessVpcAccessManagedFirewallRule => {
+                    std::option::Option::Some("SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE")
+                }
+                Self::NetworkFirewallPolicyRule => {
+                    std::option::Option::Some("NETWORK_FIREWALL_POLICY_RULE")
+                }
+                Self::NetworkRegionalFirewallPolicyRule => {
+                    std::option::Option::Some("NETWORK_REGIONAL_FIREWALL_POLICY_RULE")
+                }
+                Self::UnsupportedFirewallPolicyRule => {
+                    std::option::Option::Some("UNSUPPORTED_FIREWALL_POLICY_RULE")
+                }
+                Self::TrackingState => std::option::Option::Some("TRACKING_STATE"),
+                Self::AnalysisSkipped => std::option::Option::Some("ANALYSIS_SKIPPED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FIREWALL_RULE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FIREWALL_RULE_TYPE_UNSPECIFIED)
-                }
-                "HIERARCHICAL_FIREWALL_POLICY_RULE" => {
-                    std::option::Option::Some(Self::HIERARCHICAL_FIREWALL_POLICY_RULE)
-                }
-                "VPC_FIREWALL_RULE" => std::option::Option::Some(Self::VPC_FIREWALL_RULE),
-                "IMPLIED_VPC_FIREWALL_RULE" => {
-                    std::option::Option::Some(Self::IMPLIED_VPC_FIREWALL_RULE)
-                }
-                "SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE" => {
-                    std::option::Option::Some(Self::SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE)
-                }
-                "NETWORK_FIREWALL_POLICY_RULE" => {
-                    std::option::Option::Some(Self::NETWORK_FIREWALL_POLICY_RULE)
-                }
-                "NETWORK_REGIONAL_FIREWALL_POLICY_RULE" => {
-                    std::option::Option::Some(Self::NETWORK_REGIONAL_FIREWALL_POLICY_RULE)
-                }
-                "UNSUPPORTED_FIREWALL_POLICY_RULE" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_FIREWALL_POLICY_RULE)
-                }
-                "TRACKING_STATE" => std::option::Option::Some(Self::TRACKING_STATE),
-                "ANALYSIS_SKIPPED" => std::option::Option::Some(Self::ANALYSIS_SKIPPED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FirewallRuleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FirewallRuleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FirewallRuleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FirewallRuleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HierarchicalFirewallPolicyRule,
+                2 => Self::VpcFirewallRule,
+                3 => Self::ImpliedVpcFirewallRule,
+                4 => Self::ServerlessVpcAccessManagedFirewallRule,
+                5 => Self::NetworkFirewallPolicyRule,
+                6 => Self::NetworkRegionalFirewallPolicyRule,
+                100 => Self::UnsupportedFirewallPolicyRule,
+                101 => Self::TrackingState,
+                102 => Self::AnalysisSkipped,
+                _ => Self::UnknownValue(firewall_rule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FirewallRuleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FIREWALL_RULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "HIERARCHICAL_FIREWALL_POLICY_RULE" => Self::HierarchicalFirewallPolicyRule,
+                "VPC_FIREWALL_RULE" => Self::VpcFirewallRule,
+                "IMPLIED_VPC_FIREWALL_RULE" => Self::ImpliedVpcFirewallRule,
+                "SERVERLESS_VPC_ACCESS_MANAGED_FIREWALL_RULE" => {
+                    Self::ServerlessVpcAccessManagedFirewallRule
+                }
+                "NETWORK_FIREWALL_POLICY_RULE" => Self::NetworkFirewallPolicyRule,
+                "NETWORK_REGIONAL_FIREWALL_POLICY_RULE" => Self::NetworkRegionalFirewallPolicyRule,
+                "UNSUPPORTED_FIREWALL_POLICY_RULE" => Self::UnsupportedFirewallPolicyRule,
+                "TRACKING_STATE" => Self::TrackingState,
+                "ANALYSIS_SKIPPED" => Self::AnalysisSkipped,
+                _ => Self::UnknownValue(firewall_rule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FirewallRuleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HierarchicalFirewallPolicyRule => serializer.serialize_i32(1),
+                Self::VpcFirewallRule => serializer.serialize_i32(2),
+                Self::ImpliedVpcFirewallRule => serializer.serialize_i32(3),
+                Self::ServerlessVpcAccessManagedFirewallRule => serializer.serialize_i32(4),
+                Self::NetworkFirewallPolicyRule => serializer.serialize_i32(5),
+                Self::NetworkRegionalFirewallPolicyRule => serializer.serialize_i32(6),
+                Self::UnsupportedFirewallPolicyRule => serializer.serialize_i32(100),
+                Self::TrackingState => serializer.serialize_i32(101),
+                Self::AnalysisSkipped => serializer.serialize_i32(102),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FirewallRuleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FirewallRuleType>::new(
+                ".google.cloud.networkmanagement.v1.FirewallInfo.FirewallRuleType",
+            ))
         }
     }
 }
@@ -3999,272 +4507,483 @@ pub mod route_info {
     use super::*;
 
     /// Type of route:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RouteType(i32);
-
-    impl RouteType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RouteType {
         /// Unspecified type. Default value.
-        pub const ROUTE_TYPE_UNSPECIFIED: RouteType = RouteType::new(0);
-
+        Unspecified,
         /// Route is a subnet route automatically created by the system.
-        pub const SUBNET: RouteType = RouteType::new(1);
-
+        Subnet,
         /// Static route created by the user, including the default route to the
         /// internet.
-        pub const STATIC: RouteType = RouteType::new(2);
-
+        Static,
         /// Dynamic route exchanged between BGP peers.
-        pub const DYNAMIC: RouteType = RouteType::new(3);
-
+        Dynamic,
         /// A subnet route received from peering network or NCC Hub.
-        pub const PEERING_SUBNET: RouteType = RouteType::new(4);
-
+        PeeringSubnet,
         /// A static route received from peering network.
-        pub const PEERING_STATIC: RouteType = RouteType::new(5);
-
+        PeeringStatic,
         /// A dynamic route received from peering network or NCC Hub.
-        pub const PEERING_DYNAMIC: RouteType = RouteType::new(6);
-
+        PeeringDynamic,
         /// Policy based route.
-        pub const POLICY_BASED: RouteType = RouteType::new(7);
-
+        PolicyBased,
         /// Advertised route. Synthetic route which is used to transition from the
         /// StartFromPrivateNetwork state in Connectivity tests.
-        pub const ADVERTISED: RouteType = RouteType::new(101);
+        Advertised,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RouteType::value] or
+        /// [RouteType::name].
+        UnknownValue(route_type::UnknownValue),
+    }
 
-        /// Creates a new RouteType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod route_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RouteType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Subnet => std::option::Option::Some(1),
+                Self::Static => std::option::Option::Some(2),
+                Self::Dynamic => std::option::Option::Some(3),
+                Self::PeeringSubnet => std::option::Option::Some(4),
+                Self::PeeringStatic => std::option::Option::Some(5),
+                Self::PeeringDynamic => std::option::Option::Some(6),
+                Self::PolicyBased => std::option::Option::Some(7),
+                Self::Advertised => std::option::Option::Some(101),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUTE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUBNET"),
-                2 => std::borrow::Cow::Borrowed("STATIC"),
-                3 => std::borrow::Cow::Borrowed("DYNAMIC"),
-                4 => std::borrow::Cow::Borrowed("PEERING_SUBNET"),
-                5 => std::borrow::Cow::Borrowed("PEERING_STATIC"),
-                6 => std::borrow::Cow::Borrowed("PEERING_DYNAMIC"),
-                7 => std::borrow::Cow::Borrowed("POLICY_BASED"),
-                101 => std::borrow::Cow::Borrowed("ADVERTISED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUTE_TYPE_UNSPECIFIED"),
+                Self::Subnet => std::option::Option::Some("SUBNET"),
+                Self::Static => std::option::Option::Some("STATIC"),
+                Self::Dynamic => std::option::Option::Some("DYNAMIC"),
+                Self::PeeringSubnet => std::option::Option::Some("PEERING_SUBNET"),
+                Self::PeeringStatic => std::option::Option::Some("PEERING_STATIC"),
+                Self::PeeringDynamic => std::option::Option::Some("PEERING_DYNAMIC"),
+                Self::PolicyBased => std::option::Option::Some("POLICY_BASED"),
+                Self::Advertised => std::option::Option::Some("ADVERTISED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUTE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ROUTE_TYPE_UNSPECIFIED),
-                "SUBNET" => std::option::Option::Some(Self::SUBNET),
-                "STATIC" => std::option::Option::Some(Self::STATIC),
-                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
-                "PEERING_SUBNET" => std::option::Option::Some(Self::PEERING_SUBNET),
-                "PEERING_STATIC" => std::option::Option::Some(Self::PEERING_STATIC),
-                "PEERING_DYNAMIC" => std::option::Option::Some(Self::PEERING_DYNAMIC),
-                "POLICY_BASED" => std::option::Option::Some(Self::POLICY_BASED),
-                "ADVERTISED" => std::option::Option::Some(Self::ADVERTISED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RouteType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RouteType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RouteType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RouteType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Subnet,
+                2 => Self::Static,
+                3 => Self::Dynamic,
+                4 => Self::PeeringSubnet,
+                5 => Self::PeeringStatic,
+                6 => Self::PeeringDynamic,
+                7 => Self::PolicyBased,
+                101 => Self::Advertised,
+                _ => Self::UnknownValue(route_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RouteType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUTE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SUBNET" => Self::Subnet,
+                "STATIC" => Self::Static,
+                "DYNAMIC" => Self::Dynamic,
+                "PEERING_SUBNET" => Self::PeeringSubnet,
+                "PEERING_STATIC" => Self::PeeringStatic,
+                "PEERING_DYNAMIC" => Self::PeeringDynamic,
+                "POLICY_BASED" => Self::PolicyBased,
+                "ADVERTISED" => Self::Advertised,
+                _ => Self::UnknownValue(route_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RouteType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Subnet => serializer.serialize_i32(1),
+                Self::Static => serializer.serialize_i32(2),
+                Self::Dynamic => serializer.serialize_i32(3),
+                Self::PeeringSubnet => serializer.serialize_i32(4),
+                Self::PeeringStatic => serializer.serialize_i32(5),
+                Self::PeeringDynamic => serializer.serialize_i32(6),
+                Self::PolicyBased => serializer.serialize_i32(7),
+                Self::Advertised => serializer.serialize_i32(101),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RouteType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RouteType>::new(
+                ".google.cloud.networkmanagement.v1.RouteInfo.RouteType",
+            ))
         }
     }
 
     /// Type of next hop:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NextHopType(i32);
-
-    impl NextHopType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NextHopType {
         /// Unspecified type. Default value.
-        pub const NEXT_HOP_TYPE_UNSPECIFIED: NextHopType = NextHopType::new(0);
-
+        Unspecified,
         /// Next hop is an IP address.
-        pub const NEXT_HOP_IP: NextHopType = NextHopType::new(1);
-
+        NextHopIp,
         /// Next hop is a Compute Engine instance.
-        pub const NEXT_HOP_INSTANCE: NextHopType = NextHopType::new(2);
-
+        NextHopInstance,
         /// Next hop is a VPC network gateway.
-        pub const NEXT_HOP_NETWORK: NextHopType = NextHopType::new(3);
-
+        NextHopNetwork,
         /// Next hop is a peering VPC. This scenario only happens when the user
         /// doesn't have permissions to the project where the next hop resource is
         /// located.
-        pub const NEXT_HOP_PEERING: NextHopType = NextHopType::new(4);
-
+        NextHopPeering,
         /// Next hop is an interconnect.
-        pub const NEXT_HOP_INTERCONNECT: NextHopType = NextHopType::new(5);
-
+        NextHopInterconnect,
         /// Next hop is a VPN tunnel.
-        pub const NEXT_HOP_VPN_TUNNEL: NextHopType = NextHopType::new(6);
-
+        NextHopVpnTunnel,
         /// Next hop is a VPN gateway. This scenario only happens when tracing
         /// connectivity from an on-premises network to Google Cloud through a VPN.
         /// The analysis simulates a packet departing from the on-premises network
         /// through a VPN tunnel and arriving at a Cloud VPN gateway.
-        pub const NEXT_HOP_VPN_GATEWAY: NextHopType = NextHopType::new(7);
-
+        NextHopVpnGateway,
         /// Next hop is an internet gateway.
-        pub const NEXT_HOP_INTERNET_GATEWAY: NextHopType = NextHopType::new(8);
-
+        NextHopInternetGateway,
         /// Next hop is blackhole; that is, the next hop either does not exist or is
         /// unusable.
-        pub const NEXT_HOP_BLACKHOLE: NextHopType = NextHopType::new(9);
-
+        NextHopBlackhole,
         /// Next hop is the forwarding rule of an Internal Load Balancer.
-        pub const NEXT_HOP_ILB: NextHopType = NextHopType::new(10);
-
+        NextHopIlb,
         /// Next hop is a
         /// [router appliance
         /// instance](https://cloud.google.com/network-connectivity/docs/network-connectivity-center/concepts/ra-overview).
-        pub const NEXT_HOP_ROUTER_APPLIANCE: NextHopType = NextHopType::new(11);
-
+        NextHopRouterAppliance,
         /// Next hop is an NCC hub. This scenario only happens when the user doesn't
         /// have permissions to the project where the next hop resource is located.
-        pub const NEXT_HOP_NCC_HUB: NextHopType = NextHopType::new(12);
+        NextHopNccHub,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NextHopType::value] or
+        /// [NextHopType::name].
+        UnknownValue(next_hop_type::UnknownValue),
+    }
 
-        /// Creates a new NextHopType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod next_hop_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NextHopType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NextHopIp => std::option::Option::Some(1),
+                Self::NextHopInstance => std::option::Option::Some(2),
+                Self::NextHopNetwork => std::option::Option::Some(3),
+                Self::NextHopPeering => std::option::Option::Some(4),
+                Self::NextHopInterconnect => std::option::Option::Some(5),
+                Self::NextHopVpnTunnel => std::option::Option::Some(6),
+                Self::NextHopVpnGateway => std::option::Option::Some(7),
+                Self::NextHopInternetGateway => std::option::Option::Some(8),
+                Self::NextHopBlackhole => std::option::Option::Some(9),
+                Self::NextHopIlb => std::option::Option::Some(10),
+                Self::NextHopRouterAppliance => std::option::Option::Some(11),
+                Self::NextHopNccHub => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NEXT_HOP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEXT_HOP_IP"),
-                2 => std::borrow::Cow::Borrowed("NEXT_HOP_INSTANCE"),
-                3 => std::borrow::Cow::Borrowed("NEXT_HOP_NETWORK"),
-                4 => std::borrow::Cow::Borrowed("NEXT_HOP_PEERING"),
-                5 => std::borrow::Cow::Borrowed("NEXT_HOP_INTERCONNECT"),
-                6 => std::borrow::Cow::Borrowed("NEXT_HOP_VPN_TUNNEL"),
-                7 => std::borrow::Cow::Borrowed("NEXT_HOP_VPN_GATEWAY"),
-                8 => std::borrow::Cow::Borrowed("NEXT_HOP_INTERNET_GATEWAY"),
-                9 => std::borrow::Cow::Borrowed("NEXT_HOP_BLACKHOLE"),
-                10 => std::borrow::Cow::Borrowed("NEXT_HOP_ILB"),
-                11 => std::borrow::Cow::Borrowed("NEXT_HOP_ROUTER_APPLIANCE"),
-                12 => std::borrow::Cow::Borrowed("NEXT_HOP_NCC_HUB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NEXT_HOP_TYPE_UNSPECIFIED"),
+                Self::NextHopIp => std::option::Option::Some("NEXT_HOP_IP"),
+                Self::NextHopInstance => std::option::Option::Some("NEXT_HOP_INSTANCE"),
+                Self::NextHopNetwork => std::option::Option::Some("NEXT_HOP_NETWORK"),
+                Self::NextHopPeering => std::option::Option::Some("NEXT_HOP_PEERING"),
+                Self::NextHopInterconnect => std::option::Option::Some("NEXT_HOP_INTERCONNECT"),
+                Self::NextHopVpnTunnel => std::option::Option::Some("NEXT_HOP_VPN_TUNNEL"),
+                Self::NextHopVpnGateway => std::option::Option::Some("NEXT_HOP_VPN_GATEWAY"),
+                Self::NextHopInternetGateway => {
+                    std::option::Option::Some("NEXT_HOP_INTERNET_GATEWAY")
+                }
+                Self::NextHopBlackhole => std::option::Option::Some("NEXT_HOP_BLACKHOLE"),
+                Self::NextHopIlb => std::option::Option::Some("NEXT_HOP_ILB"),
+                Self::NextHopRouterAppliance => {
+                    std::option::Option::Some("NEXT_HOP_ROUTER_APPLIANCE")
+                }
+                Self::NextHopNccHub => std::option::Option::Some("NEXT_HOP_NCC_HUB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NEXT_HOP_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NEXT_HOP_TYPE_UNSPECIFIED)
-                }
-                "NEXT_HOP_IP" => std::option::Option::Some(Self::NEXT_HOP_IP),
-                "NEXT_HOP_INSTANCE" => std::option::Option::Some(Self::NEXT_HOP_INSTANCE),
-                "NEXT_HOP_NETWORK" => std::option::Option::Some(Self::NEXT_HOP_NETWORK),
-                "NEXT_HOP_PEERING" => std::option::Option::Some(Self::NEXT_HOP_PEERING),
-                "NEXT_HOP_INTERCONNECT" => std::option::Option::Some(Self::NEXT_HOP_INTERCONNECT),
-                "NEXT_HOP_VPN_TUNNEL" => std::option::Option::Some(Self::NEXT_HOP_VPN_TUNNEL),
-                "NEXT_HOP_VPN_GATEWAY" => std::option::Option::Some(Self::NEXT_HOP_VPN_GATEWAY),
-                "NEXT_HOP_INTERNET_GATEWAY" => {
-                    std::option::Option::Some(Self::NEXT_HOP_INTERNET_GATEWAY)
-                }
-                "NEXT_HOP_BLACKHOLE" => std::option::Option::Some(Self::NEXT_HOP_BLACKHOLE),
-                "NEXT_HOP_ILB" => std::option::Option::Some(Self::NEXT_HOP_ILB),
-                "NEXT_HOP_ROUTER_APPLIANCE" => {
-                    std::option::Option::Some(Self::NEXT_HOP_ROUTER_APPLIANCE)
-                }
-                "NEXT_HOP_NCC_HUB" => std::option::Option::Some(Self::NEXT_HOP_NCC_HUB),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NextHopType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NextHopType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NextHopType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NextHopType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NextHopIp,
+                2 => Self::NextHopInstance,
+                3 => Self::NextHopNetwork,
+                4 => Self::NextHopPeering,
+                5 => Self::NextHopInterconnect,
+                6 => Self::NextHopVpnTunnel,
+                7 => Self::NextHopVpnGateway,
+                8 => Self::NextHopInternetGateway,
+                9 => Self::NextHopBlackhole,
+                10 => Self::NextHopIlb,
+                11 => Self::NextHopRouterAppliance,
+                12 => Self::NextHopNccHub,
+                _ => Self::UnknownValue(next_hop_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NextHopType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NEXT_HOP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NEXT_HOP_IP" => Self::NextHopIp,
+                "NEXT_HOP_INSTANCE" => Self::NextHopInstance,
+                "NEXT_HOP_NETWORK" => Self::NextHopNetwork,
+                "NEXT_HOP_PEERING" => Self::NextHopPeering,
+                "NEXT_HOP_INTERCONNECT" => Self::NextHopInterconnect,
+                "NEXT_HOP_VPN_TUNNEL" => Self::NextHopVpnTunnel,
+                "NEXT_HOP_VPN_GATEWAY" => Self::NextHopVpnGateway,
+                "NEXT_HOP_INTERNET_GATEWAY" => Self::NextHopInternetGateway,
+                "NEXT_HOP_BLACKHOLE" => Self::NextHopBlackhole,
+                "NEXT_HOP_ILB" => Self::NextHopIlb,
+                "NEXT_HOP_ROUTER_APPLIANCE" => Self::NextHopRouterAppliance,
+                "NEXT_HOP_NCC_HUB" => Self::NextHopNccHub,
+                _ => Self::UnknownValue(next_hop_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NextHopType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NextHopIp => serializer.serialize_i32(1),
+                Self::NextHopInstance => serializer.serialize_i32(2),
+                Self::NextHopNetwork => serializer.serialize_i32(3),
+                Self::NextHopPeering => serializer.serialize_i32(4),
+                Self::NextHopInterconnect => serializer.serialize_i32(5),
+                Self::NextHopVpnTunnel => serializer.serialize_i32(6),
+                Self::NextHopVpnGateway => serializer.serialize_i32(7),
+                Self::NextHopInternetGateway => serializer.serialize_i32(8),
+                Self::NextHopBlackhole => serializer.serialize_i32(9),
+                Self::NextHopIlb => serializer.serialize_i32(10),
+                Self::NextHopRouterAppliance => serializer.serialize_i32(11),
+                Self::NextHopNccHub => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NextHopType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NextHopType>::new(
+                ".google.cloud.networkmanagement.v1.RouteInfo.NextHopType",
+            ))
         }
     }
 
     /// Indicates where routes are applicable.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RouteScope(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RouteScope {
+        /// Unspecified scope. Default value.
+        Unspecified,
+        /// Route is applicable to packets in Network.
+        Network,
+        /// Route is applicable to packets using NCC Hub's routing table.
+        NccHub,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RouteScope::value] or
+        /// [RouteScope::name].
+        UnknownValue(route_scope::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod route_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RouteScope {
-        /// Unspecified scope. Default value.
-        pub const ROUTE_SCOPE_UNSPECIFIED: RouteScope = RouteScope::new(0);
-
-        /// Route is applicable to packets in Network.
-        pub const NETWORK: RouteScope = RouteScope::new(1);
-
-        /// Route is applicable to packets using NCC Hub's routing table.
-        pub const NCC_HUB: RouteScope = RouteScope::new(2);
-
-        /// Creates a new RouteScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Network => std::option::Option::Some(1),
+                Self::NccHub => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUTE_SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NETWORK"),
-                2 => std::borrow::Cow::Borrowed("NCC_HUB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUTE_SCOPE_UNSPECIFIED"),
+                Self::Network => std::option::Option::Some("NETWORK"),
+                Self::NccHub => std::option::Option::Some("NCC_HUB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUTE_SCOPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROUTE_SCOPE_UNSPECIFIED)
-                }
-                "NETWORK" => std::option::Option::Some(Self::NETWORK),
-                "NCC_HUB" => std::option::Option::Some(Self::NCC_HUB),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RouteScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RouteScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RouteScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RouteScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Network,
+                2 => Self::NccHub,
+                _ => Self::UnknownValue(route_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RouteScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUTE_SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "NETWORK" => Self::Network,
+                "NCC_HUB" => Self::NccHub,
+                _ => Self::UnknownValue(route_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RouteScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Network => serializer.serialize_i32(1),
+                Self::NccHub => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RouteScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RouteScope>::new(
+                ".google.cloud.networkmanagement.v1.RouteInfo.RouteScope",
+            ))
         }
     }
 }
@@ -4325,99 +5044,168 @@ pub mod google_service_info {
     use super::*;
 
     /// Recognized type of a Google Service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GoogleServiceType(i32);
-
-    impl GoogleServiceType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum GoogleServiceType {
         /// Unspecified Google Service.
-        pub const GOOGLE_SERVICE_TYPE_UNSPECIFIED: GoogleServiceType = GoogleServiceType::new(0);
-
+        Unspecified,
         /// Identity aware proxy.
         /// <https://cloud.google.com/iap/docs/using-tcp-forwarding>
-        pub const IAP: GoogleServiceType = GoogleServiceType::new(1);
-
+        Iap,
         /// One of two services sharing IP ranges:
         ///
         /// * Load Balancer proxy
         /// * Centralized Health Check prober
         ///   <https://cloud.google.com/load-balancing/docs/firewall-rules>
-        pub const GFE_PROXY_OR_HEALTH_CHECK_PROBER: GoogleServiceType = GoogleServiceType::new(2);
-
+        GfeProxyOrHealthCheckProber,
         /// Connectivity from Cloud DNS to forwarding targets or alternate name
         /// servers that use private routing.
         /// <https://cloud.google.com/dns/docs/zones/forwarding-zones#firewall-rules>
         /// <https://cloud.google.com/dns/docs/policies#firewall-rules>
-        pub const CLOUD_DNS: GoogleServiceType = GoogleServiceType::new(3);
-
+        CloudDns,
         /// private.googleapis.com and restricted.googleapis.com
-        pub const GOOGLE_API: GoogleServiceType = GoogleServiceType::new(4);
-
+        GoogleApi,
         /// Google API via Private Service Connect.
         /// <https://cloud.google.com/vpc/docs/configure-private-service-connect-apis>
-        pub const GOOGLE_API_PSC: GoogleServiceType = GoogleServiceType::new(5);
-
+        GoogleApiPsc,
         /// Google API via VPC Service Controls.
         /// <https://cloud.google.com/vpc/docs/configure-private-service-connect-apis>
-        pub const GOOGLE_API_VPC_SC: GoogleServiceType = GoogleServiceType::new(6);
-
+        GoogleApiVpcSc,
         /// Google API via Serverless VPC Access.
         /// <https://cloud.google.com/vpc/docs/serverless-vpc-access>
-        pub const SERVERLESS_VPC_ACCESS: GoogleServiceType = GoogleServiceType::new(7);
+        ServerlessVpcAccess,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [GoogleServiceType::value] or
+        /// [GoogleServiceType::name].
+        UnknownValue(google_service_type::UnknownValue),
+    }
 
-        /// Creates a new GoogleServiceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod google_service_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl GoogleServiceType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Iap => std::option::Option::Some(1),
+                Self::GfeProxyOrHealthCheckProber => std::option::Option::Some(2),
+                Self::CloudDns => std::option::Option::Some(3),
+                Self::GoogleApi => std::option::Option::Some(4),
+                Self::GoogleApiPsc => std::option::Option::Some(5),
+                Self::GoogleApiVpcSc => std::option::Option::Some(6),
+                Self::ServerlessVpcAccess => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GOOGLE_SERVICE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IAP"),
-                2 => std::borrow::Cow::Borrowed("GFE_PROXY_OR_HEALTH_CHECK_PROBER"),
-                3 => std::borrow::Cow::Borrowed("CLOUD_DNS"),
-                4 => std::borrow::Cow::Borrowed("GOOGLE_API"),
-                5 => std::borrow::Cow::Borrowed("GOOGLE_API_PSC"),
-                6 => std::borrow::Cow::Borrowed("GOOGLE_API_VPC_SC"),
-                7 => std::borrow::Cow::Borrowed("SERVERLESS_VPC_ACCESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GOOGLE_SERVICE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::GOOGLE_SERVICE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("GOOGLE_SERVICE_TYPE_UNSPECIFIED"),
+                Self::Iap => std::option::Option::Some("IAP"),
+                Self::GfeProxyOrHealthCheckProber => {
+                    std::option::Option::Some("GFE_PROXY_OR_HEALTH_CHECK_PROBER")
                 }
-                "IAP" => std::option::Option::Some(Self::IAP),
-                "GFE_PROXY_OR_HEALTH_CHECK_PROBER" => {
-                    std::option::Option::Some(Self::GFE_PROXY_OR_HEALTH_CHECK_PROBER)
-                }
-                "CLOUD_DNS" => std::option::Option::Some(Self::CLOUD_DNS),
-                "GOOGLE_API" => std::option::Option::Some(Self::GOOGLE_API),
-                "GOOGLE_API_PSC" => std::option::Option::Some(Self::GOOGLE_API_PSC),
-                "GOOGLE_API_VPC_SC" => std::option::Option::Some(Self::GOOGLE_API_VPC_SC),
-                "SERVERLESS_VPC_ACCESS" => std::option::Option::Some(Self::SERVERLESS_VPC_ACCESS),
-                _ => std::option::Option::None,
+                Self::CloudDns => std::option::Option::Some("CLOUD_DNS"),
+                Self::GoogleApi => std::option::Option::Some("GOOGLE_API"),
+                Self::GoogleApiPsc => std::option::Option::Some("GOOGLE_API_PSC"),
+                Self::GoogleApiVpcSc => std::option::Option::Some("GOOGLE_API_VPC_SC"),
+                Self::ServerlessVpcAccess => std::option::Option::Some("SERVERLESS_VPC_ACCESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for GoogleServiceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for GoogleServiceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for GoogleServiceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for GoogleServiceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Iap,
+                2 => Self::GfeProxyOrHealthCheckProber,
+                3 => Self::CloudDns,
+                4 => Self::GoogleApi,
+                5 => Self::GoogleApiPsc,
+                6 => Self::GoogleApiVpcSc,
+                7 => Self::ServerlessVpcAccess,
+                _ => Self::UnknownValue(google_service_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for GoogleServiceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GOOGLE_SERVICE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IAP" => Self::Iap,
+                "GFE_PROXY_OR_HEALTH_CHECK_PROBER" => Self::GfeProxyOrHealthCheckProber,
+                "CLOUD_DNS" => Self::CloudDns,
+                "GOOGLE_API" => Self::GoogleApi,
+                "GOOGLE_API_PSC" => Self::GoogleApiPsc,
+                "GOOGLE_API_VPC_SC" => Self::GoogleApiVpcSc,
+                "SERVERLESS_VPC_ACCESS" => Self::ServerlessVpcAccess,
+                _ => Self::UnknownValue(google_service_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for GoogleServiceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Iap => serializer.serialize_i32(1),
+                Self::GfeProxyOrHealthCheckProber => serializer.serialize_i32(2),
+                Self::CloudDns => serializer.serialize_i32(3),
+                Self::GoogleApi => serializer.serialize_i32(4),
+                Self::GoogleApiPsc => serializer.serialize_i32(5),
+                Self::GoogleApiVpcSc => serializer.serialize_i32(6),
+                Self::ServerlessVpcAccess => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for GoogleServiceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<GoogleServiceType>::new(
+                ".google.cloud.networkmanagement.v1.GoogleServiceInfo.GoogleServiceType",
+            ))
         }
     }
 }
@@ -4667,140 +5455,266 @@ pub mod load_balancer_info {
     use super::*;
 
     /// The type definition for a load balancer:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoadBalancerType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoadBalancerType {
+        /// Type is unspecified.
+        Unspecified,
+        /// Internal TCP/UDP load balancer.
+        InternalTcpUdp,
+        /// Network TCP/UDP load balancer.
+        NetworkTcpUdp,
+        /// HTTP(S) proxy load balancer.
+        HttpProxy,
+        /// TCP proxy load balancer.
+        TcpProxy,
+        /// SSL proxy load balancer.
+        SslProxy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoadBalancerType::value] or
+        /// [LoadBalancerType::name].
+        UnknownValue(load_balancer_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod load_balancer_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LoadBalancerType {
-        /// Type is unspecified.
-        pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType = LoadBalancerType::new(0);
-
-        /// Internal TCP/UDP load balancer.
-        pub const INTERNAL_TCP_UDP: LoadBalancerType = LoadBalancerType::new(1);
-
-        /// Network TCP/UDP load balancer.
-        pub const NETWORK_TCP_UDP: LoadBalancerType = LoadBalancerType::new(2);
-
-        /// HTTP(S) proxy load balancer.
-        pub const HTTP_PROXY: LoadBalancerType = LoadBalancerType::new(3);
-
-        /// TCP proxy load balancer.
-        pub const TCP_PROXY: LoadBalancerType = LoadBalancerType::new(4);
-
-        /// SSL proxy load balancer.
-        pub const SSL_PROXY: LoadBalancerType = LoadBalancerType::new(5);
-
-        /// Creates a new LoadBalancerType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InternalTcpUdp => std::option::Option::Some(1),
+                Self::NetworkTcpUdp => std::option::Option::Some(2),
+                Self::HttpProxy => std::option::Option::Some(3),
+                Self::TcpProxy => std::option::Option::Some(4),
+                Self::SslProxy => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTERNAL_TCP_UDP"),
-                2 => std::borrow::Cow::Borrowed("NETWORK_TCP_UDP"),
-                3 => std::borrow::Cow::Borrowed("HTTP_PROXY"),
-                4 => std::borrow::Cow::Borrowed("TCP_PROXY"),
-                5 => std::borrow::Cow::Borrowed("SSL_PROXY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOAD_BALANCER_TYPE_UNSPECIFIED"),
+                Self::InternalTcpUdp => std::option::Option::Some("INTERNAL_TCP_UDP"),
+                Self::NetworkTcpUdp => std::option::Option::Some("NETWORK_TCP_UDP"),
+                Self::HttpProxy => std::option::Option::Some("HTTP_PROXY"),
+                Self::TcpProxy => std::option::Option::Some("TCP_PROXY"),
+                Self::SslProxy => std::option::Option::Some("SSL_PROXY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOAD_BALANCER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_UNSPECIFIED)
-                }
-                "INTERNAL_TCP_UDP" => std::option::Option::Some(Self::INTERNAL_TCP_UDP),
-                "NETWORK_TCP_UDP" => std::option::Option::Some(Self::NETWORK_TCP_UDP),
-                "HTTP_PROXY" => std::option::Option::Some(Self::HTTP_PROXY),
-                "TCP_PROXY" => std::option::Option::Some(Self::TCP_PROXY),
-                "SSL_PROXY" => std::option::Option::Some(Self::SSL_PROXY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoadBalancerType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoadBalancerType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoadBalancerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoadBalancerType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InternalTcpUdp,
+                2 => Self::NetworkTcpUdp,
+                3 => Self::HttpProxy,
+                4 => Self::TcpProxy,
+                5 => Self::SslProxy,
+                _ => Self::UnknownValue(load_balancer_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoadBalancerType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOAD_BALANCER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INTERNAL_TCP_UDP" => Self::InternalTcpUdp,
+                "NETWORK_TCP_UDP" => Self::NetworkTcpUdp,
+                "HTTP_PROXY" => Self::HttpProxy,
+                "TCP_PROXY" => Self::TcpProxy,
+                "SSL_PROXY" => Self::SslProxy,
+                _ => Self::UnknownValue(load_balancer_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoadBalancerType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InternalTcpUdp => serializer.serialize_i32(1),
+                Self::NetworkTcpUdp => serializer.serialize_i32(2),
+                Self::HttpProxy => serializer.serialize_i32(3),
+                Self::TcpProxy => serializer.serialize_i32(4),
+                Self::SslProxy => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoadBalancerType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoadBalancerType>::new(
+                ".google.cloud.networkmanagement.v1.LoadBalancerInfo.LoadBalancerType",
+            ))
         }
     }
 
     /// The type definition for a load balancer backend configuration:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackendType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BackendType {
+        /// Type is unspecified.
+        Unspecified,
+        /// Backend Service as the load balancer's backend.
+        BackendService,
+        /// Target Pool as the load balancer's backend.
+        TargetPool,
+        /// Target Instance as the load balancer's backend.
+        TargetInstance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BackendType::value] or
+        /// [BackendType::name].
+        UnknownValue(backend_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod backend_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BackendType {
-        /// Type is unspecified.
-        pub const BACKEND_TYPE_UNSPECIFIED: BackendType = BackendType::new(0);
-
-        /// Backend Service as the load balancer's backend.
-        pub const BACKEND_SERVICE: BackendType = BackendType::new(1);
-
-        /// Target Pool as the load balancer's backend.
-        pub const TARGET_POOL: BackendType = BackendType::new(2);
-
-        /// Target Instance as the load balancer's backend.
-        pub const TARGET_INSTANCE: BackendType = BackendType::new(3);
-
-        /// Creates a new BackendType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BackendService => std::option::Option::Some(1),
+                Self::TargetPool => std::option::Option::Some(2),
+                Self::TargetInstance => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BACKEND_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BACKEND_SERVICE"),
-                2 => std::borrow::Cow::Borrowed("TARGET_POOL"),
-                3 => std::borrow::Cow::Borrowed("TARGET_INSTANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BACKEND_TYPE_UNSPECIFIED"),
+                Self::BackendService => std::option::Option::Some("BACKEND_SERVICE"),
+                Self::TargetPool => std::option::Option::Some("TARGET_POOL"),
+                Self::TargetInstance => std::option::Option::Some("TARGET_INSTANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BACKEND_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BACKEND_TYPE_UNSPECIFIED)
-                }
-                "BACKEND_SERVICE" => std::option::Option::Some(Self::BACKEND_SERVICE),
-                "TARGET_POOL" => std::option::Option::Some(Self::TARGET_POOL),
-                "TARGET_INSTANCE" => std::option::Option::Some(Self::TARGET_INSTANCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BackendType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BackendType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BackendType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BackendType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BackendService,
+                2 => Self::TargetPool,
+                3 => Self::TargetInstance,
+                _ => Self::UnknownValue(backend_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BackendType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BACKEND_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BACKEND_SERVICE" => Self::BackendService,
+                "TARGET_POOL" => Self::TargetPool,
+                "TARGET_INSTANCE" => Self::TargetInstance,
+                _ => Self::UnknownValue(backend_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BackendType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BackendService => serializer.serialize_i32(1),
+                Self::TargetPool => serializer.serialize_i32(2),
+                Self::TargetInstance => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BackendType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackendType>::new(
+                ".google.cloud.networkmanagement.v1.LoadBalancerInfo.BackendType",
+            ))
         }
     }
 }
@@ -4897,67 +5811,126 @@ pub mod load_balancer_backend {
     use super::*;
 
     /// State of a health check firewall configuration:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HealthCheckFirewallState(i32);
-
-    impl HealthCheckFirewallState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HealthCheckFirewallState {
         /// State is unspecified. Default state if not populated.
-        pub const HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED: HealthCheckFirewallState =
-            HealthCheckFirewallState::new(0);
-
+        Unspecified,
         /// There are configured firewall rules to allow health check probes to the
         /// backend.
-        pub const CONFIGURED: HealthCheckFirewallState = HealthCheckFirewallState::new(1);
-
+        Configured,
         /// There are firewall rules configured to allow partial health check ranges
         /// or block all health check ranges.
         /// If a health check probe is sent from denied IP ranges,
         /// the health check to the backend will fail. Then, the backend will be
         /// marked unhealthy and will not receive traffic sent to the load balancer.
-        pub const MISCONFIGURED: HealthCheckFirewallState = HealthCheckFirewallState::new(2);
+        Misconfigured,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HealthCheckFirewallState::value] or
+        /// [HealthCheckFirewallState::name].
+        UnknownValue(health_check_firewall_state::UnknownValue),
+    }
 
-        /// Creates a new HealthCheckFirewallState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod health_check_firewall_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl HealthCheckFirewallState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Configured => std::option::Option::Some(1),
+                Self::Misconfigured => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFIGURED"),
-                2 => std::borrow::Cow::Borrowed("MISCONFIGURED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED")
                 }
-                "CONFIGURED" => std::option::Option::Some(Self::CONFIGURED),
-                "MISCONFIGURED" => std::option::Option::Some(Self::MISCONFIGURED),
-                _ => std::option::Option::None,
+                Self::Configured => std::option::Option::Some("CONFIGURED"),
+                Self::Misconfigured => std::option::Option::Some("MISCONFIGURED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for HealthCheckFirewallState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HealthCheckFirewallState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HealthCheckFirewallState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HealthCheckFirewallState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Configured,
+                2 => Self::Misconfigured,
+                _ => Self::UnknownValue(health_check_firewall_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HealthCheckFirewallState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HEALTH_CHECK_FIREWALL_STATE_UNSPECIFIED" => Self::Unspecified,
+                "CONFIGURED" => Self::Configured,
+                "MISCONFIGURED" => Self::Misconfigured,
+                _ => Self::UnknownValue(health_check_firewall_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HealthCheckFirewallState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Configured => serializer.serialize_i32(1),
+                Self::Misconfigured => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HealthCheckFirewallState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HealthCheckFirewallState>::new(
+                ".google.cloud.networkmanagement.v1.LoadBalancerBackend.HealthCheckFirewallState"))
         }
     }
 }
@@ -5173,66 +6146,127 @@ pub mod vpn_tunnel_info {
 
     /// Types of VPN routing policy. For details, refer to [Networks and Tunnel
     /// routing](https://cloud.google.com/network-connectivity/docs/vpn/concepts/choosing-networks-routing/).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutingType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoutingType {
+        /// Unspecified type. Default value.
+        Unspecified,
+        /// Route based VPN.
+        RouteBased,
+        /// Policy based routing.
+        PolicyBased,
+        /// Dynamic (BGP) routing.
+        Dynamic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoutingType::value] or
+        /// [RoutingType::name].
+        UnknownValue(routing_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod routing_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RoutingType {
-        /// Unspecified type. Default value.
-        pub const ROUTING_TYPE_UNSPECIFIED: RoutingType = RoutingType::new(0);
-
-        /// Route based VPN.
-        pub const ROUTE_BASED: RoutingType = RoutingType::new(1);
-
-        /// Policy based routing.
-        pub const POLICY_BASED: RoutingType = RoutingType::new(2);
-
-        /// Dynamic (BGP) routing.
-        pub const DYNAMIC: RoutingType = RoutingType::new(3);
-
-        /// Creates a new RoutingType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RouteBased => std::option::Option::Some(1),
+                Self::PolicyBased => std::option::Option::Some(2),
+                Self::Dynamic => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUTING_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ROUTE_BASED"),
-                2 => std::borrow::Cow::Borrowed("POLICY_BASED"),
-                3 => std::borrow::Cow::Borrowed("DYNAMIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUTING_TYPE_UNSPECIFIED"),
+                Self::RouteBased => std::option::Option::Some("ROUTE_BASED"),
+                Self::PolicyBased => std::option::Option::Some("POLICY_BASED"),
+                Self::Dynamic => std::option::Option::Some("DYNAMIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUTING_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROUTING_TYPE_UNSPECIFIED)
-                }
-                "ROUTE_BASED" => std::option::Option::Some(Self::ROUTE_BASED),
-                "POLICY_BASED" => std::option::Option::Some(Self::POLICY_BASED),
-                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RoutingType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutingType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoutingType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoutingType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RouteBased,
+                2 => Self::PolicyBased,
+                3 => Self::Dynamic,
+                _ => Self::UnknownValue(routing_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoutingType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUTING_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ROUTE_BASED" => Self::RouteBased,
+                "POLICY_BASED" => Self::PolicyBased,
+                "DYNAMIC" => Self::Dynamic,
+                _ => Self::UnknownValue(routing_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoutingType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RouteBased => serializer.serialize_i32(1),
+                Self::PolicyBased => serializer.serialize_i32(2),
+                Self::Dynamic => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoutingType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoutingType>::new(
+                ".google.cloud.networkmanagement.v1.VpnTunnelInfo.RoutingType",
+            ))
         }
     }
 }
@@ -5434,137 +6468,228 @@ pub mod deliver_info {
     use super::*;
 
     /// Deliver target types:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Target(i32);
-
-    impl Target {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Target {
         /// Target not specified.
-        pub const TARGET_UNSPECIFIED: Target = Target::new(0);
-
+        Unspecified,
         /// Target is a Compute Engine instance.
-        pub const INSTANCE: Target = Target::new(1);
-
+        Instance,
         /// Target is the internet.
-        pub const INTERNET: Target = Target::new(2);
-
+        Internet,
         /// Target is a Google API.
-        pub const GOOGLE_API: Target = Target::new(3);
-
+        GoogleApi,
         /// Target is a Google Kubernetes Engine cluster master.
-        pub const GKE_MASTER: Target = Target::new(4);
-
+        GkeMaster,
         /// Target is a Cloud SQL instance.
-        pub const CLOUD_SQL_INSTANCE: Target = Target::new(5);
-
+        CloudSqlInstance,
         /// Target is a published service that uses [Private Service
         /// Connect](https://cloud.google.com/vpc/docs/configure-private-service-connect-services).
-        pub const PSC_PUBLISHED_SERVICE: Target = Target::new(6);
-
+        PscPublishedService,
         /// Target is Google APIs that use [Private Service
         /// Connect](https://cloud.google.com/vpc/docs/configure-private-service-connect-apis).
-        pub const PSC_GOOGLE_API: Target = Target::new(7);
-
+        PscGoogleApi,
         /// Target is a VPC-SC that uses [Private Service
         /// Connect](https://cloud.google.com/vpc/docs/configure-private-service-connect-apis).
-        pub const PSC_VPC_SC: Target = Target::new(8);
-
+        PscVpcSc,
         /// Target is a serverless network endpoint group.
-        pub const SERVERLESS_NEG: Target = Target::new(9);
-
+        ServerlessNeg,
         /// Target is a Cloud Storage bucket.
-        pub const STORAGE_BUCKET: Target = Target::new(10);
-
+        StorageBucket,
         /// Target is a private network. Used only for return traces.
-        pub const PRIVATE_NETWORK: Target = Target::new(11);
-
+        PrivateNetwork,
         /// Target is a Cloud Function. Used only for return traces.
-        pub const CLOUD_FUNCTION: Target = Target::new(12);
-
+        CloudFunction,
         /// Target is a App Engine service version. Used only for return traces.
-        pub const APP_ENGINE_VERSION: Target = Target::new(13);
-
+        AppEngineVersion,
         /// Target is a Cloud Run revision. Used only for return traces.
-        pub const CLOUD_RUN_REVISION: Target = Target::new(14);
-
+        CloudRunRevision,
         /// Target is a Google-managed service. Used only for return traces.
-        pub const GOOGLE_MANAGED_SERVICE: Target = Target::new(15);
-
+        GoogleManagedService,
         /// Target is a Redis Instance.
-        pub const REDIS_INSTANCE: Target = Target::new(16);
-
+        RedisInstance,
         /// Target is a Redis Cluster.
-        pub const REDIS_CLUSTER: Target = Target::new(17);
+        RedisCluster,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Target::value] or
+        /// [Target::name].
+        UnknownValue(target::UnknownValue),
+    }
 
-        /// Creates a new Target instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod target {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Target {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Instance => std::option::Option::Some(1),
+                Self::Internet => std::option::Option::Some(2),
+                Self::GoogleApi => std::option::Option::Some(3),
+                Self::GkeMaster => std::option::Option::Some(4),
+                Self::CloudSqlInstance => std::option::Option::Some(5),
+                Self::PscPublishedService => std::option::Option::Some(6),
+                Self::PscGoogleApi => std::option::Option::Some(7),
+                Self::PscVpcSc => std::option::Option::Some(8),
+                Self::ServerlessNeg => std::option::Option::Some(9),
+                Self::StorageBucket => std::option::Option::Some(10),
+                Self::PrivateNetwork => std::option::Option::Some(11),
+                Self::CloudFunction => std::option::Option::Some(12),
+                Self::AppEngineVersion => std::option::Option::Some(13),
+                Self::CloudRunRevision => std::option::Option::Some(14),
+                Self::GoogleManagedService => std::option::Option::Some(15),
+                Self::RedisInstance => std::option::Option::Some(16),
+                Self::RedisCluster => std::option::Option::Some(17),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TARGET_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INSTANCE"),
-                2 => std::borrow::Cow::Borrowed("INTERNET"),
-                3 => std::borrow::Cow::Borrowed("GOOGLE_API"),
-                4 => std::borrow::Cow::Borrowed("GKE_MASTER"),
-                5 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE"),
-                6 => std::borrow::Cow::Borrowed("PSC_PUBLISHED_SERVICE"),
-                7 => std::borrow::Cow::Borrowed("PSC_GOOGLE_API"),
-                8 => std::borrow::Cow::Borrowed("PSC_VPC_SC"),
-                9 => std::borrow::Cow::Borrowed("SERVERLESS_NEG"),
-                10 => std::borrow::Cow::Borrowed("STORAGE_BUCKET"),
-                11 => std::borrow::Cow::Borrowed("PRIVATE_NETWORK"),
-                12 => std::borrow::Cow::Borrowed("CLOUD_FUNCTION"),
-                13 => std::borrow::Cow::Borrowed("APP_ENGINE_VERSION"),
-                14 => std::borrow::Cow::Borrowed("CLOUD_RUN_REVISION"),
-                15 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE"),
-                16 => std::borrow::Cow::Borrowed("REDIS_INSTANCE"),
-                17 => std::borrow::Cow::Borrowed("REDIS_CLUSTER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TARGET_UNSPECIFIED"),
+                Self::Instance => std::option::Option::Some("INSTANCE"),
+                Self::Internet => std::option::Option::Some("INTERNET"),
+                Self::GoogleApi => std::option::Option::Some("GOOGLE_API"),
+                Self::GkeMaster => std::option::Option::Some("GKE_MASTER"),
+                Self::CloudSqlInstance => std::option::Option::Some("CLOUD_SQL_INSTANCE"),
+                Self::PscPublishedService => std::option::Option::Some("PSC_PUBLISHED_SERVICE"),
+                Self::PscGoogleApi => std::option::Option::Some("PSC_GOOGLE_API"),
+                Self::PscVpcSc => std::option::Option::Some("PSC_VPC_SC"),
+                Self::ServerlessNeg => std::option::Option::Some("SERVERLESS_NEG"),
+                Self::StorageBucket => std::option::Option::Some("STORAGE_BUCKET"),
+                Self::PrivateNetwork => std::option::Option::Some("PRIVATE_NETWORK"),
+                Self::CloudFunction => std::option::Option::Some("CLOUD_FUNCTION"),
+                Self::AppEngineVersion => std::option::Option::Some("APP_ENGINE_VERSION"),
+                Self::CloudRunRevision => std::option::Option::Some("CLOUD_RUN_REVISION"),
+                Self::GoogleManagedService => std::option::Option::Some("GOOGLE_MANAGED_SERVICE"),
+                Self::RedisInstance => std::option::Option::Some("REDIS_INSTANCE"),
+                Self::RedisCluster => std::option::Option::Some("REDIS_CLUSTER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TARGET_UNSPECIFIED" => std::option::Option::Some(Self::TARGET_UNSPECIFIED),
-                "INSTANCE" => std::option::Option::Some(Self::INSTANCE),
-                "INTERNET" => std::option::Option::Some(Self::INTERNET),
-                "GOOGLE_API" => std::option::Option::Some(Self::GOOGLE_API),
-                "GKE_MASTER" => std::option::Option::Some(Self::GKE_MASTER),
-                "CLOUD_SQL_INSTANCE" => std::option::Option::Some(Self::CLOUD_SQL_INSTANCE),
-                "PSC_PUBLISHED_SERVICE" => std::option::Option::Some(Self::PSC_PUBLISHED_SERVICE),
-                "PSC_GOOGLE_API" => std::option::Option::Some(Self::PSC_GOOGLE_API),
-                "PSC_VPC_SC" => std::option::Option::Some(Self::PSC_VPC_SC),
-                "SERVERLESS_NEG" => std::option::Option::Some(Self::SERVERLESS_NEG),
-                "STORAGE_BUCKET" => std::option::Option::Some(Self::STORAGE_BUCKET),
-                "PRIVATE_NETWORK" => std::option::Option::Some(Self::PRIVATE_NETWORK),
-                "CLOUD_FUNCTION" => std::option::Option::Some(Self::CLOUD_FUNCTION),
-                "APP_ENGINE_VERSION" => std::option::Option::Some(Self::APP_ENGINE_VERSION),
-                "CLOUD_RUN_REVISION" => std::option::Option::Some(Self::CLOUD_RUN_REVISION),
-                "GOOGLE_MANAGED_SERVICE" => std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE),
-                "REDIS_INSTANCE" => std::option::Option::Some(Self::REDIS_INSTANCE),
-                "REDIS_CLUSTER" => std::option::Option::Some(Self::REDIS_CLUSTER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Target {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Target {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Target {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Target {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Instance,
+                2 => Self::Internet,
+                3 => Self::GoogleApi,
+                4 => Self::GkeMaster,
+                5 => Self::CloudSqlInstance,
+                6 => Self::PscPublishedService,
+                7 => Self::PscGoogleApi,
+                8 => Self::PscVpcSc,
+                9 => Self::ServerlessNeg,
+                10 => Self::StorageBucket,
+                11 => Self::PrivateNetwork,
+                12 => Self::CloudFunction,
+                13 => Self::AppEngineVersion,
+                14 => Self::CloudRunRevision,
+                15 => Self::GoogleManagedService,
+                16 => Self::RedisInstance,
+                17 => Self::RedisCluster,
+                _ => Self::UnknownValue(target::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Target {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TARGET_UNSPECIFIED" => Self::Unspecified,
+                "INSTANCE" => Self::Instance,
+                "INTERNET" => Self::Internet,
+                "GOOGLE_API" => Self::GoogleApi,
+                "GKE_MASTER" => Self::GkeMaster,
+                "CLOUD_SQL_INSTANCE" => Self::CloudSqlInstance,
+                "PSC_PUBLISHED_SERVICE" => Self::PscPublishedService,
+                "PSC_GOOGLE_API" => Self::PscGoogleApi,
+                "PSC_VPC_SC" => Self::PscVpcSc,
+                "SERVERLESS_NEG" => Self::ServerlessNeg,
+                "STORAGE_BUCKET" => Self::StorageBucket,
+                "PRIVATE_NETWORK" => Self::PrivateNetwork,
+                "CLOUD_FUNCTION" => Self::CloudFunction,
+                "APP_ENGINE_VERSION" => Self::AppEngineVersion,
+                "CLOUD_RUN_REVISION" => Self::CloudRunRevision,
+                "GOOGLE_MANAGED_SERVICE" => Self::GoogleManagedService,
+                "REDIS_INSTANCE" => Self::RedisInstance,
+                "REDIS_CLUSTER" => Self::RedisCluster,
+                _ => Self::UnknownValue(target::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Target {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Instance => serializer.serialize_i32(1),
+                Self::Internet => serializer.serialize_i32(2),
+                Self::GoogleApi => serializer.serialize_i32(3),
+                Self::GkeMaster => serializer.serialize_i32(4),
+                Self::CloudSqlInstance => serializer.serialize_i32(5),
+                Self::PscPublishedService => serializer.serialize_i32(6),
+                Self::PscGoogleApi => serializer.serialize_i32(7),
+                Self::PscVpcSc => serializer.serialize_i32(8),
+                Self::ServerlessNeg => serializer.serialize_i32(9),
+                Self::StorageBucket => serializer.serialize_i32(10),
+                Self::PrivateNetwork => serializer.serialize_i32(11),
+                Self::CloudFunction => serializer.serialize_i32(12),
+                Self::AppEngineVersion => serializer.serialize_i32(13),
+                Self::CloudRunRevision => serializer.serialize_i32(14),
+                Self::GoogleManagedService => serializer.serialize_i32(15),
+                Self::RedisInstance => serializer.serialize_i32(16),
+                Self::RedisCluster => serializer.serialize_i32(17),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Target {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Target>::new(
+                ".google.cloud.networkmanagement.v1.DeliverInfo.Target",
+            ))
         }
     }
 }
@@ -5629,96 +6754,171 @@ pub mod forward_info {
     use super::*;
 
     /// Forward target types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Target(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Target {
+        /// Target not specified.
+        Unspecified,
+        /// Forwarded to a VPC peering network.
+        PeeringVpc,
+        /// Forwarded to a Cloud VPN gateway.
+        VpnGateway,
+        /// Forwarded to a Cloud Interconnect connection.
+        Interconnect,
+        /// Forwarded to a Google Kubernetes Engine Container cluster master.
+        GkeMaster,
+        /// Forwarded to the next hop of a custom route imported from a peering VPC.
+        ImportedCustomRouteNextHop,
+        /// Forwarded to a Cloud SQL instance.
+        CloudSqlInstance,
+        /// Forwarded to a VPC network in another project.
+        AnotherProject,
+        /// Forwarded to an NCC Hub.
+        NccHub,
+        /// Forwarded to a router appliance.
+        RouterAppliance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Target::value] or
+        /// [Target::name].
+        UnknownValue(target::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod target {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Target {
-        /// Target not specified.
-        pub const TARGET_UNSPECIFIED: Target = Target::new(0);
-
-        /// Forwarded to a VPC peering network.
-        pub const PEERING_VPC: Target = Target::new(1);
-
-        /// Forwarded to a Cloud VPN gateway.
-        pub const VPN_GATEWAY: Target = Target::new(2);
-
-        /// Forwarded to a Cloud Interconnect connection.
-        pub const INTERCONNECT: Target = Target::new(3);
-
-        /// Forwarded to a Google Kubernetes Engine Container cluster master.
-        pub const GKE_MASTER: Target = Target::new(4);
-
-        /// Forwarded to the next hop of a custom route imported from a peering VPC.
-        pub const IMPORTED_CUSTOM_ROUTE_NEXT_HOP: Target = Target::new(5);
-
-        /// Forwarded to a Cloud SQL instance.
-        pub const CLOUD_SQL_INSTANCE: Target = Target::new(6);
-
-        /// Forwarded to a VPC network in another project.
-        pub const ANOTHER_PROJECT: Target = Target::new(7);
-
-        /// Forwarded to an NCC Hub.
-        pub const NCC_HUB: Target = Target::new(8);
-
-        /// Forwarded to a router appliance.
-        pub const ROUTER_APPLIANCE: Target = Target::new(9);
-
-        /// Creates a new Target instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PeeringVpc => std::option::Option::Some(1),
+                Self::VpnGateway => std::option::Option::Some(2),
+                Self::Interconnect => std::option::Option::Some(3),
+                Self::GkeMaster => std::option::Option::Some(4),
+                Self::ImportedCustomRouteNextHop => std::option::Option::Some(5),
+                Self::CloudSqlInstance => std::option::Option::Some(6),
+                Self::AnotherProject => std::option::Option::Some(7),
+                Self::NccHub => std::option::Option::Some(8),
+                Self::RouterAppliance => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TARGET_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PEERING_VPC"),
-                2 => std::borrow::Cow::Borrowed("VPN_GATEWAY"),
-                3 => std::borrow::Cow::Borrowed("INTERCONNECT"),
-                4 => std::borrow::Cow::Borrowed("GKE_MASTER"),
-                5 => std::borrow::Cow::Borrowed("IMPORTED_CUSTOM_ROUTE_NEXT_HOP"),
-                6 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE"),
-                7 => std::borrow::Cow::Borrowed("ANOTHER_PROJECT"),
-                8 => std::borrow::Cow::Borrowed("NCC_HUB"),
-                9 => std::borrow::Cow::Borrowed("ROUTER_APPLIANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TARGET_UNSPECIFIED" => std::option::Option::Some(Self::TARGET_UNSPECIFIED),
-                "PEERING_VPC" => std::option::Option::Some(Self::PEERING_VPC),
-                "VPN_GATEWAY" => std::option::Option::Some(Self::VPN_GATEWAY),
-                "INTERCONNECT" => std::option::Option::Some(Self::INTERCONNECT),
-                "GKE_MASTER" => std::option::Option::Some(Self::GKE_MASTER),
-                "IMPORTED_CUSTOM_ROUTE_NEXT_HOP" => {
-                    std::option::Option::Some(Self::IMPORTED_CUSTOM_ROUTE_NEXT_HOP)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TARGET_UNSPECIFIED"),
+                Self::PeeringVpc => std::option::Option::Some("PEERING_VPC"),
+                Self::VpnGateway => std::option::Option::Some("VPN_GATEWAY"),
+                Self::Interconnect => std::option::Option::Some("INTERCONNECT"),
+                Self::GkeMaster => std::option::Option::Some("GKE_MASTER"),
+                Self::ImportedCustomRouteNextHop => {
+                    std::option::Option::Some("IMPORTED_CUSTOM_ROUTE_NEXT_HOP")
                 }
-                "CLOUD_SQL_INSTANCE" => std::option::Option::Some(Self::CLOUD_SQL_INSTANCE),
-                "ANOTHER_PROJECT" => std::option::Option::Some(Self::ANOTHER_PROJECT),
-                "NCC_HUB" => std::option::Option::Some(Self::NCC_HUB),
-                "ROUTER_APPLIANCE" => std::option::Option::Some(Self::ROUTER_APPLIANCE),
-                _ => std::option::Option::None,
+                Self::CloudSqlInstance => std::option::Option::Some("CLOUD_SQL_INSTANCE"),
+                Self::AnotherProject => std::option::Option::Some("ANOTHER_PROJECT"),
+                Self::NccHub => std::option::Option::Some("NCC_HUB"),
+                Self::RouterAppliance => std::option::Option::Some("ROUTER_APPLIANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Target {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Target {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Target {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Target {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PeeringVpc,
+                2 => Self::VpnGateway,
+                3 => Self::Interconnect,
+                4 => Self::GkeMaster,
+                5 => Self::ImportedCustomRouteNextHop,
+                6 => Self::CloudSqlInstance,
+                7 => Self::AnotherProject,
+                8 => Self::NccHub,
+                9 => Self::RouterAppliance,
+                _ => Self::UnknownValue(target::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Target {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TARGET_UNSPECIFIED" => Self::Unspecified,
+                "PEERING_VPC" => Self::PeeringVpc,
+                "VPN_GATEWAY" => Self::VpnGateway,
+                "INTERCONNECT" => Self::Interconnect,
+                "GKE_MASTER" => Self::GkeMaster,
+                "IMPORTED_CUSTOM_ROUTE_NEXT_HOP" => Self::ImportedCustomRouteNextHop,
+                "CLOUD_SQL_INSTANCE" => Self::CloudSqlInstance,
+                "ANOTHER_PROJECT" => Self::AnotherProject,
+                "NCC_HUB" => Self::NccHub,
+                "ROUTER_APPLIANCE" => Self::RouterAppliance,
+                _ => Self::UnknownValue(target::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Target {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PeeringVpc => serializer.serialize_i32(1),
+                Self::VpnGateway => serializer.serialize_i32(2),
+                Self::Interconnect => serializer.serialize_i32(3),
+                Self::GkeMaster => serializer.serialize_i32(4),
+                Self::ImportedCustomRouteNextHop => serializer.serialize_i32(5),
+                Self::CloudSqlInstance => serializer.serialize_i32(6),
+                Self::AnotherProject => serializer.serialize_i32(7),
+                Self::NccHub => serializer.serialize_i32(8),
+                Self::RouterAppliance => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Target {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Target>::new(
+                ".google.cloud.networkmanagement.v1.ForwardInfo.Target",
+            ))
         }
     }
 }
@@ -5799,77 +6999,59 @@ pub mod abort_info {
     use super::*;
 
     /// Abort cause types:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cause(i32);
-
-    impl Cause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Cause {
         /// Cause is unspecified.
-        pub const CAUSE_UNSPECIFIED: Cause = Cause::new(0);
-
+        Unspecified,
         /// Aborted due to unknown network. Deprecated, not used in the new tests.
-        pub const UNKNOWN_NETWORK: Cause = Cause::new(1);
-
+        UnknownNetwork,
         /// Aborted because no project information can be derived from the test
         /// input. Deprecated, not used in the new tests.
-        pub const UNKNOWN_PROJECT: Cause = Cause::new(3);
-
+        UnknownProject,
         /// Aborted because traffic is sent from a public IP to an instance without
         /// an external IP. Deprecated, not used in the new tests.
-        pub const NO_EXTERNAL_IP: Cause = Cause::new(7);
-
+        NoExternalIp,
         /// Aborted because none of the traces matches destination information
         /// specified in the input test request. Deprecated, not used in the new
         /// tests.
-        pub const UNINTENDED_DESTINATION: Cause = Cause::new(8);
-
+        UnintendedDestination,
         /// Aborted because the source endpoint could not be found. Deprecated, not
         /// used in the new tests.
-        pub const SOURCE_ENDPOINT_NOT_FOUND: Cause = Cause::new(11);
-
+        SourceEndpointNotFound,
         /// Aborted because the source network does not match the source endpoint.
         /// Deprecated, not used in the new tests.
-        pub const MISMATCHED_SOURCE_NETWORK: Cause = Cause::new(12);
-
+        MismatchedSourceNetwork,
         /// Aborted because the destination endpoint could not be found. Deprecated,
         /// not used in the new tests.
-        pub const DESTINATION_ENDPOINT_NOT_FOUND: Cause = Cause::new(13);
-
+        DestinationEndpointNotFound,
         /// Aborted because the destination network does not match the destination
         /// endpoint. Deprecated, not used in the new tests.
-        pub const MISMATCHED_DESTINATION_NETWORK: Cause = Cause::new(14);
-
+        MismatchedDestinationNetwork,
         /// Aborted because no endpoint with the packet's destination IP address is
         /// found.
-        pub const UNKNOWN_IP: Cause = Cause::new(2);
-
+        UnknownIp,
         /// Aborted because no endpoint with the packet's destination IP is found in
         /// the Google-managed project.
-        pub const GOOGLE_MANAGED_SERVICE_UNKNOWN_IP: Cause = Cause::new(32);
-
+        GoogleManagedServiceUnknownIp,
         /// Aborted because the source IP address doesn't belong to any of the
         /// subnets of the source VPC network.
-        pub const SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK: Cause = Cause::new(23);
-
+        SourceIpAddressNotInSourceNetwork,
         /// Aborted because user lacks permission to access all or part of the
         /// network configurations required to run the test.
-        pub const PERMISSION_DENIED: Cause = Cause::new(4);
-
+        PermissionDenied,
         /// Aborted because user lacks permission to access Cloud NAT configs
         /// required to run the test.
-        pub const PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS: Cause = Cause::new(28);
-
+        PermissionDeniedNoCloudNatConfigs,
         /// Aborted because user lacks permission to access Network endpoint group
         /// endpoint configs required to run the test.
-        pub const PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS: Cause = Cause::new(29);
-
+        PermissionDeniedNoNegEndpointConfigs,
         /// Aborted because user lacks permission to access Cloud Router configs
         /// required to run the test.
-        pub const PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS: Cause = Cause::new(36);
-
+        PermissionDeniedNoCloudRouterConfigs,
         /// Aborted because no valid source or destination endpoint is derived from
         /// the input test request.
-        pub const NO_SOURCE_LOCATION: Cause = Cause::new(5);
-
+        NoSourceLocation,
         /// Aborted because the source or destination endpoint specified in
         /// the request is invalid. Some examples:
         ///
@@ -5878,230 +7060,385 @@ pub mod abort_info {
         /// - The request might contain inconsistent information (for example, the
         ///   request might include both the instance and the network, but the instance
         ///   might not have a NIC in that network).
-        pub const INVALID_ARGUMENT: Cause = Cause::new(6);
-
+        InvalidArgument,
         /// Aborted because the number of steps in the trace exceeds a certain
         /// limit. It might be caused by a routing loop.
-        pub const TRACE_TOO_LONG: Cause = Cause::new(9);
-
+        TraceTooLong,
         /// Aborted due to internal server error.
-        pub const INTERNAL_ERROR: Cause = Cause::new(10);
-
+        InternalError,
         /// Aborted because the test scenario is not supported.
-        pub const UNSUPPORTED: Cause = Cause::new(15);
-
+        Unsupported,
         /// Aborted because the source and destination resources have no common IP
         /// version.
-        pub const MISMATCHED_IP_VERSION: Cause = Cause::new(16);
-
+        MismatchedIpVersion,
         /// Aborted because the connection between the control plane and the node of
         /// the source cluster is initiated by the node and managed by the
         /// Konnectivity proxy.
-        pub const GKE_KONNECTIVITY_PROXY_UNSUPPORTED: Cause = Cause::new(17);
-
+        GkeKonnectivityProxyUnsupported,
         /// Aborted because expected resource configuration was missing.
-        pub const RESOURCE_CONFIG_NOT_FOUND: Cause = Cause::new(18);
-
+        ResourceConfigNotFound,
         /// Aborted because expected VM instance configuration was missing.
-        pub const VM_INSTANCE_CONFIG_NOT_FOUND: Cause = Cause::new(24);
-
+        VmInstanceConfigNotFound,
         /// Aborted because expected network configuration was missing.
-        pub const NETWORK_CONFIG_NOT_FOUND: Cause = Cause::new(25);
-
+        NetworkConfigNotFound,
         /// Aborted because expected firewall configuration was missing.
-        pub const FIREWALL_CONFIG_NOT_FOUND: Cause = Cause::new(26);
-
+        FirewallConfigNotFound,
         /// Aborted because expected route configuration was missing.
-        pub const ROUTE_CONFIG_NOT_FOUND: Cause = Cause::new(27);
-
+        RouteConfigNotFound,
         /// Aborted because a PSC endpoint selection for the Google-managed service
         /// is ambiguous (several PSC endpoints satisfy test input).
-        pub const GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT: Cause = Cause::new(19);
-
+        GoogleManagedServiceAmbiguousPscEndpoint,
         /// Aborted because tests with a PSC-based Cloud SQL instance as a source are
         /// not supported.
-        pub const SOURCE_PSC_CLOUD_SQL_UNSUPPORTED: Cause = Cause::new(20);
-
+        SourcePscCloudSqlUnsupported,
         /// Aborted because tests with a Redis Cluster as a source are not supported.
-        pub const SOURCE_REDIS_CLUSTER_UNSUPPORTED: Cause = Cause::new(34);
-
+        SourceRedisClusterUnsupported,
         /// Aborted because tests with a Redis Instance as a source are not
         /// supported.
-        pub const SOURCE_REDIS_INSTANCE_UNSUPPORTED: Cause = Cause::new(35);
-
+        SourceRedisInstanceUnsupported,
         /// Aborted because tests with a forwarding rule as a source are not
         /// supported.
-        pub const SOURCE_FORWARDING_RULE_UNSUPPORTED: Cause = Cause::new(21);
-
+        SourceForwardingRuleUnsupported,
         /// Aborted because one of the endpoints is a non-routable IP address
         /// (loopback, link-local, etc).
-        pub const NON_ROUTABLE_IP_ADDRESS: Cause = Cause::new(22);
-
+        NonRoutableIpAddress,
         /// Aborted due to an unknown issue in the Google-managed project.
-        pub const UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT: Cause = Cause::new(30);
-
+        UnknownIssueInGoogleManagedProject,
         /// Aborted due to an unsupported configuration of the Google-managed
         /// project.
-        pub const UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG: Cause = Cause::new(31);
-
+        UnsupportedGoogleManagedProjectConfig,
         /// Aborted because the source endpoint is a Cloud Run revision with direct
         /// VPC access enabled, but there are no reserved serverless IP ranges.
-        pub const NO_SERVERLESS_IP_RANGES: Cause = Cause::new(37);
+        NoServerlessIpRanges,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Cause::value] or
+        /// [Cause::name].
+        UnknownValue(cause::UnknownValue),
+    }
 
-        /// Creates a new Cause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Cause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UnknownNetwork => std::option::Option::Some(1),
+                Self::UnknownProject => std::option::Option::Some(3),
+                Self::NoExternalIp => std::option::Option::Some(7),
+                Self::UnintendedDestination => std::option::Option::Some(8),
+                Self::SourceEndpointNotFound => std::option::Option::Some(11),
+                Self::MismatchedSourceNetwork => std::option::Option::Some(12),
+                Self::DestinationEndpointNotFound => std::option::Option::Some(13),
+                Self::MismatchedDestinationNetwork => std::option::Option::Some(14),
+                Self::UnknownIp => std::option::Option::Some(2),
+                Self::GoogleManagedServiceUnknownIp => std::option::Option::Some(32),
+                Self::SourceIpAddressNotInSourceNetwork => std::option::Option::Some(23),
+                Self::PermissionDenied => std::option::Option::Some(4),
+                Self::PermissionDeniedNoCloudNatConfigs => std::option::Option::Some(28),
+                Self::PermissionDeniedNoNegEndpointConfigs => std::option::Option::Some(29),
+                Self::PermissionDeniedNoCloudRouterConfigs => std::option::Option::Some(36),
+                Self::NoSourceLocation => std::option::Option::Some(5),
+                Self::InvalidArgument => std::option::Option::Some(6),
+                Self::TraceTooLong => std::option::Option::Some(9),
+                Self::InternalError => std::option::Option::Some(10),
+                Self::Unsupported => std::option::Option::Some(15),
+                Self::MismatchedIpVersion => std::option::Option::Some(16),
+                Self::GkeKonnectivityProxyUnsupported => std::option::Option::Some(17),
+                Self::ResourceConfigNotFound => std::option::Option::Some(18),
+                Self::VmInstanceConfigNotFound => std::option::Option::Some(24),
+                Self::NetworkConfigNotFound => std::option::Option::Some(25),
+                Self::FirewallConfigNotFound => std::option::Option::Some(26),
+                Self::RouteConfigNotFound => std::option::Option::Some(27),
+                Self::GoogleManagedServiceAmbiguousPscEndpoint => std::option::Option::Some(19),
+                Self::SourcePscCloudSqlUnsupported => std::option::Option::Some(20),
+                Self::SourceRedisClusterUnsupported => std::option::Option::Some(34),
+                Self::SourceRedisInstanceUnsupported => std::option::Option::Some(35),
+                Self::SourceForwardingRuleUnsupported => std::option::Option::Some(21),
+                Self::NonRoutableIpAddress => std::option::Option::Some(22),
+                Self::UnknownIssueInGoogleManagedProject => std::option::Option::Some(30),
+                Self::UnsupportedGoogleManagedProjectConfig => std::option::Option::Some(31),
+                Self::NoServerlessIpRanges => std::option::Option::Some(37),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN_NETWORK"),
-                2 => std::borrow::Cow::Borrowed("UNKNOWN_IP"),
-                3 => std::borrow::Cow::Borrowed("UNKNOWN_PROJECT"),
-                4 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                5 => std::borrow::Cow::Borrowed("NO_SOURCE_LOCATION"),
-                6 => std::borrow::Cow::Borrowed("INVALID_ARGUMENT"),
-                7 => std::borrow::Cow::Borrowed("NO_EXTERNAL_IP"),
-                8 => std::borrow::Cow::Borrowed("UNINTENDED_DESTINATION"),
-                9 => std::borrow::Cow::Borrowed("TRACE_TOO_LONG"),
-                10 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
-                11 => std::borrow::Cow::Borrowed("SOURCE_ENDPOINT_NOT_FOUND"),
-                12 => std::borrow::Cow::Borrowed("MISMATCHED_SOURCE_NETWORK"),
-                13 => std::borrow::Cow::Borrowed("DESTINATION_ENDPOINT_NOT_FOUND"),
-                14 => std::borrow::Cow::Borrowed("MISMATCHED_DESTINATION_NETWORK"),
-                15 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
-                16 => std::borrow::Cow::Borrowed("MISMATCHED_IP_VERSION"),
-                17 => std::borrow::Cow::Borrowed("GKE_KONNECTIVITY_PROXY_UNSUPPORTED"),
-                18 => std::borrow::Cow::Borrowed("RESOURCE_CONFIG_NOT_FOUND"),
-                19 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT"),
-                20 => std::borrow::Cow::Borrowed("SOURCE_PSC_CLOUD_SQL_UNSUPPORTED"),
-                21 => std::borrow::Cow::Borrowed("SOURCE_FORWARDING_RULE_UNSUPPORTED"),
-                22 => std::borrow::Cow::Borrowed("NON_ROUTABLE_IP_ADDRESS"),
-                23 => std::borrow::Cow::Borrowed("SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK"),
-                24 => std::borrow::Cow::Borrowed("VM_INSTANCE_CONFIG_NOT_FOUND"),
-                25 => std::borrow::Cow::Borrowed("NETWORK_CONFIG_NOT_FOUND"),
-                26 => std::borrow::Cow::Borrowed("FIREWALL_CONFIG_NOT_FOUND"),
-                27 => std::borrow::Cow::Borrowed("ROUTE_CONFIG_NOT_FOUND"),
-                28 => std::borrow::Cow::Borrowed("PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS"),
-                29 => std::borrow::Cow::Borrowed("PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS"),
-                30 => std::borrow::Cow::Borrowed("UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT"),
-                31 => std::borrow::Cow::Borrowed("UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG"),
-                32 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_UNKNOWN_IP"),
-                34 => std::borrow::Cow::Borrowed("SOURCE_REDIS_CLUSTER_UNSUPPORTED"),
-                35 => std::borrow::Cow::Borrowed("SOURCE_REDIS_INSTANCE_UNSUPPORTED"),
-                36 => std::borrow::Cow::Borrowed("PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS"),
-                37 => std::borrow::Cow::Borrowed("NO_SERVERLESS_IP_RANGES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CAUSE_UNSPECIFIED"),
+                Self::UnknownNetwork => std::option::Option::Some("UNKNOWN_NETWORK"),
+                Self::UnknownProject => std::option::Option::Some("UNKNOWN_PROJECT"),
+                Self::NoExternalIp => std::option::Option::Some("NO_EXTERNAL_IP"),
+                Self::UnintendedDestination => std::option::Option::Some("UNINTENDED_DESTINATION"),
+                Self::SourceEndpointNotFound => {
+                    std::option::Option::Some("SOURCE_ENDPOINT_NOT_FOUND")
+                }
+                Self::MismatchedSourceNetwork => {
+                    std::option::Option::Some("MISMATCHED_SOURCE_NETWORK")
+                }
+                Self::DestinationEndpointNotFound => {
+                    std::option::Option::Some("DESTINATION_ENDPOINT_NOT_FOUND")
+                }
+                Self::MismatchedDestinationNetwork => {
+                    std::option::Option::Some("MISMATCHED_DESTINATION_NETWORK")
+                }
+                Self::UnknownIp => std::option::Option::Some("UNKNOWN_IP"),
+                Self::GoogleManagedServiceUnknownIp => {
+                    std::option::Option::Some("GOOGLE_MANAGED_SERVICE_UNKNOWN_IP")
+                }
+                Self::SourceIpAddressNotInSourceNetwork => {
+                    std::option::Option::Some("SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK")
+                }
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::PermissionDeniedNoCloudNatConfigs => {
+                    std::option::Option::Some("PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS")
+                }
+                Self::PermissionDeniedNoNegEndpointConfigs => {
+                    std::option::Option::Some("PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS")
+                }
+                Self::PermissionDeniedNoCloudRouterConfigs => {
+                    std::option::Option::Some("PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS")
+                }
+                Self::NoSourceLocation => std::option::Option::Some("NO_SOURCE_LOCATION"),
+                Self::InvalidArgument => std::option::Option::Some("INVALID_ARGUMENT"),
+                Self::TraceTooLong => std::option::Option::Some("TRACE_TOO_LONG"),
+                Self::InternalError => std::option::Option::Some("INTERNAL_ERROR"),
+                Self::Unsupported => std::option::Option::Some("UNSUPPORTED"),
+                Self::MismatchedIpVersion => std::option::Option::Some("MISMATCHED_IP_VERSION"),
+                Self::GkeKonnectivityProxyUnsupported => {
+                    std::option::Option::Some("GKE_KONNECTIVITY_PROXY_UNSUPPORTED")
+                }
+                Self::ResourceConfigNotFound => {
+                    std::option::Option::Some("RESOURCE_CONFIG_NOT_FOUND")
+                }
+                Self::VmInstanceConfigNotFound => {
+                    std::option::Option::Some("VM_INSTANCE_CONFIG_NOT_FOUND")
+                }
+                Self::NetworkConfigNotFound => {
+                    std::option::Option::Some("NETWORK_CONFIG_NOT_FOUND")
+                }
+                Self::FirewallConfigNotFound => {
+                    std::option::Option::Some("FIREWALL_CONFIG_NOT_FOUND")
+                }
+                Self::RouteConfigNotFound => std::option::Option::Some("ROUTE_CONFIG_NOT_FOUND"),
+                Self::GoogleManagedServiceAmbiguousPscEndpoint => {
+                    std::option::Option::Some("GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT")
+                }
+                Self::SourcePscCloudSqlUnsupported => {
+                    std::option::Option::Some("SOURCE_PSC_CLOUD_SQL_UNSUPPORTED")
+                }
+                Self::SourceRedisClusterUnsupported => {
+                    std::option::Option::Some("SOURCE_REDIS_CLUSTER_UNSUPPORTED")
+                }
+                Self::SourceRedisInstanceUnsupported => {
+                    std::option::Option::Some("SOURCE_REDIS_INSTANCE_UNSUPPORTED")
+                }
+                Self::SourceForwardingRuleUnsupported => {
+                    std::option::Option::Some("SOURCE_FORWARDING_RULE_UNSUPPORTED")
+                }
+                Self::NonRoutableIpAddress => std::option::Option::Some("NON_ROUTABLE_IP_ADDRESS"),
+                Self::UnknownIssueInGoogleManagedProject => {
+                    std::option::Option::Some("UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT")
+                }
+                Self::UnsupportedGoogleManagedProjectConfig => {
+                    std::option::Option::Some("UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG")
+                }
+                Self::NoServerlessIpRanges => std::option::Option::Some("NO_SERVERLESS_IP_RANGES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CAUSE_UNSPECIFIED" => std::option::Option::Some(Self::CAUSE_UNSPECIFIED),
-                "UNKNOWN_NETWORK" => std::option::Option::Some(Self::UNKNOWN_NETWORK),
-                "UNKNOWN_PROJECT" => std::option::Option::Some(Self::UNKNOWN_PROJECT),
-                "NO_EXTERNAL_IP" => std::option::Option::Some(Self::NO_EXTERNAL_IP),
-                "UNINTENDED_DESTINATION" => std::option::Option::Some(Self::UNINTENDED_DESTINATION),
-                "SOURCE_ENDPOINT_NOT_FOUND" => {
-                    std::option::Option::Some(Self::SOURCE_ENDPOINT_NOT_FOUND)
-                }
-                "MISMATCHED_SOURCE_NETWORK" => {
-                    std::option::Option::Some(Self::MISMATCHED_SOURCE_NETWORK)
-                }
-                "DESTINATION_ENDPOINT_NOT_FOUND" => {
-                    std::option::Option::Some(Self::DESTINATION_ENDPOINT_NOT_FOUND)
-                }
-                "MISMATCHED_DESTINATION_NETWORK" => {
-                    std::option::Option::Some(Self::MISMATCHED_DESTINATION_NETWORK)
-                }
-                "UNKNOWN_IP" => std::option::Option::Some(Self::UNKNOWN_IP),
-                "GOOGLE_MANAGED_SERVICE_UNKNOWN_IP" => {
-                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_UNKNOWN_IP)
-                }
-                "SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK" => {
-                    std::option::Option::Some(Self::SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK)
-                }
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                "PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS" => {
-                    std::option::Option::Some(Self::PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS)
-                }
-                "PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS" => {
-                    std::option::Option::Some(Self::PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS)
-                }
-                "PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS" => {
-                    std::option::Option::Some(Self::PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS)
-                }
-                "NO_SOURCE_LOCATION" => std::option::Option::Some(Self::NO_SOURCE_LOCATION),
-                "INVALID_ARGUMENT" => std::option::Option::Some(Self::INVALID_ARGUMENT),
-                "TRACE_TOO_LONG" => std::option::Option::Some(Self::TRACE_TOO_LONG),
-                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
-                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
-                "MISMATCHED_IP_VERSION" => std::option::Option::Some(Self::MISMATCHED_IP_VERSION),
-                "GKE_KONNECTIVITY_PROXY_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::GKE_KONNECTIVITY_PROXY_UNSUPPORTED)
-                }
-                "RESOURCE_CONFIG_NOT_FOUND" => {
-                    std::option::Option::Some(Self::RESOURCE_CONFIG_NOT_FOUND)
-                }
-                "VM_INSTANCE_CONFIG_NOT_FOUND" => {
-                    std::option::Option::Some(Self::VM_INSTANCE_CONFIG_NOT_FOUND)
-                }
-                "NETWORK_CONFIG_NOT_FOUND" => {
-                    std::option::Option::Some(Self::NETWORK_CONFIG_NOT_FOUND)
-                }
-                "FIREWALL_CONFIG_NOT_FOUND" => {
-                    std::option::Option::Some(Self::FIREWALL_CONFIG_NOT_FOUND)
-                }
-                "ROUTE_CONFIG_NOT_FOUND" => std::option::Option::Some(Self::ROUTE_CONFIG_NOT_FOUND),
-                "GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT" => {
-                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT)
-                }
-                "SOURCE_PSC_CLOUD_SQL_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::SOURCE_PSC_CLOUD_SQL_UNSUPPORTED)
-                }
-                "SOURCE_REDIS_CLUSTER_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::SOURCE_REDIS_CLUSTER_UNSUPPORTED)
-                }
-                "SOURCE_REDIS_INSTANCE_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::SOURCE_REDIS_INSTANCE_UNSUPPORTED)
-                }
-                "SOURCE_FORWARDING_RULE_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::SOURCE_FORWARDING_RULE_UNSUPPORTED)
-                }
-                "NON_ROUTABLE_IP_ADDRESS" => {
-                    std::option::Option::Some(Self::NON_ROUTABLE_IP_ADDRESS)
-                }
-                "UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT" => {
-                    std::option::Option::Some(Self::UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT)
-                }
-                "UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG)
-                }
-                "NO_SERVERLESS_IP_RANGES" => {
-                    std::option::Option::Some(Self::NO_SERVERLESS_IP_RANGES)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Cause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Cause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Cause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Cause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UnknownNetwork,
+                2 => Self::UnknownIp,
+                3 => Self::UnknownProject,
+                4 => Self::PermissionDenied,
+                5 => Self::NoSourceLocation,
+                6 => Self::InvalidArgument,
+                7 => Self::NoExternalIp,
+                8 => Self::UnintendedDestination,
+                9 => Self::TraceTooLong,
+                10 => Self::InternalError,
+                11 => Self::SourceEndpointNotFound,
+                12 => Self::MismatchedSourceNetwork,
+                13 => Self::DestinationEndpointNotFound,
+                14 => Self::MismatchedDestinationNetwork,
+                15 => Self::Unsupported,
+                16 => Self::MismatchedIpVersion,
+                17 => Self::GkeKonnectivityProxyUnsupported,
+                18 => Self::ResourceConfigNotFound,
+                19 => Self::GoogleManagedServiceAmbiguousPscEndpoint,
+                20 => Self::SourcePscCloudSqlUnsupported,
+                21 => Self::SourceForwardingRuleUnsupported,
+                22 => Self::NonRoutableIpAddress,
+                23 => Self::SourceIpAddressNotInSourceNetwork,
+                24 => Self::VmInstanceConfigNotFound,
+                25 => Self::NetworkConfigNotFound,
+                26 => Self::FirewallConfigNotFound,
+                27 => Self::RouteConfigNotFound,
+                28 => Self::PermissionDeniedNoCloudNatConfigs,
+                29 => Self::PermissionDeniedNoNegEndpointConfigs,
+                30 => Self::UnknownIssueInGoogleManagedProject,
+                31 => Self::UnsupportedGoogleManagedProjectConfig,
+                32 => Self::GoogleManagedServiceUnknownIp,
+                34 => Self::SourceRedisClusterUnsupported,
+                35 => Self::SourceRedisInstanceUnsupported,
+                36 => Self::PermissionDeniedNoCloudRouterConfigs,
+                37 => Self::NoServerlessIpRanges,
+                _ => Self::UnknownValue(cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Cause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN_NETWORK" => Self::UnknownNetwork,
+                "UNKNOWN_PROJECT" => Self::UnknownProject,
+                "NO_EXTERNAL_IP" => Self::NoExternalIp,
+                "UNINTENDED_DESTINATION" => Self::UnintendedDestination,
+                "SOURCE_ENDPOINT_NOT_FOUND" => Self::SourceEndpointNotFound,
+                "MISMATCHED_SOURCE_NETWORK" => Self::MismatchedSourceNetwork,
+                "DESTINATION_ENDPOINT_NOT_FOUND" => Self::DestinationEndpointNotFound,
+                "MISMATCHED_DESTINATION_NETWORK" => Self::MismatchedDestinationNetwork,
+                "UNKNOWN_IP" => Self::UnknownIp,
+                "GOOGLE_MANAGED_SERVICE_UNKNOWN_IP" => Self::GoogleManagedServiceUnknownIp,
+                "SOURCE_IP_ADDRESS_NOT_IN_SOURCE_NETWORK" => {
+                    Self::SourceIpAddressNotInSourceNetwork
+                }
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                "PERMISSION_DENIED_NO_CLOUD_NAT_CONFIGS" => Self::PermissionDeniedNoCloudNatConfigs,
+                "PERMISSION_DENIED_NO_NEG_ENDPOINT_CONFIGS" => {
+                    Self::PermissionDeniedNoNegEndpointConfigs
+                }
+                "PERMISSION_DENIED_NO_CLOUD_ROUTER_CONFIGS" => {
+                    Self::PermissionDeniedNoCloudRouterConfigs
+                }
+                "NO_SOURCE_LOCATION" => Self::NoSourceLocation,
+                "INVALID_ARGUMENT" => Self::InvalidArgument,
+                "TRACE_TOO_LONG" => Self::TraceTooLong,
+                "INTERNAL_ERROR" => Self::InternalError,
+                "UNSUPPORTED" => Self::Unsupported,
+                "MISMATCHED_IP_VERSION" => Self::MismatchedIpVersion,
+                "GKE_KONNECTIVITY_PROXY_UNSUPPORTED" => Self::GkeKonnectivityProxyUnsupported,
+                "RESOURCE_CONFIG_NOT_FOUND" => Self::ResourceConfigNotFound,
+                "VM_INSTANCE_CONFIG_NOT_FOUND" => Self::VmInstanceConfigNotFound,
+                "NETWORK_CONFIG_NOT_FOUND" => Self::NetworkConfigNotFound,
+                "FIREWALL_CONFIG_NOT_FOUND" => Self::FirewallConfigNotFound,
+                "ROUTE_CONFIG_NOT_FOUND" => Self::RouteConfigNotFound,
+                "GOOGLE_MANAGED_SERVICE_AMBIGUOUS_PSC_ENDPOINT" => {
+                    Self::GoogleManagedServiceAmbiguousPscEndpoint
+                }
+                "SOURCE_PSC_CLOUD_SQL_UNSUPPORTED" => Self::SourcePscCloudSqlUnsupported,
+                "SOURCE_REDIS_CLUSTER_UNSUPPORTED" => Self::SourceRedisClusterUnsupported,
+                "SOURCE_REDIS_INSTANCE_UNSUPPORTED" => Self::SourceRedisInstanceUnsupported,
+                "SOURCE_FORWARDING_RULE_UNSUPPORTED" => Self::SourceForwardingRuleUnsupported,
+                "NON_ROUTABLE_IP_ADDRESS" => Self::NonRoutableIpAddress,
+                "UNKNOWN_ISSUE_IN_GOOGLE_MANAGED_PROJECT" => {
+                    Self::UnknownIssueInGoogleManagedProject
+                }
+                "UNSUPPORTED_GOOGLE_MANAGED_PROJECT_CONFIG" => {
+                    Self::UnsupportedGoogleManagedProjectConfig
+                }
+                "NO_SERVERLESS_IP_RANGES" => Self::NoServerlessIpRanges,
+                _ => Self::UnknownValue(cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Cause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UnknownNetwork => serializer.serialize_i32(1),
+                Self::UnknownProject => serializer.serialize_i32(3),
+                Self::NoExternalIp => serializer.serialize_i32(7),
+                Self::UnintendedDestination => serializer.serialize_i32(8),
+                Self::SourceEndpointNotFound => serializer.serialize_i32(11),
+                Self::MismatchedSourceNetwork => serializer.serialize_i32(12),
+                Self::DestinationEndpointNotFound => serializer.serialize_i32(13),
+                Self::MismatchedDestinationNetwork => serializer.serialize_i32(14),
+                Self::UnknownIp => serializer.serialize_i32(2),
+                Self::GoogleManagedServiceUnknownIp => serializer.serialize_i32(32),
+                Self::SourceIpAddressNotInSourceNetwork => serializer.serialize_i32(23),
+                Self::PermissionDenied => serializer.serialize_i32(4),
+                Self::PermissionDeniedNoCloudNatConfigs => serializer.serialize_i32(28),
+                Self::PermissionDeniedNoNegEndpointConfigs => serializer.serialize_i32(29),
+                Self::PermissionDeniedNoCloudRouterConfigs => serializer.serialize_i32(36),
+                Self::NoSourceLocation => serializer.serialize_i32(5),
+                Self::InvalidArgument => serializer.serialize_i32(6),
+                Self::TraceTooLong => serializer.serialize_i32(9),
+                Self::InternalError => serializer.serialize_i32(10),
+                Self::Unsupported => serializer.serialize_i32(15),
+                Self::MismatchedIpVersion => serializer.serialize_i32(16),
+                Self::GkeKonnectivityProxyUnsupported => serializer.serialize_i32(17),
+                Self::ResourceConfigNotFound => serializer.serialize_i32(18),
+                Self::VmInstanceConfigNotFound => serializer.serialize_i32(24),
+                Self::NetworkConfigNotFound => serializer.serialize_i32(25),
+                Self::FirewallConfigNotFound => serializer.serialize_i32(26),
+                Self::RouteConfigNotFound => serializer.serialize_i32(27),
+                Self::GoogleManagedServiceAmbiguousPscEndpoint => serializer.serialize_i32(19),
+                Self::SourcePscCloudSqlUnsupported => serializer.serialize_i32(20),
+                Self::SourceRedisClusterUnsupported => serializer.serialize_i32(34),
+                Self::SourceRedisInstanceUnsupported => serializer.serialize_i32(35),
+                Self::SourceForwardingRuleUnsupported => serializer.serialize_i32(21),
+                Self::NonRoutableIpAddress => serializer.serialize_i32(22),
+                Self::UnknownIssueInGoogleManagedProject => serializer.serialize_i32(30),
+                Self::UnsupportedGoogleManagedProjectConfig => serializer.serialize_i32(31),
+                Self::NoServerlessIpRanges => serializer.serialize_i32(37),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Cause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Cause>::new(
+                ".google.cloud.networkmanagement.v1.AbortInfo.Cause",
+            ))
         }
     }
 }
@@ -6186,741 +7523,1012 @@ pub mod drop_info {
     use super::*;
 
     /// Drop cause types:
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cause(i32);
-
-    impl Cause {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Cause {
         /// Cause is unspecified.
-        pub const CAUSE_UNSPECIFIED: Cause = Cause::new(0);
-
+        Unspecified,
         /// Destination external address cannot be resolved to a known target. If
         /// the address is used in a Google Cloud project, provide the project ID
         /// as test input.
-        pub const UNKNOWN_EXTERNAL_ADDRESS: Cause = Cause::new(1);
-
+        UnknownExternalAddress,
         /// A Compute Engine instance can only send or receive a packet with a
         /// foreign IP address if ip_forward is enabled.
-        pub const FOREIGN_IP_DISALLOWED: Cause = Cause::new(2);
-
+        ForeignIpDisallowed,
         /// Dropped due to a firewall rule, unless allowed due to connection
         /// tracking.
-        pub const FIREWALL_RULE: Cause = Cause::new(3);
-
+        FirewallRule,
         /// Dropped due to no matching routes.
-        pub const NO_ROUTE: Cause = Cause::new(4);
-
+        NoRoute,
         /// Dropped due to invalid route. Route's next hop is a blackhole.
-        pub const ROUTE_BLACKHOLE: Cause = Cause::new(5);
-
+        RouteBlackhole,
         /// Packet is sent to a wrong (unintended) network. Example: you trace a
         /// packet from VM1:Network1 to VM2:Network2, however, the route configured
         /// in Network1 sends the packet destined for VM2's IP address to Network3.
-        pub const ROUTE_WRONG_NETWORK: Cause = Cause::new(6);
-
+        RouteWrongNetwork,
         /// Route's next hop IP address cannot be resolved to a GCP resource.
-        pub const ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED: Cause = Cause::new(42);
-
+        RouteNextHopIpAddressNotResolved,
         /// Route's next hop resource is not found.
-        pub const ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND: Cause = Cause::new(43);
-
+        RouteNextHopResourceNotFound,
         /// Route's next hop instance doesn't have a NIC in the route's network.
-        pub const ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK: Cause = Cause::new(49);
-
+        RouteNextHopInstanceWrongNetwork,
         /// Route's next hop IP address is not a primary IP address of the next hop
         /// instance.
-        pub const ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP: Cause = Cause::new(50);
-
+        RouteNextHopInstanceNonPrimaryIp,
         /// Route's next hop forwarding rule doesn't match next hop IP address.
-        pub const ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH: Cause = Cause::new(51);
-
+        RouteNextHopForwardingRuleIpMismatch,
         /// Route's next hop VPN tunnel is down (does not have valid IKE SAs).
-        pub const ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED: Cause = Cause::new(52);
-
+        RouteNextHopVpnTunnelNotEstablished,
         /// Route's next hop forwarding rule type is invalid (it's not a forwarding
         /// rule of the internal passthrough load balancer).
-        pub const ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID: Cause = Cause::new(53);
-
+        RouteNextHopForwardingRuleTypeInvalid,
         /// Packet is sent from the Internet to the private IPv6 address.
-        pub const NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS: Cause = Cause::new(44);
-
+        NoRouteFromInternetToPrivateIpv6Address,
         /// The packet does not match a policy-based VPN tunnel local selector.
-        pub const VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH: Cause = Cause::new(45);
-
+        VpnTunnelLocalSelectorMismatch,
         /// The packet does not match a policy-based VPN tunnel remote selector.
-        pub const VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH: Cause = Cause::new(46);
-
+        VpnTunnelRemoteSelectorMismatch,
         /// Packet with internal destination address sent to the internet gateway.
-        pub const PRIVATE_TRAFFIC_TO_INTERNET: Cause = Cause::new(7);
-
+        PrivateTrafficToInternet,
         /// Instance with only an internal IP address tries to access Google API and
         /// services, but private Google access is not enabled in the subnet.
-        pub const PRIVATE_GOOGLE_ACCESS_DISALLOWED: Cause = Cause::new(8);
-
+        PrivateGoogleAccessDisallowed,
         /// Source endpoint tries to access Google API and services through the VPN
         /// tunnel to another network, but Private Google Access needs to be enabled
         /// in the source endpoint network.
-        pub const PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED: Cause = Cause::new(47);
-
+        PrivateGoogleAccessViaVpnTunnelUnsupported,
         /// Instance with only an internal IP address tries to access external hosts,
         /// but Cloud NAT is not enabled in the subnet, unless special configurations
         /// on a VM allow this connection.
-        pub const NO_EXTERNAL_ADDRESS: Cause = Cause::new(9);
-
+        NoExternalAddress,
         /// Destination internal address cannot be resolved to a known target. If
         /// this is a shared VPC scenario, verify if the service project ID is
         /// provided as test input. Otherwise, verify if the IP address is being
         /// used in the project.
-        pub const UNKNOWN_INTERNAL_ADDRESS: Cause = Cause::new(10);
-
+        UnknownInternalAddress,
         /// Forwarding rule's protocol and ports do not match the packet header.
-        pub const FORWARDING_RULE_MISMATCH: Cause = Cause::new(11);
-
+        ForwardingRuleMismatch,
         /// Forwarding rule does not have backends configured.
-        pub const FORWARDING_RULE_NO_INSTANCES: Cause = Cause::new(12);
-
+        ForwardingRuleNoInstances,
         /// Firewalls block the health check probes to the backends and cause
         /// the backends to be unavailable for traffic from the load balancer.
         /// For more details, see [Health check firewall
         /// rules](https://cloud.google.com/load-balancing/docs/health-checks#firewall_rules).
-        pub const FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK: Cause = Cause::new(13);
-
+        FirewallBlockingLoadBalancerBackendHealthCheck,
         /// Matching ingress firewall rules by network tags for packets sent via
         /// serverless VPC direct egress is unsupported. Behavior is undefined.
         /// <https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#limitations>
-        pub const INGRESS_FIREWALL_TAGS_UNSUPPORTED_BY_DIRECT_VPC_EGRESS: Cause = Cause::new(85);
-
+        IngressFirewallTagsUnsupportedByDirectVpcEgress,
         /// Packet is sent from or to a Compute Engine instance that is not in a
         /// running state.
-        pub const INSTANCE_NOT_RUNNING: Cause = Cause::new(14);
-
+        InstanceNotRunning,
         /// Packet sent from or to a GKE cluster that is not in running state.
-        pub const GKE_CLUSTER_NOT_RUNNING: Cause = Cause::new(27);
-
+        GkeClusterNotRunning,
         /// Packet sent from or to a Cloud SQL instance that is not in running state.
-        pub const CLOUD_SQL_INSTANCE_NOT_RUNNING: Cause = Cause::new(28);
-
+        CloudSqlInstanceNotRunning,
         /// Packet sent from or to a Redis Instance that is not in running state.
-        pub const REDIS_INSTANCE_NOT_RUNNING: Cause = Cause::new(68);
-
+        RedisInstanceNotRunning,
         /// Packet sent from or to a Redis Cluster that is not in running state.
-        pub const REDIS_CLUSTER_NOT_RUNNING: Cause = Cause::new(69);
-
+        RedisClusterNotRunning,
         /// The type of traffic is blocked and the user cannot configure a firewall
         /// rule to enable it. See [Always blocked
         /// traffic](https://cloud.google.com/vpc/docs/firewalls#blockedtraffic) for
         /// more details.
-        pub const TRAFFIC_TYPE_BLOCKED: Cause = Cause::new(15);
-
+        TrafficTypeBlocked,
         /// Access to Google Kubernetes Engine cluster master's endpoint is not
         /// authorized. See [Access to the cluster
         /// endpoints](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#access_to_the_cluster_endpoints)
         /// for more details.
-        pub const GKE_MASTER_UNAUTHORIZED_ACCESS: Cause = Cause::new(16);
-
+        GkeMasterUnauthorizedAccess,
         /// Access to the Cloud SQL instance endpoint is not authorized.
         /// See [Authorizing with authorized
         /// networks](https://cloud.google.com/sql/docs/mysql/authorize-networks) for
         /// more details.
-        pub const CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS: Cause = Cause::new(17);
-
+        CloudSqlInstanceUnauthorizedAccess,
         /// Packet was dropped inside Google Kubernetes Engine Service.
-        pub const DROPPED_INSIDE_GKE_SERVICE: Cause = Cause::new(18);
-
+        DroppedInsideGkeService,
         /// Packet was dropped inside Cloud SQL Service.
-        pub const DROPPED_INSIDE_CLOUD_SQL_SERVICE: Cause = Cause::new(19);
-
+        DroppedInsideCloudSqlService,
         /// Packet was dropped because there is no peering between the originating
         /// network and the Google Managed Services Network.
-        pub const GOOGLE_MANAGED_SERVICE_NO_PEERING: Cause = Cause::new(20);
-
+        GoogleManagedServiceNoPeering,
         /// Packet was dropped because the Google-managed service uses Private
         /// Service Connect (PSC), but the PSC endpoint is not found in the project.
-        pub const GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT: Cause = Cause::new(38);
-
+        GoogleManagedServiceNoPscEndpoint,
         /// Packet was dropped because the GKE cluster uses Private Service Connect
         /// (PSC), but the PSC endpoint is not found in the project.
-        pub const GKE_PSC_ENDPOINT_MISSING: Cause = Cause::new(36);
-
+        GkePscEndpointMissing,
         /// Packet was dropped because the Cloud SQL instance has neither a private
         /// nor a public IP address.
-        pub const CLOUD_SQL_INSTANCE_NO_IP_ADDRESS: Cause = Cause::new(21);
-
+        CloudSqlInstanceNoIpAddress,
         /// Packet was dropped because a GKE cluster private endpoint is
         /// unreachable from a region different from the cluster's region.
-        pub const GKE_CONTROL_PLANE_REGION_MISMATCH: Cause = Cause::new(30);
-
+        GkeControlPlaneRegionMismatch,
         /// Packet sent from a public GKE cluster control plane to a private
         /// IP address.
-        pub const PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION: Cause = Cause::new(31);
-
+        PublicGkeControlPlaneToPrivateDestination,
         /// Packet was dropped because there is no route from a GKE cluster
         /// control plane to a destination network.
-        pub const GKE_CONTROL_PLANE_NO_ROUTE: Cause = Cause::new(32);
-
+        GkeControlPlaneNoRoute,
         /// Packet sent from a Cloud SQL instance to an external IP address is not
         /// allowed. The Cloud SQL instance is not configured to send packets to
         /// external IP addresses.
-        pub const CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC: Cause = Cause::new(33);
-
+        CloudSqlInstanceNotConfiguredForExternalTraffic,
         /// Packet sent from a Cloud SQL instance with only a public IP address to a
         /// private IP address.
-        pub const PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION: Cause = Cause::new(34);
-
+        PublicCloudSqlInstanceToPrivateDestination,
         /// Packet was dropped because there is no route from a Cloud SQL
         /// instance to a destination network.
-        pub const CLOUD_SQL_INSTANCE_NO_ROUTE: Cause = Cause::new(35);
-
+        CloudSqlInstanceNoRoute,
         /// Packet was dropped because the Cloud SQL instance requires all
         /// connections to use Cloud SQL connectors and to target the Cloud SQL proxy
         /// port (3307).
-        pub const CLOUD_SQL_CONNECTOR_REQUIRED: Cause = Cause::new(63);
-
+        CloudSqlConnectorRequired,
         /// Packet could be dropped because the Cloud Function is not in an active
         /// status.
-        pub const CLOUD_FUNCTION_NOT_ACTIVE: Cause = Cause::new(22);
-
+        CloudFunctionNotActive,
         /// Packet could be dropped because no VPC connector is set.
-        pub const VPC_CONNECTOR_NOT_SET: Cause = Cause::new(23);
-
+        VpcConnectorNotSet,
         /// Packet could be dropped because the VPC connector is not in a running
         /// state.
-        pub const VPC_CONNECTOR_NOT_RUNNING: Cause = Cause::new(24);
-
+        VpcConnectorNotRunning,
         /// Packet could be dropped because the traffic from the serverless service
         /// to the VPC connector is not allowed.
-        pub const VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED: Cause = Cause::new(60);
-
+        VpcConnectorServerlessTrafficBlocked,
         /// Packet could be dropped because the health check traffic to the VPC
         /// connector is not allowed.
-        pub const VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED: Cause = Cause::new(61);
-
+        VpcConnectorHealthCheckTrafficBlocked,
         /// Packet could be dropped because it was sent from a different region
         /// to a regional forwarding without global access.
-        pub const FORWARDING_RULE_REGION_MISMATCH: Cause = Cause::new(25);
-
+        ForwardingRuleRegionMismatch,
         /// The Private Service Connect endpoint is in a project that is not approved
         /// to connect to the service.
-        pub const PSC_CONNECTION_NOT_ACCEPTED: Cause = Cause::new(26);
-
+        PscConnectionNotAccepted,
         /// The packet is sent to the Private Service Connect endpoint over the
         /// peering, but [it's not
         /// supported](https://cloud.google.com/vpc/docs/configure-private-service-connect-services#on-premises).
-        pub const PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK: Cause = Cause::new(41);
-
+        PscEndpointAccessedFromPeeredNetwork,
         /// The packet is sent to the Private Service Connect backend (network
         /// endpoint group), but the producer PSC forwarding rule does not have
         /// global access enabled.
-        pub const PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS: Cause = Cause::new(48);
-
+        PscNegProducerEndpointNoGlobalAccess,
         /// The packet is sent to the Private Service Connect backend (network
         /// endpoint group), but the producer PSC forwarding rule has multiple ports
         /// specified.
-        pub const PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS: Cause = Cause::new(54);
-
+        PscNegProducerForwardingRuleMultiplePorts,
         /// The packet is sent to the Private Service Connect backend (network
         /// endpoint group) targeting a Cloud SQL service attachment, but this
         /// configuration is not supported.
-        pub const CLOUD_SQL_PSC_NEG_UNSUPPORTED: Cause = Cause::new(58);
-
+        CloudSqlPscNegUnsupported,
         /// No NAT subnets are defined for the PSC service attachment.
-        pub const NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT: Cause = Cause::new(57);
-
+        NoNatSubnetsForPscServiceAttachment,
         /// PSC endpoint is accessed via NCC, but PSC transitivity configuration is
         /// not yet propagated.
-        pub const PSC_TRANSITIVITY_NOT_PROPAGATED: Cause = Cause::new(64);
-
+        PscTransitivityNotPropagated,
         /// The packet sent from the hybrid NEG proxy matches a non-dynamic route,
         /// but such a configuration is not supported.
-        pub const HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED: Cause = Cause::new(55);
-
+        HybridNegNonDynamicRouteMatched,
         /// The packet sent from the hybrid NEG proxy matches a dynamic route with a
         /// next hop in a different region, but such a configuration is not
         /// supported.
-        pub const HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED: Cause = Cause::new(56);
-
+        HybridNegNonLocalDynamicRouteMatched,
         /// Packet sent from a Cloud Run revision that is not ready.
-        pub const CLOUD_RUN_REVISION_NOT_READY: Cause = Cause::new(29);
-
+        CloudRunRevisionNotReady,
         /// Packet was dropped inside Private Service Connect service producer.
-        pub const DROPPED_INSIDE_PSC_SERVICE_PRODUCER: Cause = Cause::new(37);
-
+        DroppedInsidePscServiceProducer,
         /// Packet sent to a load balancer, which requires a proxy-only subnet and
         /// the subnet is not found.
-        pub const LOAD_BALANCER_HAS_NO_PROXY_SUBNET: Cause = Cause::new(39);
-
+        LoadBalancerHasNoProxySubnet,
         /// Packet sent to Cloud Nat without active NAT IPs.
-        pub const CLOUD_NAT_NO_ADDRESSES: Cause = Cause::new(40);
-
+        CloudNatNoAddresses,
         /// Packet is stuck in a routing loop.
-        pub const ROUTING_LOOP: Cause = Cause::new(59);
-
+        RoutingLoop,
         /// Packet is dropped inside a Google-managed service due to being delivered
         /// in return trace to an endpoint that doesn't match the endpoint the packet
         /// was sent from in forward trace. Used only for return traces.
-        pub const DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE: Cause = Cause::new(62);
-
+        DroppedInsideGoogleManagedService,
         /// Packet is dropped due to a load balancer backend instance not having a
         /// network interface in the network expected by the load balancer.
-        pub const LOAD_BALANCER_BACKEND_INVALID_NETWORK: Cause = Cause::new(65);
-
+        LoadBalancerBackendInvalidNetwork,
         /// Packet is dropped due to a backend service named port not being defined
         /// on the instance group level.
-        pub const BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED: Cause = Cause::new(66);
-
+        BackendServiceNamedPortNotDefined,
         /// Packet is dropped due to a destination IP range being part of a Private
         /// NAT IP range.
-        pub const DESTINATION_IS_PRIVATE_NAT_IP_RANGE: Cause = Cause::new(67);
-
+        DestinationIsPrivateNatIpRange,
         /// Generic drop cause for a packet being dropped inside a Redis Instance
         /// service project.
-        pub const DROPPED_INSIDE_REDIS_INSTANCE_SERVICE: Cause = Cause::new(70);
-
+        DroppedInsideRedisInstanceService,
         /// Packet is dropped due to an unsupported port being used to connect to a
         /// Redis Instance. Port 6379 should be used to connect to a Redis Instance.
-        pub const REDIS_INSTANCE_UNSUPPORTED_PORT: Cause = Cause::new(71);
-
+        RedisInstanceUnsupportedPort,
         /// Packet is dropped due to connecting from PUPI address to a PSA based
         /// Redis Instance.
-        pub const REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS: Cause = Cause::new(72);
-
+        RedisInstanceConnectingFromPupiAddress,
         /// Packet is dropped due to no route to the destination network.
-        pub const REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK: Cause = Cause::new(73);
-
+        RedisInstanceNoRouteToDestinationNetwork,
         /// Redis Instance does not have an external IP address.
-        pub const REDIS_INSTANCE_NO_EXTERNAL_IP: Cause = Cause::new(74);
-
+        RedisInstanceNoExternalIp,
         /// Packet is dropped due to an unsupported protocol being used to connect to
         /// a Redis Instance. Only TCP connections are accepted by a Redis Instance.
-        pub const REDIS_INSTANCE_UNSUPPORTED_PROTOCOL: Cause = Cause::new(78);
-
+        RedisInstanceUnsupportedProtocol,
         /// Generic drop cause for a packet being dropped inside a Redis Cluster
         /// service project.
-        pub const DROPPED_INSIDE_REDIS_CLUSTER_SERVICE: Cause = Cause::new(75);
-
+        DroppedInsideRedisClusterService,
         /// Packet is dropped due to an unsupported port being used to connect to a
         /// Redis Cluster. Ports 6379 and 11000 to 13047 should be used to connect to
         /// a Redis Cluster.
-        pub const REDIS_CLUSTER_UNSUPPORTED_PORT: Cause = Cause::new(76);
-
+        RedisClusterUnsupportedPort,
         /// Redis Cluster does not have an external IP address.
-        pub const REDIS_CLUSTER_NO_EXTERNAL_IP: Cause = Cause::new(77);
-
+        RedisClusterNoExternalIp,
         /// Packet is dropped due to an unsupported protocol being used to connect to
         /// a Redis Cluster. Only TCP connections are accepted by a Redis Cluster.
-        pub const REDIS_CLUSTER_UNSUPPORTED_PROTOCOL: Cause = Cause::new(79);
-
+        RedisClusterUnsupportedProtocol,
         /// Packet from the non-GCP (on-prem) or unknown GCP network is dropped due
         /// to the destination IP address not belonging to any IP prefix advertised
         /// via BGP by the Cloud Router.
-        pub const NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION: Cause = Cause::new(80);
-
+        NoAdvertisedRouteToGcpDestination,
         /// Packet from the non-GCP (on-prem) or unknown GCP network is dropped due
         /// to the destination IP address not belonging to any IP prefix included to
         /// the local traffic selector of the VPN tunnel.
-        pub const NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION: Cause = Cause::new(81);
-
+        NoTrafficSelectorToGcpDestination,
         /// Packet from the unknown peered network is dropped due to no known route
         /// from the source network to the destination IP address.
-        pub const NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION: Cause = Cause::new(82);
-
+        NoKnownRouteFromPeeredNetworkToDestination,
         /// Sending packets processed by the Private NAT Gateways to the Private
         /// Service Connect endpoints is not supported.
-        pub const PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED: Cause = Cause::new(83);
-
+        PrivateNatToPscEndpointUnsupported,
         /// Packet is sent to the PSC port mapping service, but its destination port
         /// does not match any port mapping rules.
-        pub const PSC_PORT_MAPPING_PORT_MISMATCH: Cause = Cause::new(86);
-
+        PscPortMappingPortMismatch,
         /// Sending packets directly to the PSC port mapping service without going
         /// through the PSC connection is not supported.
-        pub const PSC_PORT_MAPPING_WITHOUT_PSC_CONNECTION_UNSUPPORTED: Cause = Cause::new(87);
-
+        PscPortMappingWithoutPscConnectionUnsupported,
         /// Packet with destination IP address within the reserved NAT64 range is
         /// dropped due to matching a route of an unsupported type.
-        pub const UNSUPPORTED_ROUTE_MATCHED_FOR_NAT64_DESTINATION: Cause = Cause::new(88);
+        UnsupportedRouteMatchedForNat64Destination,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Cause::value] or
+        /// [Cause::name].
+        UnknownValue(cause::UnknownValue),
+    }
 
-        /// Creates a new Cause instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cause {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Cause {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UnknownExternalAddress => std::option::Option::Some(1),
+                Self::ForeignIpDisallowed => std::option::Option::Some(2),
+                Self::FirewallRule => std::option::Option::Some(3),
+                Self::NoRoute => std::option::Option::Some(4),
+                Self::RouteBlackhole => std::option::Option::Some(5),
+                Self::RouteWrongNetwork => std::option::Option::Some(6),
+                Self::RouteNextHopIpAddressNotResolved => std::option::Option::Some(42),
+                Self::RouteNextHopResourceNotFound => std::option::Option::Some(43),
+                Self::RouteNextHopInstanceWrongNetwork => std::option::Option::Some(49),
+                Self::RouteNextHopInstanceNonPrimaryIp => std::option::Option::Some(50),
+                Self::RouteNextHopForwardingRuleIpMismatch => std::option::Option::Some(51),
+                Self::RouteNextHopVpnTunnelNotEstablished => std::option::Option::Some(52),
+                Self::RouteNextHopForwardingRuleTypeInvalid => std::option::Option::Some(53),
+                Self::NoRouteFromInternetToPrivateIpv6Address => std::option::Option::Some(44),
+                Self::VpnTunnelLocalSelectorMismatch => std::option::Option::Some(45),
+                Self::VpnTunnelRemoteSelectorMismatch => std::option::Option::Some(46),
+                Self::PrivateTrafficToInternet => std::option::Option::Some(7),
+                Self::PrivateGoogleAccessDisallowed => std::option::Option::Some(8),
+                Self::PrivateGoogleAccessViaVpnTunnelUnsupported => std::option::Option::Some(47),
+                Self::NoExternalAddress => std::option::Option::Some(9),
+                Self::UnknownInternalAddress => std::option::Option::Some(10),
+                Self::ForwardingRuleMismatch => std::option::Option::Some(11),
+                Self::ForwardingRuleNoInstances => std::option::Option::Some(12),
+                Self::FirewallBlockingLoadBalancerBackendHealthCheck => {
+                    std::option::Option::Some(13)
+                }
+                Self::IngressFirewallTagsUnsupportedByDirectVpcEgress => {
+                    std::option::Option::Some(85)
+                }
+                Self::InstanceNotRunning => std::option::Option::Some(14),
+                Self::GkeClusterNotRunning => std::option::Option::Some(27),
+                Self::CloudSqlInstanceNotRunning => std::option::Option::Some(28),
+                Self::RedisInstanceNotRunning => std::option::Option::Some(68),
+                Self::RedisClusterNotRunning => std::option::Option::Some(69),
+                Self::TrafficTypeBlocked => std::option::Option::Some(15),
+                Self::GkeMasterUnauthorizedAccess => std::option::Option::Some(16),
+                Self::CloudSqlInstanceUnauthorizedAccess => std::option::Option::Some(17),
+                Self::DroppedInsideGkeService => std::option::Option::Some(18),
+                Self::DroppedInsideCloudSqlService => std::option::Option::Some(19),
+                Self::GoogleManagedServiceNoPeering => std::option::Option::Some(20),
+                Self::GoogleManagedServiceNoPscEndpoint => std::option::Option::Some(38),
+                Self::GkePscEndpointMissing => std::option::Option::Some(36),
+                Self::CloudSqlInstanceNoIpAddress => std::option::Option::Some(21),
+                Self::GkeControlPlaneRegionMismatch => std::option::Option::Some(30),
+                Self::PublicGkeControlPlaneToPrivateDestination => std::option::Option::Some(31),
+                Self::GkeControlPlaneNoRoute => std::option::Option::Some(32),
+                Self::CloudSqlInstanceNotConfiguredForExternalTraffic => {
+                    std::option::Option::Some(33)
+                }
+                Self::PublicCloudSqlInstanceToPrivateDestination => std::option::Option::Some(34),
+                Self::CloudSqlInstanceNoRoute => std::option::Option::Some(35),
+                Self::CloudSqlConnectorRequired => std::option::Option::Some(63),
+                Self::CloudFunctionNotActive => std::option::Option::Some(22),
+                Self::VpcConnectorNotSet => std::option::Option::Some(23),
+                Self::VpcConnectorNotRunning => std::option::Option::Some(24),
+                Self::VpcConnectorServerlessTrafficBlocked => std::option::Option::Some(60),
+                Self::VpcConnectorHealthCheckTrafficBlocked => std::option::Option::Some(61),
+                Self::ForwardingRuleRegionMismatch => std::option::Option::Some(25),
+                Self::PscConnectionNotAccepted => std::option::Option::Some(26),
+                Self::PscEndpointAccessedFromPeeredNetwork => std::option::Option::Some(41),
+                Self::PscNegProducerEndpointNoGlobalAccess => std::option::Option::Some(48),
+                Self::PscNegProducerForwardingRuleMultiplePorts => std::option::Option::Some(54),
+                Self::CloudSqlPscNegUnsupported => std::option::Option::Some(58),
+                Self::NoNatSubnetsForPscServiceAttachment => std::option::Option::Some(57),
+                Self::PscTransitivityNotPropagated => std::option::Option::Some(64),
+                Self::HybridNegNonDynamicRouteMatched => std::option::Option::Some(55),
+                Self::HybridNegNonLocalDynamicRouteMatched => std::option::Option::Some(56),
+                Self::CloudRunRevisionNotReady => std::option::Option::Some(29),
+                Self::DroppedInsidePscServiceProducer => std::option::Option::Some(37),
+                Self::LoadBalancerHasNoProxySubnet => std::option::Option::Some(39),
+                Self::CloudNatNoAddresses => std::option::Option::Some(40),
+                Self::RoutingLoop => std::option::Option::Some(59),
+                Self::DroppedInsideGoogleManagedService => std::option::Option::Some(62),
+                Self::LoadBalancerBackendInvalidNetwork => std::option::Option::Some(65),
+                Self::BackendServiceNamedPortNotDefined => std::option::Option::Some(66),
+                Self::DestinationIsPrivateNatIpRange => std::option::Option::Some(67),
+                Self::DroppedInsideRedisInstanceService => std::option::Option::Some(70),
+                Self::RedisInstanceUnsupportedPort => std::option::Option::Some(71),
+                Self::RedisInstanceConnectingFromPupiAddress => std::option::Option::Some(72),
+                Self::RedisInstanceNoRouteToDestinationNetwork => std::option::Option::Some(73),
+                Self::RedisInstanceNoExternalIp => std::option::Option::Some(74),
+                Self::RedisInstanceUnsupportedProtocol => std::option::Option::Some(78),
+                Self::DroppedInsideRedisClusterService => std::option::Option::Some(75),
+                Self::RedisClusterUnsupportedPort => std::option::Option::Some(76),
+                Self::RedisClusterNoExternalIp => std::option::Option::Some(77),
+                Self::RedisClusterUnsupportedProtocol => std::option::Option::Some(79),
+                Self::NoAdvertisedRouteToGcpDestination => std::option::Option::Some(80),
+                Self::NoTrafficSelectorToGcpDestination => std::option::Option::Some(81),
+                Self::NoKnownRouteFromPeeredNetworkToDestination => std::option::Option::Some(82),
+                Self::PrivateNatToPscEndpointUnsupported => std::option::Option::Some(83),
+                Self::PscPortMappingPortMismatch => std::option::Option::Some(86),
+                Self::PscPortMappingWithoutPscConnectionUnsupported => {
+                    std::option::Option::Some(87)
+                }
+                Self::UnsupportedRouteMatchedForNat64Destination => std::option::Option::Some(88),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CAUSE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN_EXTERNAL_ADDRESS"),
-                2 => std::borrow::Cow::Borrowed("FOREIGN_IP_DISALLOWED"),
-                3 => std::borrow::Cow::Borrowed("FIREWALL_RULE"),
-                4 => std::borrow::Cow::Borrowed("NO_ROUTE"),
-                5 => std::borrow::Cow::Borrowed("ROUTE_BLACKHOLE"),
-                6 => std::borrow::Cow::Borrowed("ROUTE_WRONG_NETWORK"),
-                7 => std::borrow::Cow::Borrowed("PRIVATE_TRAFFIC_TO_INTERNET"),
-                8 => std::borrow::Cow::Borrowed("PRIVATE_GOOGLE_ACCESS_DISALLOWED"),
-                9 => std::borrow::Cow::Borrowed("NO_EXTERNAL_ADDRESS"),
-                10 => std::borrow::Cow::Borrowed("UNKNOWN_INTERNAL_ADDRESS"),
-                11 => std::borrow::Cow::Borrowed("FORWARDING_RULE_MISMATCH"),
-                12 => std::borrow::Cow::Borrowed("FORWARDING_RULE_NO_INSTANCES"),
-                13 => std::borrow::Cow::Borrowed(
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CAUSE_UNSPECIFIED"),
+                Self::UnknownExternalAddress => {
+                    std::option::Option::Some("UNKNOWN_EXTERNAL_ADDRESS")
+                }
+                Self::ForeignIpDisallowed => std::option::Option::Some("FOREIGN_IP_DISALLOWED"),
+                Self::FirewallRule => std::option::Option::Some("FIREWALL_RULE"),
+                Self::NoRoute => std::option::Option::Some("NO_ROUTE"),
+                Self::RouteBlackhole => std::option::Option::Some("ROUTE_BLACKHOLE"),
+                Self::RouteWrongNetwork => std::option::Option::Some("ROUTE_WRONG_NETWORK"),
+                Self::RouteNextHopIpAddressNotResolved => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED")
+                }
+                Self::RouteNextHopResourceNotFound => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND")
+                }
+                Self::RouteNextHopInstanceWrongNetwork => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK")
+                }
+                Self::RouteNextHopInstanceNonPrimaryIp => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP")
+                }
+                Self::RouteNextHopForwardingRuleIpMismatch => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH")
+                }
+                Self::RouteNextHopVpnTunnelNotEstablished => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED")
+                }
+                Self::RouteNextHopForwardingRuleTypeInvalid => {
+                    std::option::Option::Some("ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID")
+                }
+                Self::NoRouteFromInternetToPrivateIpv6Address => {
+                    std::option::Option::Some("NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS")
+                }
+                Self::VpnTunnelLocalSelectorMismatch => {
+                    std::option::Option::Some("VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH")
+                }
+                Self::VpnTunnelRemoteSelectorMismatch => {
+                    std::option::Option::Some("VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH")
+                }
+                Self::PrivateTrafficToInternet => {
+                    std::option::Option::Some("PRIVATE_TRAFFIC_TO_INTERNET")
+                }
+                Self::PrivateGoogleAccessDisallowed => {
+                    std::option::Option::Some("PRIVATE_GOOGLE_ACCESS_DISALLOWED")
+                }
+                Self::PrivateGoogleAccessViaVpnTunnelUnsupported => {
+                    std::option::Option::Some("PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED")
+                }
+                Self::NoExternalAddress => std::option::Option::Some("NO_EXTERNAL_ADDRESS"),
+                Self::UnknownInternalAddress => {
+                    std::option::Option::Some("UNKNOWN_INTERNAL_ADDRESS")
+                }
+                Self::ForwardingRuleMismatch => {
+                    std::option::Option::Some("FORWARDING_RULE_MISMATCH")
+                }
+                Self::ForwardingRuleNoInstances => {
+                    std::option::Option::Some("FORWARDING_RULE_NO_INSTANCES")
+                }
+                Self::FirewallBlockingLoadBalancerBackendHealthCheck => std::option::Option::Some(
                     "FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK",
                 ),
-                14 => std::borrow::Cow::Borrowed("INSTANCE_NOT_RUNNING"),
-                15 => std::borrow::Cow::Borrowed("TRAFFIC_TYPE_BLOCKED"),
-                16 => std::borrow::Cow::Borrowed("GKE_MASTER_UNAUTHORIZED_ACCESS"),
-                17 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS"),
-                18 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_GKE_SERVICE"),
-                19 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_CLOUD_SQL_SERVICE"),
-                20 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_NO_PEERING"),
-                21 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_NO_IP_ADDRESS"),
-                22 => std::borrow::Cow::Borrowed("CLOUD_FUNCTION_NOT_ACTIVE"),
-                23 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_NOT_SET"),
-                24 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_NOT_RUNNING"),
-                25 => std::borrow::Cow::Borrowed("FORWARDING_RULE_REGION_MISMATCH"),
-                26 => std::borrow::Cow::Borrowed("PSC_CONNECTION_NOT_ACCEPTED"),
-                27 => std::borrow::Cow::Borrowed("GKE_CLUSTER_NOT_RUNNING"),
-                28 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_NOT_RUNNING"),
-                29 => std::borrow::Cow::Borrowed("CLOUD_RUN_REVISION_NOT_READY"),
-                30 => std::borrow::Cow::Borrowed("GKE_CONTROL_PLANE_REGION_MISMATCH"),
-                31 => std::borrow::Cow::Borrowed("PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION"),
-                32 => std::borrow::Cow::Borrowed("GKE_CONTROL_PLANE_NO_ROUTE"),
-                33 => std::borrow::Cow::Borrowed(
-                    "CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC",
-                ),
-                34 => {
-                    std::borrow::Cow::Borrowed("PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION")
-                }
-                35 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE_NO_ROUTE"),
-                36 => std::borrow::Cow::Borrowed("GKE_PSC_ENDPOINT_MISSING"),
-                37 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_PSC_SERVICE_PRODUCER"),
-                38 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT"),
-                39 => std::borrow::Cow::Borrowed("LOAD_BALANCER_HAS_NO_PROXY_SUBNET"),
-                40 => std::borrow::Cow::Borrowed("CLOUD_NAT_NO_ADDRESSES"),
-                41 => std::borrow::Cow::Borrowed("PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK"),
-                42 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED"),
-                43 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND"),
-                44 => std::borrow::Cow::Borrowed("NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS"),
-                45 => std::borrow::Cow::Borrowed("VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH"),
-                46 => std::borrow::Cow::Borrowed("VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH"),
-                47 => {
-                    std::borrow::Cow::Borrowed("PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED")
-                }
-                48 => std::borrow::Cow::Borrowed("PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS"),
-                49 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK"),
-                50 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP"),
-                51 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH"),
-                52 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED"),
-                53 => std::borrow::Cow::Borrowed("ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID"),
-                54 => std::borrow::Cow::Borrowed("PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS"),
-                55 => std::borrow::Cow::Borrowed("HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED"),
-                56 => std::borrow::Cow::Borrowed("HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED"),
-                57 => std::borrow::Cow::Borrowed("NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT"),
-                58 => std::borrow::Cow::Borrowed("CLOUD_SQL_PSC_NEG_UNSUPPORTED"),
-                59 => std::borrow::Cow::Borrowed("ROUTING_LOOP"),
-                60 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED"),
-                61 => std::borrow::Cow::Borrowed("VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED"),
-                62 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE"),
-                63 => std::borrow::Cow::Borrowed("CLOUD_SQL_CONNECTOR_REQUIRED"),
-                64 => std::borrow::Cow::Borrowed("PSC_TRANSITIVITY_NOT_PROPAGATED"),
-                65 => std::borrow::Cow::Borrowed("LOAD_BALANCER_BACKEND_INVALID_NETWORK"),
-                66 => std::borrow::Cow::Borrowed("BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED"),
-                67 => std::borrow::Cow::Borrowed("DESTINATION_IS_PRIVATE_NAT_IP_RANGE"),
-                68 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_NOT_RUNNING"),
-                69 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_NOT_RUNNING"),
-                70 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_REDIS_INSTANCE_SERVICE"),
-                71 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_UNSUPPORTED_PORT"),
-                72 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS"),
-                73 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK"),
-                74 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_NO_EXTERNAL_IP"),
-                75 => std::borrow::Cow::Borrowed("DROPPED_INSIDE_REDIS_CLUSTER_SERVICE"),
-                76 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_UNSUPPORTED_PORT"),
-                77 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_NO_EXTERNAL_IP"),
-                78 => std::borrow::Cow::Borrowed("REDIS_INSTANCE_UNSUPPORTED_PROTOCOL"),
-                79 => std::borrow::Cow::Borrowed("REDIS_CLUSTER_UNSUPPORTED_PROTOCOL"),
-                80 => std::borrow::Cow::Borrowed("NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION"),
-                81 => std::borrow::Cow::Borrowed("NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION"),
-                82 => {
-                    std::borrow::Cow::Borrowed("NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION")
-                }
-                83 => std::borrow::Cow::Borrowed("PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED"),
-                85 => std::borrow::Cow::Borrowed(
+                Self::IngressFirewallTagsUnsupportedByDirectVpcEgress => std::option::Option::Some(
                     "INGRESS_FIREWALL_TAGS_UNSUPPORTED_BY_DIRECT_VPC_EGRESS",
                 ),
-                86 => std::borrow::Cow::Borrowed("PSC_PORT_MAPPING_PORT_MISMATCH"),
-                87 => std::borrow::Cow::Borrowed(
-                    "PSC_PORT_MAPPING_WITHOUT_PSC_CONNECTION_UNSUPPORTED",
+                Self::InstanceNotRunning => std::option::Option::Some("INSTANCE_NOT_RUNNING"),
+                Self::GkeClusterNotRunning => std::option::Option::Some("GKE_CLUSTER_NOT_RUNNING"),
+                Self::CloudSqlInstanceNotRunning => {
+                    std::option::Option::Some("CLOUD_SQL_INSTANCE_NOT_RUNNING")
+                }
+                Self::RedisInstanceNotRunning => {
+                    std::option::Option::Some("REDIS_INSTANCE_NOT_RUNNING")
+                }
+                Self::RedisClusterNotRunning => {
+                    std::option::Option::Some("REDIS_CLUSTER_NOT_RUNNING")
+                }
+                Self::TrafficTypeBlocked => std::option::Option::Some("TRAFFIC_TYPE_BLOCKED"),
+                Self::GkeMasterUnauthorizedAccess => {
+                    std::option::Option::Some("GKE_MASTER_UNAUTHORIZED_ACCESS")
+                }
+                Self::CloudSqlInstanceUnauthorizedAccess => {
+                    std::option::Option::Some("CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS")
+                }
+                Self::DroppedInsideGkeService => {
+                    std::option::Option::Some("DROPPED_INSIDE_GKE_SERVICE")
+                }
+                Self::DroppedInsideCloudSqlService => {
+                    std::option::Option::Some("DROPPED_INSIDE_CLOUD_SQL_SERVICE")
+                }
+                Self::GoogleManagedServiceNoPeering => {
+                    std::option::Option::Some("GOOGLE_MANAGED_SERVICE_NO_PEERING")
+                }
+                Self::GoogleManagedServiceNoPscEndpoint => {
+                    std::option::Option::Some("GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT")
+                }
+                Self::GkePscEndpointMissing => {
+                    std::option::Option::Some("GKE_PSC_ENDPOINT_MISSING")
+                }
+                Self::CloudSqlInstanceNoIpAddress => {
+                    std::option::Option::Some("CLOUD_SQL_INSTANCE_NO_IP_ADDRESS")
+                }
+                Self::GkeControlPlaneRegionMismatch => {
+                    std::option::Option::Some("GKE_CONTROL_PLANE_REGION_MISMATCH")
+                }
+                Self::PublicGkeControlPlaneToPrivateDestination => {
+                    std::option::Option::Some("PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION")
+                }
+                Self::GkeControlPlaneNoRoute => {
+                    std::option::Option::Some("GKE_CONTROL_PLANE_NO_ROUTE")
+                }
+                Self::CloudSqlInstanceNotConfiguredForExternalTraffic => std::option::Option::Some(
+                    "CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC",
                 ),
-                88 => std::borrow::Cow::Borrowed("UNSUPPORTED_ROUTE_MATCHED_FOR_NAT64_DESTINATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                Self::PublicCloudSqlInstanceToPrivateDestination => {
+                    std::option::Option::Some("PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION")
+                }
+                Self::CloudSqlInstanceNoRoute => {
+                    std::option::Option::Some("CLOUD_SQL_INSTANCE_NO_ROUTE")
+                }
+                Self::CloudSqlConnectorRequired => {
+                    std::option::Option::Some("CLOUD_SQL_CONNECTOR_REQUIRED")
+                }
+                Self::CloudFunctionNotActive => {
+                    std::option::Option::Some("CLOUD_FUNCTION_NOT_ACTIVE")
+                }
+                Self::VpcConnectorNotSet => std::option::Option::Some("VPC_CONNECTOR_NOT_SET"),
+                Self::VpcConnectorNotRunning => {
+                    std::option::Option::Some("VPC_CONNECTOR_NOT_RUNNING")
+                }
+                Self::VpcConnectorServerlessTrafficBlocked => {
+                    std::option::Option::Some("VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED")
+                }
+                Self::VpcConnectorHealthCheckTrafficBlocked => {
+                    std::option::Option::Some("VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED")
+                }
+                Self::ForwardingRuleRegionMismatch => {
+                    std::option::Option::Some("FORWARDING_RULE_REGION_MISMATCH")
+                }
+                Self::PscConnectionNotAccepted => {
+                    std::option::Option::Some("PSC_CONNECTION_NOT_ACCEPTED")
+                }
+                Self::PscEndpointAccessedFromPeeredNetwork => {
+                    std::option::Option::Some("PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK")
+                }
+                Self::PscNegProducerEndpointNoGlobalAccess => {
+                    std::option::Option::Some("PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS")
+                }
+                Self::PscNegProducerForwardingRuleMultiplePorts => {
+                    std::option::Option::Some("PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS")
+                }
+                Self::CloudSqlPscNegUnsupported => {
+                    std::option::Option::Some("CLOUD_SQL_PSC_NEG_UNSUPPORTED")
+                }
+                Self::NoNatSubnetsForPscServiceAttachment => {
+                    std::option::Option::Some("NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT")
+                }
+                Self::PscTransitivityNotPropagated => {
+                    std::option::Option::Some("PSC_TRANSITIVITY_NOT_PROPAGATED")
+                }
+                Self::HybridNegNonDynamicRouteMatched => {
+                    std::option::Option::Some("HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED")
+                }
+                Self::HybridNegNonLocalDynamicRouteMatched => {
+                    std::option::Option::Some("HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED")
+                }
+                Self::CloudRunRevisionNotReady => {
+                    std::option::Option::Some("CLOUD_RUN_REVISION_NOT_READY")
+                }
+                Self::DroppedInsidePscServiceProducer => {
+                    std::option::Option::Some("DROPPED_INSIDE_PSC_SERVICE_PRODUCER")
+                }
+                Self::LoadBalancerHasNoProxySubnet => {
+                    std::option::Option::Some("LOAD_BALANCER_HAS_NO_PROXY_SUBNET")
+                }
+                Self::CloudNatNoAddresses => std::option::Option::Some("CLOUD_NAT_NO_ADDRESSES"),
+                Self::RoutingLoop => std::option::Option::Some("ROUTING_LOOP"),
+                Self::DroppedInsideGoogleManagedService => {
+                    std::option::Option::Some("DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE")
+                }
+                Self::LoadBalancerBackendInvalidNetwork => {
+                    std::option::Option::Some("LOAD_BALANCER_BACKEND_INVALID_NETWORK")
+                }
+                Self::BackendServiceNamedPortNotDefined => {
+                    std::option::Option::Some("BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED")
+                }
+                Self::DestinationIsPrivateNatIpRange => {
+                    std::option::Option::Some("DESTINATION_IS_PRIVATE_NAT_IP_RANGE")
+                }
+                Self::DroppedInsideRedisInstanceService => {
+                    std::option::Option::Some("DROPPED_INSIDE_REDIS_INSTANCE_SERVICE")
+                }
+                Self::RedisInstanceUnsupportedPort => {
+                    std::option::Option::Some("REDIS_INSTANCE_UNSUPPORTED_PORT")
+                }
+                Self::RedisInstanceConnectingFromPupiAddress => {
+                    std::option::Option::Some("REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS")
+                }
+                Self::RedisInstanceNoRouteToDestinationNetwork => {
+                    std::option::Option::Some("REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK")
+                }
+                Self::RedisInstanceNoExternalIp => {
+                    std::option::Option::Some("REDIS_INSTANCE_NO_EXTERNAL_IP")
+                }
+                Self::RedisInstanceUnsupportedProtocol => {
+                    std::option::Option::Some("REDIS_INSTANCE_UNSUPPORTED_PROTOCOL")
+                }
+                Self::DroppedInsideRedisClusterService => {
+                    std::option::Option::Some("DROPPED_INSIDE_REDIS_CLUSTER_SERVICE")
+                }
+                Self::RedisClusterUnsupportedPort => {
+                    std::option::Option::Some("REDIS_CLUSTER_UNSUPPORTED_PORT")
+                }
+                Self::RedisClusterNoExternalIp => {
+                    std::option::Option::Some("REDIS_CLUSTER_NO_EXTERNAL_IP")
+                }
+                Self::RedisClusterUnsupportedProtocol => {
+                    std::option::Option::Some("REDIS_CLUSTER_UNSUPPORTED_PROTOCOL")
+                }
+                Self::NoAdvertisedRouteToGcpDestination => {
+                    std::option::Option::Some("NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION")
+                }
+                Self::NoTrafficSelectorToGcpDestination => {
+                    std::option::Option::Some("NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION")
+                }
+                Self::NoKnownRouteFromPeeredNetworkToDestination => {
+                    std::option::Option::Some("NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION")
+                }
+                Self::PrivateNatToPscEndpointUnsupported => {
+                    std::option::Option::Some("PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED")
+                }
+                Self::PscPortMappingPortMismatch => {
+                    std::option::Option::Some("PSC_PORT_MAPPING_PORT_MISMATCH")
+                }
+                Self::PscPortMappingWithoutPscConnectionUnsupported => {
+                    std::option::Option::Some("PSC_PORT_MAPPING_WITHOUT_PSC_CONNECTION_UNSUPPORTED")
+                }
+                Self::UnsupportedRouteMatchedForNat64Destination => {
+                    std::option::Option::Some("UNSUPPORTED_ROUTE_MATCHED_FOR_NAT64_DESTINATION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CAUSE_UNSPECIFIED" => std::option::Option::Some(Self::CAUSE_UNSPECIFIED),
-                "UNKNOWN_EXTERNAL_ADDRESS" => {
-                    std::option::Option::Some(Self::UNKNOWN_EXTERNAL_ADDRESS)
-                }
-                "FOREIGN_IP_DISALLOWED" => std::option::Option::Some(Self::FOREIGN_IP_DISALLOWED),
-                "FIREWALL_RULE" => std::option::Option::Some(Self::FIREWALL_RULE),
-                "NO_ROUTE" => std::option::Option::Some(Self::NO_ROUTE),
-                "ROUTE_BLACKHOLE" => std::option::Option::Some(Self::ROUTE_BLACKHOLE),
-                "ROUTE_WRONG_NETWORK" => std::option::Option::Some(Self::ROUTE_WRONG_NETWORK),
-                "ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED)
-                }
-                "ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND)
-                }
-                "ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK)
-                }
-                "ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP)
-                }
-                "ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH)
-                }
-                "ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED)
-                }
-                "ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID" => {
-                    std::option::Option::Some(Self::ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID)
-                }
-                "NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS" => {
-                    std::option::Option::Some(Self::NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS)
-                }
-                "VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH" => {
-                    std::option::Option::Some(Self::VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH)
-                }
-                "VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH" => {
-                    std::option::Option::Some(Self::VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH)
-                }
-                "PRIVATE_TRAFFIC_TO_INTERNET" => {
-                    std::option::Option::Some(Self::PRIVATE_TRAFFIC_TO_INTERNET)
-                }
-                "PRIVATE_GOOGLE_ACCESS_DISALLOWED" => {
-                    std::option::Option::Some(Self::PRIVATE_GOOGLE_ACCESS_DISALLOWED)
-                }
-                "PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED" => std::option::Option::Some(
-                    Self::PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED,
-                ),
-                "NO_EXTERNAL_ADDRESS" => std::option::Option::Some(Self::NO_EXTERNAL_ADDRESS),
-                "UNKNOWN_INTERNAL_ADDRESS" => {
-                    std::option::Option::Some(Self::UNKNOWN_INTERNAL_ADDRESS)
-                }
-                "FORWARDING_RULE_MISMATCH" => {
-                    std::option::Option::Some(Self::FORWARDING_RULE_MISMATCH)
-                }
-                "FORWARDING_RULE_NO_INSTANCES" => {
-                    std::option::Option::Some(Self::FORWARDING_RULE_NO_INSTANCES)
-                }
-                "FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK" => {
-                    std::option::Option::Some(
-                        Self::FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK,
-                    )
-                }
-                "INGRESS_FIREWALL_TAGS_UNSUPPORTED_BY_DIRECT_VPC_EGRESS" => {
-                    std::option::Option::Some(
-                        Self::INGRESS_FIREWALL_TAGS_UNSUPPORTED_BY_DIRECT_VPC_EGRESS,
-                    )
-                }
-                "INSTANCE_NOT_RUNNING" => std::option::Option::Some(Self::INSTANCE_NOT_RUNNING),
-                "GKE_CLUSTER_NOT_RUNNING" => {
-                    std::option::Option::Some(Self::GKE_CLUSTER_NOT_RUNNING)
-                }
-                "CLOUD_SQL_INSTANCE_NOT_RUNNING" => {
-                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_NOT_RUNNING)
-                }
-                "REDIS_INSTANCE_NOT_RUNNING" => {
-                    std::option::Option::Some(Self::REDIS_INSTANCE_NOT_RUNNING)
-                }
-                "REDIS_CLUSTER_NOT_RUNNING" => {
-                    std::option::Option::Some(Self::REDIS_CLUSTER_NOT_RUNNING)
-                }
-                "TRAFFIC_TYPE_BLOCKED" => std::option::Option::Some(Self::TRAFFIC_TYPE_BLOCKED),
-                "GKE_MASTER_UNAUTHORIZED_ACCESS" => {
-                    std::option::Option::Some(Self::GKE_MASTER_UNAUTHORIZED_ACCESS)
-                }
-                "CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS" => {
-                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS)
-                }
-                "DROPPED_INSIDE_GKE_SERVICE" => {
-                    std::option::Option::Some(Self::DROPPED_INSIDE_GKE_SERVICE)
-                }
-                "DROPPED_INSIDE_CLOUD_SQL_SERVICE" => {
-                    std::option::Option::Some(Self::DROPPED_INSIDE_CLOUD_SQL_SERVICE)
-                }
-                "GOOGLE_MANAGED_SERVICE_NO_PEERING" => {
-                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_NO_PEERING)
-                }
-                "GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT" => {
-                    std::option::Option::Some(Self::GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT)
-                }
-                "GKE_PSC_ENDPOINT_MISSING" => {
-                    std::option::Option::Some(Self::GKE_PSC_ENDPOINT_MISSING)
-                }
-                "CLOUD_SQL_INSTANCE_NO_IP_ADDRESS" => {
-                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_NO_IP_ADDRESS)
-                }
-                "GKE_CONTROL_PLANE_REGION_MISMATCH" => {
-                    std::option::Option::Some(Self::GKE_CONTROL_PLANE_REGION_MISMATCH)
-                }
-                "PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION" => {
-                    std::option::Option::Some(Self::PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION)
-                }
-                "GKE_CONTROL_PLANE_NO_ROUTE" => {
-                    std::option::Option::Some(Self::GKE_CONTROL_PLANE_NO_ROUTE)
-                }
-                "CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC" => {
-                    std::option::Option::Some(
-                        Self::CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC,
-                    )
-                }
-                "PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION" => std::option::Option::Some(
-                    Self::PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION,
-                ),
-                "CLOUD_SQL_INSTANCE_NO_ROUTE" => {
-                    std::option::Option::Some(Self::CLOUD_SQL_INSTANCE_NO_ROUTE)
-                }
-                "CLOUD_SQL_CONNECTOR_REQUIRED" => {
-                    std::option::Option::Some(Self::CLOUD_SQL_CONNECTOR_REQUIRED)
-                }
-                "CLOUD_FUNCTION_NOT_ACTIVE" => {
-                    std::option::Option::Some(Self::CLOUD_FUNCTION_NOT_ACTIVE)
-                }
-                "VPC_CONNECTOR_NOT_SET" => std::option::Option::Some(Self::VPC_CONNECTOR_NOT_SET),
-                "VPC_CONNECTOR_NOT_RUNNING" => {
-                    std::option::Option::Some(Self::VPC_CONNECTOR_NOT_RUNNING)
-                }
-                "VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED" => {
-                    std::option::Option::Some(Self::VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED)
-                }
-                "VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED" => {
-                    std::option::Option::Some(Self::VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED)
-                }
-                "FORWARDING_RULE_REGION_MISMATCH" => {
-                    std::option::Option::Some(Self::FORWARDING_RULE_REGION_MISMATCH)
-                }
-                "PSC_CONNECTION_NOT_ACCEPTED" => {
-                    std::option::Option::Some(Self::PSC_CONNECTION_NOT_ACCEPTED)
-                }
-                "PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK" => {
-                    std::option::Option::Some(Self::PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK)
-                }
-                "PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS" => {
-                    std::option::Option::Some(Self::PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS)
-                }
-                "PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS" => {
-                    std::option::Option::Some(Self::PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS)
-                }
-                "CLOUD_SQL_PSC_NEG_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::CLOUD_SQL_PSC_NEG_UNSUPPORTED)
-                }
-                "NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT" => {
-                    std::option::Option::Some(Self::NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT)
-                }
-                "PSC_TRANSITIVITY_NOT_PROPAGATED" => {
-                    std::option::Option::Some(Self::PSC_TRANSITIVITY_NOT_PROPAGATED)
-                }
-                "HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED" => {
-                    std::option::Option::Some(Self::HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED)
-                }
-                "HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED" => {
-                    std::option::Option::Some(Self::HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED)
-                }
-                "CLOUD_RUN_REVISION_NOT_READY" => {
-                    std::option::Option::Some(Self::CLOUD_RUN_REVISION_NOT_READY)
-                }
-                "DROPPED_INSIDE_PSC_SERVICE_PRODUCER" => {
-                    std::option::Option::Some(Self::DROPPED_INSIDE_PSC_SERVICE_PRODUCER)
-                }
-                "LOAD_BALANCER_HAS_NO_PROXY_SUBNET" => {
-                    std::option::Option::Some(Self::LOAD_BALANCER_HAS_NO_PROXY_SUBNET)
-                }
-                "CLOUD_NAT_NO_ADDRESSES" => std::option::Option::Some(Self::CLOUD_NAT_NO_ADDRESSES),
-                "ROUTING_LOOP" => std::option::Option::Some(Self::ROUTING_LOOP),
-                "DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE" => {
-                    std::option::Option::Some(Self::DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE)
-                }
-                "LOAD_BALANCER_BACKEND_INVALID_NETWORK" => {
-                    std::option::Option::Some(Self::LOAD_BALANCER_BACKEND_INVALID_NETWORK)
-                }
-                "BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED" => {
-                    std::option::Option::Some(Self::BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED)
-                }
-                "DESTINATION_IS_PRIVATE_NAT_IP_RANGE" => {
-                    std::option::Option::Some(Self::DESTINATION_IS_PRIVATE_NAT_IP_RANGE)
-                }
-                "DROPPED_INSIDE_REDIS_INSTANCE_SERVICE" => {
-                    std::option::Option::Some(Self::DROPPED_INSIDE_REDIS_INSTANCE_SERVICE)
-                }
-                "REDIS_INSTANCE_UNSUPPORTED_PORT" => {
-                    std::option::Option::Some(Self::REDIS_INSTANCE_UNSUPPORTED_PORT)
-                }
-                "REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS" => {
-                    std::option::Option::Some(Self::REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS)
-                }
-                "REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK" => {
-                    std::option::Option::Some(Self::REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK)
-                }
-                "REDIS_INSTANCE_NO_EXTERNAL_IP" => {
-                    std::option::Option::Some(Self::REDIS_INSTANCE_NO_EXTERNAL_IP)
-                }
-                "REDIS_INSTANCE_UNSUPPORTED_PROTOCOL" => {
-                    std::option::Option::Some(Self::REDIS_INSTANCE_UNSUPPORTED_PROTOCOL)
-                }
-                "DROPPED_INSIDE_REDIS_CLUSTER_SERVICE" => {
-                    std::option::Option::Some(Self::DROPPED_INSIDE_REDIS_CLUSTER_SERVICE)
-                }
-                "REDIS_CLUSTER_UNSUPPORTED_PORT" => {
-                    std::option::Option::Some(Self::REDIS_CLUSTER_UNSUPPORTED_PORT)
-                }
-                "REDIS_CLUSTER_NO_EXTERNAL_IP" => {
-                    std::option::Option::Some(Self::REDIS_CLUSTER_NO_EXTERNAL_IP)
-                }
-                "REDIS_CLUSTER_UNSUPPORTED_PROTOCOL" => {
-                    std::option::Option::Some(Self::REDIS_CLUSTER_UNSUPPORTED_PROTOCOL)
-                }
-                "NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION" => {
-                    std::option::Option::Some(Self::NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION)
-                }
-                "NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION" => {
-                    std::option::Option::Some(Self::NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION)
-                }
-                "NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION" => std::option::Option::Some(
-                    Self::NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION,
-                ),
-                "PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED)
-                }
-                "PSC_PORT_MAPPING_PORT_MISMATCH" => {
-                    std::option::Option::Some(Self::PSC_PORT_MAPPING_PORT_MISMATCH)
-                }
-                "PSC_PORT_MAPPING_WITHOUT_PSC_CONNECTION_UNSUPPORTED" => std::option::Option::Some(
-                    Self::PSC_PORT_MAPPING_WITHOUT_PSC_CONNECTION_UNSUPPORTED,
-                ),
-                "UNSUPPORTED_ROUTE_MATCHED_FOR_NAT64_DESTINATION" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_ROUTE_MATCHED_FOR_NAT64_DESTINATION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Cause {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Cause {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Cause {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Cause {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UnknownExternalAddress,
+                2 => Self::ForeignIpDisallowed,
+                3 => Self::FirewallRule,
+                4 => Self::NoRoute,
+                5 => Self::RouteBlackhole,
+                6 => Self::RouteWrongNetwork,
+                7 => Self::PrivateTrafficToInternet,
+                8 => Self::PrivateGoogleAccessDisallowed,
+                9 => Self::NoExternalAddress,
+                10 => Self::UnknownInternalAddress,
+                11 => Self::ForwardingRuleMismatch,
+                12 => Self::ForwardingRuleNoInstances,
+                13 => Self::FirewallBlockingLoadBalancerBackendHealthCheck,
+                14 => Self::InstanceNotRunning,
+                15 => Self::TrafficTypeBlocked,
+                16 => Self::GkeMasterUnauthorizedAccess,
+                17 => Self::CloudSqlInstanceUnauthorizedAccess,
+                18 => Self::DroppedInsideGkeService,
+                19 => Self::DroppedInsideCloudSqlService,
+                20 => Self::GoogleManagedServiceNoPeering,
+                21 => Self::CloudSqlInstanceNoIpAddress,
+                22 => Self::CloudFunctionNotActive,
+                23 => Self::VpcConnectorNotSet,
+                24 => Self::VpcConnectorNotRunning,
+                25 => Self::ForwardingRuleRegionMismatch,
+                26 => Self::PscConnectionNotAccepted,
+                27 => Self::GkeClusterNotRunning,
+                28 => Self::CloudSqlInstanceNotRunning,
+                29 => Self::CloudRunRevisionNotReady,
+                30 => Self::GkeControlPlaneRegionMismatch,
+                31 => Self::PublicGkeControlPlaneToPrivateDestination,
+                32 => Self::GkeControlPlaneNoRoute,
+                33 => Self::CloudSqlInstanceNotConfiguredForExternalTraffic,
+                34 => Self::PublicCloudSqlInstanceToPrivateDestination,
+                35 => Self::CloudSqlInstanceNoRoute,
+                36 => Self::GkePscEndpointMissing,
+                37 => Self::DroppedInsidePscServiceProducer,
+                38 => Self::GoogleManagedServiceNoPscEndpoint,
+                39 => Self::LoadBalancerHasNoProxySubnet,
+                40 => Self::CloudNatNoAddresses,
+                41 => Self::PscEndpointAccessedFromPeeredNetwork,
+                42 => Self::RouteNextHopIpAddressNotResolved,
+                43 => Self::RouteNextHopResourceNotFound,
+                44 => Self::NoRouteFromInternetToPrivateIpv6Address,
+                45 => Self::VpnTunnelLocalSelectorMismatch,
+                46 => Self::VpnTunnelRemoteSelectorMismatch,
+                47 => Self::PrivateGoogleAccessViaVpnTunnelUnsupported,
+                48 => Self::PscNegProducerEndpointNoGlobalAccess,
+                49 => Self::RouteNextHopInstanceWrongNetwork,
+                50 => Self::RouteNextHopInstanceNonPrimaryIp,
+                51 => Self::RouteNextHopForwardingRuleIpMismatch,
+                52 => Self::RouteNextHopVpnTunnelNotEstablished,
+                53 => Self::RouteNextHopForwardingRuleTypeInvalid,
+                54 => Self::PscNegProducerForwardingRuleMultiplePorts,
+                55 => Self::HybridNegNonDynamicRouteMatched,
+                56 => Self::HybridNegNonLocalDynamicRouteMatched,
+                57 => Self::NoNatSubnetsForPscServiceAttachment,
+                58 => Self::CloudSqlPscNegUnsupported,
+                59 => Self::RoutingLoop,
+                60 => Self::VpcConnectorServerlessTrafficBlocked,
+                61 => Self::VpcConnectorHealthCheckTrafficBlocked,
+                62 => Self::DroppedInsideGoogleManagedService,
+                63 => Self::CloudSqlConnectorRequired,
+                64 => Self::PscTransitivityNotPropagated,
+                65 => Self::LoadBalancerBackendInvalidNetwork,
+                66 => Self::BackendServiceNamedPortNotDefined,
+                67 => Self::DestinationIsPrivateNatIpRange,
+                68 => Self::RedisInstanceNotRunning,
+                69 => Self::RedisClusterNotRunning,
+                70 => Self::DroppedInsideRedisInstanceService,
+                71 => Self::RedisInstanceUnsupportedPort,
+                72 => Self::RedisInstanceConnectingFromPupiAddress,
+                73 => Self::RedisInstanceNoRouteToDestinationNetwork,
+                74 => Self::RedisInstanceNoExternalIp,
+                75 => Self::DroppedInsideRedisClusterService,
+                76 => Self::RedisClusterUnsupportedPort,
+                77 => Self::RedisClusterNoExternalIp,
+                78 => Self::RedisInstanceUnsupportedProtocol,
+                79 => Self::RedisClusterUnsupportedProtocol,
+                80 => Self::NoAdvertisedRouteToGcpDestination,
+                81 => Self::NoTrafficSelectorToGcpDestination,
+                82 => Self::NoKnownRouteFromPeeredNetworkToDestination,
+                83 => Self::PrivateNatToPscEndpointUnsupported,
+                85 => Self::IngressFirewallTagsUnsupportedByDirectVpcEgress,
+                86 => Self::PscPortMappingPortMismatch,
+                87 => Self::PscPortMappingWithoutPscConnectionUnsupported,
+                88 => Self::UnsupportedRouteMatchedForNat64Destination,
+                _ => Self::UnknownValue(cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Cause {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CAUSE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN_EXTERNAL_ADDRESS" => Self::UnknownExternalAddress,
+                "FOREIGN_IP_DISALLOWED" => Self::ForeignIpDisallowed,
+                "FIREWALL_RULE" => Self::FirewallRule,
+                "NO_ROUTE" => Self::NoRoute,
+                "ROUTE_BLACKHOLE" => Self::RouteBlackhole,
+                "ROUTE_WRONG_NETWORK" => Self::RouteWrongNetwork,
+                "ROUTE_NEXT_HOP_IP_ADDRESS_NOT_RESOLVED" => Self::RouteNextHopIpAddressNotResolved,
+                "ROUTE_NEXT_HOP_RESOURCE_NOT_FOUND" => Self::RouteNextHopResourceNotFound,
+                "ROUTE_NEXT_HOP_INSTANCE_WRONG_NETWORK" => Self::RouteNextHopInstanceWrongNetwork,
+                "ROUTE_NEXT_HOP_INSTANCE_NON_PRIMARY_IP" => Self::RouteNextHopInstanceNonPrimaryIp,
+                "ROUTE_NEXT_HOP_FORWARDING_RULE_IP_MISMATCH" => {
+                    Self::RouteNextHopForwardingRuleIpMismatch
+                }
+                "ROUTE_NEXT_HOP_VPN_TUNNEL_NOT_ESTABLISHED" => {
+                    Self::RouteNextHopVpnTunnelNotEstablished
+                }
+                "ROUTE_NEXT_HOP_FORWARDING_RULE_TYPE_INVALID" => {
+                    Self::RouteNextHopForwardingRuleTypeInvalid
+                }
+                "NO_ROUTE_FROM_INTERNET_TO_PRIVATE_IPV6_ADDRESS" => {
+                    Self::NoRouteFromInternetToPrivateIpv6Address
+                }
+                "VPN_TUNNEL_LOCAL_SELECTOR_MISMATCH" => Self::VpnTunnelLocalSelectorMismatch,
+                "VPN_TUNNEL_REMOTE_SELECTOR_MISMATCH" => Self::VpnTunnelRemoteSelectorMismatch,
+                "PRIVATE_TRAFFIC_TO_INTERNET" => Self::PrivateTrafficToInternet,
+                "PRIVATE_GOOGLE_ACCESS_DISALLOWED" => Self::PrivateGoogleAccessDisallowed,
+                "PRIVATE_GOOGLE_ACCESS_VIA_VPN_TUNNEL_UNSUPPORTED" => {
+                    Self::PrivateGoogleAccessViaVpnTunnelUnsupported
+                }
+                "NO_EXTERNAL_ADDRESS" => Self::NoExternalAddress,
+                "UNKNOWN_INTERNAL_ADDRESS" => Self::UnknownInternalAddress,
+                "FORWARDING_RULE_MISMATCH" => Self::ForwardingRuleMismatch,
+                "FORWARDING_RULE_NO_INSTANCES" => Self::ForwardingRuleNoInstances,
+                "FIREWALL_BLOCKING_LOAD_BALANCER_BACKEND_HEALTH_CHECK" => {
+                    Self::FirewallBlockingLoadBalancerBackendHealthCheck
+                }
+                "INGRESS_FIREWALL_TAGS_UNSUPPORTED_BY_DIRECT_VPC_EGRESS" => {
+                    Self::IngressFirewallTagsUnsupportedByDirectVpcEgress
+                }
+                "INSTANCE_NOT_RUNNING" => Self::InstanceNotRunning,
+                "GKE_CLUSTER_NOT_RUNNING" => Self::GkeClusterNotRunning,
+                "CLOUD_SQL_INSTANCE_NOT_RUNNING" => Self::CloudSqlInstanceNotRunning,
+                "REDIS_INSTANCE_NOT_RUNNING" => Self::RedisInstanceNotRunning,
+                "REDIS_CLUSTER_NOT_RUNNING" => Self::RedisClusterNotRunning,
+                "TRAFFIC_TYPE_BLOCKED" => Self::TrafficTypeBlocked,
+                "GKE_MASTER_UNAUTHORIZED_ACCESS" => Self::GkeMasterUnauthorizedAccess,
+                "CLOUD_SQL_INSTANCE_UNAUTHORIZED_ACCESS" => {
+                    Self::CloudSqlInstanceUnauthorizedAccess
+                }
+                "DROPPED_INSIDE_GKE_SERVICE" => Self::DroppedInsideGkeService,
+                "DROPPED_INSIDE_CLOUD_SQL_SERVICE" => Self::DroppedInsideCloudSqlService,
+                "GOOGLE_MANAGED_SERVICE_NO_PEERING" => Self::GoogleManagedServiceNoPeering,
+                "GOOGLE_MANAGED_SERVICE_NO_PSC_ENDPOINT" => Self::GoogleManagedServiceNoPscEndpoint,
+                "GKE_PSC_ENDPOINT_MISSING" => Self::GkePscEndpointMissing,
+                "CLOUD_SQL_INSTANCE_NO_IP_ADDRESS" => Self::CloudSqlInstanceNoIpAddress,
+                "GKE_CONTROL_PLANE_REGION_MISMATCH" => Self::GkeControlPlaneRegionMismatch,
+                "PUBLIC_GKE_CONTROL_PLANE_TO_PRIVATE_DESTINATION" => {
+                    Self::PublicGkeControlPlaneToPrivateDestination
+                }
+                "GKE_CONTROL_PLANE_NO_ROUTE" => Self::GkeControlPlaneNoRoute,
+                "CLOUD_SQL_INSTANCE_NOT_CONFIGURED_FOR_EXTERNAL_TRAFFIC" => {
+                    Self::CloudSqlInstanceNotConfiguredForExternalTraffic
+                }
+                "PUBLIC_CLOUD_SQL_INSTANCE_TO_PRIVATE_DESTINATION" => {
+                    Self::PublicCloudSqlInstanceToPrivateDestination
+                }
+                "CLOUD_SQL_INSTANCE_NO_ROUTE" => Self::CloudSqlInstanceNoRoute,
+                "CLOUD_SQL_CONNECTOR_REQUIRED" => Self::CloudSqlConnectorRequired,
+                "CLOUD_FUNCTION_NOT_ACTIVE" => Self::CloudFunctionNotActive,
+                "VPC_CONNECTOR_NOT_SET" => Self::VpcConnectorNotSet,
+                "VPC_CONNECTOR_NOT_RUNNING" => Self::VpcConnectorNotRunning,
+                "VPC_CONNECTOR_SERVERLESS_TRAFFIC_BLOCKED" => {
+                    Self::VpcConnectorServerlessTrafficBlocked
+                }
+                "VPC_CONNECTOR_HEALTH_CHECK_TRAFFIC_BLOCKED" => {
+                    Self::VpcConnectorHealthCheckTrafficBlocked
+                }
+                "FORWARDING_RULE_REGION_MISMATCH" => Self::ForwardingRuleRegionMismatch,
+                "PSC_CONNECTION_NOT_ACCEPTED" => Self::PscConnectionNotAccepted,
+                "PSC_ENDPOINT_ACCESSED_FROM_PEERED_NETWORK" => {
+                    Self::PscEndpointAccessedFromPeeredNetwork
+                }
+                "PSC_NEG_PRODUCER_ENDPOINT_NO_GLOBAL_ACCESS" => {
+                    Self::PscNegProducerEndpointNoGlobalAccess
+                }
+                "PSC_NEG_PRODUCER_FORWARDING_RULE_MULTIPLE_PORTS" => {
+                    Self::PscNegProducerForwardingRuleMultiplePorts
+                }
+                "CLOUD_SQL_PSC_NEG_UNSUPPORTED" => Self::CloudSqlPscNegUnsupported,
+                "NO_NAT_SUBNETS_FOR_PSC_SERVICE_ATTACHMENT" => {
+                    Self::NoNatSubnetsForPscServiceAttachment
+                }
+                "PSC_TRANSITIVITY_NOT_PROPAGATED" => Self::PscTransitivityNotPropagated,
+                "HYBRID_NEG_NON_DYNAMIC_ROUTE_MATCHED" => Self::HybridNegNonDynamicRouteMatched,
+                "HYBRID_NEG_NON_LOCAL_DYNAMIC_ROUTE_MATCHED" => {
+                    Self::HybridNegNonLocalDynamicRouteMatched
+                }
+                "CLOUD_RUN_REVISION_NOT_READY" => Self::CloudRunRevisionNotReady,
+                "DROPPED_INSIDE_PSC_SERVICE_PRODUCER" => Self::DroppedInsidePscServiceProducer,
+                "LOAD_BALANCER_HAS_NO_PROXY_SUBNET" => Self::LoadBalancerHasNoProxySubnet,
+                "CLOUD_NAT_NO_ADDRESSES" => Self::CloudNatNoAddresses,
+                "ROUTING_LOOP" => Self::RoutingLoop,
+                "DROPPED_INSIDE_GOOGLE_MANAGED_SERVICE" => Self::DroppedInsideGoogleManagedService,
+                "LOAD_BALANCER_BACKEND_INVALID_NETWORK" => Self::LoadBalancerBackendInvalidNetwork,
+                "BACKEND_SERVICE_NAMED_PORT_NOT_DEFINED" => Self::BackendServiceNamedPortNotDefined,
+                "DESTINATION_IS_PRIVATE_NAT_IP_RANGE" => Self::DestinationIsPrivateNatIpRange,
+                "DROPPED_INSIDE_REDIS_INSTANCE_SERVICE" => Self::DroppedInsideRedisInstanceService,
+                "REDIS_INSTANCE_UNSUPPORTED_PORT" => Self::RedisInstanceUnsupportedPort,
+                "REDIS_INSTANCE_CONNECTING_FROM_PUPI_ADDRESS" => {
+                    Self::RedisInstanceConnectingFromPupiAddress
+                }
+                "REDIS_INSTANCE_NO_ROUTE_TO_DESTINATION_NETWORK" => {
+                    Self::RedisInstanceNoRouteToDestinationNetwork
+                }
+                "REDIS_INSTANCE_NO_EXTERNAL_IP" => Self::RedisInstanceNoExternalIp,
+                "REDIS_INSTANCE_UNSUPPORTED_PROTOCOL" => Self::RedisInstanceUnsupportedProtocol,
+                "DROPPED_INSIDE_REDIS_CLUSTER_SERVICE" => Self::DroppedInsideRedisClusterService,
+                "REDIS_CLUSTER_UNSUPPORTED_PORT" => Self::RedisClusterUnsupportedPort,
+                "REDIS_CLUSTER_NO_EXTERNAL_IP" => Self::RedisClusterNoExternalIp,
+                "REDIS_CLUSTER_UNSUPPORTED_PROTOCOL" => Self::RedisClusterUnsupportedProtocol,
+                "NO_ADVERTISED_ROUTE_TO_GCP_DESTINATION" => Self::NoAdvertisedRouteToGcpDestination,
+                "NO_TRAFFIC_SELECTOR_TO_GCP_DESTINATION" => Self::NoTrafficSelectorToGcpDestination,
+                "NO_KNOWN_ROUTE_FROM_PEERED_NETWORK_TO_DESTINATION" => {
+                    Self::NoKnownRouteFromPeeredNetworkToDestination
+                }
+                "PRIVATE_NAT_TO_PSC_ENDPOINT_UNSUPPORTED" => {
+                    Self::PrivateNatToPscEndpointUnsupported
+                }
+                "PSC_PORT_MAPPING_PORT_MISMATCH" => Self::PscPortMappingPortMismatch,
+                "PSC_PORT_MAPPING_WITHOUT_PSC_CONNECTION_UNSUPPORTED" => {
+                    Self::PscPortMappingWithoutPscConnectionUnsupported
+                }
+                "UNSUPPORTED_ROUTE_MATCHED_FOR_NAT64_DESTINATION" => {
+                    Self::UnsupportedRouteMatchedForNat64Destination
+                }
+                _ => Self::UnknownValue(cause::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Cause {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UnknownExternalAddress => serializer.serialize_i32(1),
+                Self::ForeignIpDisallowed => serializer.serialize_i32(2),
+                Self::FirewallRule => serializer.serialize_i32(3),
+                Self::NoRoute => serializer.serialize_i32(4),
+                Self::RouteBlackhole => serializer.serialize_i32(5),
+                Self::RouteWrongNetwork => serializer.serialize_i32(6),
+                Self::RouteNextHopIpAddressNotResolved => serializer.serialize_i32(42),
+                Self::RouteNextHopResourceNotFound => serializer.serialize_i32(43),
+                Self::RouteNextHopInstanceWrongNetwork => serializer.serialize_i32(49),
+                Self::RouteNextHopInstanceNonPrimaryIp => serializer.serialize_i32(50),
+                Self::RouteNextHopForwardingRuleIpMismatch => serializer.serialize_i32(51),
+                Self::RouteNextHopVpnTunnelNotEstablished => serializer.serialize_i32(52),
+                Self::RouteNextHopForwardingRuleTypeInvalid => serializer.serialize_i32(53),
+                Self::NoRouteFromInternetToPrivateIpv6Address => serializer.serialize_i32(44),
+                Self::VpnTunnelLocalSelectorMismatch => serializer.serialize_i32(45),
+                Self::VpnTunnelRemoteSelectorMismatch => serializer.serialize_i32(46),
+                Self::PrivateTrafficToInternet => serializer.serialize_i32(7),
+                Self::PrivateGoogleAccessDisallowed => serializer.serialize_i32(8),
+                Self::PrivateGoogleAccessViaVpnTunnelUnsupported => serializer.serialize_i32(47),
+                Self::NoExternalAddress => serializer.serialize_i32(9),
+                Self::UnknownInternalAddress => serializer.serialize_i32(10),
+                Self::ForwardingRuleMismatch => serializer.serialize_i32(11),
+                Self::ForwardingRuleNoInstances => serializer.serialize_i32(12),
+                Self::FirewallBlockingLoadBalancerBackendHealthCheck => {
+                    serializer.serialize_i32(13)
+                }
+                Self::IngressFirewallTagsUnsupportedByDirectVpcEgress => {
+                    serializer.serialize_i32(85)
+                }
+                Self::InstanceNotRunning => serializer.serialize_i32(14),
+                Self::GkeClusterNotRunning => serializer.serialize_i32(27),
+                Self::CloudSqlInstanceNotRunning => serializer.serialize_i32(28),
+                Self::RedisInstanceNotRunning => serializer.serialize_i32(68),
+                Self::RedisClusterNotRunning => serializer.serialize_i32(69),
+                Self::TrafficTypeBlocked => serializer.serialize_i32(15),
+                Self::GkeMasterUnauthorizedAccess => serializer.serialize_i32(16),
+                Self::CloudSqlInstanceUnauthorizedAccess => serializer.serialize_i32(17),
+                Self::DroppedInsideGkeService => serializer.serialize_i32(18),
+                Self::DroppedInsideCloudSqlService => serializer.serialize_i32(19),
+                Self::GoogleManagedServiceNoPeering => serializer.serialize_i32(20),
+                Self::GoogleManagedServiceNoPscEndpoint => serializer.serialize_i32(38),
+                Self::GkePscEndpointMissing => serializer.serialize_i32(36),
+                Self::CloudSqlInstanceNoIpAddress => serializer.serialize_i32(21),
+                Self::GkeControlPlaneRegionMismatch => serializer.serialize_i32(30),
+                Self::PublicGkeControlPlaneToPrivateDestination => serializer.serialize_i32(31),
+                Self::GkeControlPlaneNoRoute => serializer.serialize_i32(32),
+                Self::CloudSqlInstanceNotConfiguredForExternalTraffic => {
+                    serializer.serialize_i32(33)
+                }
+                Self::PublicCloudSqlInstanceToPrivateDestination => serializer.serialize_i32(34),
+                Self::CloudSqlInstanceNoRoute => serializer.serialize_i32(35),
+                Self::CloudSqlConnectorRequired => serializer.serialize_i32(63),
+                Self::CloudFunctionNotActive => serializer.serialize_i32(22),
+                Self::VpcConnectorNotSet => serializer.serialize_i32(23),
+                Self::VpcConnectorNotRunning => serializer.serialize_i32(24),
+                Self::VpcConnectorServerlessTrafficBlocked => serializer.serialize_i32(60),
+                Self::VpcConnectorHealthCheckTrafficBlocked => serializer.serialize_i32(61),
+                Self::ForwardingRuleRegionMismatch => serializer.serialize_i32(25),
+                Self::PscConnectionNotAccepted => serializer.serialize_i32(26),
+                Self::PscEndpointAccessedFromPeeredNetwork => serializer.serialize_i32(41),
+                Self::PscNegProducerEndpointNoGlobalAccess => serializer.serialize_i32(48),
+                Self::PscNegProducerForwardingRuleMultiplePorts => serializer.serialize_i32(54),
+                Self::CloudSqlPscNegUnsupported => serializer.serialize_i32(58),
+                Self::NoNatSubnetsForPscServiceAttachment => serializer.serialize_i32(57),
+                Self::PscTransitivityNotPropagated => serializer.serialize_i32(64),
+                Self::HybridNegNonDynamicRouteMatched => serializer.serialize_i32(55),
+                Self::HybridNegNonLocalDynamicRouteMatched => serializer.serialize_i32(56),
+                Self::CloudRunRevisionNotReady => serializer.serialize_i32(29),
+                Self::DroppedInsidePscServiceProducer => serializer.serialize_i32(37),
+                Self::LoadBalancerHasNoProxySubnet => serializer.serialize_i32(39),
+                Self::CloudNatNoAddresses => serializer.serialize_i32(40),
+                Self::RoutingLoop => serializer.serialize_i32(59),
+                Self::DroppedInsideGoogleManagedService => serializer.serialize_i32(62),
+                Self::LoadBalancerBackendInvalidNetwork => serializer.serialize_i32(65),
+                Self::BackendServiceNamedPortNotDefined => serializer.serialize_i32(66),
+                Self::DestinationIsPrivateNatIpRange => serializer.serialize_i32(67),
+                Self::DroppedInsideRedisInstanceService => serializer.serialize_i32(70),
+                Self::RedisInstanceUnsupportedPort => serializer.serialize_i32(71),
+                Self::RedisInstanceConnectingFromPupiAddress => serializer.serialize_i32(72),
+                Self::RedisInstanceNoRouteToDestinationNetwork => serializer.serialize_i32(73),
+                Self::RedisInstanceNoExternalIp => serializer.serialize_i32(74),
+                Self::RedisInstanceUnsupportedProtocol => serializer.serialize_i32(78),
+                Self::DroppedInsideRedisClusterService => serializer.serialize_i32(75),
+                Self::RedisClusterUnsupportedPort => serializer.serialize_i32(76),
+                Self::RedisClusterNoExternalIp => serializer.serialize_i32(77),
+                Self::RedisClusterUnsupportedProtocol => serializer.serialize_i32(79),
+                Self::NoAdvertisedRouteToGcpDestination => serializer.serialize_i32(80),
+                Self::NoTrafficSelectorToGcpDestination => serializer.serialize_i32(81),
+                Self::NoKnownRouteFromPeeredNetworkToDestination => serializer.serialize_i32(82),
+                Self::PrivateNatToPscEndpointUnsupported => serializer.serialize_i32(83),
+                Self::PscPortMappingPortMismatch => serializer.serialize_i32(86),
+                Self::PscPortMappingWithoutPscConnectionUnsupported => serializer.serialize_i32(87),
+                Self::UnsupportedRouteMatchedForNat64Destination => serializer.serialize_i32(88),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Cause {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Cause>::new(
+                ".google.cloud.networkmanagement.v1.DropInfo.Cause",
+            ))
         }
     }
 }
@@ -7785,71 +9393,134 @@ pub mod nat_info {
     use super::*;
 
     /// Types of NAT.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Type is unspecified.
+        Unspecified,
+        /// From Compute Engine instance's internal address to external address.
+        InternalToExternal,
+        /// From Compute Engine instance's external address to internal address.
+        ExternalToInternal,
+        /// Cloud NAT Gateway.
+        CloudNat,
+        /// Private service connect NAT.
+        PrivateServiceConnect,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Type is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// From Compute Engine instance's internal address to external address.
-        pub const INTERNAL_TO_EXTERNAL: Type = Type::new(1);
-
-        /// From Compute Engine instance's external address to internal address.
-        pub const EXTERNAL_TO_INTERNAL: Type = Type::new(2);
-
-        /// Cloud NAT Gateway.
-        pub const CLOUD_NAT: Type = Type::new(3);
-
-        /// Private service connect NAT.
-        pub const PRIVATE_SERVICE_CONNECT: Type = Type::new(4);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InternalToExternal => std::option::Option::Some(1),
+                Self::ExternalToInternal => std::option::Option::Some(2),
+                Self::CloudNat => std::option::Option::Some(3),
+                Self::PrivateServiceConnect => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTERNAL_TO_EXTERNAL"),
-                2 => std::borrow::Cow::Borrowed("EXTERNAL_TO_INTERNAL"),
-                3 => std::borrow::Cow::Borrowed("CLOUD_NAT"),
-                4 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_CONNECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::InternalToExternal => std::option::Option::Some("INTERNAL_TO_EXTERNAL"),
+                Self::ExternalToInternal => std::option::Option::Some("EXTERNAL_TO_INTERNAL"),
+                Self::CloudNat => std::option::Option::Some("CLOUD_NAT"),
+                Self::PrivateServiceConnect => std::option::Option::Some("PRIVATE_SERVICE_CONNECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "INTERNAL_TO_EXTERNAL" => std::option::Option::Some(Self::INTERNAL_TO_EXTERNAL),
-                "EXTERNAL_TO_INTERNAL" => std::option::Option::Some(Self::EXTERNAL_TO_INTERNAL),
-                "CLOUD_NAT" => std::option::Option::Some(Self::CLOUD_NAT),
-                "PRIVATE_SERVICE_CONNECT" => {
-                    std::option::Option::Some(Self::PRIVATE_SERVICE_CONNECT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InternalToExternal,
+                2 => Self::ExternalToInternal,
+                3 => Self::CloudNat,
+                4 => Self::PrivateServiceConnect,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INTERNAL_TO_EXTERNAL" => Self::InternalToExternal,
+                "EXTERNAL_TO_INTERNAL" => Self::ExternalToInternal,
+                "CLOUD_NAT" => Self::CloudNat,
+                "PRIVATE_SERVICE_CONNECT" => Self::PrivateServiceConnect,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InternalToExternal => serializer.serialize_i32(1),
+                Self::ExternalToInternal => serializer.serialize_i32(2),
+                Self::CloudNat => serializer.serialize_i32(3),
+                Self::PrivateServiceConnect => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.networkmanagement.v1.NatInfo.Type",
+            ))
         }
     }
 }
@@ -8160,88 +9831,147 @@ pub mod load_balancer_backend_info {
     use super::*;
 
     /// Health check firewalls configuration state enum.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HealthCheckFirewallsConfigState(i32);
-
-    impl HealthCheckFirewallsConfigState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HealthCheckFirewallsConfigState {
         /// Configuration state unspecified. It usually means that the backend has
         /// no health check attached, or there was an unexpected configuration error
         /// preventing Connectivity tests from verifying health check configuration.
-        pub const HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new(0);
-
+        Unspecified,
         /// Firewall rules (policies) allowing health check traffic from all required
         /// IP ranges to the backend are configured.
-        pub const FIREWALLS_CONFIGURED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new(1);
-
+        FirewallsConfigured,
         /// Firewall rules (policies) allow health check traffic only from a part of
         /// required IP ranges.
-        pub const FIREWALLS_PARTIALLY_CONFIGURED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new(2);
-
+        FirewallsPartiallyConfigured,
         /// Firewall rules (policies) deny health check traffic from all required
         /// IP ranges to the backend.
-        pub const FIREWALLS_NOT_CONFIGURED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new(3);
-
+        FirewallsNotConfigured,
         /// The network contains firewall rules of unsupported types, so Connectivity
         /// tests were not able to verify health check configuration status. Please
         /// refer to the documentation for the list of unsupported configurations:
         /// <https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/concepts/overview#unsupported-configs>
-        pub const FIREWALLS_UNSUPPORTED: HealthCheckFirewallsConfigState =
-            HealthCheckFirewallsConfigState::new(4);
+        FirewallsUnsupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HealthCheckFirewallsConfigState::value] or
+        /// [HealthCheckFirewallsConfigState::name].
+        UnknownValue(health_check_firewalls_config_state::UnknownValue),
+    }
 
-        /// Creates a new HealthCheckFirewallsConfigState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod health_check_firewalls_config_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl HealthCheckFirewallsConfigState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FirewallsConfigured => std::option::Option::Some(1),
+                Self::FirewallsPartiallyConfigured => std::option::Option::Some(2),
+                Self::FirewallsNotConfigured => std::option::Option::Some(3),
+                Self::FirewallsUnsupported => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIREWALLS_CONFIGURED"),
-                2 => std::borrow::Cow::Borrowed("FIREWALLS_PARTIALLY_CONFIGURED"),
-                3 => std::borrow::Cow::Borrowed("FIREWALLS_NOT_CONFIGURED"),
-                4 => std::borrow::Cow::Borrowed("FIREWALLS_UNSUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED")
+                }
+                Self::FirewallsConfigured => std::option::Option::Some("FIREWALLS_CONFIGURED"),
+                Self::FirewallsPartiallyConfigured => {
+                    std::option::Option::Some("FIREWALLS_PARTIALLY_CONFIGURED")
+                }
+                Self::FirewallsNotConfigured => {
+                    std::option::Option::Some("FIREWALLS_NOT_CONFIGURED")
+                }
+                Self::FirewallsUnsupported => std::option::Option::Some("FIREWALLS_UNSUPPORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED)
-                }
-                "FIREWALLS_CONFIGURED" => std::option::Option::Some(Self::FIREWALLS_CONFIGURED),
-                "FIREWALLS_PARTIALLY_CONFIGURED" => {
-                    std::option::Option::Some(Self::FIREWALLS_PARTIALLY_CONFIGURED)
-                }
-                "FIREWALLS_NOT_CONFIGURED" => {
-                    std::option::Option::Some(Self::FIREWALLS_NOT_CONFIGURED)
-                }
-                "FIREWALLS_UNSUPPORTED" => std::option::Option::Some(Self::FIREWALLS_UNSUPPORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HealthCheckFirewallsConfigState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HealthCheckFirewallsConfigState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HealthCheckFirewallsConfigState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HealthCheckFirewallsConfigState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FirewallsConfigured,
+                2 => Self::FirewallsPartiallyConfigured,
+                3 => Self::FirewallsNotConfigured,
+                4 => Self::FirewallsUnsupported,
+                _ => Self::UnknownValue(health_check_firewalls_config_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HealthCheckFirewallsConfigState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HEALTH_CHECK_FIREWALLS_CONFIG_STATE_UNSPECIFIED" => Self::Unspecified,
+                "FIREWALLS_CONFIGURED" => Self::FirewallsConfigured,
+                "FIREWALLS_PARTIALLY_CONFIGURED" => Self::FirewallsPartiallyConfigured,
+                "FIREWALLS_NOT_CONFIGURED" => Self::FirewallsNotConfigured,
+                "FIREWALLS_UNSUPPORTED" => Self::FirewallsUnsupported,
+                _ => Self::UnknownValue(health_check_firewalls_config_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HealthCheckFirewallsConfigState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FirewallsConfigured => serializer.serialize_i32(1),
+                Self::FirewallsPartiallyConfigured => serializer.serialize_i32(2),
+                Self::FirewallsNotConfigured => serializer.serialize_i32(3),
+                Self::FirewallsUnsupported => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HealthCheckFirewallsConfigState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HealthCheckFirewallsConfigState>::new(
+                ".google.cloud.networkmanagement.v1.LoadBalancerBackendInfo.HealthCheckFirewallsConfigState"))
         }
     }
 }
@@ -8927,264 +10657,512 @@ pub mod vpc_flow_logs_config {
 
     /// Determines whether this configuration will be generating logs.
     /// Setting state=DISABLED will pause the log generation for this config.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// If not specified, will default to ENABLED.
+        Unspecified,
+        /// When ENABLED, this configuration will generate logs.
+        Enabled,
+        /// When DISABLED, this configuration will not generate logs.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// If not specified, will default to ENABLED.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// When ENABLED, this configuration will generate logs.
-        pub const ENABLED: State = State::new(1);
-
-        /// When DISABLED, this configuration will not generate logs.
-        pub const DISABLED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.networkmanagement.v1.VpcFlowLogsConfig.State",
+            ))
         }
     }
 
     /// Toggles the aggregation interval for collecting flow logs by 5-tuple.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationInterval(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AggregationInterval {
+        /// If not specified, will default to INTERVAL_5_SEC.
+        Unspecified,
+        /// Aggregate logs in 5s intervals.
+        Interval5Sec,
+        /// Aggregate logs in 30s intervals.
+        Interval30Sec,
+        /// Aggregate logs in 1m intervals.
+        Interval1Min,
+        /// Aggregate logs in 5m intervals.
+        Interval5Min,
+        /// Aggregate logs in 10m intervals.
+        Interval10Min,
+        /// Aggregate logs in 15m intervals.
+        Interval15Min,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AggregationInterval::value] or
+        /// [AggregationInterval::name].
+        UnknownValue(aggregation_interval::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod aggregation_interval {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AggregationInterval {
-        /// If not specified, will default to INTERVAL_5_SEC.
-        pub const AGGREGATION_INTERVAL_UNSPECIFIED: AggregationInterval =
-            AggregationInterval::new(0);
-
-        /// Aggregate logs in 5s intervals.
-        pub const INTERVAL_5_SEC: AggregationInterval = AggregationInterval::new(1);
-
-        /// Aggregate logs in 30s intervals.
-        pub const INTERVAL_30_SEC: AggregationInterval = AggregationInterval::new(2);
-
-        /// Aggregate logs in 1m intervals.
-        pub const INTERVAL_1_MIN: AggregationInterval = AggregationInterval::new(3);
-
-        /// Aggregate logs in 5m intervals.
-        pub const INTERVAL_5_MIN: AggregationInterval = AggregationInterval::new(4);
-
-        /// Aggregate logs in 10m intervals.
-        pub const INTERVAL_10_MIN: AggregationInterval = AggregationInterval::new(5);
-
-        /// Aggregate logs in 15m intervals.
-        pub const INTERVAL_15_MIN: AggregationInterval = AggregationInterval::new(6);
-
-        /// Creates a new AggregationInterval instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Interval5Sec => std::option::Option::Some(1),
+                Self::Interval30Sec => std::option::Option::Some(2),
+                Self::Interval1Min => std::option::Option::Some(3),
+                Self::Interval5Min => std::option::Option::Some(4),
+                Self::Interval10Min => std::option::Option::Some(5),
+                Self::Interval15Min => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AGGREGATION_INTERVAL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTERVAL_5_SEC"),
-                2 => std::borrow::Cow::Borrowed("INTERVAL_30_SEC"),
-                3 => std::borrow::Cow::Borrowed("INTERVAL_1_MIN"),
-                4 => std::borrow::Cow::Borrowed("INTERVAL_5_MIN"),
-                5 => std::borrow::Cow::Borrowed("INTERVAL_10_MIN"),
-                6 => std::borrow::Cow::Borrowed("INTERVAL_15_MIN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AGGREGATION_INTERVAL_UNSPECIFIED"),
+                Self::Interval5Sec => std::option::Option::Some("INTERVAL_5_SEC"),
+                Self::Interval30Sec => std::option::Option::Some("INTERVAL_30_SEC"),
+                Self::Interval1Min => std::option::Option::Some("INTERVAL_1_MIN"),
+                Self::Interval5Min => std::option::Option::Some("INTERVAL_5_MIN"),
+                Self::Interval10Min => std::option::Option::Some("INTERVAL_10_MIN"),
+                Self::Interval15Min => std::option::Option::Some("INTERVAL_15_MIN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AGGREGATION_INTERVAL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AGGREGATION_INTERVAL_UNSPECIFIED)
-                }
-                "INTERVAL_5_SEC" => std::option::Option::Some(Self::INTERVAL_5_SEC),
-                "INTERVAL_30_SEC" => std::option::Option::Some(Self::INTERVAL_30_SEC),
-                "INTERVAL_1_MIN" => std::option::Option::Some(Self::INTERVAL_1_MIN),
-                "INTERVAL_5_MIN" => std::option::Option::Some(Self::INTERVAL_5_MIN),
-                "INTERVAL_10_MIN" => std::option::Option::Some(Self::INTERVAL_10_MIN),
-                "INTERVAL_15_MIN" => std::option::Option::Some(Self::INTERVAL_15_MIN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AggregationInterval {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationInterval {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AggregationInterval {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AggregationInterval {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Interval5Sec,
+                2 => Self::Interval30Sec,
+                3 => Self::Interval1Min,
+                4 => Self::Interval5Min,
+                5 => Self::Interval10Min,
+                6 => Self::Interval15Min,
+                _ => Self::UnknownValue(aggregation_interval::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AggregationInterval {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AGGREGATION_INTERVAL_UNSPECIFIED" => Self::Unspecified,
+                "INTERVAL_5_SEC" => Self::Interval5Sec,
+                "INTERVAL_30_SEC" => Self::Interval30Sec,
+                "INTERVAL_1_MIN" => Self::Interval1Min,
+                "INTERVAL_5_MIN" => Self::Interval5Min,
+                "INTERVAL_10_MIN" => Self::Interval10Min,
+                "INTERVAL_15_MIN" => Self::Interval15Min,
+                _ => Self::UnknownValue(aggregation_interval::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AggregationInterval {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Interval5Sec => serializer.serialize_i32(1),
+                Self::Interval30Sec => serializer.serialize_i32(2),
+                Self::Interval1Min => serializer.serialize_i32(3),
+                Self::Interval5Min => serializer.serialize_i32(4),
+                Self::Interval10Min => serializer.serialize_i32(5),
+                Self::Interval15Min => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AggregationInterval {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AggregationInterval>::new(
+                ".google.cloud.networkmanagement.v1.VpcFlowLogsConfig.AggregationInterval",
+            ))
         }
     }
 
     /// Configures which log fields would be included.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Metadata(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Metadata {
+        /// If not specified, will default to INCLUDE_ALL_METADATA.
+        Unspecified,
+        /// Include all metadata fields.
+        IncludeAllMetadata,
+        /// Exclude all metadata fields.
+        ExcludeAllMetadata,
+        /// Include only custom fields (specified in metadata_fields).
+        CustomMetadata,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Metadata::value] or
+        /// [Metadata::name].
+        UnknownValue(metadata::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod metadata {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Metadata {
-        /// If not specified, will default to INCLUDE_ALL_METADATA.
-        pub const METADATA_UNSPECIFIED: Metadata = Metadata::new(0);
-
-        /// Include all metadata fields.
-        pub const INCLUDE_ALL_METADATA: Metadata = Metadata::new(1);
-
-        /// Exclude all metadata fields.
-        pub const EXCLUDE_ALL_METADATA: Metadata = Metadata::new(2);
-
-        /// Include only custom fields (specified in metadata_fields).
-        pub const CUSTOM_METADATA: Metadata = Metadata::new(3);
-
-        /// Creates a new Metadata instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::IncludeAllMetadata => std::option::Option::Some(1),
+                Self::ExcludeAllMetadata => std::option::Option::Some(2),
+                Self::CustomMetadata => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METADATA_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCLUDE_ALL_METADATA"),
-                2 => std::borrow::Cow::Borrowed("EXCLUDE_ALL_METADATA"),
-                3 => std::borrow::Cow::Borrowed("CUSTOM_METADATA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METADATA_UNSPECIFIED"),
+                Self::IncludeAllMetadata => std::option::Option::Some("INCLUDE_ALL_METADATA"),
+                Self::ExcludeAllMetadata => std::option::Option::Some("EXCLUDE_ALL_METADATA"),
+                Self::CustomMetadata => std::option::Option::Some("CUSTOM_METADATA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METADATA_UNSPECIFIED" => std::option::Option::Some(Self::METADATA_UNSPECIFIED),
-                "INCLUDE_ALL_METADATA" => std::option::Option::Some(Self::INCLUDE_ALL_METADATA),
-                "EXCLUDE_ALL_METADATA" => std::option::Option::Some(Self::EXCLUDE_ALL_METADATA),
-                "CUSTOM_METADATA" => std::option::Option::Some(Self::CUSTOM_METADATA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Metadata {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Metadata {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Metadata {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Metadata {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::IncludeAllMetadata,
+                2 => Self::ExcludeAllMetadata,
+                3 => Self::CustomMetadata,
+                _ => Self::UnknownValue(metadata::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Metadata {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METADATA_UNSPECIFIED" => Self::Unspecified,
+                "INCLUDE_ALL_METADATA" => Self::IncludeAllMetadata,
+                "EXCLUDE_ALL_METADATA" => Self::ExcludeAllMetadata,
+                "CUSTOM_METADATA" => Self::CustomMetadata,
+                _ => Self::UnknownValue(metadata::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Metadata {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::IncludeAllMetadata => serializer.serialize_i32(1),
+                Self::ExcludeAllMetadata => serializer.serialize_i32(2),
+                Self::CustomMetadata => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Metadata {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Metadata>::new(
+                ".google.cloud.networkmanagement.v1.VpcFlowLogsConfig.Metadata",
+            ))
         }
     }
 
     /// Optional states of the target resource that are used as part of the
     /// diagnostic bit.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TargetResourceState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TargetResourceState {
+        /// Unspecified target resource state.
+        Unspecified,
+        /// Indicates that the target resource exists.
+        TargetResourceExists,
+        /// Indicates that the target resource does not exist.
+        TargetResourceDoesNotExist,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TargetResourceState::value] or
+        /// [TargetResourceState::name].
+        UnknownValue(target_resource_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod target_resource_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TargetResourceState {
-        /// Unspecified target resource state.
-        pub const TARGET_RESOURCE_STATE_UNSPECIFIED: TargetResourceState =
-            TargetResourceState::new(0);
-
-        /// Indicates that the target resource exists.
-        pub const TARGET_RESOURCE_EXISTS: TargetResourceState = TargetResourceState::new(1);
-
-        /// Indicates that the target resource does not exist.
-        pub const TARGET_RESOURCE_DOES_NOT_EXIST: TargetResourceState = TargetResourceState::new(2);
-
-        /// Creates a new TargetResourceState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TargetResourceExists => std::option::Option::Some(1),
+                Self::TargetResourceDoesNotExist => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TARGET_RESOURCE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TARGET_RESOURCE_EXISTS"),
-                2 => std::borrow::Cow::Borrowed("TARGET_RESOURCE_DOES_NOT_EXIST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TARGET_RESOURCE_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TARGET_RESOURCE_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TARGET_RESOURCE_STATE_UNSPECIFIED"),
+                Self::TargetResourceExists => std::option::Option::Some("TARGET_RESOURCE_EXISTS"),
+                Self::TargetResourceDoesNotExist => {
+                    std::option::Option::Some("TARGET_RESOURCE_DOES_NOT_EXIST")
                 }
-                "TARGET_RESOURCE_EXISTS" => std::option::Option::Some(Self::TARGET_RESOURCE_EXISTS),
-                "TARGET_RESOURCE_DOES_NOT_EXIST" => {
-                    std::option::Option::Some(Self::TARGET_RESOURCE_DOES_NOT_EXIST)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TargetResourceState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TargetResourceState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TargetResourceState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TargetResourceState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TargetResourceExists,
+                2 => Self::TargetResourceDoesNotExist,
+                _ => Self::UnknownValue(target_resource_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TargetResourceState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TARGET_RESOURCE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "TARGET_RESOURCE_EXISTS" => Self::TargetResourceExists,
+                "TARGET_RESOURCE_DOES_NOT_EXIST" => Self::TargetResourceDoesNotExist,
+                _ => Self::UnknownValue(target_resource_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TargetResourceState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TargetResourceExists => serializer.serialize_i32(1),
+                Self::TargetResourceDoesNotExist => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TargetResourceState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TargetResourceState>::new(
+                ".google.cloud.networkmanagement.v1.VpcFlowLogsConfig.TargetResourceState",
+            ))
         }
     }
 
@@ -9208,113 +11186,188 @@ pub mod vpc_flow_logs_config {
 /// Type of a load balancer. For more information, see [Summary of Google Cloud
 /// load
 /// balancers](https://cloud.google.com/load-balancing/docs/load-balancing-overview#summary-of-google-cloud-load-balancers).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LoadBalancerType(i32);
-
-impl LoadBalancerType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LoadBalancerType {
     /// Forwarding rule points to a different target than a load balancer or a
     /// load balancer type is unknown.
-    pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType = LoadBalancerType::new(0);
-
+    Unspecified,
     /// Global external HTTP(S) load balancer.
-    pub const HTTPS_ADVANCED_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(1);
-
+    HttpsAdvancedLoadBalancer,
     /// Global external HTTP(S) load balancer (classic)
-    pub const HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(2);
-
+    HttpsLoadBalancer,
     /// Regional external HTTP(S) load balancer.
-    pub const REGIONAL_HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(3);
-
+    RegionalHttpsLoadBalancer,
     /// Internal HTTP(S) load balancer.
-    pub const INTERNAL_HTTPS_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(4);
-
+    InternalHttpsLoadBalancer,
     /// External SSL proxy load balancer.
-    pub const SSL_PROXY_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(5);
-
+    SslProxyLoadBalancer,
     /// External TCP proxy load balancer.
-    pub const TCP_PROXY_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(6);
-
+    TcpProxyLoadBalancer,
     /// Internal regional TCP proxy load balancer.
-    pub const INTERNAL_TCP_PROXY_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(7);
-
+    InternalTcpProxyLoadBalancer,
     /// External TCP/UDP Network load balancer.
-    pub const NETWORK_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(8);
-
+    NetworkLoadBalancer,
     /// Target-pool based external TCP/UDP Network load balancer.
-    pub const LEGACY_NETWORK_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(9);
-
+    LegacyNetworkLoadBalancer,
     /// Internal TCP/UDP load balancer.
-    pub const TCP_UDP_INTERNAL_LOAD_BALANCER: LoadBalancerType = LoadBalancerType::new(10);
+    TcpUdpInternalLoadBalancer,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LoadBalancerType::value] or
+    /// [LoadBalancerType::name].
+    UnknownValue(load_balancer_type::UnknownValue),
+}
 
-    /// Creates a new LoadBalancerType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod load_balancer_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LoadBalancerType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::HttpsAdvancedLoadBalancer => std::option::Option::Some(1),
+            Self::HttpsLoadBalancer => std::option::Option::Some(2),
+            Self::RegionalHttpsLoadBalancer => std::option::Option::Some(3),
+            Self::InternalHttpsLoadBalancer => std::option::Option::Some(4),
+            Self::SslProxyLoadBalancer => std::option::Option::Some(5),
+            Self::TcpProxyLoadBalancer => std::option::Option::Some(6),
+            Self::InternalTcpProxyLoadBalancer => std::option::Option::Some(7),
+            Self::NetworkLoadBalancer => std::option::Option::Some(8),
+            Self::LegacyNetworkLoadBalancer => std::option::Option::Some(9),
+            Self::TcpUdpInternalLoadBalancer => std::option::Option::Some(10),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HTTPS_ADVANCED_LOAD_BALANCER"),
-            2 => std::borrow::Cow::Borrowed("HTTPS_LOAD_BALANCER"),
-            3 => std::borrow::Cow::Borrowed("REGIONAL_HTTPS_LOAD_BALANCER"),
-            4 => std::borrow::Cow::Borrowed("INTERNAL_HTTPS_LOAD_BALANCER"),
-            5 => std::borrow::Cow::Borrowed("SSL_PROXY_LOAD_BALANCER"),
-            6 => std::borrow::Cow::Borrowed("TCP_PROXY_LOAD_BALANCER"),
-            7 => std::borrow::Cow::Borrowed("INTERNAL_TCP_PROXY_LOAD_BALANCER"),
-            8 => std::borrow::Cow::Borrowed("NETWORK_LOAD_BALANCER"),
-            9 => std::borrow::Cow::Borrowed("LEGACY_NETWORK_LOAD_BALANCER"),
-            10 => std::borrow::Cow::Borrowed("TCP_UDP_INTERNAL_LOAD_BALANCER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LOAD_BALANCER_TYPE_UNSPECIFIED"),
+            Self::HttpsAdvancedLoadBalancer => {
+                std::option::Option::Some("HTTPS_ADVANCED_LOAD_BALANCER")
+            }
+            Self::HttpsLoadBalancer => std::option::Option::Some("HTTPS_LOAD_BALANCER"),
+            Self::RegionalHttpsLoadBalancer => {
+                std::option::Option::Some("REGIONAL_HTTPS_LOAD_BALANCER")
+            }
+            Self::InternalHttpsLoadBalancer => {
+                std::option::Option::Some("INTERNAL_HTTPS_LOAD_BALANCER")
+            }
+            Self::SslProxyLoadBalancer => std::option::Option::Some("SSL_PROXY_LOAD_BALANCER"),
+            Self::TcpProxyLoadBalancer => std::option::Option::Some("TCP_PROXY_LOAD_BALANCER"),
+            Self::InternalTcpProxyLoadBalancer => {
+                std::option::Option::Some("INTERNAL_TCP_PROXY_LOAD_BALANCER")
+            }
+            Self::NetworkLoadBalancer => std::option::Option::Some("NETWORK_LOAD_BALANCER"),
+            Self::LegacyNetworkLoadBalancer => {
+                std::option::Option::Some("LEGACY_NETWORK_LOAD_BALANCER")
+            }
+            Self::TcpUdpInternalLoadBalancer => {
+                std::option::Option::Some("TCP_UDP_INTERNAL_LOAD_BALANCER")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LOAD_BALANCER_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LOAD_BALANCER_TYPE_UNSPECIFIED)
-            }
-            "HTTPS_ADVANCED_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::HTTPS_ADVANCED_LOAD_BALANCER)
-            }
-            "HTTPS_LOAD_BALANCER" => std::option::Option::Some(Self::HTTPS_LOAD_BALANCER),
-            "REGIONAL_HTTPS_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::REGIONAL_HTTPS_LOAD_BALANCER)
-            }
-            "INTERNAL_HTTPS_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::INTERNAL_HTTPS_LOAD_BALANCER)
-            }
-            "SSL_PROXY_LOAD_BALANCER" => std::option::Option::Some(Self::SSL_PROXY_LOAD_BALANCER),
-            "TCP_PROXY_LOAD_BALANCER" => std::option::Option::Some(Self::TCP_PROXY_LOAD_BALANCER),
-            "INTERNAL_TCP_PROXY_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::INTERNAL_TCP_PROXY_LOAD_BALANCER)
-            }
-            "NETWORK_LOAD_BALANCER" => std::option::Option::Some(Self::NETWORK_LOAD_BALANCER),
-            "LEGACY_NETWORK_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::LEGACY_NETWORK_LOAD_BALANCER)
-            }
-            "TCP_UDP_INTERNAL_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::TCP_UDP_INTERNAL_LOAD_BALANCER)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LoadBalancerType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LoadBalancerType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LoadBalancerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LoadBalancerType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::HttpsAdvancedLoadBalancer,
+            2 => Self::HttpsLoadBalancer,
+            3 => Self::RegionalHttpsLoadBalancer,
+            4 => Self::InternalHttpsLoadBalancer,
+            5 => Self::SslProxyLoadBalancer,
+            6 => Self::TcpProxyLoadBalancer,
+            7 => Self::InternalTcpProxyLoadBalancer,
+            8 => Self::NetworkLoadBalancer,
+            9 => Self::LegacyNetworkLoadBalancer,
+            10 => Self::TcpUdpInternalLoadBalancer,
+            _ => Self::UnknownValue(load_balancer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LoadBalancerType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LOAD_BALANCER_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "HTTPS_ADVANCED_LOAD_BALANCER" => Self::HttpsAdvancedLoadBalancer,
+            "HTTPS_LOAD_BALANCER" => Self::HttpsLoadBalancer,
+            "REGIONAL_HTTPS_LOAD_BALANCER" => Self::RegionalHttpsLoadBalancer,
+            "INTERNAL_HTTPS_LOAD_BALANCER" => Self::InternalHttpsLoadBalancer,
+            "SSL_PROXY_LOAD_BALANCER" => Self::SslProxyLoadBalancer,
+            "TCP_PROXY_LOAD_BALANCER" => Self::TcpProxyLoadBalancer,
+            "INTERNAL_TCP_PROXY_LOAD_BALANCER" => Self::InternalTcpProxyLoadBalancer,
+            "NETWORK_LOAD_BALANCER" => Self::NetworkLoadBalancer,
+            "LEGACY_NETWORK_LOAD_BALANCER" => Self::LegacyNetworkLoadBalancer,
+            "TCP_UDP_INTERNAL_LOAD_BALANCER" => Self::TcpUdpInternalLoadBalancer,
+            _ => Self::UnknownValue(load_balancer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LoadBalancerType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::HttpsAdvancedLoadBalancer => serializer.serialize_i32(1),
+            Self::HttpsLoadBalancer => serializer.serialize_i32(2),
+            Self::RegionalHttpsLoadBalancer => serializer.serialize_i32(3),
+            Self::InternalHttpsLoadBalancer => serializer.serialize_i32(4),
+            Self::SslProxyLoadBalancer => serializer.serialize_i32(5),
+            Self::TcpProxyLoadBalancer => serializer.serialize_i32(6),
+            Self::InternalTcpProxyLoadBalancer => serializer.serialize_i32(7),
+            Self::NetworkLoadBalancer => serializer.serialize_i32(8),
+            Self::LegacyNetworkLoadBalancer => serializer.serialize_i32(9),
+            Self::TcpUdpInternalLoadBalancer => serializer.serialize_i32(10),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LoadBalancerType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoadBalancerType>::new(
+            ".google.cloud.networkmanagement.v1.LoadBalancerType",
+        ))
     }
 }

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -488,61 +488,122 @@ pub mod authorization_policy {
     }
 
     /// Possible values that define what action to take.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
-
-    impl Action {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
         /// Default value.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
+        Unspecified,
         /// Grant access.
-        pub const ALLOW: Action = Action::new(1);
-
+        Allow,
         /// Deny access.
         /// Deny rules should be avoided unless they are used to provide a default
         /// "deny all" fallback.
-        pub const DENY: Action = Action::new(2);
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
 
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Action {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.cloud.networksecurity.v1.AuthorizationPolicy.Action",
+            ))
         }
     }
 }

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -391,64 +391,126 @@ pub mod endpoint_matcher {
         }
 
         /// Possible criteria values that define logic of how matching is made.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MetadataLabelMatchCriteria(i32);
-
-        impl MetadataLabelMatchCriteria {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MetadataLabelMatchCriteria {
             /// Default value. Should not be used.
-            pub const METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED: MetadataLabelMatchCriteria =
-                MetadataLabelMatchCriteria::new(0);
-
+            Unspecified,
             /// At least one of the Labels specified in the matcher should match the
             /// metadata presented by xDS client.
-            pub const MATCH_ANY: MetadataLabelMatchCriteria = MetadataLabelMatchCriteria::new(1);
-
+            MatchAny,
             /// The metadata presented by the xDS client should contain all of the
             /// labels specified here.
-            pub const MATCH_ALL: MetadataLabelMatchCriteria = MetadataLabelMatchCriteria::new(2);
+            MatchAll,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MetadataLabelMatchCriteria::value] or
+            /// [MetadataLabelMatchCriteria::name].
+            UnknownValue(metadata_label_match_criteria::UnknownValue),
+        }
 
-            /// Creates a new MetadataLabelMatchCriteria instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod metadata_label_match_criteria {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl MetadataLabelMatchCriteria {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::MatchAny => std::option::Option::Some(1),
+                    Self::MatchAll => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MATCH_ANY"),
-                    2 => std::borrow::Cow::Borrowed("MATCH_ALL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED")
                     }
-                    "MATCH_ANY" => std::option::Option::Some(Self::MATCH_ANY),
-                    "MATCH_ALL" => std::option::Option::Some(Self::MATCH_ALL),
-                    _ => std::option::Option::None,
+                    Self::MatchAny => std::option::Option::Some("MATCH_ANY"),
+                    Self::MatchAll => std::option::Option::Some("MATCH_ALL"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for MetadataLabelMatchCriteria {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MetadataLabelMatchCriteria {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MetadataLabelMatchCriteria {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MetadataLabelMatchCriteria {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::MatchAny,
+                    2 => Self::MatchAll,
+                    _ => Self::UnknownValue(metadata_label_match_criteria::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MetadataLabelMatchCriteria {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "METADATA_LABEL_MATCH_CRITERIA_UNSPECIFIED" => Self::Unspecified,
+                    "MATCH_ANY" => Self::MatchAny,
+                    "MATCH_ALL" => Self::MatchAll,
+                    _ => Self::UnknownValue(metadata_label_match_criteria::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MetadataLabelMatchCriteria {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::MatchAny => serializer.serialize_i32(1),
+                    Self::MatchAll => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MetadataLabelMatchCriteria {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetadataLabelMatchCriteria>::new(
+                    ".google.cloud.networkservices.v1.EndpointMatcher.MetadataLabelMatcher.MetadataLabelMatchCriteria"))
             }
         }
     }
@@ -2051,61 +2113,120 @@ pub mod endpoint_policy {
     use super::*;
 
     /// The type of endpoint policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EndpointPolicyType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EndpointPolicyType {
+        /// Default value. Must not be used.
+        Unspecified,
+        /// Represents a proxy deployed as a sidecar.
+        SidecarProxy,
+        /// Represents a proxyless gRPC backend.
+        GrpcServer,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EndpointPolicyType::value] or
+        /// [EndpointPolicyType::name].
+        UnknownValue(endpoint_policy_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod endpoint_policy_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EndpointPolicyType {
-        /// Default value. Must not be used.
-        pub const ENDPOINT_POLICY_TYPE_UNSPECIFIED: EndpointPolicyType = EndpointPolicyType::new(0);
-
-        /// Represents a proxy deployed as a sidecar.
-        pub const SIDECAR_PROXY: EndpointPolicyType = EndpointPolicyType::new(1);
-
-        /// Represents a proxyless gRPC backend.
-        pub const GRPC_SERVER: EndpointPolicyType = EndpointPolicyType::new(2);
-
-        /// Creates a new EndpointPolicyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SidecarProxy => std::option::Option::Some(1),
+                Self::GrpcServer => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENDPOINT_POLICY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SIDECAR_PROXY"),
-                2 => std::borrow::Cow::Borrowed("GRPC_SERVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENDPOINT_POLICY_TYPE_UNSPECIFIED"),
+                Self::SidecarProxy => std::option::Option::Some("SIDECAR_PROXY"),
+                Self::GrpcServer => std::option::Option::Some("GRPC_SERVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENDPOINT_POLICY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENDPOINT_POLICY_TYPE_UNSPECIFIED)
-                }
-                "SIDECAR_PROXY" => std::option::Option::Some(Self::SIDECAR_PROXY),
-                "GRPC_SERVER" => std::option::Option::Some(Self::GRPC_SERVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EndpointPolicyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EndpointPolicyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EndpointPolicyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EndpointPolicyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SidecarProxy,
+                2 => Self::GrpcServer,
+                _ => Self::UnknownValue(endpoint_policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EndpointPolicyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENDPOINT_POLICY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SIDECAR_PROXY" => Self::SidecarProxy,
+                "GRPC_SERVER" => Self::GrpcServer,
+                _ => Self::UnknownValue(endpoint_policy_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EndpointPolicyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SidecarProxy => serializer.serialize_i32(1),
+                Self::GrpcServer => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EndpointPolicyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EndpointPolicyType>::new(
+                ".google.cloud.networkservices.v1.EndpointPolicy.EndpointPolicyType",
+            ))
         }
     }
 }
@@ -2579,60 +2700,121 @@ pub mod gateway {
     ///
     /// * OPEN_MESH
     /// * SECURE_WEB_GATEWAY
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// The type of the customer managed gateway is unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The type of the customer managed gateway is TrafficDirector Open
         /// Mesh.
-        pub const OPEN_MESH: Type = Type::new(1);
-
+        OpenMesh,
         /// The type of the customer managed gateway is SecureWebGateway (SWG).
-        pub const SECURE_WEB_GATEWAY: Type = Type::new(2);
+        SecureWebGateway,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OpenMesh => std::option::Option::Some(1),
+                Self::SecureWebGateway => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OPEN_MESH"),
-                2 => std::borrow::Cow::Borrowed("SECURE_WEB_GATEWAY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::OpenMesh => std::option::Option::Some("OPEN_MESH"),
+                Self::SecureWebGateway => std::option::Option::Some("SECURE_WEB_GATEWAY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "OPEN_MESH" => std::option::Option::Some(Self::OPEN_MESH),
-                "SECURE_WEB_GATEWAY" => std::option::Option::Some(Self::SECURE_WEB_GATEWAY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OpenMesh,
+                2 => Self::SecureWebGateway,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "OPEN_MESH" => Self::OpenMesh,
+                "SECURE_WEB_GATEWAY" => Self::SecureWebGateway,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OpenMesh => serializer.serialize_i32(1),
+                Self::SecureWebGateway => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.networkservices.v1.Gateway.Type",
+            ))
         }
     }
 }
@@ -3217,60 +3399,124 @@ pub mod grpc_route {
         use super::*;
 
         /// The type of the match.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
-
-        impl Type {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
             /// Unspecified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+            Unspecified,
             /// Will only match the exact name provided.
-            pub const EXACT: Type = Type::new(1);
-
+            Exact,
             /// Will interpret grpc_method and grpc_service as regexes. RE2 syntax is
             /// supported.
-            pub const REGULAR_EXPRESSION: Type = Type::new(2);
+            RegularExpression,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
 
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Type {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Exact => std::option::Option::Some(1),
+                    Self::RegularExpression => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EXACT"),
-                    2 => std::borrow::Cow::Borrowed("REGULAR_EXPRESSION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::Exact => std::option::Option::Some("EXACT"),
+                    Self::RegularExpression => std::option::Option::Some("REGULAR_EXPRESSION"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "EXACT" => std::option::Option::Some(Self::EXACT),
-                    "REGULAR_EXPRESSION" => std::option::Option::Some(Self::REGULAR_EXPRESSION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Exact,
+                    2 => Self::RegularExpression,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "EXACT" => Self::Exact,
+                    "REGULAR_EXPRESSION" => Self::RegularExpression,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Exact => serializer.serialize_i32(1),
+                    Self::RegularExpression => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.networkservices.v1.GrpcRoute.MethodMatch.Type",
+                ))
             }
         }
     }
@@ -3337,60 +3583,124 @@ pub mod grpc_route {
         use super::*;
 
         /// The type of match.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
-
-        impl Type {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
             /// Unspecified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+            Unspecified,
             /// Will only match the exact value provided.
-            pub const EXACT: Type = Type::new(1);
-
+            Exact,
             /// Will match paths conforming to the prefix specified by value. RE2
             /// syntax is supported.
-            pub const REGULAR_EXPRESSION: Type = Type::new(2);
+            RegularExpression,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
 
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Type {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Exact => std::option::Option::Some(1),
+                    Self::RegularExpression => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EXACT"),
-                    2 => std::borrow::Cow::Borrowed("REGULAR_EXPRESSION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::Exact => std::option::Option::Some("EXACT"),
+                    Self::RegularExpression => std::option::Option::Some("REGULAR_EXPRESSION"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "EXACT" => std::option::Option::Some(Self::EXACT),
-                    "REGULAR_EXPRESSION" => std::option::Option::Some(Self::REGULAR_EXPRESSION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Exact,
+                    2 => Self::RegularExpression,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "EXACT" => Self::Exact,
+                    "REGULAR_EXPRESSION" => Self::RegularExpression,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Exact => serializer.serialize_i32(1),
+                    Self::RegularExpression => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.networkservices.v1.GrpcRoute.HeaderMatch.Type",
+                ))
             }
         }
     }
@@ -5279,78 +5589,146 @@ pub mod http_route {
         use super::*;
 
         /// Supported HTTP response code.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ResponseCode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ResponseCode {
+            /// Default value
+            Unspecified,
+            /// Corresponds to 301.
+            MovedPermanentlyDefault,
+            /// Corresponds to 302.
+            Found,
+            /// Corresponds to 303.
+            SeeOther,
+            /// Corresponds to 307. In this case, the request method will be retained.
+            TemporaryRedirect,
+            /// Corresponds to 308. In this case, the request method will be retained.
+            PermanentRedirect,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ResponseCode::value] or
+            /// [ResponseCode::name].
+            UnknownValue(response_code::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod response_code {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ResponseCode {
-            /// Default value
-            pub const RESPONSE_CODE_UNSPECIFIED: ResponseCode = ResponseCode::new(0);
-
-            /// Corresponds to 301.
-            pub const MOVED_PERMANENTLY_DEFAULT: ResponseCode = ResponseCode::new(1);
-
-            /// Corresponds to 302.
-            pub const FOUND: ResponseCode = ResponseCode::new(2);
-
-            /// Corresponds to 303.
-            pub const SEE_OTHER: ResponseCode = ResponseCode::new(3);
-
-            /// Corresponds to 307. In this case, the request method will be retained.
-            pub const TEMPORARY_REDIRECT: ResponseCode = ResponseCode::new(4);
-
-            /// Corresponds to 308. In this case, the request method will be retained.
-            pub const PERMANENT_REDIRECT: ResponseCode = ResponseCode::new(5);
-
-            /// Creates a new ResponseCode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::MovedPermanentlyDefault => std::option::Option::Some(1),
+                    Self::Found => std::option::Option::Some(2),
+                    Self::SeeOther => std::option::Option::Some(3),
+                    Self::TemporaryRedirect => std::option::Option::Some(4),
+                    Self::PermanentRedirect => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("RESPONSE_CODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MOVED_PERMANENTLY_DEFAULT"),
-                    2 => std::borrow::Cow::Borrowed("FOUND"),
-                    3 => std::borrow::Cow::Borrowed("SEE_OTHER"),
-                    4 => std::borrow::Cow::Borrowed("TEMPORARY_REDIRECT"),
-                    5 => std::borrow::Cow::Borrowed("PERMANENT_REDIRECT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "RESPONSE_CODE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::RESPONSE_CODE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("RESPONSE_CODE_UNSPECIFIED"),
+                    Self::MovedPermanentlyDefault => {
+                        std::option::Option::Some("MOVED_PERMANENTLY_DEFAULT")
                     }
-                    "MOVED_PERMANENTLY_DEFAULT" => {
-                        std::option::Option::Some(Self::MOVED_PERMANENTLY_DEFAULT)
-                    }
-                    "FOUND" => std::option::Option::Some(Self::FOUND),
-                    "SEE_OTHER" => std::option::Option::Some(Self::SEE_OTHER),
-                    "TEMPORARY_REDIRECT" => std::option::Option::Some(Self::TEMPORARY_REDIRECT),
-                    "PERMANENT_REDIRECT" => std::option::Option::Some(Self::PERMANENT_REDIRECT),
-                    _ => std::option::Option::None,
+                    Self::Found => std::option::Option::Some("FOUND"),
+                    Self::SeeOther => std::option::Option::Some("SEE_OTHER"),
+                    Self::TemporaryRedirect => std::option::Option::Some("TEMPORARY_REDIRECT"),
+                    Self::PermanentRedirect => std::option::Option::Some("PERMANENT_REDIRECT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ResponseCode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ResponseCode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ResponseCode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ResponseCode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::MovedPermanentlyDefault,
+                    2 => Self::Found,
+                    3 => Self::SeeOther,
+                    4 => Self::TemporaryRedirect,
+                    5 => Self::PermanentRedirect,
+                    _ => Self::UnknownValue(response_code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ResponseCode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "RESPONSE_CODE_UNSPECIFIED" => Self::Unspecified,
+                    "MOVED_PERMANENTLY_DEFAULT" => Self::MovedPermanentlyDefault,
+                    "FOUND" => Self::Found,
+                    "SEE_OTHER" => Self::SeeOther,
+                    "TEMPORARY_REDIRECT" => Self::TemporaryRedirect,
+                    "PERMANENT_REDIRECT" => Self::PermanentRedirect,
+                    _ => Self::UnknownValue(response_code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ResponseCode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::MovedPermanentlyDefault => serializer.serialize_i32(1),
+                    Self::Found => serializer.serialize_i32(2),
+                    Self::SeeOther => serializer.serialize_i32(3),
+                    Self::TemporaryRedirect => serializer.serialize_i32(4),
+                    Self::PermanentRedirect => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ResponseCode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseCode>::new(
+                    ".google.cloud.networkservices.v1.HttpRoute.Redirect.ResponseCode",
+                ))
             }
         }
     }
@@ -8509,85 +8887,154 @@ impl wkt::message::Message for DeleteTlsRouteRequest {
 }
 
 /// The part of the request or response for which the extension is called.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EventType(i32);
-
-impl EventType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EventType {
     /// Unspecified value. Do not use.
-    pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
+    Unspecified,
     /// If included in `supported_events`,
     /// the extension is called when the HTTP request headers arrive.
-    pub const REQUEST_HEADERS: EventType = EventType::new(1);
-
+    RequestHeaders,
     /// If included in `supported_events`,
     /// the extension is called when the HTTP request body arrives.
-    pub const REQUEST_BODY: EventType = EventType::new(2);
-
+    RequestBody,
     /// If included in `supported_events`,
     /// the extension is called when the HTTP response headers arrive.
-    pub const RESPONSE_HEADERS: EventType = EventType::new(3);
-
+    ResponseHeaders,
     /// If included in `supported_events`,
     /// the extension is called when the HTTP response body arrives.
-    pub const RESPONSE_BODY: EventType = EventType::new(4);
-
+    ResponseBody,
     /// If included in `supported_events`,
     /// the extension is called when the HTTP request trailers arrives.
-    pub const REQUEST_TRAILERS: EventType = EventType::new(5);
-
+    RequestTrailers,
     /// If included in `supported_events`,
     /// the extension is called when the HTTP response trailers arrives.
-    pub const RESPONSE_TRAILERS: EventType = EventType::new(6);
+    ResponseTrailers,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EventType::value] or
+    /// [EventType::name].
+    UnknownValue(event_type::UnknownValue),
+}
 
-    /// Creates a new EventType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod event_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl EventType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RequestHeaders => std::option::Option::Some(1),
+            Self::RequestBody => std::option::Option::Some(2),
+            Self::ResponseHeaders => std::option::Option::Some(3),
+            Self::ResponseBody => std::option::Option::Some(4),
+            Self::RequestTrailers => std::option::Option::Some(5),
+            Self::ResponseTrailers => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("REQUEST_HEADERS"),
-            2 => std::borrow::Cow::Borrowed("REQUEST_BODY"),
-            3 => std::borrow::Cow::Borrowed("RESPONSE_HEADERS"),
-            4 => std::borrow::Cow::Borrowed("RESPONSE_BODY"),
-            5 => std::borrow::Cow::Borrowed("REQUEST_TRAILERS"),
-            6 => std::borrow::Cow::Borrowed("RESPONSE_TRAILERS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+            Self::RequestHeaders => std::option::Option::Some("REQUEST_HEADERS"),
+            Self::RequestBody => std::option::Option::Some("REQUEST_BODY"),
+            Self::ResponseHeaders => std::option::Option::Some("RESPONSE_HEADERS"),
+            Self::ResponseBody => std::option::Option::Some("RESPONSE_BODY"),
+            Self::RequestTrailers => std::option::Option::Some("REQUEST_TRAILERS"),
+            Self::ResponseTrailers => std::option::Option::Some("RESPONSE_TRAILERS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-            "REQUEST_HEADERS" => std::option::Option::Some(Self::REQUEST_HEADERS),
-            "REQUEST_BODY" => std::option::Option::Some(Self::REQUEST_BODY),
-            "RESPONSE_HEADERS" => std::option::Option::Some(Self::RESPONSE_HEADERS),
-            "RESPONSE_BODY" => std::option::Option::Some(Self::RESPONSE_BODY),
-            "REQUEST_TRAILERS" => std::option::Option::Some(Self::REQUEST_TRAILERS),
-            "RESPONSE_TRAILERS" => std::option::Option::Some(Self::RESPONSE_TRAILERS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EventType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EventType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EventType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RequestHeaders,
+            2 => Self::RequestBody,
+            3 => Self::ResponseHeaders,
+            4 => Self::ResponseBody,
+            5 => Self::RequestTrailers,
+            6 => Self::ResponseTrailers,
+            _ => Self::UnknownValue(event_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EventType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "REQUEST_HEADERS" => Self::RequestHeaders,
+            "REQUEST_BODY" => Self::RequestBody,
+            "RESPONSE_HEADERS" => Self::ResponseHeaders,
+            "RESPONSE_BODY" => Self::ResponseBody,
+            "REQUEST_TRAILERS" => Self::RequestTrailers,
+            "RESPONSE_TRAILERS" => Self::ResponseTrailers,
+            _ => Self::UnknownValue(event_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EventType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RequestHeaders => serializer.serialize_i32(1),
+            Self::RequestBody => serializer.serialize_i32(2),
+            Self::ResponseHeaders => serializer.serialize_i32(3),
+            Self::ResponseBody => serializer.serialize_i32(4),
+            Self::RequestTrailers => serializer.serialize_i32(5),
+            Self::ResponseTrailers => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EventType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+            ".google.cloud.networkservices.v1.EventType",
+        ))
     }
 }
 
@@ -8595,61 +9042,120 @@ impl std::default::Default for EventType {
 /// `LbRouteExtension` resource.
 /// For more information, refer to [Choosing a load
 /// balancer](https://cloud.google.com/load-balancing/docs/backend-service).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LoadBalancingScheme(i32);
-
-impl LoadBalancingScheme {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LoadBalancingScheme {
     /// Default value. Do not use.
-    pub const LOAD_BALANCING_SCHEME_UNSPECIFIED: LoadBalancingScheme = LoadBalancingScheme::new(0);
-
+    Unspecified,
     /// Signifies that this is used for Internal HTTP(S) Load Balancing.
-    pub const INTERNAL_MANAGED: LoadBalancingScheme = LoadBalancingScheme::new(1);
-
+    InternalManaged,
     /// Signifies that this is used for External Managed HTTP(S) Load
     /// Balancing.
-    pub const EXTERNAL_MANAGED: LoadBalancingScheme = LoadBalancingScheme::new(2);
+    ExternalManaged,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LoadBalancingScheme::value] or
+    /// [LoadBalancingScheme::name].
+    UnknownValue(load_balancing_scheme::UnknownValue),
+}
 
-    /// Creates a new LoadBalancingScheme instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod load_balancing_scheme {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LoadBalancingScheme {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::InternalManaged => std::option::Option::Some(1),
+            Self::ExternalManaged => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LOAD_BALANCING_SCHEME_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INTERNAL_MANAGED"),
-            2 => std::borrow::Cow::Borrowed("EXTERNAL_MANAGED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LOAD_BALANCING_SCHEME_UNSPECIFIED"),
+            Self::InternalManaged => std::option::Option::Some("INTERNAL_MANAGED"),
+            Self::ExternalManaged => std::option::Option::Some("EXTERNAL_MANAGED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LOAD_BALANCING_SCHEME_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LOAD_BALANCING_SCHEME_UNSPECIFIED)
-            }
-            "INTERNAL_MANAGED" => std::option::Option::Some(Self::INTERNAL_MANAGED),
-            "EXTERNAL_MANAGED" => std::option::Option::Some(Self::EXTERNAL_MANAGED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LoadBalancingScheme {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LoadBalancingScheme {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LoadBalancingScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LoadBalancingScheme {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::InternalManaged,
+            2 => Self::ExternalManaged,
+            _ => Self::UnknownValue(load_balancing_scheme::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LoadBalancingScheme {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LOAD_BALANCING_SCHEME_UNSPECIFIED" => Self::Unspecified,
+            "INTERNAL_MANAGED" => Self::InternalManaged,
+            "EXTERNAL_MANAGED" => Self::ExternalManaged,
+            _ => Self::UnknownValue(load_balancing_scheme::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LoadBalancingScheme {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::InternalManaged => serializer.serialize_i32(1),
+            Self::ExternalManaged => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LoadBalancingScheme {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoadBalancingScheme>::new(
+            ".google.cloud.networkservices.v1.LoadBalancingScheme",
+        ))
     }
 }

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -190,82 +190,149 @@ pub mod event {
     use super::*;
 
     /// The definition of the event types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
-
-    impl EventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
         /// Event is not specified.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
+        Unspecified,
         /// The instance / runtime is idle
-        pub const IDLE: EventType = EventType::new(1);
-
+        Idle,
         /// The instance / runtime is available.
         /// This event indicates that instance / runtime underlying compute is
         /// operational.
-        pub const HEARTBEAT: EventType = EventType::new(2);
-
+        Heartbeat,
         /// The instance / runtime health is available.
         /// This event indicates that instance / runtime health information.
-        pub const HEALTH: EventType = EventType::new(3);
-
+        Health,
         /// The instance / runtime is available.
         /// This event allows instance / runtime to send Host maintenance
         /// information to Control Plane.
         /// <https://cloud.google.com/compute/docs/gpus/gpu-host-maintenance>
-        pub const MAINTENANCE: EventType = EventType::new(4);
-
+        Maintenance,
         /// The instance / runtime is available.
         /// This event indicates that the instance had metadata that needs to be
         /// modified.
-        pub const METADATA_CHANGE: EventType = EventType::new(5);
+        MetadataChange,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
 
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Idle => std::option::Option::Some(1),
+                Self::Heartbeat => std::option::Option::Some(2),
+                Self::Health => std::option::Option::Some(3),
+                Self::Maintenance => std::option::Option::Some(4),
+                Self::MetadataChange => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IDLE"),
-                2 => std::borrow::Cow::Borrowed("HEARTBEAT"),
-                3 => std::borrow::Cow::Borrowed("HEALTH"),
-                4 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                5 => std::borrow::Cow::Borrowed("METADATA_CHANGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::Idle => std::option::Option::Some("IDLE"),
+                Self::Heartbeat => std::option::Option::Some("HEARTBEAT"),
+                Self::Health => std::option::Option::Some("HEALTH"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::MetadataChange => std::option::Option::Some("METADATA_CHANGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "IDLE" => std::option::Option::Some(Self::IDLE),
-                "HEARTBEAT" => std::option::Option::Some(Self::HEARTBEAT),
-                "HEALTH" => std::option::Option::Some(Self::HEALTH),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "METADATA_CHANGE" => std::option::Option::Some(Self::METADATA_CHANGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Idle,
+                2 => Self::Heartbeat,
+                3 => Self::Health,
+                4 => Self::Maintenance,
+                5 => Self::MetadataChange,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IDLE" => Self::Idle,
+                "HEARTBEAT" => Self::Heartbeat,
+                "HEALTH" => Self::Health,
+                "MAINTENANCE" => Self::Maintenance,
+                "METADATA_CHANGE" => Self::MetadataChange,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Idle => serializer.serialize_i32(1),
+                Self::Heartbeat => serializer.serialize_i32(2),
+                Self::Health => serializer.serialize_i32(3),
+                Self::Maintenance => serializer.serialize_i32(4),
+                Self::MetadataChange => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.notebooks.v2.Event.EventType",
+            ))
         }
     }
 }
@@ -336,59 +403,120 @@ pub mod network_interface {
 
     /// The type of vNIC driver.
     /// Default should be NIC_TYPE_UNSPECIFIED.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NicType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NicType {
+        /// No type specified.
+        Unspecified,
+        /// VIRTIO
+        VirtioNet,
+        /// GVNIC
+        Gvnic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NicType::value] or
+        /// [NicType::name].
+        UnknownValue(nic_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod nic_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl NicType {
-        /// No type specified.
-        pub const NIC_TYPE_UNSPECIFIED: NicType = NicType::new(0);
-
-        /// VIRTIO
-        pub const VIRTIO_NET: NicType = NicType::new(1);
-
-        /// GVNIC
-        pub const GVNIC: NicType = NicType::new(2);
-
-        /// Creates a new NicType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VirtioNet => std::option::Option::Some(1),
+                Self::Gvnic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NIC_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VIRTIO_NET"),
-                2 => std::borrow::Cow::Borrowed("GVNIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NIC_TYPE_UNSPECIFIED"),
+                Self::VirtioNet => std::option::Option::Some("VIRTIO_NET"),
+                Self::Gvnic => std::option::Option::Some("GVNIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NIC_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NIC_TYPE_UNSPECIFIED),
-                "VIRTIO_NET" => std::option::Option::Some(Self::VIRTIO_NET),
-                "GVNIC" => std::option::Option::Some(Self::GVNIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NicType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NicType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NicType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NicType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VirtioNet,
+                2 => Self::Gvnic,
+                _ => Self::UnknownValue(nic_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NicType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NIC_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "VIRTIO_NET" => Self::VirtioNet,
+                "GVNIC" => Self::Gvnic,
+                _ => Self::UnknownValue(nic_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NicType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VirtioNet => serializer.serialize_i32(1),
+                Self::Gvnic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NicType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NicType>::new(
+                ".google.cloud.notebooks.v2.NetworkInterface.NicType",
+            ))
         }
     }
 }
@@ -606,101 +734,176 @@ pub mod accelerator_config {
 
     /// Definition of the types of hardware accelerators that can be used on
     /// this instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AcceleratorType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AcceleratorType {
+        /// Accelerator type is not specified.
+        Unspecified,
+        /// Accelerator type is Nvidia Tesla P100.
+        NvidiaTeslaP100,
+        /// Accelerator type is Nvidia Tesla V100.
+        NvidiaTeslaV100,
+        /// Accelerator type is Nvidia Tesla P4.
+        NvidiaTeslaP4,
+        /// Accelerator type is Nvidia Tesla T4.
+        NvidiaTeslaT4,
+        /// Accelerator type is Nvidia Tesla A100 - 40GB.
+        NvidiaTeslaA100,
+        /// Accelerator type is Nvidia Tesla A100 - 80GB.
+        NvidiaA10080Gb,
+        /// Accelerator type is Nvidia Tesla L4.
+        NvidiaL4,
+        /// Accelerator type is NVIDIA Tesla T4 Virtual Workstations.
+        NvidiaTeslaT4Vws,
+        /// Accelerator type is NVIDIA Tesla P100 Virtual Workstations.
+        NvidiaTeslaP100Vws,
+        /// Accelerator type is NVIDIA Tesla P4 Virtual Workstations.
+        NvidiaTeslaP4Vws,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AcceleratorType::value] or
+        /// [AcceleratorType::name].
+        UnknownValue(accelerator_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod accelerator_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AcceleratorType {
-        /// Accelerator type is not specified.
-        pub const ACCELERATOR_TYPE_UNSPECIFIED: AcceleratorType = AcceleratorType::new(0);
-
-        /// Accelerator type is Nvidia Tesla P100.
-        pub const NVIDIA_TESLA_P100: AcceleratorType = AcceleratorType::new(2);
-
-        /// Accelerator type is Nvidia Tesla V100.
-        pub const NVIDIA_TESLA_V100: AcceleratorType = AcceleratorType::new(3);
-
-        /// Accelerator type is Nvidia Tesla P4.
-        pub const NVIDIA_TESLA_P4: AcceleratorType = AcceleratorType::new(4);
-
-        /// Accelerator type is Nvidia Tesla T4.
-        pub const NVIDIA_TESLA_T4: AcceleratorType = AcceleratorType::new(5);
-
-        /// Accelerator type is Nvidia Tesla A100 - 40GB.
-        pub const NVIDIA_TESLA_A100: AcceleratorType = AcceleratorType::new(11);
-
-        /// Accelerator type is Nvidia Tesla A100 - 80GB.
-        pub const NVIDIA_A100_80GB: AcceleratorType = AcceleratorType::new(12);
-
-        /// Accelerator type is Nvidia Tesla L4.
-        pub const NVIDIA_L4: AcceleratorType = AcceleratorType::new(13);
-
-        /// Accelerator type is NVIDIA Tesla T4 Virtual Workstations.
-        pub const NVIDIA_TESLA_T4_VWS: AcceleratorType = AcceleratorType::new(8);
-
-        /// Accelerator type is NVIDIA Tesla P100 Virtual Workstations.
-        pub const NVIDIA_TESLA_P100_VWS: AcceleratorType = AcceleratorType::new(9);
-
-        /// Accelerator type is NVIDIA Tesla P4 Virtual Workstations.
-        pub const NVIDIA_TESLA_P4_VWS: AcceleratorType = AcceleratorType::new(10);
-
-        /// Creates a new AcceleratorType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NvidiaTeslaP100 => std::option::Option::Some(2),
+                Self::NvidiaTeslaV100 => std::option::Option::Some(3),
+                Self::NvidiaTeslaP4 => std::option::Option::Some(4),
+                Self::NvidiaTeslaT4 => std::option::Option::Some(5),
+                Self::NvidiaTeslaA100 => std::option::Option::Some(11),
+                Self::NvidiaA10080Gb => std::option::Option::Some(12),
+                Self::NvidiaL4 => std::option::Option::Some(13),
+                Self::NvidiaTeslaT4Vws => std::option::Option::Some(8),
+                Self::NvidiaTeslaP100Vws => std::option::Option::Some(9),
+                Self::NvidiaTeslaP4Vws => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCELERATOR_TYPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P100"),
-                3 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_V100"),
-                4 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P4"),
-                5 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_T4"),
-                8 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_T4_VWS"),
-                9 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P100_VWS"),
-                10 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_P4_VWS"),
-                11 => std::borrow::Cow::Borrowed("NVIDIA_TESLA_A100"),
-                12 => std::borrow::Cow::Borrowed("NVIDIA_A100_80GB"),
-                13 => std::borrow::Cow::Borrowed("NVIDIA_L4"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCELERATOR_TYPE_UNSPECIFIED"),
+                Self::NvidiaTeslaP100 => std::option::Option::Some("NVIDIA_TESLA_P100"),
+                Self::NvidiaTeslaV100 => std::option::Option::Some("NVIDIA_TESLA_V100"),
+                Self::NvidiaTeslaP4 => std::option::Option::Some("NVIDIA_TESLA_P4"),
+                Self::NvidiaTeslaT4 => std::option::Option::Some("NVIDIA_TESLA_T4"),
+                Self::NvidiaTeslaA100 => std::option::Option::Some("NVIDIA_TESLA_A100"),
+                Self::NvidiaA10080Gb => std::option::Option::Some("NVIDIA_A100_80GB"),
+                Self::NvidiaL4 => std::option::Option::Some("NVIDIA_L4"),
+                Self::NvidiaTeslaT4Vws => std::option::Option::Some("NVIDIA_TESLA_T4_VWS"),
+                Self::NvidiaTeslaP100Vws => std::option::Option::Some("NVIDIA_TESLA_P100_VWS"),
+                Self::NvidiaTeslaP4Vws => std::option::Option::Some("NVIDIA_TESLA_P4_VWS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCELERATOR_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCELERATOR_TYPE_UNSPECIFIED)
-                }
-                "NVIDIA_TESLA_P100" => std::option::Option::Some(Self::NVIDIA_TESLA_P100),
-                "NVIDIA_TESLA_V100" => std::option::Option::Some(Self::NVIDIA_TESLA_V100),
-                "NVIDIA_TESLA_P4" => std::option::Option::Some(Self::NVIDIA_TESLA_P4),
-                "NVIDIA_TESLA_T4" => std::option::Option::Some(Self::NVIDIA_TESLA_T4),
-                "NVIDIA_TESLA_A100" => std::option::Option::Some(Self::NVIDIA_TESLA_A100),
-                "NVIDIA_A100_80GB" => std::option::Option::Some(Self::NVIDIA_A100_80GB),
-                "NVIDIA_L4" => std::option::Option::Some(Self::NVIDIA_L4),
-                "NVIDIA_TESLA_T4_VWS" => std::option::Option::Some(Self::NVIDIA_TESLA_T4_VWS),
-                "NVIDIA_TESLA_P100_VWS" => std::option::Option::Some(Self::NVIDIA_TESLA_P100_VWS),
-                "NVIDIA_TESLA_P4_VWS" => std::option::Option::Some(Self::NVIDIA_TESLA_P4_VWS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AcceleratorType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AcceleratorType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AcceleratorType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AcceleratorType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::NvidiaTeslaP100,
+                3 => Self::NvidiaTeslaV100,
+                4 => Self::NvidiaTeslaP4,
+                5 => Self::NvidiaTeslaT4,
+                8 => Self::NvidiaTeslaT4Vws,
+                9 => Self::NvidiaTeslaP100Vws,
+                10 => Self::NvidiaTeslaP4Vws,
+                11 => Self::NvidiaTeslaA100,
+                12 => Self::NvidiaA10080Gb,
+                13 => Self::NvidiaL4,
+                _ => Self::UnknownValue(accelerator_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AcceleratorType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCELERATOR_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NVIDIA_TESLA_P100" => Self::NvidiaTeslaP100,
+                "NVIDIA_TESLA_V100" => Self::NvidiaTeslaV100,
+                "NVIDIA_TESLA_P4" => Self::NvidiaTeslaP4,
+                "NVIDIA_TESLA_T4" => Self::NvidiaTeslaT4,
+                "NVIDIA_TESLA_A100" => Self::NvidiaTeslaA100,
+                "NVIDIA_A100_80GB" => Self::NvidiaA10080Gb,
+                "NVIDIA_L4" => Self::NvidiaL4,
+                "NVIDIA_TESLA_T4_VWS" => Self::NvidiaTeslaT4Vws,
+                "NVIDIA_TESLA_P100_VWS" => Self::NvidiaTeslaP100Vws,
+                "NVIDIA_TESLA_P4_VWS" => Self::NvidiaTeslaP4Vws,
+                _ => Self::UnknownValue(accelerator_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AcceleratorType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NvidiaTeslaP100 => serializer.serialize_i32(2),
+                Self::NvidiaTeslaV100 => serializer.serialize_i32(3),
+                Self::NvidiaTeslaP4 => serializer.serialize_i32(4),
+                Self::NvidiaTeslaT4 => serializer.serialize_i32(5),
+                Self::NvidiaTeslaA100 => serializer.serialize_i32(11),
+                Self::NvidiaA10080Gb => serializer.serialize_i32(12),
+                Self::NvidiaL4 => serializer.serialize_i32(13),
+                Self::NvidiaTeslaT4Vws => serializer.serialize_i32(8),
+                Self::NvidiaTeslaP100Vws => serializer.serialize_i32(9),
+                Self::NvidiaTeslaP4Vws => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AcceleratorType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AcceleratorType>::new(
+                ".google.cloud.notebooks.v2.AcceleratorConfig.AcceleratorType",
+            ))
         }
     }
 }
@@ -1419,121 +1622,245 @@ pub mod upgrade_history_entry {
     use super::*;
 
     /// The definition of the states of this upgrade history entry.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is not specified.
+        Unspecified,
+        /// The instance upgrade is started.
+        Started,
+        /// The instance upgrade is succeeded.
+        Succeeded,
+        /// The instance upgrade is failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The instance upgrade is started.
-        pub const STARTED: State = State::new(1);
-
-        /// The instance upgrade is succeeded.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The instance upgrade is failed.
-        pub const FAILED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Started => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STARTED"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Started => std::option::Option::Some("STARTED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STARTED" => std::option::Option::Some(Self::STARTED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Started,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STARTED" => Self::Started,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Started => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.notebooks.v2.UpgradeHistoryEntry.State",
+            ))
         }
     }
 
     /// The definition of operations of this upgrade history entry.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Operation is not specified.
+        Unspecified,
+        /// Upgrade.
+        Upgrade,
+        /// Rollback.
+        Rollback,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Operation is not specified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Upgrade.
-        pub const UPGRADE: Action = Action::new(1);
-
-        /// Rollback.
-        pub const ROLLBACK: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Upgrade => std::option::Option::Some(1),
+                Self::Rollback => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UPGRADE"),
-                2 => std::borrow::Cow::Borrowed("ROLLBACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Upgrade => std::option::Option::Some("UPGRADE"),
+                Self::Rollback => std::option::Option::Some("ROLLBACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "UPGRADE" => std::option::Option::Some(Self::UPGRADE),
-                "ROLLBACK" => std::option::Option::Some(Self::ROLLBACK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Upgrade,
+                2 => Self::Rollback,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "UPGRADE" => Self::Upgrade,
+                "ROLLBACK" => Self::Rollback,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Upgrade => serializer.serialize_i32(1),
+                Self::Rollback => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.cloud.notebooks.v2.UpgradeHistoryEntry.Action",
+            ))
         }
     }
 }
@@ -2612,298 +2939,564 @@ impl wkt::message::Message for DiagnoseInstanceRequest {
 }
 
 /// Definition of the disk encryption options.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DiskEncryption(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DiskEncryption {
+    /// Disk encryption is not specified.
+    Unspecified,
+    /// Use Google managed encryption keys to encrypt the boot disk.
+    Gmek,
+    /// Use customer managed encryption keys to encrypt the boot disk.
+    Cmek,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DiskEncryption::value] or
+    /// [DiskEncryption::name].
+    UnknownValue(disk_encryption::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod disk_encryption {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DiskEncryption {
-    /// Disk encryption is not specified.
-    pub const DISK_ENCRYPTION_UNSPECIFIED: DiskEncryption = DiskEncryption::new(0);
-
-    /// Use Google managed encryption keys to encrypt the boot disk.
-    pub const GMEK: DiskEncryption = DiskEncryption::new(1);
-
-    /// Use customer managed encryption keys to encrypt the boot disk.
-    pub const CMEK: DiskEncryption = DiskEncryption::new(2);
-
-    /// Creates a new DiskEncryption instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Gmek => std::option::Option::Some(1),
+            Self::Cmek => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DISK_ENCRYPTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GMEK"),
-            2 => std::borrow::Cow::Borrowed("CMEK"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DISK_ENCRYPTION_UNSPECIFIED"),
+            Self::Gmek => std::option::Option::Some("GMEK"),
+            Self::Cmek => std::option::Option::Some("CMEK"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DISK_ENCRYPTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DISK_ENCRYPTION_UNSPECIFIED)
-            }
-            "GMEK" => std::option::Option::Some(Self::GMEK),
-            "CMEK" => std::option::Option::Some(Self::CMEK),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DiskEncryption {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DiskEncryption {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DiskEncryption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DiskEncryption {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Gmek,
+            2 => Self::Cmek,
+            _ => Self::UnknownValue(disk_encryption::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DiskEncryption {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DISK_ENCRYPTION_UNSPECIFIED" => Self::Unspecified,
+            "GMEK" => Self::Gmek,
+            "CMEK" => Self::Cmek,
+            _ => Self::UnknownValue(disk_encryption::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DiskEncryption {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Gmek => serializer.serialize_i32(1),
+            Self::Cmek => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DiskEncryption {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskEncryption>::new(
+            ".google.cloud.notebooks.v2.DiskEncryption",
+        ))
     }
 }
 
 /// Possible disk types.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DiskType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DiskType {
+    /// Disk type not set.
+    Unspecified,
+    /// Standard persistent disk type.
+    PdStandard,
+    /// SSD persistent disk type.
+    PdSsd,
+    /// Balanced persistent disk type.
+    PdBalanced,
+    /// Extreme persistent disk type.
+    PdExtreme,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DiskType::value] or
+    /// [DiskType::name].
+    UnknownValue(disk_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod disk_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DiskType {
-    /// Disk type not set.
-    pub const DISK_TYPE_UNSPECIFIED: DiskType = DiskType::new(0);
-
-    /// Standard persistent disk type.
-    pub const PD_STANDARD: DiskType = DiskType::new(1);
-
-    /// SSD persistent disk type.
-    pub const PD_SSD: DiskType = DiskType::new(2);
-
-    /// Balanced persistent disk type.
-    pub const PD_BALANCED: DiskType = DiskType::new(3);
-
-    /// Extreme persistent disk type.
-    pub const PD_EXTREME: DiskType = DiskType::new(4);
-
-    /// Creates a new DiskType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PdStandard => std::option::Option::Some(1),
+            Self::PdSsd => std::option::Option::Some(2),
+            Self::PdBalanced => std::option::Option::Some(3),
+            Self::PdExtreme => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DISK_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PD_STANDARD"),
-            2 => std::borrow::Cow::Borrowed("PD_SSD"),
-            3 => std::borrow::Cow::Borrowed("PD_BALANCED"),
-            4 => std::borrow::Cow::Borrowed("PD_EXTREME"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DISK_TYPE_UNSPECIFIED"),
+            Self::PdStandard => std::option::Option::Some("PD_STANDARD"),
+            Self::PdSsd => std::option::Option::Some("PD_SSD"),
+            Self::PdBalanced => std::option::Option::Some("PD_BALANCED"),
+            Self::PdExtreme => std::option::Option::Some("PD_EXTREME"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_TYPE_UNSPECIFIED),
-            "PD_STANDARD" => std::option::Option::Some(Self::PD_STANDARD),
-            "PD_SSD" => std::option::Option::Some(Self::PD_SSD),
-            "PD_BALANCED" => std::option::Option::Some(Self::PD_BALANCED),
-            "PD_EXTREME" => std::option::Option::Some(Self::PD_EXTREME),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DiskType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DiskType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DiskType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DiskType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PdStandard,
+            2 => Self::PdSsd,
+            3 => Self::PdBalanced,
+            4 => Self::PdExtreme,
+            _ => Self::UnknownValue(disk_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DiskType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PD_STANDARD" => Self::PdStandard,
+            "PD_SSD" => Self::PdSsd,
+            "PD_BALANCED" => Self::PdBalanced,
+            "PD_EXTREME" => Self::PdExtreme,
+            _ => Self::UnknownValue(disk_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DiskType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PdStandard => serializer.serialize_i32(1),
+            Self::PdSsd => serializer.serialize_i32(2),
+            Self::PdBalanced => serializer.serialize_i32(3),
+            Self::PdExtreme => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DiskType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskType>::new(
+            ".google.cloud.notebooks.v2.DiskType",
+        ))
     }
 }
 
 /// The definition of the states of this instance.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(i32);
-
-impl State {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum State {
     /// State is not specified.
-    pub const STATE_UNSPECIFIED: State = State::new(0);
-
+    Unspecified,
     /// The control logic is starting the instance.
-    pub const STARTING: State = State::new(1);
-
+    Starting,
     /// The control logic is installing required frameworks and registering the
     /// instance with notebook proxy
-    pub const PROVISIONING: State = State::new(2);
-
+    Provisioning,
     /// The instance is running.
-    pub const ACTIVE: State = State::new(3);
-
+    Active,
     /// The control logic is stopping the instance.
-    pub const STOPPING: State = State::new(4);
-
+    Stopping,
     /// The instance is stopped.
-    pub const STOPPED: State = State::new(5);
-
+    Stopped,
     /// The instance is deleted.
-    pub const DELETED: State = State::new(6);
-
+    Deleted,
     /// The instance is upgrading.
-    pub const UPGRADING: State = State::new(7);
-
+    Upgrading,
     /// The instance is being created.
-    pub const INITIALIZING: State = State::new(8);
-
+    Initializing,
     /// The instance is suspending.
-    pub const SUSPENDING: State = State::new(9);
-
+    Suspending,
     /// The instance is suspended.
-    pub const SUSPENDED: State = State::new(10);
+    Suspended,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [State::value] or
+    /// [State::name].
+    UnknownValue(state::UnknownValue),
+}
 
-    /// Creates a new State instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl State {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Starting => std::option::Option::Some(1),
+            Self::Provisioning => std::option::Option::Some(2),
+            Self::Active => std::option::Option::Some(3),
+            Self::Stopping => std::option::Option::Some(4),
+            Self::Stopped => std::option::Option::Some(5),
+            Self::Deleted => std::option::Option::Some(6),
+            Self::Upgrading => std::option::Option::Some(7),
+            Self::Initializing => std::option::Option::Some(8),
+            Self::Suspending => std::option::Option::Some(9),
+            Self::Suspended => std::option::Option::Some(10),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("STARTING"),
-            2 => std::borrow::Cow::Borrowed("PROVISIONING"),
-            3 => std::borrow::Cow::Borrowed("ACTIVE"),
-            4 => std::borrow::Cow::Borrowed("STOPPING"),
-            5 => std::borrow::Cow::Borrowed("STOPPED"),
-            6 => std::borrow::Cow::Borrowed("DELETED"),
-            7 => std::borrow::Cow::Borrowed("UPGRADING"),
-            8 => std::borrow::Cow::Borrowed("INITIALIZING"),
-            9 => std::borrow::Cow::Borrowed("SUSPENDING"),
-            10 => std::borrow::Cow::Borrowed("SUSPENDED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+            Self::Starting => std::option::Option::Some("STARTING"),
+            Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::Stopping => std::option::Option::Some("STOPPING"),
+            Self::Stopped => std::option::Option::Some("STOPPED"),
+            Self::Deleted => std::option::Option::Some("DELETED"),
+            Self::Upgrading => std::option::Option::Some("UPGRADING"),
+            Self::Initializing => std::option::Option::Some("INITIALIZING"),
+            Self::Suspending => std::option::Option::Some("SUSPENDING"),
+            Self::Suspended => std::option::Option::Some("SUSPENDED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-            "STARTING" => std::option::Option::Some(Self::STARTING),
-            "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "STOPPING" => std::option::Option::Some(Self::STOPPING),
-            "STOPPED" => std::option::Option::Some(Self::STOPPED),
-            "DELETED" => std::option::Option::Some(Self::DELETED),
-            "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
-            "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
-            "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
-            "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for State {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Starting,
+            2 => Self::Provisioning,
+            3 => Self::Active,
+            4 => Self::Stopping,
+            5 => Self::Stopped,
+            6 => Self::Deleted,
+            7 => Self::Upgrading,
+            8 => Self::Initializing,
+            9 => Self::Suspending,
+            10 => Self::Suspended,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for State {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_UNSPECIFIED" => Self::Unspecified,
+            "STARTING" => Self::Starting,
+            "PROVISIONING" => Self::Provisioning,
+            "ACTIVE" => Self::Active,
+            "STOPPING" => Self::Stopping,
+            "STOPPED" => Self::Stopped,
+            "DELETED" => Self::Deleted,
+            "UPGRADING" => Self::Upgrading,
+            "INITIALIZING" => Self::Initializing,
+            "SUSPENDING" => Self::Suspending,
+            "SUSPENDED" => Self::Suspended,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Starting => serializer.serialize_i32(1),
+            Self::Provisioning => serializer.serialize_i32(2),
+            Self::Active => serializer.serialize_i32(3),
+            Self::Stopping => serializer.serialize_i32(4),
+            Self::Stopped => serializer.serialize_i32(5),
+            Self::Deleted => serializer.serialize_i32(6),
+            Self::Upgrading => serializer.serialize_i32(7),
+            Self::Initializing => serializer.serialize_i32(8),
+            Self::Suspending => serializer.serialize_i32(9),
+            Self::Suspended => serializer.serialize_i32(10),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+            ".google.cloud.notebooks.v2.State",
+        ))
     }
 }
 
 /// The instance health state.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HealthState(i32);
-
-impl HealthState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HealthState {
     /// The instance substate is unknown.
-    pub const HEALTH_STATE_UNSPECIFIED: HealthState = HealthState::new(0);
-
+    Unspecified,
     /// The instance is known to be in an healthy state
     /// (for example, critical daemons are running)
     /// Applies to ACTIVE state.
-    pub const HEALTHY: HealthState = HealthState::new(1);
-
+    Healthy,
     /// The instance is known to be in an unhealthy state
     /// (for example, critical daemons are not running)
     /// Applies to ACTIVE state.
-    pub const UNHEALTHY: HealthState = HealthState::new(2);
-
+    Unhealthy,
     /// The instance has not installed health monitoring agent.
     /// Applies to ACTIVE state.
-    pub const AGENT_NOT_INSTALLED: HealthState = HealthState::new(3);
-
+    AgentNotInstalled,
     /// The instance health monitoring agent is not running.
     /// Applies to ACTIVE state.
-    pub const AGENT_NOT_RUNNING: HealthState = HealthState::new(4);
+    AgentNotRunning,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HealthState::value] or
+    /// [HealthState::name].
+    UnknownValue(health_state::UnknownValue),
+}
 
-    /// Creates a new HealthState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod health_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl HealthState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Healthy => std::option::Option::Some(1),
+            Self::Unhealthy => std::option::Option::Some(2),
+            Self::AgentNotInstalled => std::option::Option::Some(3),
+            Self::AgentNotRunning => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HEALTH_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HEALTHY"),
-            2 => std::borrow::Cow::Borrowed("UNHEALTHY"),
-            3 => std::borrow::Cow::Borrowed("AGENT_NOT_INSTALLED"),
-            4 => std::borrow::Cow::Borrowed("AGENT_NOT_RUNNING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HEALTH_STATE_UNSPECIFIED"),
+            Self::Healthy => std::option::Option::Some("HEALTHY"),
+            Self::Unhealthy => std::option::Option::Some("UNHEALTHY"),
+            Self::AgentNotInstalled => std::option::Option::Some("AGENT_NOT_INSTALLED"),
+            Self::AgentNotRunning => std::option::Option::Some("AGENT_NOT_RUNNING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HEALTH_STATE_UNSPECIFIED" => std::option::Option::Some(Self::HEALTH_STATE_UNSPECIFIED),
-            "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
-            "UNHEALTHY" => std::option::Option::Some(Self::UNHEALTHY),
-            "AGENT_NOT_INSTALLED" => std::option::Option::Some(Self::AGENT_NOT_INSTALLED),
-            "AGENT_NOT_RUNNING" => std::option::Option::Some(Self::AGENT_NOT_RUNNING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HealthState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HealthState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HealthState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HealthState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Healthy,
+            2 => Self::Unhealthy,
+            3 => Self::AgentNotInstalled,
+            4 => Self::AgentNotRunning,
+            _ => Self::UnknownValue(health_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HealthState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HEALTH_STATE_UNSPECIFIED" => Self::Unspecified,
+            "HEALTHY" => Self::Healthy,
+            "UNHEALTHY" => Self::Unhealthy,
+            "AGENT_NOT_INSTALLED" => Self::AgentNotInstalled,
+            "AGENT_NOT_RUNNING" => Self::AgentNotRunning,
+            _ => Self::UnknownValue(health_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HealthState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Healthy => serializer.serialize_i32(1),
+            Self::Unhealthy => serializer.serialize_i32(2),
+            Self::AgentNotInstalled => serializer.serialize_i32(3),
+            Self::AgentNotRunning => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HealthState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HealthState>::new(
+            ".google.cloud.notebooks.v2.HealthState",
+        ))
     }
 }

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -370,69 +370,134 @@ pub mod async_model_metadata {
     use super::*;
 
     /// Possible states of the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// Request is being processed.
+        Running,
+        /// The operation completed successfully.
+        Succeeded,
+        /// The operation was cancelled.
+        Cancelled,
+        /// The operation has failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Request is being processed.
-        pub const RUNNING: State = State::new(1);
-
-        /// The operation completed successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The operation was cancelled.
-        pub const CANCELLED: State = State::new(3);
-
-        /// The operation has failed.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Cancelled,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.optimization.v1.AsyncModelMetadata.State",
+            ))
         }
     }
 }
@@ -871,20 +936,17 @@ pub mod optimize_tours_request {
     /// to cap the number of errors returned.
     ///
     /// [google.cloud.optimization.v1.OptimizeToursRequest.max_validation_errors]: crate::model::OptimizeToursRequest::max_validation_errors
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SolvingMode(i32);
-
-    impl SolvingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SolvingMode {
         /// Solve the model.
-        pub const DEFAULT_SOLVE: SolvingMode = SolvingMode::new(0);
-
+        DefaultSolve,
         /// Only validates the model without solving it: populates as many
         /// [OptimizeToursResponse.validation_errors][google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]
         /// as possible.
         ///
         /// [google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]: crate::model::OptimizeToursResponse::validation_errors
-        pub const VALIDATE_ONLY: SolvingMode = SolvingMode::new(1);
-
+        ValidateOnly,
         /// Only populates
         /// [OptimizeToursResponse.validation_errors][google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]
         /// or
@@ -903,112 +965,235 @@ pub mod optimize_tours_request {
         ///
         /// [google.cloud.optimization.v1.OptimizeToursResponse.skipped_shipments]: crate::model::OptimizeToursResponse::skipped_shipments
         /// [google.cloud.optimization.v1.OptimizeToursResponse.validation_errors]: crate::model::OptimizeToursResponse::validation_errors
-        pub const DETECT_SOME_INFEASIBLE_SHIPMENTS: SolvingMode = SolvingMode::new(2);
+        DetectSomeInfeasibleShipments,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SolvingMode::value] or
+        /// [SolvingMode::name].
+        UnknownValue(solving_mode::UnknownValue),
+    }
 
-        /// Creates a new SolvingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod solving_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SolvingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::DefaultSolve => std::option::Option::Some(0),
+                Self::ValidateOnly => std::option::Option::Some(1),
+                Self::DetectSomeInfeasibleShipments => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEFAULT_SOLVE"),
-                1 => std::borrow::Cow::Borrowed("VALIDATE_ONLY"),
-                2 => std::borrow::Cow::Borrowed("DETECT_SOME_INFEASIBLE_SHIPMENTS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEFAULT_SOLVE" => std::option::Option::Some(Self::DEFAULT_SOLVE),
-                "VALIDATE_ONLY" => std::option::Option::Some(Self::VALIDATE_ONLY),
-                "DETECT_SOME_INFEASIBLE_SHIPMENTS" => {
-                    std::option::Option::Some(Self::DETECT_SOME_INFEASIBLE_SHIPMENTS)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::DefaultSolve => std::option::Option::Some("DEFAULT_SOLVE"),
+                Self::ValidateOnly => std::option::Option::Some("VALIDATE_ONLY"),
+                Self::DetectSomeInfeasibleShipments => {
+                    std::option::Option::Some("DETECT_SOME_INFEASIBLE_SHIPMENTS")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SolvingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SolvingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SolvingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SolvingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::DefaultSolve,
+                1 => Self::ValidateOnly,
+                2 => Self::DetectSomeInfeasibleShipments,
+                _ => Self::UnknownValue(solving_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SolvingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEFAULT_SOLVE" => Self::DefaultSolve,
+                "VALIDATE_ONLY" => Self::ValidateOnly,
+                "DETECT_SOME_INFEASIBLE_SHIPMENTS" => Self::DetectSomeInfeasibleShipments,
+                _ => Self::UnknownValue(solving_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SolvingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::DefaultSolve => serializer.serialize_i32(0),
+                Self::ValidateOnly => serializer.serialize_i32(1),
+                Self::DetectSomeInfeasibleShipments => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SolvingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SolvingMode>::new(
+                ".google.cloud.optimization.v1.OptimizeToursRequest.SolvingMode",
+            ))
         }
     }
 
     /// Mode defining the behavior of the search, trading off latency versus
     /// solution quality. In all modes, the global request deadline is enforced.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SearchMode {
+        /// Unspecified search mode, equivalent to `RETURN_FAST`.
+        Unspecified,
+        /// Stop the search after finding the first good solution.
+        ReturnFast,
+        /// Spend all the available time to search for better solutions.
+        ConsumeAllAvailableTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SearchMode::value] or
+        /// [SearchMode::name].
+        UnknownValue(search_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod search_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SearchMode {
-        /// Unspecified search mode, equivalent to `RETURN_FAST`.
-        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new(0);
-
-        /// Stop the search after finding the first good solution.
-        pub const RETURN_FAST: SearchMode = SearchMode::new(1);
-
-        /// Spend all the available time to search for better solutions.
-        pub const CONSUME_ALL_AVAILABLE_TIME: SearchMode = SearchMode::new(2);
-
-        /// Creates a new SearchMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReturnFast => std::option::Option::Some(1),
+                Self::ConsumeAllAvailableTime => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEARCH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RETURN_FAST"),
-                2 => std::borrow::Cow::Borrowed("CONSUME_ALL_AVAILABLE_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEARCH_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SEARCH_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEARCH_MODE_UNSPECIFIED"),
+                Self::ReturnFast => std::option::Option::Some("RETURN_FAST"),
+                Self::ConsumeAllAvailableTime => {
+                    std::option::Option::Some("CONSUME_ALL_AVAILABLE_TIME")
                 }
-                "RETURN_FAST" => std::option::Option::Some(Self::RETURN_FAST),
-                "CONSUME_ALL_AVAILABLE_TIME" => {
-                    std::option::Option::Some(Self::CONSUME_ALL_AVAILABLE_TIME)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SearchMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SearchMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SearchMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReturnFast,
+                2 => Self::ConsumeAllAvailableTime,
+                _ => Self::UnknownValue(search_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SearchMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEARCH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "RETURN_FAST" => Self::ReturnFast,
+                "CONSUME_ALL_AVAILABLE_TIME" => Self::ConsumeAllAvailableTime,
+                _ => Self::UnknownValue(search_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SearchMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReturnFast => serializer.serialize_i32(1),
+                Self::ConsumeAllAvailableTime => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SearchMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchMode>::new(
+                ".google.cloud.optimization.v1.OptimizeToursRequest.SearchMode",
+            ))
         }
     }
 }
@@ -2942,18 +3127,14 @@ pub mod shipment_type_incompatibility {
 
     /// Modes defining how the appearance of incompatible shipments are restricted
     /// on the same route.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IncompatibilityMode(i32);
-
-    impl IncompatibilityMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IncompatibilityMode {
         /// Unspecified incompatibility mode. This value should never be used.
-        pub const INCOMPATIBILITY_MODE_UNSPECIFIED: IncompatibilityMode =
-            IncompatibilityMode::new(0);
-
+        Unspecified,
         /// In this mode, two shipments with incompatible types can never share the
         /// same vehicle.
-        pub const NOT_PERFORMED_BY_SAME_VEHICLE: IncompatibilityMode = IncompatibilityMode::new(1);
-
+        NotPerformedBySameVehicle,
         /// For two shipments with incompatible types with the
         /// `NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY` incompatibility mode:
         ///
@@ -2962,55 +3143,116 @@ pub mod shipment_type_incompatibility {
         /// * If one of the shipments has a delivery and the other a pickup, the two
         ///   shipments can share the same vehicle iff the former shipment is
         ///   delivered before the latter is picked up.
-        pub const NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY: IncompatibilityMode =
-            IncompatibilityMode::new(2);
+        NotInSameVehicleSimultaneously,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IncompatibilityMode::value] or
+        /// [IncompatibilityMode::name].
+        UnknownValue(incompatibility_mode::UnknownValue),
+    }
 
-        /// Creates a new IncompatibilityMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod incompatibility_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl IncompatibilityMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotPerformedBySameVehicle => std::option::Option::Some(1),
+                Self::NotInSameVehicleSimultaneously => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INCOMPATIBILITY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_PERFORMED_BY_SAME_VEHICLE"),
-                2 => std::borrow::Cow::Borrowed("NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INCOMPATIBILITY_MODE_UNSPECIFIED"),
+                Self::NotPerformedBySameVehicle => {
+                    std::option::Option::Some("NOT_PERFORMED_BY_SAME_VEHICLE")
+                }
+                Self::NotInSameVehicleSimultaneously => {
+                    std::option::Option::Some("NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INCOMPATIBILITY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INCOMPATIBILITY_MODE_UNSPECIFIED)
-                }
-                "NOT_PERFORMED_BY_SAME_VEHICLE" => {
-                    std::option::Option::Some(Self::NOT_PERFORMED_BY_SAME_VEHICLE)
-                }
-                "NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY" => {
-                    std::option::Option::Some(Self::NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IncompatibilityMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IncompatibilityMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IncompatibilityMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IncompatibilityMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotPerformedBySameVehicle,
+                2 => Self::NotInSameVehicleSimultaneously,
+                _ => Self::UnknownValue(incompatibility_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IncompatibilityMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INCOMPATIBILITY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "NOT_PERFORMED_BY_SAME_VEHICLE" => Self::NotPerformedBySameVehicle,
+                "NOT_IN_SAME_VEHICLE_SIMULTANEOUSLY" => Self::NotInSameVehicleSimultaneously,
+                _ => Self::UnknownValue(incompatibility_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IncompatibilityMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotPerformedBySameVehicle => serializer.serialize_i32(1),
+                Self::NotInSameVehicleSimultaneously => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IncompatibilityMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IncompatibilityMode>::new(
+                ".google.cloud.optimization.v1.ShipmentTypeIncompatibility.IncompatibilityMode",
+            ))
         }
     }
 }
@@ -3094,17 +3336,14 @@ pub mod shipment_type_requirement {
     use super::*;
 
     /// Modes defining the appearance of dependent shipments on a route.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RequirementMode(i32);
-
-    impl RequirementMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RequirementMode {
         /// Unspecified requirement mode. This value should never be used.
-        pub const REQUIREMENT_MODE_UNSPECIFIED: RequirementMode = RequirementMode::new(0);
-
+        Unspecified,
         /// In this mode, all "dependent" shipments must share the same vehicle as at
         /// least one of their "required" shipments.
-        pub const PERFORMED_BY_SAME_VEHICLE: RequirementMode = RequirementMode::new(1);
-
+        PerformedBySameVehicle,
         /// With the `IN_SAME_VEHICLE_AT_PICKUP_TIME` mode, all "dependent"
         /// shipments need to have at least one "required" shipment on their vehicle
         /// at the time of their pickup.
@@ -3115,62 +3354,126 @@ pub mod shipment_type_requirement {
         /// * A "required" shipment picked up on the route before it, and if the
         ///   "required" shipment has a delivery, this delivery must be performed
         ///   after the "dependent" shipment's pickup.
-        pub const IN_SAME_VEHICLE_AT_PICKUP_TIME: RequirementMode = RequirementMode::new(2);
-
+        InSameVehicleAtPickupTime,
         /// Same as before, except the "dependent" shipments need to have a
         /// "required" shipment on their vehicle at the time of their *delivery*.
-        pub const IN_SAME_VEHICLE_AT_DELIVERY_TIME: RequirementMode = RequirementMode::new(3);
+        InSameVehicleAtDeliveryTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RequirementMode::value] or
+        /// [RequirementMode::name].
+        UnknownValue(requirement_mode::UnknownValue),
+    }
 
-        /// Creates a new RequirementMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod requirement_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RequirementMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PerformedBySameVehicle => std::option::Option::Some(1),
+                Self::InSameVehicleAtPickupTime => std::option::Option::Some(2),
+                Self::InSameVehicleAtDeliveryTime => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REQUIREMENT_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PERFORMED_BY_SAME_VEHICLE"),
-                2 => std::borrow::Cow::Borrowed("IN_SAME_VEHICLE_AT_PICKUP_TIME"),
-                3 => std::borrow::Cow::Borrowed("IN_SAME_VEHICLE_AT_DELIVERY_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REQUIREMENT_MODE_UNSPECIFIED"),
+                Self::PerformedBySameVehicle => {
+                    std::option::Option::Some("PERFORMED_BY_SAME_VEHICLE")
+                }
+                Self::InSameVehicleAtPickupTime => {
+                    std::option::Option::Some("IN_SAME_VEHICLE_AT_PICKUP_TIME")
+                }
+                Self::InSameVehicleAtDeliveryTime => {
+                    std::option::Option::Some("IN_SAME_VEHICLE_AT_DELIVERY_TIME")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REQUIREMENT_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REQUIREMENT_MODE_UNSPECIFIED)
-                }
-                "PERFORMED_BY_SAME_VEHICLE" => {
-                    std::option::Option::Some(Self::PERFORMED_BY_SAME_VEHICLE)
-                }
-                "IN_SAME_VEHICLE_AT_PICKUP_TIME" => {
-                    std::option::Option::Some(Self::IN_SAME_VEHICLE_AT_PICKUP_TIME)
-                }
-                "IN_SAME_VEHICLE_AT_DELIVERY_TIME" => {
-                    std::option::Option::Some(Self::IN_SAME_VEHICLE_AT_DELIVERY_TIME)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RequirementMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RequirementMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RequirementMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RequirementMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PerformedBySameVehicle,
+                2 => Self::InSameVehicleAtPickupTime,
+                3 => Self::InSameVehicleAtDeliveryTime,
+                _ => Self::UnknownValue(requirement_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RequirementMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REQUIREMENT_MODE_UNSPECIFIED" => Self::Unspecified,
+                "PERFORMED_BY_SAME_VEHICLE" => Self::PerformedBySameVehicle,
+                "IN_SAME_VEHICLE_AT_PICKUP_TIME" => Self::InSameVehicleAtPickupTime,
+                "IN_SAME_VEHICLE_AT_DELIVERY_TIME" => Self::InSameVehicleAtDeliveryTime,
+                _ => Self::UnknownValue(requirement_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RequirementMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PerformedBySameVehicle => serializer.serialize_i32(1),
+                Self::InSameVehicleAtPickupTime => serializer.serialize_i32(2),
+                Self::InSameVehicleAtDeliveryTime => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RequirementMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RequirementMode>::new(
+                ".google.cloud.optimization.v1.ShipmentTypeRequirement.RequirementMode",
+            ))
         }
     }
 }
@@ -4129,61 +4432,120 @@ pub mod vehicle {
     /// These should be a subset of the Google Maps Platform Routes Preferred API
     /// travel modes, see:
     /// <https://developers.google.com/maps/documentation/routes_preferred/reference/rest/Shared.Types/RouteTravelMode>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TravelMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TravelMode {
+        /// Unspecified travel mode, equivalent to `DRIVING`.
+        Unspecified,
+        /// Travel mode corresponding to driving directions (car, ...).
+        Driving,
+        /// Travel mode corresponding to walking directions.
+        Walking,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TravelMode::value] or
+        /// [TravelMode::name].
+        UnknownValue(travel_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod travel_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TravelMode {
-        /// Unspecified travel mode, equivalent to `DRIVING`.
-        pub const TRAVEL_MODE_UNSPECIFIED: TravelMode = TravelMode::new(0);
-
-        /// Travel mode corresponding to driving directions (car, ...).
-        pub const DRIVING: TravelMode = TravelMode::new(1);
-
-        /// Travel mode corresponding to walking directions.
-        pub const WALKING: TravelMode = TravelMode::new(2);
-
-        /// Creates a new TravelMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Driving => std::option::Option::Some(1),
+                Self::Walking => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRAVEL_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRIVING"),
-                2 => std::borrow::Cow::Borrowed("WALKING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRAVEL_MODE_UNSPECIFIED"),
+                Self::Driving => std::option::Option::Some("DRIVING"),
+                Self::Walking => std::option::Option::Some("WALKING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRAVEL_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRAVEL_MODE_UNSPECIFIED)
-                }
-                "DRIVING" => std::option::Option::Some(Self::DRIVING),
-                "WALKING" => std::option::Option::Some(Self::WALKING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TravelMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TravelMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TravelMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TravelMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Driving,
+                2 => Self::Walking,
+                _ => Self::UnknownValue(travel_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TravelMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRAVEL_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DRIVING" => Self::Driving,
+                "WALKING" => Self::Walking,
+                _ => Self::UnknownValue(travel_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TravelMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Driving => serializer.serialize_i32(1),
+                Self::Walking => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TravelMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TravelMode>::new(
+                ".google.cloud.optimization.v1.Vehicle.TravelMode",
+            ))
         }
     }
 
@@ -4192,62 +4554,121 @@ pub mod vehicle {
     ///
     /// Other shipments are free to occur anywhere on the route independent of
     /// `unloading_policy`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UnloadingPolicy(i32);
-
-    impl UnloadingPolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UnloadingPolicy {
         /// Unspecified unloading policy; deliveries must just occur after their
         /// corresponding pickups.
-        pub const UNLOADING_POLICY_UNSPECIFIED: UnloadingPolicy = UnloadingPolicy::new(0);
-
+        Unspecified,
         /// Deliveries must occur in reverse order of pickups
-        pub const LAST_IN_FIRST_OUT: UnloadingPolicy = UnloadingPolicy::new(1);
-
+        LastInFirstOut,
         /// Deliveries must occur in the same order as pickups
-        pub const FIRST_IN_FIRST_OUT: UnloadingPolicy = UnloadingPolicy::new(2);
+        FirstInFirstOut,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UnloadingPolicy::value] or
+        /// [UnloadingPolicy::name].
+        UnknownValue(unloading_policy::UnknownValue),
+    }
 
-        /// Creates a new UnloadingPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod unloading_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl UnloadingPolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LastInFirstOut => std::option::Option::Some(1),
+                Self::FirstInFirstOut => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNLOADING_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LAST_IN_FIRST_OUT"),
-                2 => std::borrow::Cow::Borrowed("FIRST_IN_FIRST_OUT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNLOADING_POLICY_UNSPECIFIED"),
+                Self::LastInFirstOut => std::option::Option::Some("LAST_IN_FIRST_OUT"),
+                Self::FirstInFirstOut => std::option::Option::Some("FIRST_IN_FIRST_OUT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNLOADING_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::UNLOADING_POLICY_UNSPECIFIED)
-                }
-                "LAST_IN_FIRST_OUT" => std::option::Option::Some(Self::LAST_IN_FIRST_OUT),
-                "FIRST_IN_FIRST_OUT" => std::option::Option::Some(Self::FIRST_IN_FIRST_OUT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UnloadingPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UnloadingPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UnloadingPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UnloadingPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LastInFirstOut,
+                2 => Self::FirstInFirstOut,
+                _ => Self::UnknownValue(unloading_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UnloadingPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNLOADING_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "LAST_IN_FIRST_OUT" => Self::LastInFirstOut,
+                "FIRST_IN_FIRST_OUT" => Self::FirstInFirstOut,
+                _ => Self::UnknownValue(unloading_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UnloadingPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LastInFirstOut => serializer.serialize_i32(1),
+                Self::FirstInFirstOut => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UnloadingPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UnloadingPolicy>::new(
+                ".google.cloud.optimization.v1.Vehicle.UnloadingPolicy",
+            ))
         }
     }
 }
@@ -6436,125 +6857,207 @@ pub mod skipped_shipment {
         /// Code identifying the reason type. The order here is meaningless. In
         /// particular, it gives no indication of whether a given reason will
         /// appear before another in the solution, if both apply.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Code(i32);
-
-        impl Code {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Code {
             /// This should never be used. If we are unable to understand why a
             /// shipment was skipped, we simply return an empty set of reasons.
-            pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+            Unspecified,
             /// There is no vehicle in the model making all shipments infeasible.
-            pub const NO_VEHICLE: Code = Code::new(1);
-
+            NoVehicle,
             /// The demand of the shipment exceeds a vehicle's capacity for some
             /// capacity types, one of which is `example_exceeded_capacity_type`.
-            pub const DEMAND_EXCEEDS_VEHICLE_CAPACITY: Code = Code::new(2);
-
+            DemandExceedsVehicleCapacity,
             /// The minimum distance necessary to perform this shipment, i.e. from
             /// the vehicle's `start_location` to the shipment's pickup and/or delivery
             /// locations and to the vehicle's end location exceeds the vehicle's
             /// `route_distance_limit`.
             ///
             /// Note that for this computation we use the geodesic distances.
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT: Code = Code::new(3);
-
+            CannotBePerformedWithinVehicleDistanceLimit,
             /// The minimum time necessary to perform this shipment, including travel
             /// time, wait time and service time exceeds the vehicle's
             /// `route_duration_limit`.
             ///
             /// Note: travel time is computed in the best-case scenario, namely as
             /// geodesic distance x 36 m/s (roughly 130 km/hour).
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT: Code = Code::new(4);
-
+            CannotBePerformedWithinVehicleDurationLimit,
             /// Same as above but we only compare minimum travel time and the
             /// vehicle's `travel_duration_limit`.
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT: Code = Code::new(5);
-
+            CannotBePerformedWithinVehicleTravelDurationLimit,
             /// The vehicle cannot perform this shipment in the best-case scenario
             /// (see `CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT` for time
             /// computation) if it starts at its earliest start time: the total time
             /// would make the vehicle end after its latest end time.
-            pub const CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS: Code = Code::new(6);
-
+            CannotBePerformedWithinVehicleTimeWindows,
             /// The `allowed_vehicle_indices` field of the shipment is not empty and
             /// this vehicle does not belong to it.
-            pub const VEHICLE_NOT_ALLOWED: Code = Code::new(7);
+            VehicleNotAllowed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Code::value] or
+            /// [Code::name].
+            UnknownValue(code::UnknownValue),
+        }
 
-            /// Creates a new Code instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod code {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Code {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::NoVehicle => std::option::Option::Some(1),
+                    Self::DemandExceedsVehicleCapacity => std::option::Option::Some(2),
+                    Self::CannotBePerformedWithinVehicleDistanceLimit => {
+                        std::option::Option::Some(3)
+                    }
+                    Self::CannotBePerformedWithinVehicleDurationLimit => {
+                        std::option::Option::Some(4)
+                    }
+                    Self::CannotBePerformedWithinVehicleTravelDurationLimit => {
+                        std::option::Option::Some(5)
+                    }
+                    Self::CannotBePerformedWithinVehicleTimeWindows => std::option::Option::Some(6),
+                    Self::VehicleNotAllowed => std::option::Option::Some(7),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NO_VEHICLE"),
-                    2 => std::borrow::Cow::Borrowed("DEMAND_EXCEEDS_VEHICLE_CAPACITY"),
-                    3 => std::borrow::Cow::Borrowed(
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                    Self::NoVehicle => std::option::Option::Some("NO_VEHICLE"),
+                    Self::DemandExceedsVehicleCapacity => {
+                        std::option::Option::Some("DEMAND_EXCEEDS_VEHICLE_CAPACITY")
+                    }
+                    Self::CannotBePerformedWithinVehicleDistanceLimit => std::option::Option::Some(
                         "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT",
                     ),
-                    4 => std::borrow::Cow::Borrowed(
+                    Self::CannotBePerformedWithinVehicleDurationLimit => std::option::Option::Some(
                         "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT",
                     ),
-                    5 => std::borrow::Cow::Borrowed(
-                        "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT",
-                    ),
-                    6 => std::borrow::Cow::Borrowed(
-                        "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS",
-                    ),
-                    7 => std::borrow::Cow::Borrowed("VEHICLE_NOT_ALLOWED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                    Self::CannotBePerformedWithinVehicleTravelDurationLimit => {
+                        std::option::Option::Some(
+                            "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT",
+                        )
+                    }
+                    Self::CannotBePerformedWithinVehicleTimeWindows => {
+                        std::option::Option::Some("CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS")
+                    }
+                    Self::VehicleNotAllowed => std::option::Option::Some("VEHICLE_NOT_ALLOWED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                    "NO_VEHICLE" => std::option::Option::Some(Self::NO_VEHICLE),
-                    "DEMAND_EXCEEDS_VEHICLE_CAPACITY" => {
-                        std::option::Option::Some(Self::DEMAND_EXCEEDS_VEHICLE_CAPACITY)
-                    }
-                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT" => {
-                        std::option::Option::Some(
-                            Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT,
-                        )
-                    }
-                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT" => {
-                        std::option::Option::Some(
-                            Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT,
-                        )
-                    }
-                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT" => {
-                        std::option::Option::Some(
-                            Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT,
-                        )
-                    }
-                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS" => std::option::Option::Some(
-                        Self::CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS,
-                    ),
-                    "VEHICLE_NOT_ALLOWED" => std::option::Option::Some(Self::VEHICLE_NOT_ALLOWED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Code {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Code {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Code {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Code {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::NoVehicle,
+                    2 => Self::DemandExceedsVehicleCapacity,
+                    3 => Self::CannotBePerformedWithinVehicleDistanceLimit,
+                    4 => Self::CannotBePerformedWithinVehicleDurationLimit,
+                    5 => Self::CannotBePerformedWithinVehicleTravelDurationLimit,
+                    6 => Self::CannotBePerformedWithinVehicleTimeWindows,
+                    7 => Self::VehicleNotAllowed,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Code {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CODE_UNSPECIFIED" => Self::Unspecified,
+                    "NO_VEHICLE" => Self::NoVehicle,
+                    "DEMAND_EXCEEDS_VEHICLE_CAPACITY" => Self::DemandExceedsVehicleCapacity,
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DISTANCE_LIMIT" => {
+                        Self::CannotBePerformedWithinVehicleDistanceLimit
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_DURATION_LIMIT" => {
+                        Self::CannotBePerformedWithinVehicleDurationLimit
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TRAVEL_DURATION_LIMIT" => {
+                        Self::CannotBePerformedWithinVehicleTravelDurationLimit
+                    }
+                    "CANNOT_BE_PERFORMED_WITHIN_VEHICLE_TIME_WINDOWS" => {
+                        Self::CannotBePerformedWithinVehicleTimeWindows
+                    }
+                    "VEHICLE_NOT_ALLOWED" => Self::VehicleNotAllowed,
+                    _ => Self::UnknownValue(code::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Code {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::NoVehicle => serializer.serialize_i32(1),
+                    Self::DemandExceedsVehicleCapacity => serializer.serialize_i32(2),
+                    Self::CannotBePerformedWithinVehicleDistanceLimit => {
+                        serializer.serialize_i32(3)
+                    }
+                    Self::CannotBePerformedWithinVehicleDurationLimit => {
+                        serializer.serialize_i32(4)
+                    }
+                    Self::CannotBePerformedWithinVehicleTravelDurationLimit => {
+                        serializer.serialize_i32(5)
+                    }
+                    Self::CannotBePerformedWithinVehicleTimeWindows => serializer.serialize_i32(6),
+                    Self::VehicleNotAllowed => serializer.serialize_i32(7),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Code {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                    ".google.cloud.optimization.v1.SkippedShipment.Reason.Code",
+                ))
             }
         }
     }
@@ -7029,84 +7532,153 @@ pub mod injected_solution_constraint {
             /// threshold conditions.
             ///
             /// The enumeration below is in order of increasing relaxation.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Level(i32);
-
-            impl Level {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Level {
                 /// Implicit default relaxation level: no constraints are relaxed,
                 /// i.e., all visits are fully constrained.
                 ///
                 /// This value must not be explicitly used in `level`.
-                pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
-
+                Unspecified,
                 /// Visit start times and vehicle start/end times will be relaxed, but
                 /// each visit remains bound to the same vehicle and the visit sequence
                 /// must be observed: no visit can be inserted between them or before
                 /// them.
-                pub const RELAX_VISIT_TIMES_AFTER_THRESHOLD: Level = Level::new(1);
-
+                RelaxVisitTimesAfterThreshold,
                 /// Same as `RELAX_VISIT_TIMES_AFTER_THRESHOLD`, but the visit sequence
                 /// is also relaxed: visits can only be performed by this vehicle, but
                 /// can potentially become unperformed.
-                pub const RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD: Level = Level::new(2);
-
+                RelaxVisitTimesAndSequenceAfterThreshold,
                 /// Same as `RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD`, but the
                 /// vehicle is also relaxed: visits are completely free at or after the
                 /// threshold time and can potentially become unperformed.
-                pub const RELAX_ALL_AFTER_THRESHOLD: Level = Level::new(3);
+                RelaxAllAfterThreshold,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Level::value] or
+                /// [Level::name].
+                UnknownValue(level::UnknownValue),
+            }
 
-                /// Creates a new Level instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod level {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl Level {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::RelaxVisitTimesAfterThreshold => std::option::Option::Some(1),
+                        Self::RelaxVisitTimesAndSequenceAfterThreshold => {
+                            std::option::Option::Some(2)
+                        }
+                        Self::RelaxAllAfterThreshold => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("RELAX_VISIT_TIMES_AFTER_THRESHOLD"),
-                        2 => std::borrow::Cow::Borrowed(
-                            "RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD",
-                        ),
-                        3 => std::borrow::Cow::Borrowed("RELAX_ALL_AFTER_THRESHOLD"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
-                        "RELAX_VISIT_TIMES_AFTER_THRESHOLD" => {
-                            std::option::Option::Some(Self::RELAX_VISIT_TIMES_AFTER_THRESHOLD)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("LEVEL_UNSPECIFIED"),
+                        Self::RelaxVisitTimesAfterThreshold => {
+                            std::option::Option::Some("RELAX_VISIT_TIMES_AFTER_THRESHOLD")
                         }
-                        "RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD" => {
+                        Self::RelaxVisitTimesAndSequenceAfterThreshold => {
                             std::option::Option::Some(
-                                Self::RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD,
+                                "RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD",
                             )
                         }
-                        "RELAX_ALL_AFTER_THRESHOLD" => {
-                            std::option::Option::Some(Self::RELAX_ALL_AFTER_THRESHOLD)
+                        Self::RelaxAllAfterThreshold => {
+                            std::option::Option::Some("RELAX_ALL_AFTER_THRESHOLD")
                         }
-                        _ => std::option::Option::None,
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for Level {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Level {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Level {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Level {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::RelaxVisitTimesAfterThreshold,
+                        2 => Self::RelaxVisitTimesAndSequenceAfterThreshold,
+                        3 => Self::RelaxAllAfterThreshold,
+                        _ => Self::UnknownValue(level::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Level {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "LEVEL_UNSPECIFIED" => Self::Unspecified,
+                        "RELAX_VISIT_TIMES_AFTER_THRESHOLD" => Self::RelaxVisitTimesAfterThreshold,
+                        "RELAX_VISIT_TIMES_AND_SEQUENCE_AFTER_THRESHOLD" => {
+                            Self::RelaxVisitTimesAndSequenceAfterThreshold
+                        }
+                        "RELAX_ALL_AFTER_THRESHOLD" => Self::RelaxAllAfterThreshold,
+                        _ => Self::UnknownValue(level::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Level {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::RelaxVisitTimesAfterThreshold => serializer.serialize_i32(1),
+                        Self::RelaxVisitTimesAndSequenceAfterThreshold => {
+                            serializer.serialize_i32(2)
+                        }
+                        Self::RelaxAllAfterThreshold => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Level {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Level>::new(
+                        ".google.cloud.optimization.v1.InjectedSolutionConstraint.ConstraintRelaxation.Relaxation.Level"))
                 }
             }
         }
@@ -7637,58 +8209,119 @@ pub mod optimize_tours_validation_error {
 }
 
 /// Data formats for input and output files.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataFormat(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DataFormat {
+    /// Default value.
+    Unspecified,
+    /// Input data in json format.
+    Json,
+    /// Input data in string format.
+    String,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DataFormat::value] or
+    /// [DataFormat::name].
+    UnknownValue(data_format::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod data_format {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DataFormat {
-    /// Default value.
-    pub const DATA_FORMAT_UNSPECIFIED: DataFormat = DataFormat::new(0);
-
-    /// Input data in json format.
-    pub const JSON: DataFormat = DataFormat::new(1);
-
-    /// Input data in string format.
-    pub const STRING: DataFormat = DataFormat::new(2);
-
-    /// Creates a new DataFormat instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Json => std::option::Option::Some(1),
+            Self::String => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATA_FORMAT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("JSON"),
-            2 => std::borrow::Cow::Borrowed("STRING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATA_FORMAT_UNSPECIFIED"),
+            Self::Json => std::option::Option::Some("JSON"),
+            Self::String => std::option::Option::Some("STRING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATA_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::DATA_FORMAT_UNSPECIFIED),
-            "JSON" => std::option::Option::Some(Self::JSON),
-            "STRING" => std::option::Option::Some(Self::STRING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DataFormat {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DataFormat {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DataFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DataFormat {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Json,
+            2 => Self::String,
+            _ => Self::UnknownValue(data_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DataFormat {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATA_FORMAT_UNSPECIFIED" => Self::Unspecified,
+            "JSON" => Self::Json,
+            "STRING" => Self::String,
+            _ => Self::UnknownValue(data_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DataFormat {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Json => serializer.serialize_i32(1),
+            Self::String => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DataFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataFormat>::new(
+            ".google.cloud.optimization.v1.DataFormat",
+        ))
     }
 }

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -961,703 +961,1376 @@ pub mod autonomous_database_properties {
     use super::*;
 
     /// The editions available for the Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEdition(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseEdition {
+        /// Default unspecified value.
+        Unspecified,
+        /// Standard Database Edition
+        StandardEdition,
+        /// Enterprise Database Edition
+        EnterpriseEdition,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseEdition::value] or
+        /// [DatabaseEdition::name].
+        UnknownValue(database_edition::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_edition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseEdition {
-        /// Default unspecified value.
-        pub const DATABASE_EDITION_UNSPECIFIED: DatabaseEdition = DatabaseEdition::new(0);
-
-        /// Standard Database Edition
-        pub const STANDARD_EDITION: DatabaseEdition = DatabaseEdition::new(1);
-
-        /// Enterprise Database Edition
-        pub const ENTERPRISE_EDITION: DatabaseEdition = DatabaseEdition::new(2);
-
-        /// Creates a new DatabaseEdition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StandardEdition => std::option::Option::Some(1),
+                Self::EnterpriseEdition => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_EDITION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD_EDITION"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE_EDITION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_EDITION_UNSPECIFIED"),
+                Self::StandardEdition => std::option::Option::Some("STANDARD_EDITION"),
+                Self::EnterpriseEdition => std::option::Option::Some("ENTERPRISE_EDITION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_EDITION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_EDITION_UNSPECIFIED)
-                }
-                "STANDARD_EDITION" => std::option::Option::Some(Self::STANDARD_EDITION),
-                "ENTERPRISE_EDITION" => std::option::Option::Some(Self::ENTERPRISE_EDITION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseEdition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEdition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseEdition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseEdition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StandardEdition,
+                2 => Self::EnterpriseEdition,
+                _ => Self::UnknownValue(database_edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseEdition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_EDITION_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD_EDITION" => Self::StandardEdition,
+                "ENTERPRISE_EDITION" => Self::EnterpriseEdition,
+                _ => Self::UnknownValue(database_edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseEdition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StandardEdition => serializer.serialize_i32(1),
+                Self::EnterpriseEdition => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseEdition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEdition>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.DatabaseEdition",
+            ))
         }
     }
 
     /// The license types available for the Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LicenseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LicenseType {
+        /// Unspecified
+        Unspecified,
+        /// License included part of offer
+        LicenseIncluded,
+        /// Bring your own license
+        BringYourOwnLicense,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LicenseType::value] or
+        /// [LicenseType::name].
+        UnknownValue(license_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod license_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LicenseType {
-        /// Unspecified
-        pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
-
-        /// License included part of offer
-        pub const LICENSE_INCLUDED: LicenseType = LicenseType::new(1);
-
-        /// Bring your own license
-        pub const BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
-
-        /// Creates a new LicenseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LicenseIncluded => std::option::Option::Some(1),
+                Self::BringYourOwnLicense => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LICENSE_INCLUDED"),
-                2 => std::borrow::Cow::Borrowed("BRING_YOUR_OWN_LICENSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LICENSE_TYPE_UNSPECIFIED"),
+                Self::LicenseIncluded => std::option::Option::Some("LICENSE_INCLUDED"),
+                Self::BringYourOwnLicense => std::option::Option::Some("BRING_YOUR_OWN_LICENSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LICENSE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED)
-                }
-                "LICENSE_INCLUDED" => std::option::Option::Some(Self::LICENSE_INCLUDED),
-                "BRING_YOUR_OWN_LICENSE" => std::option::Option::Some(Self::BRING_YOUR_OWN_LICENSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LicenseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LicenseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LicenseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LicenseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LicenseIncluded,
+                2 => Self::BringYourOwnLicense,
+                _ => Self::UnknownValue(license_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LicenseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LICENSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LICENSE_INCLUDED" => Self::LicenseIncluded,
+                "BRING_YOUR_OWN_LICENSE" => Self::BringYourOwnLicense,
+                _ => Self::UnknownValue(license_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LicenseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LicenseIncluded => serializer.serialize_i32(1),
+                Self::BringYourOwnLicense => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LicenseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LicenseType>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.LicenseType",
+            ))
         }
     }
 
     /// The available maintenance schedules for the Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MaintenanceScheduleType(i32);
-
-    impl MaintenanceScheduleType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MaintenanceScheduleType {
         /// Default unspecified value.
-        pub const MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED: MaintenanceScheduleType =
-            MaintenanceScheduleType::new(0);
-
+        Unspecified,
         /// An EARLY maintenance schedule patches the database before
         /// the regular scheduled maintenance.
-        pub const EARLY: MaintenanceScheduleType = MaintenanceScheduleType::new(1);
-
+        Early,
         /// A REGULAR maintenance schedule follows the normal maintenance cycle.
-        pub const REGULAR: MaintenanceScheduleType = MaintenanceScheduleType::new(2);
+        Regular,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MaintenanceScheduleType::value] or
+        /// [MaintenanceScheduleType::name].
+        UnknownValue(maintenance_schedule_type::UnknownValue),
+    }
 
-        /// Creates a new MaintenanceScheduleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod maintenance_schedule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MaintenanceScheduleType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Early => std::option::Option::Some(1),
+                Self::Regular => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EARLY"),
-                2 => std::borrow::Cow::Borrowed("REGULAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED")
                 }
-                "EARLY" => std::option::Option::Some(Self::EARLY),
-                "REGULAR" => std::option::Option::Some(Self::REGULAR),
-                _ => std::option::Option::None,
+                Self::Early => std::option::Option::Some("EARLY"),
+                Self::Regular => std::option::Option::Some("REGULAR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for MaintenanceScheduleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MaintenanceScheduleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MaintenanceScheduleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MaintenanceScheduleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Early,
+                2 => Self::Regular,
+                _ => Self::UnknownValue(maintenance_schedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MaintenanceScheduleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MAINTENANCE_SCHEDULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "EARLY" => Self::Early,
+                "REGULAR" => Self::Regular,
+                _ => Self::UnknownValue(maintenance_schedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MaintenanceScheduleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Early => serializer.serialize_i32(1),
+                Self::Regular => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MaintenanceScheduleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MaintenanceScheduleType>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.MaintenanceScheduleType"))
         }
     }
 
     /// The types of local disaster recovery available for an Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocalDisasterRecoveryType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LocalDisasterRecoveryType {
+        /// Default unspecified value.
+        Unspecified,
+        /// Autonomous Data Guard recovery.
+        Adg,
+        /// Backup based recovery.
+        BackupBased,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LocalDisasterRecoveryType::value] or
+        /// [LocalDisasterRecoveryType::name].
+        UnknownValue(local_disaster_recovery_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod local_disaster_recovery_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LocalDisasterRecoveryType {
-        /// Default unspecified value.
-        pub const LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED: LocalDisasterRecoveryType =
-            LocalDisasterRecoveryType::new(0);
-
-        /// Autonomous Data Guard recovery.
-        pub const ADG: LocalDisasterRecoveryType = LocalDisasterRecoveryType::new(1);
-
-        /// Backup based recovery.
-        pub const BACKUP_BASED: LocalDisasterRecoveryType = LocalDisasterRecoveryType::new(2);
-
-        /// Creates a new LocalDisasterRecoveryType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Adg => std::option::Option::Some(1),
+                Self::BackupBased => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADG"),
-                2 => std::borrow::Cow::Borrowed("BACKUP_BASED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED")
                 }
-                "ADG" => std::option::Option::Some(Self::ADG),
-                "BACKUP_BASED" => std::option::Option::Some(Self::BACKUP_BASED),
-                _ => std::option::Option::None,
+                Self::Adg => std::option::Option::Some("ADG"),
+                Self::BackupBased => std::option::Option::Some("BACKUP_BASED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for LocalDisasterRecoveryType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LocalDisasterRecoveryType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LocalDisasterRecoveryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LocalDisasterRecoveryType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Adg,
+                2 => Self::BackupBased,
+                _ => Self::UnknownValue(local_disaster_recovery_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LocalDisasterRecoveryType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCAL_DISASTER_RECOVERY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ADG" => Self::Adg,
+                "BACKUP_BASED" => Self::BackupBased,
+                _ => Self::UnknownValue(local_disaster_recovery_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LocalDisasterRecoveryType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Adg => serializer.serialize_i32(1),
+                Self::BackupBased => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LocalDisasterRecoveryType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocalDisasterRecoveryType>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.LocalDisasterRecoveryType"))
         }
     }
 
     /// Varies states of the Data Safe registration for the Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataSafeState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataSafeState {
+        /// Default unspecified value.
+        Unspecified,
+        /// Registering data safe state.
+        Registering,
+        /// Registered data safe state.
+        Registered,
+        /// Deregistering data safe state.
+        Deregistering,
+        /// Not registered data safe state.
+        NotRegistered,
+        /// Failed data safe state.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataSafeState::value] or
+        /// [DataSafeState::name].
+        UnknownValue(data_safe_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod data_safe_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DataSafeState {
-        /// Default unspecified value.
-        pub const DATA_SAFE_STATE_UNSPECIFIED: DataSafeState = DataSafeState::new(0);
-
-        /// Registering data safe state.
-        pub const REGISTERING: DataSafeState = DataSafeState::new(1);
-
-        /// Registered data safe state.
-        pub const REGISTERED: DataSafeState = DataSafeState::new(2);
-
-        /// Deregistering data safe state.
-        pub const DEREGISTERING: DataSafeState = DataSafeState::new(3);
-
-        /// Not registered data safe state.
-        pub const NOT_REGISTERED: DataSafeState = DataSafeState::new(4);
-
-        /// Failed data safe state.
-        pub const FAILED: DataSafeState = DataSafeState::new(5);
-
-        /// Creates a new DataSafeState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Registering => std::option::Option::Some(1),
+                Self::Registered => std::option::Option::Some(2),
+                Self::Deregistering => std::option::Option::Some(3),
+                Self::NotRegistered => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_SAFE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGISTERING"),
-                2 => std::borrow::Cow::Borrowed("REGISTERED"),
-                3 => std::borrow::Cow::Borrowed("DEREGISTERING"),
-                4 => std::borrow::Cow::Borrowed("NOT_REGISTERED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_SAFE_STATE_UNSPECIFIED"),
+                Self::Registering => std::option::Option::Some("REGISTERING"),
+                Self::Registered => std::option::Option::Some("REGISTERED"),
+                Self::Deregistering => std::option::Option::Some("DEREGISTERING"),
+                Self::NotRegistered => std::option::Option::Some("NOT_REGISTERED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_SAFE_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_SAFE_STATE_UNSPECIFIED)
-                }
-                "REGISTERING" => std::option::Option::Some(Self::REGISTERING),
-                "REGISTERED" => std::option::Option::Some(Self::REGISTERED),
-                "DEREGISTERING" => std::option::Option::Some(Self::DEREGISTERING),
-                "NOT_REGISTERED" => std::option::Option::Some(Self::NOT_REGISTERED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataSafeState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataSafeState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataSafeState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataSafeState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Registering,
+                2 => Self::Registered,
+                3 => Self::Deregistering,
+                4 => Self::NotRegistered,
+                5 => Self::Failed,
+                _ => Self::UnknownValue(data_safe_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataSafeState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_SAFE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "REGISTERING" => Self::Registering,
+                "REGISTERED" => Self::Registered,
+                "DEREGISTERING" => Self::Deregistering,
+                "NOT_REGISTERED" => Self::NotRegistered,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(data_safe_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataSafeState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Registering => serializer.serialize_i32(1),
+                Self::Registered => serializer.serialize_i32(2),
+                Self::Deregistering => serializer.serialize_i32(3),
+                Self::NotRegistered => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataSafeState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataSafeState>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.DataSafeState",
+            ))
         }
     }
 
     /// The different states of database management for an Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseManagementState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseManagementState {
+        /// Default unspecified value.
+        Unspecified,
+        /// Enabling Database Management state
+        Enabling,
+        /// Enabled Database Management state
+        Enabled,
+        /// Disabling Database Management state
+        Disabling,
+        /// Not Enabled Database Management state
+        NotEnabled,
+        /// Failed enabling Database Management state
+        FailedEnabling,
+        /// Failed disabling Database Management state
+        FailedDisabling,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseManagementState::value] or
+        /// [DatabaseManagementState::name].
+        UnknownValue(database_management_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_management_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseManagementState {
-        /// Default unspecified value.
-        pub const DATABASE_MANAGEMENT_STATE_UNSPECIFIED: DatabaseManagementState =
-            DatabaseManagementState::new(0);
-
-        /// Enabling Database Management state
-        pub const ENABLING: DatabaseManagementState = DatabaseManagementState::new(1);
-
-        /// Enabled Database Management state
-        pub const ENABLED: DatabaseManagementState = DatabaseManagementState::new(2);
-
-        /// Disabling Database Management state
-        pub const DISABLING: DatabaseManagementState = DatabaseManagementState::new(3);
-
-        /// Not Enabled Database Management state
-        pub const NOT_ENABLED: DatabaseManagementState = DatabaseManagementState::new(4);
-
-        /// Failed enabling Database Management state
-        pub const FAILED_ENABLING: DatabaseManagementState = DatabaseManagementState::new(5);
-
-        /// Failed disabling Database Management state
-        pub const FAILED_DISABLING: DatabaseManagementState = DatabaseManagementState::new(6);
-
-        /// Creates a new DatabaseManagementState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabling => std::option::Option::Some(1),
+                Self::Enabled => std::option::Option::Some(2),
+                Self::Disabling => std::option::Option::Some(3),
+                Self::NotEnabled => std::option::Option::Some(4),
+                Self::FailedEnabling => std::option::Option::Some(5),
+                Self::FailedDisabling => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_MANAGEMENT_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLING"),
-                2 => std::borrow::Cow::Borrowed("ENABLED"),
-                3 => std::borrow::Cow::Borrowed("DISABLING"),
-                4 => std::borrow::Cow::Borrowed("NOT_ENABLED"),
-                5 => std::borrow::Cow::Borrowed("FAILED_ENABLING"),
-                6 => std::borrow::Cow::Borrowed("FAILED_DISABLING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_MANAGEMENT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_MANAGEMENT_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DATABASE_MANAGEMENT_STATE_UNSPECIFIED")
                 }
-                "ENABLING" => std::option::Option::Some(Self::ENABLING),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLING" => std::option::Option::Some(Self::DISABLING),
-                "NOT_ENABLED" => std::option::Option::Some(Self::NOT_ENABLED),
-                "FAILED_ENABLING" => std::option::Option::Some(Self::FAILED_ENABLING),
-                "FAILED_DISABLING" => std::option::Option::Some(Self::FAILED_DISABLING),
-                _ => std::option::Option::None,
+                Self::Enabling => std::option::Option::Some("ENABLING"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabling => std::option::Option::Some("DISABLING"),
+                Self::NotEnabled => std::option::Option::Some("NOT_ENABLED"),
+                Self::FailedEnabling => std::option::Option::Some("FAILED_ENABLING"),
+                Self::FailedDisabling => std::option::Option::Some("FAILED_DISABLING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseManagementState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseManagementState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseManagementState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseManagementState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabling,
+                2 => Self::Enabled,
+                3 => Self::Disabling,
+                4 => Self::NotEnabled,
+                5 => Self::FailedEnabling,
+                6 => Self::FailedDisabling,
+                _ => Self::UnknownValue(database_management_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseManagementState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_MANAGEMENT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLING" => Self::Enabling,
+                "ENABLED" => Self::Enabled,
+                "DISABLING" => Self::Disabling,
+                "NOT_ENABLED" => Self::NotEnabled,
+                "FAILED_ENABLING" => Self::FailedEnabling,
+                "FAILED_DISABLING" => Self::FailedDisabling,
+                _ => Self::UnknownValue(database_management_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseManagementState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabling => serializer.serialize_i32(1),
+                Self::Enabled => serializer.serialize_i32(2),
+                Self::Disabling => serializer.serialize_i32(3),
+                Self::NotEnabled => serializer.serialize_i32(4),
+                Self::FailedEnabling => serializer.serialize_i32(5),
+                Self::FailedDisabling => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseManagementState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseManagementState>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.DatabaseManagementState"))
         }
     }
 
     /// This field indicates the modes of an Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OpenMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OpenMode {
+        /// Default unspecified value.
+        Unspecified,
+        /// Read Only Mode
+        ReadOnly,
+        /// Read Write Mode
+        ReadWrite,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OpenMode::value] or
+        /// [OpenMode::name].
+        UnknownValue(open_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod open_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OpenMode {
-        /// Default unspecified value.
-        pub const OPEN_MODE_UNSPECIFIED: OpenMode = OpenMode::new(0);
-
-        /// Read Only Mode
-        pub const READ_ONLY: OpenMode = OpenMode::new(1);
-
-        /// Read Write Mode
-        pub const READ_WRITE: OpenMode = OpenMode::new(2);
-
-        /// Creates a new OpenMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReadOnly => std::option::Option::Some(1),
+                Self::ReadWrite => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPEN_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                2 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPEN_MODE_UNSPECIFIED"),
+                Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPEN_MODE_UNSPECIFIED" => std::option::Option::Some(Self::OPEN_MODE_UNSPECIFIED),
-                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OpenMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OpenMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OpenMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OpenMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReadOnly,
+                2 => Self::ReadWrite,
+                _ => Self::UnknownValue(open_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OpenMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPEN_MODE_UNSPECIFIED" => Self::Unspecified,
+                "READ_ONLY" => Self::ReadOnly,
+                "READ_WRITE" => Self::ReadWrite,
+                _ => Self::UnknownValue(open_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OpenMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReadOnly => serializer.serialize_i32(1),
+                Self::ReadWrite => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OpenMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OpenMode>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.OpenMode",
+            ))
         }
     }
 
     /// The types of permission levels for an Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PermissionLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PermissionLevel {
+        /// Default unspecified value.
+        Unspecified,
+        /// Restricted mode allows access only by admin users.
+        Restricted,
+        /// Normal access.
+        Unrestricted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PermissionLevel::value] or
+        /// [PermissionLevel::name].
+        UnknownValue(permission_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod permission_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PermissionLevel {
-        /// Default unspecified value.
-        pub const PERMISSION_LEVEL_UNSPECIFIED: PermissionLevel = PermissionLevel::new(0);
-
-        /// Restricted mode allows access only by admin users.
-        pub const RESTRICTED: PermissionLevel = PermissionLevel::new(1);
-
-        /// Normal access.
-        pub const UNRESTRICTED: PermissionLevel = PermissionLevel::new(2);
-
-        /// Creates a new PermissionLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Restricted => std::option::Option::Some(1),
+                Self::Unrestricted => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERMISSION_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESTRICTED"),
-                2 => std::borrow::Cow::Borrowed("UNRESTRICTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERMISSION_LEVEL_UNSPECIFIED"),
+                Self::Restricted => std::option::Option::Some("RESTRICTED"),
+                Self::Unrestricted => std::option::Option::Some("UNRESTRICTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERMISSION_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PERMISSION_LEVEL_UNSPECIFIED)
-                }
-                "RESTRICTED" => std::option::Option::Some(Self::RESTRICTED),
-                "UNRESTRICTED" => std::option::Option::Some(Self::UNRESTRICTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PermissionLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PermissionLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PermissionLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PermissionLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Restricted,
+                2 => Self::Unrestricted,
+                _ => Self::UnknownValue(permission_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PermissionLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERMISSION_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "RESTRICTED" => Self::Restricted,
+                "UNRESTRICTED" => Self::Unrestricted,
+                _ => Self::UnknownValue(permission_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PermissionLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Restricted => serializer.serialize_i32(1),
+                Self::Unrestricted => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PermissionLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PermissionLevel>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.PermissionLevel",
+            ))
         }
     }
 
     /// The refresh mode of the cloned Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefreshableMode(i32);
-
-    impl RefreshableMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RefreshableMode {
         /// The default unspecified value.
-        pub const REFRESHABLE_MODE_UNSPECIFIED: RefreshableMode = RefreshableMode::new(0);
-
+        Unspecified,
         /// AUTOMATIC indicates that the cloned database is automatically
         /// refreshed with data from the source Autonomous Database.
-        pub const AUTOMATIC: RefreshableMode = RefreshableMode::new(1);
-
+        Automatic,
         /// MANUAL indicates that the cloned database is manually refreshed with
         /// data from the source Autonomous Database.
-        pub const MANUAL: RefreshableMode = RefreshableMode::new(2);
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RefreshableMode::value] or
+        /// [RefreshableMode::name].
+        UnknownValue(refreshable_mode::UnknownValue),
+    }
 
-        /// Creates a new RefreshableMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod refreshable_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RefreshableMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REFRESHABLE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REFRESHABLE_MODE_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REFRESHABLE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REFRESHABLE_MODE_UNSPECIFIED)
-                }
-                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RefreshableMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RefreshableMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RefreshableMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RefreshableMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(refreshable_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RefreshableMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REFRESHABLE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC" => Self::Automatic,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(refreshable_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RefreshableMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RefreshableMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RefreshableMode>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.RefreshableMode",
+            ))
         }
     }
 
     /// The refresh state of the cloned Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefreshableState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RefreshableState {
+        /// Default unspecified value.
+        Unspecified,
+        /// Refreshing
+        Refreshing,
+        /// Not refreshed
+        NotRefreshing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RefreshableState::value] or
+        /// [RefreshableState::name].
+        UnknownValue(refreshable_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod refreshable_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RefreshableState {
-        /// Default unspecified value.
-        pub const REFRESHABLE_STATE_UNSPECIFIED: RefreshableState = RefreshableState::new(0);
-
-        /// Refreshing
-        pub const REFRESHING: RefreshableState = RefreshableState::new(1);
-
-        /// Not refreshed
-        pub const NOT_REFRESHING: RefreshableState = RefreshableState::new(2);
-
-        /// Creates a new RefreshableState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Refreshing => std::option::Option::Some(1),
+                Self::NotRefreshing => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REFRESHABLE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REFRESHING"),
-                2 => std::borrow::Cow::Borrowed("NOT_REFRESHING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REFRESHABLE_STATE_UNSPECIFIED"),
+                Self::Refreshing => std::option::Option::Some("REFRESHING"),
+                Self::NotRefreshing => std::option::Option::Some("NOT_REFRESHING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REFRESHABLE_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REFRESHABLE_STATE_UNSPECIFIED)
-                }
-                "REFRESHING" => std::option::Option::Some(Self::REFRESHING),
-                "NOT_REFRESHING" => std::option::Option::Some(Self::NOT_REFRESHING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RefreshableState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RefreshableState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RefreshableState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RefreshableState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Refreshing,
+                2 => Self::NotRefreshing,
+                _ => Self::UnknownValue(refreshable_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RefreshableState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REFRESHABLE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "REFRESHING" => Self::Refreshing,
+                "NOT_REFRESHING" => Self::NotRefreshing,
+                _ => Self::UnknownValue(refreshable_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RefreshableState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Refreshing => serializer.serialize_i32(1),
+                Self::NotRefreshing => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RefreshableState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RefreshableState>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.RefreshableState",
+            ))
         }
     }
 
     /// The Data Guard role of the Autonomous Database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Role(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Role {
+        /// Default unspecified value.
+        Unspecified,
+        /// Primary role
+        Primary,
+        /// Standby role
+        Standby,
+        /// Disabled standby role
+        DisabledStandby,
+        /// Backup copy role
+        BackupCopy,
+        /// Snapshot standby role
+        SnapshotStandby,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Role::value] or
+        /// [Role::name].
+        UnknownValue(role::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Role {
-        /// Default unspecified value.
-        pub const ROLE_UNSPECIFIED: Role = Role::new(0);
-
-        /// Primary role
-        pub const PRIMARY: Role = Role::new(1);
-
-        /// Standby role
-        pub const STANDBY: Role = Role::new(2);
-
-        /// Disabled standby role
-        pub const DISABLED_STANDBY: Role = Role::new(3);
-
-        /// Backup copy role
-        pub const BACKUP_COPY: Role = Role::new(4);
-
-        /// Snapshot standby role
-        pub const SNAPSHOT_STANDBY: Role = Role::new(5);
-
-        /// Creates a new Role instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Primary => std::option::Option::Some(1),
+                Self::Standby => std::option::Option::Some(2),
+                Self::DisabledStandby => std::option::Option::Some(3),
+                Self::BackupCopy => std::option::Option::Some(4),
+                Self::SnapshotStandby => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIMARY"),
-                2 => std::borrow::Cow::Borrowed("STANDBY"),
-                3 => std::borrow::Cow::Borrowed("DISABLED_STANDBY"),
-                4 => std::borrow::Cow::Borrowed("BACKUP_COPY"),
-                5 => std::borrow::Cow::Borrowed("SNAPSHOT_STANDBY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_UNSPECIFIED"),
+                Self::Primary => std::option::Option::Some("PRIMARY"),
+                Self::Standby => std::option::Option::Some("STANDBY"),
+                Self::DisabledStandby => std::option::Option::Some("DISABLED_STANDBY"),
+                Self::BackupCopy => std::option::Option::Some("BACKUP_COPY"),
+                Self::SnapshotStandby => std::option::Option::Some("SNAPSHOT_STANDBY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_UNSPECIFIED" => std::option::Option::Some(Self::ROLE_UNSPECIFIED),
-                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-                "STANDBY" => std::option::Option::Some(Self::STANDBY),
-                "DISABLED_STANDBY" => std::option::Option::Some(Self::DISABLED_STANDBY),
-                "BACKUP_COPY" => std::option::Option::Some(Self::BACKUP_COPY),
-                "SNAPSHOT_STANDBY" => std::option::Option::Some(Self::SNAPSHOT_STANDBY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Role {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Role {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Role {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Primary,
+                2 => Self::Standby,
+                3 => Self::DisabledStandby,
+                4 => Self::BackupCopy,
+                5 => Self::SnapshotStandby,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Role {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_UNSPECIFIED" => Self::Unspecified,
+                "PRIMARY" => Self::Primary,
+                "STANDBY" => Self::Standby,
+                "DISABLED_STANDBY" => Self::DisabledStandby,
+                "BACKUP_COPY" => Self::BackupCopy,
+                "SNAPSHOT_STANDBY" => Self::SnapshotStandby,
+                _ => Self::UnknownValue(role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Role {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Primary => serializer.serialize_i32(1),
+                Self::Standby => serializer.serialize_i32(2),
+                Self::DisabledStandby => serializer.serialize_i32(3),
+                Self::BackupCopy => serializer.serialize_i32(4),
+                Self::SnapshotStandby => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Role {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Role>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseProperties.Role",
+            ))
         }
     }
 }
@@ -1951,374 +2624,738 @@ pub mod database_connection_string_profile {
     use super::*;
 
     /// The various consumer groups available in the connection string profile.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConsumerGroup(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConsumerGroup {
+        /// Default unspecified value.
+        Unspecified,
+        /// High consumer group.
+        High,
+        /// Medium consumer group.
+        Medium,
+        /// Low consumer group.
+        Low,
+        /// TP consumer group.
+        Tp,
+        /// TPURGENT consumer group.
+        Tpurgent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConsumerGroup::value] or
+        /// [ConsumerGroup::name].
+        UnknownValue(consumer_group::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod consumer_group {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConsumerGroup {
-        /// Default unspecified value.
-        pub const CONSUMER_GROUP_UNSPECIFIED: ConsumerGroup = ConsumerGroup::new(0);
-
-        /// High consumer group.
-        pub const HIGH: ConsumerGroup = ConsumerGroup::new(1);
-
-        /// Medium consumer group.
-        pub const MEDIUM: ConsumerGroup = ConsumerGroup::new(2);
-
-        /// Low consumer group.
-        pub const LOW: ConsumerGroup = ConsumerGroup::new(3);
-
-        /// TP consumer group.
-        pub const TP: ConsumerGroup = ConsumerGroup::new(4);
-
-        /// TPURGENT consumer group.
-        pub const TPURGENT: ConsumerGroup = ConsumerGroup::new(5);
-
-        /// Creates a new ConsumerGroup instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::Medium => std::option::Option::Some(2),
+                Self::Low => std::option::Option::Some(3),
+                Self::Tp => std::option::Option::Some(4),
+                Self::Tpurgent => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONSUMER_GROUP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIGH"),
-                2 => std::borrow::Cow::Borrowed("MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("LOW"),
-                4 => std::borrow::Cow::Borrowed("TP"),
-                5 => std::borrow::Cow::Borrowed("TPURGENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONSUMER_GROUP_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Tp => std::option::Option::Some("TP"),
+                Self::Tpurgent => std::option::Option::Some("TPURGENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONSUMER_GROUP_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONSUMER_GROUP_UNSPECIFIED)
-                }
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "TP" => std::option::Option::Some(Self::TP),
-                "TPURGENT" => std::option::Option::Some(Self::TPURGENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConsumerGroup {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConsumerGroup {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConsumerGroup {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConsumerGroup {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::Medium,
+                3 => Self::Low,
+                4 => Self::Tp,
+                5 => Self::Tpurgent,
+                _ => Self::UnknownValue(consumer_group::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConsumerGroup {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONSUMER_GROUP_UNSPECIFIED" => Self::Unspecified,
+                "HIGH" => Self::High,
+                "MEDIUM" => Self::Medium,
+                "LOW" => Self::Low,
+                "TP" => Self::Tp,
+                "TPURGENT" => Self::Tpurgent,
+                _ => Self::UnknownValue(consumer_group::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConsumerGroup {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::Medium => serializer.serialize_i32(2),
+                Self::Low => serializer.serialize_i32(3),
+                Self::Tp => serializer.serialize_i32(4),
+                Self::Tpurgent => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConsumerGroup {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConsumerGroup>::new(
+                ".google.cloud.oracledatabase.v1.DatabaseConnectionStringProfile.ConsumerGroup",
+            ))
         }
     }
 
     /// The host name format being used in the connection string.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HostFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HostFormat {
+        /// Default unspecified value.
+        Unspecified,
+        /// FQDN
+        Fqdn,
+        /// IP
+        Ip,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HostFormat::value] or
+        /// [HostFormat::name].
+        UnknownValue(host_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod host_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HostFormat {
-        /// Default unspecified value.
-        pub const HOST_FORMAT_UNSPECIFIED: HostFormat = HostFormat::new(0);
-
-        /// FQDN
-        pub const FQDN: HostFormat = HostFormat::new(1);
-
-        /// IP
-        pub const IP: HostFormat = HostFormat::new(2);
-
-        /// Creates a new HostFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Fqdn => std::option::Option::Some(1),
+                Self::Ip => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HOST_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FQDN"),
-                2 => std::borrow::Cow::Borrowed("IP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HOST_FORMAT_UNSPECIFIED"),
+                Self::Fqdn => std::option::Option::Some("FQDN"),
+                Self::Ip => std::option::Option::Some("IP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HOST_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HOST_FORMAT_UNSPECIFIED)
-                }
-                "FQDN" => std::option::Option::Some(Self::FQDN),
-                "IP" => std::option::Option::Some(Self::IP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HostFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HostFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HostFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HostFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Fqdn,
+                2 => Self::Ip,
+                _ => Self::UnknownValue(host_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HostFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HOST_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "FQDN" => Self::Fqdn,
+                "IP" => Self::Ip,
+                _ => Self::UnknownValue(host_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HostFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Fqdn => serializer.serialize_i32(1),
+                Self::Ip => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HostFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HostFormat>::new(
+                ".google.cloud.oracledatabase.v1.DatabaseConnectionStringProfile.HostFormat",
+            ))
         }
     }
 
     /// The protocol being used by the connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Protocol {
+        /// Default unspecified value.
+        Unspecified,
+        /// Tcp
+        Tcp,
+        /// Tcps
+        Tcps,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Protocol::value] or
+        /// [Protocol::name].
+        UnknownValue(protocol::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Protocol {
-        /// Default unspecified value.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
-
-        /// Tcp
-        pub const TCP: Protocol = Protocol::new(1);
-
-        /// Tcps
-        pub const TCPS: Protocol = Protocol::new(2);
-
-        /// Creates a new Protocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tcp => std::option::Option::Some(1),
+                Self::Tcps => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TCP"),
-                2 => std::borrow::Cow::Borrowed("TCPS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROTOCOL_UNSPECIFIED"),
+                Self::Tcp => std::option::Option::Some("TCP"),
+                Self::Tcps => std::option::Option::Some("TCPS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
-                "TCP" => std::option::Option::Some(Self::TCP),
-                "TCPS" => std::option::Option::Some(Self::TCPS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Protocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Protocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tcp,
+                2 => Self::Tcps,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Protocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "TCP" => Self::Tcp,
+                "TCPS" => Self::Tcps,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Protocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tcp => serializer.serialize_i32(1),
+                Self::Tcps => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Protocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Protocol>::new(
+                ".google.cloud.oracledatabase.v1.DatabaseConnectionStringProfile.Protocol",
+            ))
         }
     }
 
     /// The session mode of the connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SessionMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SessionMode {
+        /// Default unspecified value.
+        Unspecified,
+        /// Direct
+        Direct,
+        /// Indirect
+        Indirect,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SessionMode::value] or
+        /// [SessionMode::name].
+        UnknownValue(session_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod session_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SessionMode {
-        /// Default unspecified value.
-        pub const SESSION_MODE_UNSPECIFIED: SessionMode = SessionMode::new(0);
-
-        /// Direct
-        pub const DIRECT: SessionMode = SessionMode::new(1);
-
-        /// Indirect
-        pub const INDIRECT: SessionMode = SessionMode::new(2);
-
-        /// Creates a new SessionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Direct => std::option::Option::Some(1),
+                Self::Indirect => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SESSION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIRECT"),
-                2 => std::borrow::Cow::Borrowed("INDIRECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SESSION_MODE_UNSPECIFIED"),
+                Self::Direct => std::option::Option::Some("DIRECT"),
+                Self::Indirect => std::option::Option::Some("INDIRECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SESSION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SESSION_MODE_UNSPECIFIED)
-                }
-                "DIRECT" => std::option::Option::Some(Self::DIRECT),
-                "INDIRECT" => std::option::Option::Some(Self::INDIRECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SessionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SessionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SessionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SessionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Direct,
+                2 => Self::Indirect,
+                _ => Self::UnknownValue(session_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SessionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SESSION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DIRECT" => Self::Direct,
+                "INDIRECT" => Self::Indirect,
+                _ => Self::UnknownValue(session_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SessionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Direct => serializer.serialize_i32(1),
+                Self::Indirect => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SessionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SessionMode>::new(
+                ".google.cloud.oracledatabase.v1.DatabaseConnectionStringProfile.SessionMode",
+            ))
         }
     }
 
     /// Specifies syntax of the connection string.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SyntaxFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SyntaxFormat {
+        /// Default unspecified value.
+        Unspecified,
+        /// Long
+        Long,
+        /// Ezconnect
+        Ezconnect,
+        /// Ezconnectplus
+        Ezconnectplus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SyntaxFormat::value] or
+        /// [SyntaxFormat::name].
+        UnknownValue(syntax_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod syntax_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SyntaxFormat {
-        /// Default unspecified value.
-        pub const SYNTAX_FORMAT_UNSPECIFIED: SyntaxFormat = SyntaxFormat::new(0);
-
-        /// Long
-        pub const LONG: SyntaxFormat = SyntaxFormat::new(1);
-
-        /// Ezconnect
-        pub const EZCONNECT: SyntaxFormat = SyntaxFormat::new(2);
-
-        /// Ezconnectplus
-        pub const EZCONNECTPLUS: SyntaxFormat = SyntaxFormat::new(3);
-
-        /// Creates a new SyntaxFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Long => std::option::Option::Some(1),
+                Self::Ezconnect => std::option::Option::Some(2),
+                Self::Ezconnectplus => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SYNTAX_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LONG"),
-                2 => std::borrow::Cow::Borrowed("EZCONNECT"),
-                3 => std::borrow::Cow::Borrowed("EZCONNECTPLUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SYNTAX_FORMAT_UNSPECIFIED"),
+                Self::Long => std::option::Option::Some("LONG"),
+                Self::Ezconnect => std::option::Option::Some("EZCONNECT"),
+                Self::Ezconnectplus => std::option::Option::Some("EZCONNECTPLUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SYNTAX_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SYNTAX_FORMAT_UNSPECIFIED)
-                }
-                "LONG" => std::option::Option::Some(Self::LONG),
-                "EZCONNECT" => std::option::Option::Some(Self::EZCONNECT),
-                "EZCONNECTPLUS" => std::option::Option::Some(Self::EZCONNECTPLUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SyntaxFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SyntaxFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SyntaxFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SyntaxFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Long,
+                2 => Self::Ezconnect,
+                3 => Self::Ezconnectplus,
+                _ => Self::UnknownValue(syntax_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SyntaxFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SYNTAX_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "LONG" => Self::Long,
+                "EZCONNECT" => Self::Ezconnect,
+                "EZCONNECTPLUS" => Self::Ezconnectplus,
+                _ => Self::UnknownValue(syntax_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SyntaxFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Long => serializer.serialize_i32(1),
+                Self::Ezconnect => serializer.serialize_i32(2),
+                Self::Ezconnectplus => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SyntaxFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SyntaxFormat>::new(
+                ".google.cloud.oracledatabase.v1.DatabaseConnectionStringProfile.SyntaxFormat",
+            ))
         }
     }
 
     /// This field indicates the TLS authentication type of the connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TLSAuthentication(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TLSAuthentication {
+        /// Default unspecified value.
+        Unspecified,
+        /// Server
+        Server,
+        /// Mutual
+        Mutual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TLSAuthentication::value] or
+        /// [TLSAuthentication::name].
+        UnknownValue(tls_authentication::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tls_authentication {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TLSAuthentication {
-        /// Default unspecified value.
-        pub const TLS_AUTHENTICATION_UNSPECIFIED: TLSAuthentication = TLSAuthentication::new(0);
-
-        /// Server
-        pub const SERVER: TLSAuthentication = TLSAuthentication::new(1);
-
-        /// Mutual
-        pub const MUTUAL: TLSAuthentication = TLSAuthentication::new(2);
-
-        /// Creates a new TLSAuthentication instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Server => std::option::Option::Some(1),
+                Self::Mutual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TLS_AUTHENTICATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVER"),
-                2 => std::borrow::Cow::Borrowed("MUTUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TLS_AUTHENTICATION_UNSPECIFIED"),
+                Self::Server => std::option::Option::Some("SERVER"),
+                Self::Mutual => std::option::Option::Some("MUTUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TLS_AUTHENTICATION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TLS_AUTHENTICATION_UNSPECIFIED)
-                }
-                "SERVER" => std::option::Option::Some(Self::SERVER),
-                "MUTUAL" => std::option::Option::Some(Self::MUTUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TLSAuthentication {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TLSAuthentication {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TLSAuthentication {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TLSAuthentication {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Server,
+                2 => Self::Mutual,
+                _ => Self::UnknownValue(tls_authentication::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TLSAuthentication {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TLS_AUTHENTICATION_UNSPECIFIED" => Self::Unspecified,
+                "SERVER" => Self::Server,
+                "MUTUAL" => Self::Mutual,
+                _ => Self::UnknownValue(tls_authentication::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TLSAuthentication {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Server => serializer.serialize_i32(1),
+                Self::Mutual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TLSAuthentication {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TLSAuthentication>::new(
+                ".google.cloud.oracledatabase.v1.DatabaseConnectionStringProfile.TLSAuthentication",
+            ))
         }
     }
 }
@@ -2716,61 +3753,120 @@ pub mod autonomous_database_character_set {
     use super::*;
 
     /// The type of character set an Autonomous Database can have.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CharacterSetType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CharacterSetType {
+        /// Character set type is not specified.
+        Unspecified,
+        /// Character set type is set to database.
+        Database,
+        /// Character set type is set to national.
+        National,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CharacterSetType::value] or
+        /// [CharacterSetType::name].
+        UnknownValue(character_set_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod character_set_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CharacterSetType {
-        /// Character set type is not specified.
-        pub const CHARACTER_SET_TYPE_UNSPECIFIED: CharacterSetType = CharacterSetType::new(0);
-
-        /// Character set type is set to database.
-        pub const DATABASE: CharacterSetType = CharacterSetType::new(1);
-
-        /// Character set type is set to national.
-        pub const NATIONAL: CharacterSetType = CharacterSetType::new(2);
-
-        /// Creates a new CharacterSetType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Database => std::option::Option::Some(1),
+                Self::National => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CHARACTER_SET_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATABASE"),
-                2 => std::borrow::Cow::Borrowed("NATIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CHARACTER_SET_TYPE_UNSPECIFIED"),
+                Self::Database => std::option::Option::Some("DATABASE"),
+                Self::National => std::option::Option::Some("NATIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CHARACTER_SET_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CHARACTER_SET_TYPE_UNSPECIFIED)
-                }
-                "DATABASE" => std::option::Option::Some(Self::DATABASE),
-                "NATIONAL" => std::option::Option::Some(Self::NATIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CharacterSetType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CharacterSetType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CharacterSetType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CharacterSetType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Database,
+                2 => Self::National,
+                _ => Self::UnknownValue(character_set_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CharacterSetType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CHARACTER_SET_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DATABASE" => Self::Database,
+                "NATIONAL" => Self::National,
+                _ => Self::UnknownValue(character_set_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CharacterSetType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Database => serializer.serialize_i32(1),
+                Self::National => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CharacterSetType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CharacterSetType>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseCharacterSet.CharacterSetType",
+            ))
         }
     }
 }
@@ -3130,141 +4226,273 @@ pub mod autonomous_database_backup_properties {
     use super::*;
 
     /// // The various lifecycle states of the Autonomous Database Backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified value.
+        Unspecified,
+        /// Indicates that the resource is in creating state.
+        Creating,
+        /// Indicates that the resource is in active state.
+        Active,
+        /// Indicates that the resource is in deleting state.
+        Deleting,
+        /// Indicates that the resource is in deleted state.
+        Deleted,
+        /// Indicates that the resource is in failed state.
+        Failed,
+        /// Indicates that the resource is in updating state.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Indicates that the resource is in creating state.
-        pub const CREATING: State = State::new(1);
-
-        /// Indicates that the resource is in active state.
-        pub const ACTIVE: State = State::new(2);
-
-        /// Indicates that the resource is in deleting state.
-        pub const DELETING: State = State::new(3);
-
-        /// Indicates that the resource is in deleted state.
-        pub const DELETED: State = State::new(4);
-
-        /// Indicates that the resource is in failed state.
-        pub const FAILED: State = State::new(6);
-
-        /// Indicates that the resource is in updating state.
-        pub const UPDATING: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Updating => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Deleted,
+                6 => Self::Failed,
+                7 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "DELETED" => Self::Deleted,
+                "FAILED" => Self::Failed,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Updating => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseBackupProperties.State",
+            ))
         }
     }
 
     /// The type of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Default unspecified value.
+        Unspecified,
+        /// Incremental backups.
+        Incremental,
+        /// Full backups.
+        Full,
+        /// Long term backups.
+        LongTerm,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Default unspecified value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Incremental backups.
-        pub const INCREMENTAL: Type = Type::new(1);
-
-        /// Full backups.
-        pub const FULL: Type = Type::new(2);
-
-        /// Long term backups.
-        pub const LONG_TERM: Type = Type::new(3);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incremental => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::LongTerm => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCREMENTAL"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                3 => std::borrow::Cow::Borrowed("LONG_TERM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Incremental => std::option::Option::Some("INCREMENTAL"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::LongTerm => std::option::Option::Some("LONG_TERM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                "LONG_TERM" => std::option::Option::Some(Self::LONG_TERM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Incremental,
+                2 => Self::Full,
+                3 => Self::LongTerm,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "INCREMENTAL" => Self::Incremental,
+                "FULL" => Self::Full,
+                "LONG_TERM" => Self::LongTerm,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incremental => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::LongTerm => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.oracledatabase.v1.AutonomousDatabaseBackupProperties.Type",
+            ))
         }
     }
 }
@@ -3530,94 +4758,169 @@ pub mod db_node_properties {
     use super::*;
 
     /// The various lifecycle states of the database node.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified value.
+        Unspecified,
+        /// Indicates that the resource is in provisioning state.
+        Provisioning,
+        /// Indicates that the resource is in available state.
+        Available,
+        /// Indicates that the resource is in updating state.
+        Updating,
+        /// Indicates that the resource is in stopping state.
+        Stopping,
+        /// Indicates that the resource is in stopped state.
+        Stopped,
+        /// Indicates that the resource is in starting state.
+        Starting,
+        /// Indicates that the resource is in terminating state.
+        Terminating,
+        /// Indicates that the resource is in terminated state.
+        Terminated,
+        /// Indicates that the resource is in failed state.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Indicates that the resource is in provisioning state.
-        pub const PROVISIONING: State = State::new(1);
-
-        /// Indicates that the resource is in available state.
-        pub const AVAILABLE: State = State::new(2);
-
-        /// Indicates that the resource is in updating state.
-        pub const UPDATING: State = State::new(3);
-
-        /// Indicates that the resource is in stopping state.
-        pub const STOPPING: State = State::new(4);
-
-        /// Indicates that the resource is in stopped state.
-        pub const STOPPED: State = State::new(5);
-
-        /// Indicates that the resource is in starting state.
-        pub const STARTING: State = State::new(6);
-
-        /// Indicates that the resource is in terminating state.
-        pub const TERMINATING: State = State::new(7);
-
-        /// Indicates that the resource is in terminated state.
-        pub const TERMINATED: State = State::new(8);
-
-        /// Indicates that the resource is in failed state.
-        pub const FAILED: State = State::new(9);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Available => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Stopped => std::option::Option::Some(5),
+                Self::Starting => std::option::Option::Some(6),
+                Self::Terminating => std::option::Option::Some(7),
+                Self::Terminated => std::option::Option::Some(8),
+                Self::Failed => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("STOPPED"),
-                6 => std::borrow::Cow::Borrowed("STARTING"),
-                7 => std::borrow::Cow::Borrowed("TERMINATING"),
-                8 => std::borrow::Cow::Borrowed("TERMINATED"),
-                9 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Terminating => std::option::Option::Some("TERMINATING"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Available,
+                3 => Self::Updating,
+                4 => Self::Stopping,
+                5 => Self::Stopped,
+                6 => Self::Starting,
+                7 => Self::Terminating,
+                8 => Self::Terminated,
+                9 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "AVAILABLE" => Self::Available,
+                "UPDATING" => Self::Updating,
+                "STOPPING" => Self::Stopping,
+                "STOPPED" => Self::Stopped,
+                "STARTING" => Self::Starting,
+                "TERMINATING" => Self::Terminating,
+                "TERMINATED" => Self::Terminated,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Available => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Stopped => serializer.serialize_i32(5),
+                Self::Starting => serializer.serialize_i32(6),
+                Self::Terminating => serializer.serialize_i32(7),
+                Self::Terminated => serializer.serialize_i32(8),
+                Self::Failed => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.oracledatabase.v1.DbNodeProperties.State",
+            ))
         }
     }
 }
@@ -3816,74 +5119,141 @@ pub mod db_server_properties {
     use super::*;
 
     /// The various lifecycle states of the database server.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified value.
+        Unspecified,
+        /// Indicates that the resource is in creating state.
+        Creating,
+        /// Indicates that the resource is in available state.
+        Available,
+        /// Indicates that the resource is in unavailable state.
+        Unavailable,
+        /// Indicates that the resource is in deleting state.
+        Deleting,
+        /// Indicates that the resource is in deleted state.
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Indicates that the resource is in creating state.
-        pub const CREATING: State = State::new(1);
-
-        /// Indicates that the resource is in available state.
-        pub const AVAILABLE: State = State::new(2);
-
-        /// Indicates that the resource is in unavailable state.
-        pub const UNAVAILABLE: State = State::new(3);
-
-        /// Indicates that the resource is in deleting state.
-        pub const DELETING: State = State::new(4);
-
-        /// Indicates that the resource is in deleted state.
-        pub const DELETED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Available => std::option::Option::Some(2),
+                Self::Unavailable => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Deleted => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Available,
+                3 => Self::Unavailable,
+                4 => Self::Deleting,
+                5 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "AVAILABLE" => Self::Available,
+                "UNAVAILABLE" => Self::Unavailable,
+                "DELETING" => Self::Deleting,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Available => serializer.serialize_i32(2),
+                Self::Unavailable => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Deleted => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.oracledatabase.v1.DbServerProperties.State",
+            ))
         }
     }
 }
@@ -4108,76 +5478,143 @@ pub mod entitlement {
     use super::*;
 
     /// The various lifecycle states of the subscription.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified value.
+        Unspecified,
+        /// Account not linked.
+        AccountNotLinked,
+        /// Account is linked but not active.
+        AccountNotActive,
+        /// Entitlement and Account are active.
+        Active,
+        /// Account is suspended.
+        AccountSuspended,
+        /// Entitlement is not approved in private marketplace.
+        NotApprovedInPrivateMarketplace,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Account not linked.
-        pub const ACCOUNT_NOT_LINKED: State = State::new(1);
-
-        /// Account is linked but not active.
-        pub const ACCOUNT_NOT_ACTIVE: State = State::new(2);
-
-        /// Entitlement and Account are active.
-        pub const ACTIVE: State = State::new(3);
-
-        /// Account is suspended.
-        pub const ACCOUNT_SUSPENDED: State = State::new(4);
-
-        /// Entitlement is not approved in private marketplace.
-        pub const NOT_APPROVED_IN_PRIVATE_MARKETPLACE: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AccountNotLinked => std::option::Option::Some(1),
+                Self::AccountNotActive => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::AccountSuspended => std::option::Option::Some(4),
+                Self::NotApprovedInPrivateMarketplace => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACCOUNT_NOT_LINKED"),
-                2 => std::borrow::Cow::Borrowed("ACCOUNT_NOT_ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("ACCOUNT_SUSPENDED"),
-                5 => std::borrow::Cow::Borrowed("NOT_APPROVED_IN_PRIVATE_MARKETPLACE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACCOUNT_NOT_LINKED" => std::option::Option::Some(Self::ACCOUNT_NOT_LINKED),
-                "ACCOUNT_NOT_ACTIVE" => std::option::Option::Some(Self::ACCOUNT_NOT_ACTIVE),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "ACCOUNT_SUSPENDED" => std::option::Option::Some(Self::ACCOUNT_SUSPENDED),
-                "NOT_APPROVED_IN_PRIVATE_MARKETPLACE" => {
-                    std::option::Option::Some(Self::NOT_APPROVED_IN_PRIVATE_MARKETPLACE)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::AccountNotLinked => std::option::Option::Some("ACCOUNT_NOT_LINKED"),
+                Self::AccountNotActive => std::option::Option::Some("ACCOUNT_NOT_ACTIVE"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::AccountSuspended => std::option::Option::Some("ACCOUNT_SUSPENDED"),
+                Self::NotApprovedInPrivateMarketplace => {
+                    std::option::Option::Some("NOT_APPROVED_IN_PRIVATE_MARKETPLACE")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AccountNotLinked,
+                2 => Self::AccountNotActive,
+                3 => Self::Active,
+                4 => Self::AccountSuspended,
+                5 => Self::NotApprovedInPrivateMarketplace,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACCOUNT_NOT_LINKED" => Self::AccountNotLinked,
+                "ACCOUNT_NOT_ACTIVE" => Self::AccountNotActive,
+                "ACTIVE" => Self::Active,
+                "ACCOUNT_SUSPENDED" => Self::AccountSuspended,
+                "NOT_APPROVED_IN_PRIVATE_MARKETPLACE" => Self::NotApprovedInPrivateMarketplace,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AccountNotLinked => serializer.serialize_i32(1),
+                Self::AccountNotActive => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::AccountSuspended => serializer.serialize_i32(4),
+                Self::NotApprovedInPrivateMarketplace => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.oracledatabase.v1.Entitlement.State",
+            ))
         }
     }
 }
@@ -4715,86 +6152,155 @@ pub mod cloud_exadata_infrastructure_properties {
     use super::*;
 
     /// The various lifecycle states of the Exadata Infrastructure.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified value.
+        Unspecified,
+        /// The Exadata Infrastructure is being provisioned.
+        Provisioning,
+        /// The Exadata Infrastructure is available for use.
+        Available,
+        /// The Exadata Infrastructure is being updated.
+        Updating,
+        /// The Exadata Infrastructure is being terminated.
+        Terminating,
+        /// The Exadata Infrastructure is terminated.
+        Terminated,
+        /// The Exadata Infrastructure is in failed state.
+        Failed,
+        /// The Exadata Infrastructure is in maintenance.
+        MaintenanceInProgress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Exadata Infrastructure is being provisioned.
-        pub const PROVISIONING: State = State::new(1);
-
-        /// The Exadata Infrastructure is available for use.
-        pub const AVAILABLE: State = State::new(2);
-
-        /// The Exadata Infrastructure is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The Exadata Infrastructure is being terminated.
-        pub const TERMINATING: State = State::new(4);
-
-        /// The Exadata Infrastructure is terminated.
-        pub const TERMINATED: State = State::new(5);
-
-        /// The Exadata Infrastructure is in failed state.
-        pub const FAILED: State = State::new(6);
-
-        /// The Exadata Infrastructure is in maintenance.
-        pub const MAINTENANCE_IN_PROGRESS: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Available => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Terminating => std::option::Option::Some(4),
+                Self::Terminated => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::MaintenanceInProgress => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("TERMINATING"),
-                5 => std::borrow::Cow::Borrowed("TERMINATED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("MAINTENANCE_IN_PROGRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Terminating => std::option::Option::Some("TERMINATING"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::MaintenanceInProgress => std::option::Option::Some("MAINTENANCE_IN_PROGRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "MAINTENANCE_IN_PROGRESS" => {
-                    std::option::Option::Some(Self::MAINTENANCE_IN_PROGRESS)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Available,
+                3 => Self::Updating,
+                4 => Self::Terminating,
+                5 => Self::Terminated,
+                6 => Self::Failed,
+                7 => Self::MaintenanceInProgress,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "AVAILABLE" => Self::Available,
+                "UPDATING" => Self::Updating,
+                "TERMINATING" => Self::Terminating,
+                "TERMINATED" => Self::Terminated,
+                "FAILED" => Self::Failed,
+                "MAINTENANCE_IN_PROGRESS" => Self::MaintenanceInProgress,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Available => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Terminating => serializer.serialize_i32(4),
+                Self::Terminated => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::MaintenanceInProgress => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.oracledatabase.v1.CloudExadataInfrastructureProperties.State",
+            ))
         }
     }
 }
@@ -4964,123 +6470,243 @@ pub mod maintenance_window {
     use super::*;
 
     /// Maintenance window preference.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MaintenanceWindowPreference(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MaintenanceWindowPreference {
+        /// Default unspecified value.
+        Unspecified,
+        /// Custom preference.
+        CustomPreference,
+        /// No preference.
+        NoPreference,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MaintenanceWindowPreference::value] or
+        /// [MaintenanceWindowPreference::name].
+        UnknownValue(maintenance_window_preference::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod maintenance_window_preference {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MaintenanceWindowPreference {
-        /// Default unspecified value.
-        pub const MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED: MaintenanceWindowPreference =
-            MaintenanceWindowPreference::new(0);
-
-        /// Custom preference.
-        pub const CUSTOM_PREFERENCE: MaintenanceWindowPreference =
-            MaintenanceWindowPreference::new(1);
-
-        /// No preference.
-        pub const NO_PREFERENCE: MaintenanceWindowPreference = MaintenanceWindowPreference::new(2);
-
-        /// Creates a new MaintenanceWindowPreference instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CustomPreference => std::option::Option::Some(1),
+                Self::NoPreference => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CUSTOM_PREFERENCE"),
-                2 => std::borrow::Cow::Borrowed("NO_PREFERENCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED")
                 }
-                "CUSTOM_PREFERENCE" => std::option::Option::Some(Self::CUSTOM_PREFERENCE),
-                "NO_PREFERENCE" => std::option::Option::Some(Self::NO_PREFERENCE),
-                _ => std::option::Option::None,
+                Self::CustomPreference => std::option::Option::Some("CUSTOM_PREFERENCE"),
+                Self::NoPreference => std::option::Option::Some("NO_PREFERENCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for MaintenanceWindowPreference {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MaintenanceWindowPreference {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MaintenanceWindowPreference {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MaintenanceWindowPreference {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CustomPreference,
+                2 => Self::NoPreference,
+                _ => Self::UnknownValue(maintenance_window_preference::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MaintenanceWindowPreference {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MAINTENANCE_WINDOW_PREFERENCE_UNSPECIFIED" => Self::Unspecified,
+                "CUSTOM_PREFERENCE" => Self::CustomPreference,
+                "NO_PREFERENCE" => Self::NoPreference,
+                _ => Self::UnknownValue(maintenance_window_preference::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MaintenanceWindowPreference {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CustomPreference => serializer.serialize_i32(1),
+                Self::NoPreference => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MaintenanceWindowPreference {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<MaintenanceWindowPreference>::new(
+                    ".google.cloud.oracledatabase.v1.MaintenanceWindow.MaintenanceWindowPreference",
+                ),
+            )
         }
     }
 
     /// Patching mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PatchingMode(i32);
-
-    impl PatchingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PatchingMode {
         /// Default unspecified value.
-        pub const PATCHING_MODE_UNSPECIFIED: PatchingMode = PatchingMode::new(0);
-
+        Unspecified,
         /// Updates the Cloud Exadata database server hosts in a rolling fashion.
-        pub const ROLLING: PatchingMode = PatchingMode::new(1);
-
+        Rolling,
         /// The non-rolling maintenance method first updates your storage servers at
         /// the same time, then your database servers at the same time.
-        pub const NON_ROLLING: PatchingMode = PatchingMode::new(2);
+        NonRolling,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PatchingMode::value] or
+        /// [PatchingMode::name].
+        UnknownValue(patching_mode::UnknownValue),
+    }
 
-        /// Creates a new PatchingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod patching_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PatchingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Rolling => std::option::Option::Some(1),
+                Self::NonRolling => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PATCHING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ROLLING"),
-                2 => std::borrow::Cow::Borrowed("NON_ROLLING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PATCHING_MODE_UNSPECIFIED"),
+                Self::Rolling => std::option::Option::Some("ROLLING"),
+                Self::NonRolling => std::option::Option::Some("NON_ROLLING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PATCHING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PATCHING_MODE_UNSPECIFIED)
-                }
-                "ROLLING" => std::option::Option::Some(Self::ROLLING),
-                "NON_ROLLING" => std::option::Option::Some(Self::NON_ROLLING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PatchingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PatchingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PatchingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PatchingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Rolling,
+                2 => Self::NonRolling,
+                _ => Self::UnknownValue(patching_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PatchingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PATCHING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ROLLING" => Self::Rolling,
+                "NON_ROLLING" => Self::NonRolling,
+                _ => Self::UnknownValue(patching_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PatchingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Rolling => serializer.serialize_i32(1),
+                Self::NonRolling => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PatchingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PatchingMode>::new(
+                ".google.cloud.oracledatabase.v1.MaintenanceWindow.PatchingMode",
+            ))
         }
     }
 }
@@ -7920,204 +9546,391 @@ pub mod cloud_vm_cluster_properties {
     use super::*;
 
     /// Different licenses supported.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LicenseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LicenseType {
+        /// Unspecified
+        Unspecified,
+        /// License included part of offer
+        LicenseIncluded,
+        /// Bring your own license
+        BringYourOwnLicense,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LicenseType::value] or
+        /// [LicenseType::name].
+        UnknownValue(license_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod license_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LicenseType {
-        /// Unspecified
-        pub const LICENSE_TYPE_UNSPECIFIED: LicenseType = LicenseType::new(0);
-
-        /// License included part of offer
-        pub const LICENSE_INCLUDED: LicenseType = LicenseType::new(1);
-
-        /// Bring your own license
-        pub const BRING_YOUR_OWN_LICENSE: LicenseType = LicenseType::new(2);
-
-        /// Creates a new LicenseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LicenseIncluded => std::option::Option::Some(1),
+                Self::BringYourOwnLicense => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LICENSE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LICENSE_INCLUDED"),
-                2 => std::borrow::Cow::Borrowed("BRING_YOUR_OWN_LICENSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LICENSE_TYPE_UNSPECIFIED"),
+                Self::LicenseIncluded => std::option::Option::Some("LICENSE_INCLUDED"),
+                Self::BringYourOwnLicense => std::option::Option::Some("BRING_YOUR_OWN_LICENSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LICENSE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LICENSE_TYPE_UNSPECIFIED)
-                }
-                "LICENSE_INCLUDED" => std::option::Option::Some(Self::LICENSE_INCLUDED),
-                "BRING_YOUR_OWN_LICENSE" => std::option::Option::Some(Self::BRING_YOUR_OWN_LICENSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LicenseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LicenseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LicenseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LicenseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LicenseIncluded,
+                2 => Self::BringYourOwnLicense,
+                _ => Self::UnknownValue(license_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LicenseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LICENSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LICENSE_INCLUDED" => Self::LicenseIncluded,
+                "BRING_YOUR_OWN_LICENSE" => Self::BringYourOwnLicense,
+                _ => Self::UnknownValue(license_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LicenseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LicenseIncluded => serializer.serialize_i32(1),
+                Self::BringYourOwnLicense => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LicenseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LicenseType>::new(
+                ".google.cloud.oracledatabase.v1.CloudVmClusterProperties.LicenseType",
+            ))
         }
     }
 
     /// Types of disk redundancy provided by Oracle.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskRedundancy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiskRedundancy {
+        /// Unspecified.
+        Unspecified,
+        /// High -  3 way mirror.
+        High,
+        /// Normal - 2 way mirror.
+        Normal,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiskRedundancy::value] or
+        /// [DiskRedundancy::name].
+        UnknownValue(disk_redundancy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod disk_redundancy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiskRedundancy {
-        /// Unspecified.
-        pub const DISK_REDUNDANCY_UNSPECIFIED: DiskRedundancy = DiskRedundancy::new(0);
-
-        /// High -  3 way mirror.
-        pub const HIGH: DiskRedundancy = DiskRedundancy::new(1);
-
-        /// Normal - 2 way mirror.
-        pub const NORMAL: DiskRedundancy = DiskRedundancy::new(2);
-
-        /// Creates a new DiskRedundancy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::Normal => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISK_REDUNDANCY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIGH"),
-                2 => std::borrow::Cow::Borrowed("NORMAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISK_REDUNDANCY_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Normal => std::option::Option::Some("NORMAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISK_REDUNDANCY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISK_REDUNDANCY_UNSPECIFIED)
-                }
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "NORMAL" => std::option::Option::Some(Self::NORMAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiskRedundancy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskRedundancy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiskRedundancy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiskRedundancy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::Normal,
+                _ => Self::UnknownValue(disk_redundancy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiskRedundancy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISK_REDUNDANCY_UNSPECIFIED" => Self::Unspecified,
+                "HIGH" => Self::High,
+                "NORMAL" => Self::Normal,
+                _ => Self::UnknownValue(disk_redundancy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiskRedundancy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::Normal => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiskRedundancy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskRedundancy>::new(
+                ".google.cloud.oracledatabase.v1.CloudVmClusterProperties.DiskRedundancy",
+            ))
         }
     }
 
     /// The various lifecycle states of the VM cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified value.
+        Unspecified,
+        /// Indicates that the resource is in provisioning state.
+        Provisioning,
+        /// Indicates that the resource is in available state.
+        Available,
+        /// Indicates that the resource is in updating state.
+        Updating,
+        /// Indicates that the resource is in terminating state.
+        Terminating,
+        /// Indicates that the resource is in terminated state.
+        Terminated,
+        /// Indicates that the resource is in failed state.
+        Failed,
+        /// Indicates that the resource is in maintenance in progress state.
+        MaintenanceInProgress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Indicates that the resource is in provisioning state.
-        pub const PROVISIONING: State = State::new(1);
-
-        /// Indicates that the resource is in available state.
-        pub const AVAILABLE: State = State::new(2);
-
-        /// Indicates that the resource is in updating state.
-        pub const UPDATING: State = State::new(3);
-
-        /// Indicates that the resource is in terminating state.
-        pub const TERMINATING: State = State::new(4);
-
-        /// Indicates that the resource is in terminated state.
-        pub const TERMINATED: State = State::new(5);
-
-        /// Indicates that the resource is in failed state.
-        pub const FAILED: State = State::new(6);
-
-        /// Indicates that the resource is in maintenance in progress state.
-        pub const MAINTENANCE_IN_PROGRESS: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Available => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Terminating => std::option::Option::Some(4),
+                Self::Terminated => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::MaintenanceInProgress => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("TERMINATING"),
-                5 => std::borrow::Cow::Borrowed("TERMINATED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("MAINTENANCE_IN_PROGRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Terminating => std::option::Option::Some("TERMINATING"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::MaintenanceInProgress => std::option::Option::Some("MAINTENANCE_IN_PROGRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "MAINTENANCE_IN_PROGRESS" => {
-                    std::option::Option::Some(Self::MAINTENANCE_IN_PROGRESS)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Available,
+                3 => Self::Updating,
+                4 => Self::Terminating,
+                5 => Self::Terminated,
+                6 => Self::Failed,
+                7 => Self::MaintenanceInProgress,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "AVAILABLE" => Self::Available,
+                "UPDATING" => Self::Updating,
+                "TERMINATING" => Self::Terminating,
+                "TERMINATED" => Self::Terminated,
+                "FAILED" => Self::Failed,
+                "MAINTENANCE_IN_PROGRESS" => Self::MaintenanceInProgress,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Available => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Terminating => serializer.serialize_i32(4),
+                Self::Terminated => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::MaintenanceInProgress => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.oracledatabase.v1.CloudVmClusterProperties.State",
+            ))
         }
     }
 }
@@ -8177,363 +9990,650 @@ impl wkt::message::Message for DataCollectionOptions {
 }
 
 /// The type of wallet generation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GenerateType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum GenerateType {
+    /// Default unspecified value.
+    Unspecified,
+    /// Used to generate wallet for all databases in the region.
+    All,
+    /// Used to generate wallet for a single database.
+    Single,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [GenerateType::value] or
+    /// [GenerateType::name].
+    UnknownValue(generate_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod generate_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl GenerateType {
-    /// Default unspecified value.
-    pub const GENERATE_TYPE_UNSPECIFIED: GenerateType = GenerateType::new(0);
-
-    /// Used to generate wallet for all databases in the region.
-    pub const ALL: GenerateType = GenerateType::new(1);
-
-    /// Used to generate wallet for a single database.
-    pub const SINGLE: GenerateType = GenerateType::new(2);
-
-    /// Creates a new GenerateType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::All => std::option::Option::Some(1),
+            Self::Single => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("GENERATE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ALL"),
-            2 => std::borrow::Cow::Borrowed("SINGLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("GENERATE_TYPE_UNSPECIFIED"),
+            Self::All => std::option::Option::Some("ALL"),
+            Self::Single => std::option::Option::Some("SINGLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "GENERATE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::GENERATE_TYPE_UNSPECIFIED)
-            }
-            "ALL" => std::option::Option::Some(Self::ALL),
-            "SINGLE" => std::option::Option::Some(Self::SINGLE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for GenerateType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for GenerateType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for GenerateType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for GenerateType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::All,
+            2 => Self::Single,
+            _ => Self::UnknownValue(generate_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for GenerateType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "GENERATE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ALL" => Self::All,
+            "SINGLE" => Self::Single,
+            _ => Self::UnknownValue(generate_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for GenerateType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::All => serializer.serialize_i32(1),
+            Self::Single => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for GenerateType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<GenerateType>::new(
+            ".google.cloud.oracledatabase.v1.GenerateType",
+        ))
     }
 }
 
 /// The various lifecycle states of the Autonomous Database.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct State(i32);
-
-impl State {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum State {
     /// Default unspecified value.
-    pub const STATE_UNSPECIFIED: State = State::new(0);
-
+    Unspecified,
     /// Indicates that the Autonomous Database is in provisioning state.
-    pub const PROVISIONING: State = State::new(1);
-
+    Provisioning,
     /// Indicates that the Autonomous Database is in available state.
-    pub const AVAILABLE: State = State::new(2);
-
+    Available,
     /// Indicates that the Autonomous Database is in stopping state.
-    pub const STOPPING: State = State::new(3);
-
+    Stopping,
     /// Indicates that the Autonomous Database is in stopped state.
-    pub const STOPPED: State = State::new(4);
-
+    Stopped,
     /// Indicates that the Autonomous Database is in starting state.
-    pub const STARTING: State = State::new(5);
-
+    Starting,
     /// Indicates that the Autonomous Database is in terminating state.
-    pub const TERMINATING: State = State::new(6);
-
+    Terminating,
     /// Indicates that the Autonomous Database is in terminated state.
-    pub const TERMINATED: State = State::new(7);
-
+    Terminated,
     /// Indicates that the Autonomous Database is in unavailable state.
-    pub const UNAVAILABLE: State = State::new(8);
-
+    Unavailable,
     /// Indicates that the Autonomous Database restore is in progress.
-    pub const RESTORE_IN_PROGRESS: State = State::new(9);
-
+    RestoreInProgress,
     /// Indicates that the Autonomous Database failed to restore.
-    pub const RESTORE_FAILED: State = State::new(10);
-
+    RestoreFailed,
     /// Indicates that the Autonomous Database backup is in progress.
-    pub const BACKUP_IN_PROGRESS: State = State::new(11);
-
+    BackupInProgress,
     /// Indicates that the Autonomous Database scale is in progress.
-    pub const SCALE_IN_PROGRESS: State = State::new(12);
-
+    ScaleInProgress,
     /// Indicates that the Autonomous Database is available but needs attention
     /// state.
-    pub const AVAILABLE_NEEDS_ATTENTION: State = State::new(13);
-
+    AvailableNeedsAttention,
     /// Indicates that the Autonomous Database is in updating state.
-    pub const UPDATING: State = State::new(14);
-
+    Updating,
     /// Indicates that the Autonomous Database's maintenance is in progress state.
-    pub const MAINTENANCE_IN_PROGRESS: State = State::new(15);
-
+    MaintenanceInProgress,
     /// Indicates that the Autonomous Database is in restarting state.
-    pub const RESTARTING: State = State::new(16);
-
+    Restarting,
     /// Indicates that the Autonomous Database is in recreating state.
-    pub const RECREATING: State = State::new(17);
-
+    Recreating,
     /// Indicates that the Autonomous Database's role change is in progress state.
-    pub const ROLE_CHANGE_IN_PROGRESS: State = State::new(18);
-
+    RoleChangeInProgress,
     /// Indicates that the Autonomous Database is in upgrading state.
-    pub const UPGRADING: State = State::new(19);
-
+    Upgrading,
     /// Indicates that the Autonomous Database is in inaccessible state.
-    pub const INACCESSIBLE: State = State::new(20);
-
+    Inaccessible,
     /// Indicates that the Autonomous Database is in standby state.
-    pub const STANDBY: State = State::new(21);
+    Standby,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [State::value] or
+    /// [State::name].
+    UnknownValue(state::UnknownValue),
+}
 
-    /// Creates a new State instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl State {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Provisioning => std::option::Option::Some(1),
+            Self::Available => std::option::Option::Some(2),
+            Self::Stopping => std::option::Option::Some(3),
+            Self::Stopped => std::option::Option::Some(4),
+            Self::Starting => std::option::Option::Some(5),
+            Self::Terminating => std::option::Option::Some(6),
+            Self::Terminated => std::option::Option::Some(7),
+            Self::Unavailable => std::option::Option::Some(8),
+            Self::RestoreInProgress => std::option::Option::Some(9),
+            Self::RestoreFailed => std::option::Option::Some(10),
+            Self::BackupInProgress => std::option::Option::Some(11),
+            Self::ScaleInProgress => std::option::Option::Some(12),
+            Self::AvailableNeedsAttention => std::option::Option::Some(13),
+            Self::Updating => std::option::Option::Some(14),
+            Self::MaintenanceInProgress => std::option::Option::Some(15),
+            Self::Restarting => std::option::Option::Some(16),
+            Self::Recreating => std::option::Option::Some(17),
+            Self::RoleChangeInProgress => std::option::Option::Some(18),
+            Self::Upgrading => std::option::Option::Some(19),
+            Self::Inaccessible => std::option::Option::Some(20),
+            Self::Standby => std::option::Option::Some(21),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-            2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-            3 => std::borrow::Cow::Borrowed("STOPPING"),
-            4 => std::borrow::Cow::Borrowed("STOPPED"),
-            5 => std::borrow::Cow::Borrowed("STARTING"),
-            6 => std::borrow::Cow::Borrowed("TERMINATING"),
-            7 => std::borrow::Cow::Borrowed("TERMINATED"),
-            8 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-            9 => std::borrow::Cow::Borrowed("RESTORE_IN_PROGRESS"),
-            10 => std::borrow::Cow::Borrowed("RESTORE_FAILED"),
-            11 => std::borrow::Cow::Borrowed("BACKUP_IN_PROGRESS"),
-            12 => std::borrow::Cow::Borrowed("SCALE_IN_PROGRESS"),
-            13 => std::borrow::Cow::Borrowed("AVAILABLE_NEEDS_ATTENTION"),
-            14 => std::borrow::Cow::Borrowed("UPDATING"),
-            15 => std::borrow::Cow::Borrowed("MAINTENANCE_IN_PROGRESS"),
-            16 => std::borrow::Cow::Borrowed("RESTARTING"),
-            17 => std::borrow::Cow::Borrowed("RECREATING"),
-            18 => std::borrow::Cow::Borrowed("ROLE_CHANGE_IN_PROGRESS"),
-            19 => std::borrow::Cow::Borrowed("UPGRADING"),
-            20 => std::borrow::Cow::Borrowed("INACCESSIBLE"),
-            21 => std::borrow::Cow::Borrowed("STANDBY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+            Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+            Self::Available => std::option::Option::Some("AVAILABLE"),
+            Self::Stopping => std::option::Option::Some("STOPPING"),
+            Self::Stopped => std::option::Option::Some("STOPPED"),
+            Self::Starting => std::option::Option::Some("STARTING"),
+            Self::Terminating => std::option::Option::Some("TERMINATING"),
+            Self::Terminated => std::option::Option::Some("TERMINATED"),
+            Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+            Self::RestoreInProgress => std::option::Option::Some("RESTORE_IN_PROGRESS"),
+            Self::RestoreFailed => std::option::Option::Some("RESTORE_FAILED"),
+            Self::BackupInProgress => std::option::Option::Some("BACKUP_IN_PROGRESS"),
+            Self::ScaleInProgress => std::option::Option::Some("SCALE_IN_PROGRESS"),
+            Self::AvailableNeedsAttention => std::option::Option::Some("AVAILABLE_NEEDS_ATTENTION"),
+            Self::Updating => std::option::Option::Some("UPDATING"),
+            Self::MaintenanceInProgress => std::option::Option::Some("MAINTENANCE_IN_PROGRESS"),
+            Self::Restarting => std::option::Option::Some("RESTARTING"),
+            Self::Recreating => std::option::Option::Some("RECREATING"),
+            Self::RoleChangeInProgress => std::option::Option::Some("ROLE_CHANGE_IN_PROGRESS"),
+            Self::Upgrading => std::option::Option::Some("UPGRADING"),
+            Self::Inaccessible => std::option::Option::Some("INACCESSIBLE"),
+            Self::Standby => std::option::Option::Some("STANDBY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-            "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-            "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-            "STOPPING" => std::option::Option::Some(Self::STOPPING),
-            "STOPPED" => std::option::Option::Some(Self::STOPPED),
-            "STARTING" => std::option::Option::Some(Self::STARTING),
-            "TERMINATING" => std::option::Option::Some(Self::TERMINATING),
-            "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-            "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-            "RESTORE_IN_PROGRESS" => std::option::Option::Some(Self::RESTORE_IN_PROGRESS),
-            "RESTORE_FAILED" => std::option::Option::Some(Self::RESTORE_FAILED),
-            "BACKUP_IN_PROGRESS" => std::option::Option::Some(Self::BACKUP_IN_PROGRESS),
-            "SCALE_IN_PROGRESS" => std::option::Option::Some(Self::SCALE_IN_PROGRESS),
-            "AVAILABLE_NEEDS_ATTENTION" => {
-                std::option::Option::Some(Self::AVAILABLE_NEEDS_ATTENTION)
-            }
-            "UPDATING" => std::option::Option::Some(Self::UPDATING),
-            "MAINTENANCE_IN_PROGRESS" => std::option::Option::Some(Self::MAINTENANCE_IN_PROGRESS),
-            "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
-            "RECREATING" => std::option::Option::Some(Self::RECREATING),
-            "ROLE_CHANGE_IN_PROGRESS" => std::option::Option::Some(Self::ROLE_CHANGE_IN_PROGRESS),
-            "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
-            "INACCESSIBLE" => std::option::Option::Some(Self::INACCESSIBLE),
-            "STANDBY" => std::option::Option::Some(Self::STANDBY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for State {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for State {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for State {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Provisioning,
+            2 => Self::Available,
+            3 => Self::Stopping,
+            4 => Self::Stopped,
+            5 => Self::Starting,
+            6 => Self::Terminating,
+            7 => Self::Terminated,
+            8 => Self::Unavailable,
+            9 => Self::RestoreInProgress,
+            10 => Self::RestoreFailed,
+            11 => Self::BackupInProgress,
+            12 => Self::ScaleInProgress,
+            13 => Self::AvailableNeedsAttention,
+            14 => Self::Updating,
+            15 => Self::MaintenanceInProgress,
+            16 => Self::Restarting,
+            17 => Self::Recreating,
+            18 => Self::RoleChangeInProgress,
+            19 => Self::Upgrading,
+            20 => Self::Inaccessible,
+            21 => Self::Standby,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for State {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_UNSPECIFIED" => Self::Unspecified,
+            "PROVISIONING" => Self::Provisioning,
+            "AVAILABLE" => Self::Available,
+            "STOPPING" => Self::Stopping,
+            "STOPPED" => Self::Stopped,
+            "STARTING" => Self::Starting,
+            "TERMINATING" => Self::Terminating,
+            "TERMINATED" => Self::Terminated,
+            "UNAVAILABLE" => Self::Unavailable,
+            "RESTORE_IN_PROGRESS" => Self::RestoreInProgress,
+            "RESTORE_FAILED" => Self::RestoreFailed,
+            "BACKUP_IN_PROGRESS" => Self::BackupInProgress,
+            "SCALE_IN_PROGRESS" => Self::ScaleInProgress,
+            "AVAILABLE_NEEDS_ATTENTION" => Self::AvailableNeedsAttention,
+            "UPDATING" => Self::Updating,
+            "MAINTENANCE_IN_PROGRESS" => Self::MaintenanceInProgress,
+            "RESTARTING" => Self::Restarting,
+            "RECREATING" => Self::Recreating,
+            "ROLE_CHANGE_IN_PROGRESS" => Self::RoleChangeInProgress,
+            "UPGRADING" => Self::Upgrading,
+            "INACCESSIBLE" => Self::Inaccessible,
+            "STANDBY" => Self::Standby,
+            _ => Self::UnknownValue(state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for State {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Provisioning => serializer.serialize_i32(1),
+            Self::Available => serializer.serialize_i32(2),
+            Self::Stopping => serializer.serialize_i32(3),
+            Self::Stopped => serializer.serialize_i32(4),
+            Self::Starting => serializer.serialize_i32(5),
+            Self::Terminating => serializer.serialize_i32(6),
+            Self::Terminated => serializer.serialize_i32(7),
+            Self::Unavailable => serializer.serialize_i32(8),
+            Self::RestoreInProgress => serializer.serialize_i32(9),
+            Self::RestoreFailed => serializer.serialize_i32(10),
+            Self::BackupInProgress => serializer.serialize_i32(11),
+            Self::ScaleInProgress => serializer.serialize_i32(12),
+            Self::AvailableNeedsAttention => serializer.serialize_i32(13),
+            Self::Updating => serializer.serialize_i32(14),
+            Self::MaintenanceInProgress => serializer.serialize_i32(15),
+            Self::Restarting => serializer.serialize_i32(16),
+            Self::Recreating => serializer.serialize_i32(17),
+            Self::RoleChangeInProgress => serializer.serialize_i32(18),
+            Self::Upgrading => serializer.serialize_i32(19),
+            Self::Inaccessible => serializer.serialize_i32(20),
+            Self::Standby => serializer.serialize_i32(21),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+            ".google.cloud.oracledatabase.v1.State",
+        ))
     }
 }
 
 /// The state of the Operations Insights for this Autonomous Database.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationsInsightsState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperationsInsightsState {
+    /// Default unspecified value.
+    Unspecified,
+    /// Enabling status for operation insights.
+    Enabling,
+    /// Enabled status for operation insights.
+    Enabled,
+    /// Disabling status for operation insights.
+    Disabling,
+    /// Not Enabled status for operation insights.
+    NotEnabled,
+    /// Failed enabling status for operation insights.
+    FailedEnabling,
+    /// Failed disabling status for operation insights.
+    FailedDisabling,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperationsInsightsState::value] or
+    /// [OperationsInsightsState::name].
+    UnknownValue(operations_insights_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod operations_insights_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl OperationsInsightsState {
-    /// Default unspecified value.
-    pub const OPERATIONS_INSIGHTS_STATE_UNSPECIFIED: OperationsInsightsState =
-        OperationsInsightsState::new(0);
-
-    /// Enabling status for operation insights.
-    pub const ENABLING: OperationsInsightsState = OperationsInsightsState::new(1);
-
-    /// Enabled status for operation insights.
-    pub const ENABLED: OperationsInsightsState = OperationsInsightsState::new(2);
-
-    /// Disabling status for operation insights.
-    pub const DISABLING: OperationsInsightsState = OperationsInsightsState::new(3);
-
-    /// Not Enabled status for operation insights.
-    pub const NOT_ENABLED: OperationsInsightsState = OperationsInsightsState::new(4);
-
-    /// Failed enabling status for operation insights.
-    pub const FAILED_ENABLING: OperationsInsightsState = OperationsInsightsState::new(5);
-
-    /// Failed disabling status for operation insights.
-    pub const FAILED_DISABLING: OperationsInsightsState = OperationsInsightsState::new(6);
-
-    /// Creates a new OperationsInsightsState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enabling => std::option::Option::Some(1),
+            Self::Enabled => std::option::Option::Some(2),
+            Self::Disabling => std::option::Option::Some(3),
+            Self::NotEnabled => std::option::Option::Some(4),
+            Self::FailedEnabling => std::option::Option::Some(5),
+            Self::FailedDisabling => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATIONS_INSIGHTS_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENABLING"),
-            2 => std::borrow::Cow::Borrowed("ENABLED"),
-            3 => std::borrow::Cow::Borrowed("DISABLING"),
-            4 => std::borrow::Cow::Borrowed("NOT_ENABLED"),
-            5 => std::borrow::Cow::Borrowed("FAILED_ENABLING"),
-            6 => std::borrow::Cow::Borrowed("FAILED_DISABLING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OPERATIONS_INSIGHTS_STATE_UNSPECIFIED"),
+            Self::Enabling => std::option::Option::Some("ENABLING"),
+            Self::Enabled => std::option::Option::Some("ENABLED"),
+            Self::Disabling => std::option::Option::Some("DISABLING"),
+            Self::NotEnabled => std::option::Option::Some("NOT_ENABLED"),
+            Self::FailedEnabling => std::option::Option::Some("FAILED_ENABLING"),
+            Self::FailedDisabling => std::option::Option::Some("FAILED_DISABLING"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATIONS_INSIGHTS_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATIONS_INSIGHTS_STATE_UNSPECIFIED)
-            }
-            "ENABLING" => std::option::Option::Some(Self::ENABLING),
-            "ENABLED" => std::option::Option::Some(Self::ENABLED),
-            "DISABLING" => std::option::Option::Some(Self::DISABLING),
-            "NOT_ENABLED" => std::option::Option::Some(Self::NOT_ENABLED),
-            "FAILED_ENABLING" => std::option::Option::Some(Self::FAILED_ENABLING),
-            "FAILED_DISABLING" => std::option::Option::Some(Self::FAILED_DISABLING),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperationsInsightsState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationsInsightsState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperationsInsightsState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperationsInsightsState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enabling,
+            2 => Self::Enabled,
+            3 => Self::Disabling,
+            4 => Self::NotEnabled,
+            5 => Self::FailedEnabling,
+            6 => Self::FailedDisabling,
+            _ => Self::UnknownValue(operations_insights_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperationsInsightsState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATIONS_INSIGHTS_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ENABLING" => Self::Enabling,
+            "ENABLED" => Self::Enabled,
+            "DISABLING" => Self::Disabling,
+            "NOT_ENABLED" => Self::NotEnabled,
+            "FAILED_ENABLING" => Self::FailedEnabling,
+            "FAILED_DISABLING" => Self::FailedDisabling,
+            _ => Self::UnknownValue(operations_insights_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperationsInsightsState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enabling => serializer.serialize_i32(1),
+            Self::Enabled => serializer.serialize_i32(2),
+            Self::Disabling => serializer.serialize_i32(3),
+            Self::NotEnabled => serializer.serialize_i32(4),
+            Self::FailedEnabling => serializer.serialize_i32(5),
+            Self::FailedDisabling => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperationsInsightsState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationsInsightsState>::new(
+            ".google.cloud.oracledatabase.v1.OperationsInsightsState",
+        ))
     }
 }
 
 /// The various states available for the Autonomous Database workload type.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DBWorkload(i32);
-
-impl DBWorkload {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DBWorkload {
     /// Default unspecified value.
-    pub const DB_WORKLOAD_UNSPECIFIED: DBWorkload = DBWorkload::new(0);
-
+    Unspecified,
     /// Autonomous Transaction Processing database.
-    pub const OLTP: DBWorkload = DBWorkload::new(1);
-
+    Oltp,
     /// Autonomous Data Warehouse database.
-    pub const DW: DBWorkload = DBWorkload::new(2);
-
+    Dw,
     /// Autonomous JSON Database.
-    pub const AJD: DBWorkload = DBWorkload::new(3);
-
+    Ajd,
     /// Autonomous Database with the Oracle APEX Application Development workload
     /// type.
-    pub const APEX: DBWorkload = DBWorkload::new(4);
+    Apex,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DBWorkload::value] or
+    /// [DBWorkload::name].
+    UnknownValue(db_workload::UnknownValue),
+}
 
-    /// Creates a new DBWorkload instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod db_workload {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DBWorkload {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Oltp => std::option::Option::Some(1),
+            Self::Dw => std::option::Option::Some(2),
+            Self::Ajd => std::option::Option::Some(3),
+            Self::Apex => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DB_WORKLOAD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OLTP"),
-            2 => std::borrow::Cow::Borrowed("DW"),
-            3 => std::borrow::Cow::Borrowed("AJD"),
-            4 => std::borrow::Cow::Borrowed("APEX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DB_WORKLOAD_UNSPECIFIED"),
+            Self::Oltp => std::option::Option::Some("OLTP"),
+            Self::Dw => std::option::Option::Some("DW"),
+            Self::Ajd => std::option::Option::Some("AJD"),
+            Self::Apex => std::option::Option::Some("APEX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DB_WORKLOAD_UNSPECIFIED" => std::option::Option::Some(Self::DB_WORKLOAD_UNSPECIFIED),
-            "OLTP" => std::option::Option::Some(Self::OLTP),
-            "DW" => std::option::Option::Some(Self::DW),
-            "AJD" => std::option::Option::Some(Self::AJD),
-            "APEX" => std::option::Option::Some(Self::APEX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DBWorkload {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DBWorkload {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DBWorkload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DBWorkload {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Oltp,
+            2 => Self::Dw,
+            3 => Self::Ajd,
+            4 => Self::Apex,
+            _ => Self::UnknownValue(db_workload::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DBWorkload {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DB_WORKLOAD_UNSPECIFIED" => Self::Unspecified,
+            "OLTP" => Self::Oltp,
+            "DW" => Self::Dw,
+            "AJD" => Self::Ajd,
+            "APEX" => Self::Apex,
+            _ => Self::UnknownValue(db_workload::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DBWorkload {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Oltp => serializer.serialize_i32(1),
+            Self::Dw => serializer.serialize_i32(2),
+            Self::Ajd => serializer.serialize_i32(3),
+            Self::Apex => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DBWorkload {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DBWorkload>::new(
+            ".google.cloud.oracledatabase.v1.DBWorkload",
+        ))
     }
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -1849,174 +1849,310 @@ pub mod list_workloads_response {
     }
 
     /// Supported workload types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ComposerWorkloadType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ComposerWorkloadType {
+        /// Not able to determine the type of the workload.
+        Unspecified,
+        /// Celery worker.
+        CeleryWorker,
+        /// Kubernetes worker.
+        KubernetesWorker,
+        /// Workload created by Kubernetes Pod Operator.
+        KubernetesOperatorPod,
+        /// Airflow scheduler.
+        Scheduler,
+        /// Airflow Dag processor.
+        DagProcessor,
+        /// Airflow triggerer.
+        Triggerer,
+        /// Airflow web server UI.
+        WebServer,
+        /// Redis.
+        Redis,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ComposerWorkloadType::value] or
+        /// [ComposerWorkloadType::name].
+        UnknownValue(composer_workload_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod composer_workload_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ComposerWorkloadType {
-        /// Not able to determine the type of the workload.
-        pub const COMPOSER_WORKLOAD_TYPE_UNSPECIFIED: ComposerWorkloadType =
-            ComposerWorkloadType::new(0);
-
-        /// Celery worker.
-        pub const CELERY_WORKER: ComposerWorkloadType = ComposerWorkloadType::new(1);
-
-        /// Kubernetes worker.
-        pub const KUBERNETES_WORKER: ComposerWorkloadType = ComposerWorkloadType::new(2);
-
-        /// Workload created by Kubernetes Pod Operator.
-        pub const KUBERNETES_OPERATOR_POD: ComposerWorkloadType = ComposerWorkloadType::new(3);
-
-        /// Airflow scheduler.
-        pub const SCHEDULER: ComposerWorkloadType = ComposerWorkloadType::new(4);
-
-        /// Airflow Dag processor.
-        pub const DAG_PROCESSOR: ComposerWorkloadType = ComposerWorkloadType::new(5);
-
-        /// Airflow triggerer.
-        pub const TRIGGERER: ComposerWorkloadType = ComposerWorkloadType::new(6);
-
-        /// Airflow web server UI.
-        pub const WEB_SERVER: ComposerWorkloadType = ComposerWorkloadType::new(7);
-
-        /// Redis.
-        pub const REDIS: ComposerWorkloadType = ComposerWorkloadType::new(8);
-
-        /// Creates a new ComposerWorkloadType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CeleryWorker => std::option::Option::Some(1),
+                Self::KubernetesWorker => std::option::Option::Some(2),
+                Self::KubernetesOperatorPod => std::option::Option::Some(3),
+                Self::Scheduler => std::option::Option::Some(4),
+                Self::DagProcessor => std::option::Option::Some(5),
+                Self::Triggerer => std::option::Option::Some(6),
+                Self::WebServer => std::option::Option::Some(7),
+                Self::Redis => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPOSER_WORKLOAD_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CELERY_WORKER"),
-                2 => std::borrow::Cow::Borrowed("KUBERNETES_WORKER"),
-                3 => std::borrow::Cow::Borrowed("KUBERNETES_OPERATOR_POD"),
-                4 => std::borrow::Cow::Borrowed("SCHEDULER"),
-                5 => std::borrow::Cow::Borrowed("DAG_PROCESSOR"),
-                6 => std::borrow::Cow::Borrowed("TRIGGERER"),
-                7 => std::borrow::Cow::Borrowed("WEB_SERVER"),
-                8 => std::borrow::Cow::Borrowed("REDIS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPOSER_WORKLOAD_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPOSER_WORKLOAD_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("COMPOSER_WORKLOAD_TYPE_UNSPECIFIED")
                 }
-                "CELERY_WORKER" => std::option::Option::Some(Self::CELERY_WORKER),
-                "KUBERNETES_WORKER" => std::option::Option::Some(Self::KUBERNETES_WORKER),
-                "KUBERNETES_OPERATOR_POD" => {
-                    std::option::Option::Some(Self::KUBERNETES_OPERATOR_POD)
-                }
-                "SCHEDULER" => std::option::Option::Some(Self::SCHEDULER),
-                "DAG_PROCESSOR" => std::option::Option::Some(Self::DAG_PROCESSOR),
-                "TRIGGERER" => std::option::Option::Some(Self::TRIGGERER),
-                "WEB_SERVER" => std::option::Option::Some(Self::WEB_SERVER),
-                "REDIS" => std::option::Option::Some(Self::REDIS),
-                _ => std::option::Option::None,
+                Self::CeleryWorker => std::option::Option::Some("CELERY_WORKER"),
+                Self::KubernetesWorker => std::option::Option::Some("KUBERNETES_WORKER"),
+                Self::KubernetesOperatorPod => std::option::Option::Some("KUBERNETES_OPERATOR_POD"),
+                Self::Scheduler => std::option::Option::Some("SCHEDULER"),
+                Self::DagProcessor => std::option::Option::Some("DAG_PROCESSOR"),
+                Self::Triggerer => std::option::Option::Some("TRIGGERER"),
+                Self::WebServer => std::option::Option::Some("WEB_SERVER"),
+                Self::Redis => std::option::Option::Some("REDIS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ComposerWorkloadType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ComposerWorkloadType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ComposerWorkloadType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ComposerWorkloadType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CeleryWorker,
+                2 => Self::KubernetesWorker,
+                3 => Self::KubernetesOperatorPod,
+                4 => Self::Scheduler,
+                5 => Self::DagProcessor,
+                6 => Self::Triggerer,
+                7 => Self::WebServer,
+                8 => Self::Redis,
+                _ => Self::UnknownValue(composer_workload_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ComposerWorkloadType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPOSER_WORKLOAD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CELERY_WORKER" => Self::CeleryWorker,
+                "KUBERNETES_WORKER" => Self::KubernetesWorker,
+                "KUBERNETES_OPERATOR_POD" => Self::KubernetesOperatorPod,
+                "SCHEDULER" => Self::Scheduler,
+                "DAG_PROCESSOR" => Self::DagProcessor,
+                "TRIGGERER" => Self::Triggerer,
+                "WEB_SERVER" => Self::WebServer,
+                "REDIS" => Self::Redis,
+                _ => Self::UnknownValue(composer_workload_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ComposerWorkloadType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CeleryWorker => serializer.serialize_i32(1),
+                Self::KubernetesWorker => serializer.serialize_i32(2),
+                Self::KubernetesOperatorPod => serializer.serialize_i32(3),
+                Self::Scheduler => serializer.serialize_i32(4),
+                Self::DagProcessor => serializer.serialize_i32(5),
+                Self::Triggerer => serializer.serialize_i32(6),
+                Self::WebServer => serializer.serialize_i32(7),
+                Self::Redis => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ComposerWorkloadType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComposerWorkloadType>::new(
+                ".google.cloud.orchestration.airflow.service.v1.ListWorkloadsResponse.ComposerWorkloadType"))
         }
     }
 
     /// Workload states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ComposerWorkloadState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ComposerWorkloadState {
+        /// Not able to determine the status of the workload.
+        Unspecified,
+        /// Workload is in pending state and has not yet started.
+        Pending,
+        /// Workload is running fine.
+        Ok,
+        /// Workload is running but there are some non-critical problems.
+        Warning,
+        /// Workload is not running due to an error.
+        Error,
+        /// Workload has finished execution with success.
+        Succeeded,
+        /// Workload has finished execution with failure.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ComposerWorkloadState::value] or
+        /// [ComposerWorkloadState::name].
+        UnknownValue(composer_workload_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod composer_workload_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ComposerWorkloadState {
-        /// Not able to determine the status of the workload.
-        pub const COMPOSER_WORKLOAD_STATE_UNSPECIFIED: ComposerWorkloadState =
-            ComposerWorkloadState::new(0);
-
-        /// Workload is in pending state and has not yet started.
-        pub const PENDING: ComposerWorkloadState = ComposerWorkloadState::new(1);
-
-        /// Workload is running fine.
-        pub const OK: ComposerWorkloadState = ComposerWorkloadState::new(2);
-
-        /// Workload is running but there are some non-critical problems.
-        pub const WARNING: ComposerWorkloadState = ComposerWorkloadState::new(3);
-
-        /// Workload is not running due to an error.
-        pub const ERROR: ComposerWorkloadState = ComposerWorkloadState::new(4);
-
-        /// Workload has finished execution with success.
-        pub const SUCCEEDED: ComposerWorkloadState = ComposerWorkloadState::new(5);
-
-        /// Workload has finished execution with failure.
-        pub const FAILED: ComposerWorkloadState = ComposerWorkloadState::new(6);
-
-        /// Creates a new ComposerWorkloadState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Ok => std::option::Option::Some(2),
+                Self::Warning => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::Succeeded => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPOSER_WORKLOAD_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("OK"),
-                3 => std::borrow::Cow::Borrowed("WARNING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                5 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPOSER_WORKLOAD_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPOSER_WORKLOAD_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("COMPOSER_WORKLOAD_STATE_UNSPECIFIED")
                 }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "OK" => std::option::Option::Some(Self::OK),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ComposerWorkloadState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ComposerWorkloadState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ComposerWorkloadState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ComposerWorkloadState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Ok,
+                3 => Self::Warning,
+                4 => Self::Error,
+                5 => Self::Succeeded,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(composer_workload_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ComposerWorkloadState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPOSER_WORKLOAD_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "OK" => Self::Ok,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(composer_workload_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ComposerWorkloadState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Ok => serializer.serialize_i32(2),
+                Self::Warning => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::Succeeded => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ComposerWorkloadState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComposerWorkloadState>::new(
+                ".google.cloud.orchestration.airflow.service.v1.ListWorkloadsResponse.ComposerWorkloadState"))
         }
     }
 }
@@ -2745,122 +2881,238 @@ pub mod environment_config {
     use super::*;
 
     /// The size of the Cloud Composer environment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EnvironmentSize(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EnvironmentSize {
+        /// The size of the environment is unspecified.
+        Unspecified,
+        /// The environment size is small.
+        Small,
+        /// The environment size is medium.
+        Medium,
+        /// The environment size is large.
+        Large,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EnvironmentSize::value] or
+        /// [EnvironmentSize::name].
+        UnknownValue(environment_size::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod environment_size {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EnvironmentSize {
-        /// The size of the environment is unspecified.
-        pub const ENVIRONMENT_SIZE_UNSPECIFIED: EnvironmentSize = EnvironmentSize::new(0);
-
-        /// The environment size is small.
-        pub const ENVIRONMENT_SIZE_SMALL: EnvironmentSize = EnvironmentSize::new(1);
-
-        /// The environment size is medium.
-        pub const ENVIRONMENT_SIZE_MEDIUM: EnvironmentSize = EnvironmentSize::new(2);
-
-        /// The environment size is large.
-        pub const ENVIRONMENT_SIZE_LARGE: EnvironmentSize = EnvironmentSize::new(3);
-
-        /// Creates a new EnvironmentSize instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Small => std::option::Option::Some(1),
+                Self::Medium => std::option::Option::Some(2),
+                Self::Large => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_SMALL"),
-                2 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("ENVIRONMENT_SIZE_LARGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENVIRONMENT_SIZE_UNSPECIFIED"),
+                Self::Small => std::option::Option::Some("ENVIRONMENT_SIZE_SMALL"),
+                Self::Medium => std::option::Option::Some("ENVIRONMENT_SIZE_MEDIUM"),
+                Self::Large => std::option::Option::Some("ENVIRONMENT_SIZE_LARGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENVIRONMENT_SIZE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENVIRONMENT_SIZE_UNSPECIFIED)
-                }
-                "ENVIRONMENT_SIZE_SMALL" => std::option::Option::Some(Self::ENVIRONMENT_SIZE_SMALL),
-                "ENVIRONMENT_SIZE_MEDIUM" => {
-                    std::option::Option::Some(Self::ENVIRONMENT_SIZE_MEDIUM)
-                }
-                "ENVIRONMENT_SIZE_LARGE" => std::option::Option::Some(Self::ENVIRONMENT_SIZE_LARGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EnvironmentSize {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EnvironmentSize {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EnvironmentSize {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EnvironmentSize {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Small,
+                2 => Self::Medium,
+                3 => Self::Large,
+                _ => Self::UnknownValue(environment_size::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EnvironmentSize {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENVIRONMENT_SIZE_UNSPECIFIED" => Self::Unspecified,
+                "ENVIRONMENT_SIZE_SMALL" => Self::Small,
+                "ENVIRONMENT_SIZE_MEDIUM" => Self::Medium,
+                "ENVIRONMENT_SIZE_LARGE" => Self::Large,
+                _ => Self::UnknownValue(environment_size::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EnvironmentSize {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Small => serializer.serialize_i32(1),
+                Self::Medium => serializer.serialize_i32(2),
+                Self::Large => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EnvironmentSize {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnvironmentSize>::new(
+                ".google.cloud.orchestration.airflow.service.v1.EnvironmentConfig.EnvironmentSize",
+            ))
         }
     }
 
     /// Resilience mode of the Cloud Composer Environment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResilienceMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResilienceMode {
+        /// Default mode doesn't change environment parameters.
+        Unspecified,
+        /// Enabled High Resilience mode, including Cloud SQL HA.
+        HighResilience,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResilienceMode::value] or
+        /// [ResilienceMode::name].
+        UnknownValue(resilience_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod resilience_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ResilienceMode {
-        /// Default mode doesn't change environment parameters.
-        pub const RESILIENCE_MODE_UNSPECIFIED: ResilienceMode = ResilienceMode::new(0);
-
-        /// Enabled High Resilience mode, including Cloud SQL HA.
-        pub const HIGH_RESILIENCE: ResilienceMode = ResilienceMode::new(1);
-
-        /// Creates a new ResilienceMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HighResilience => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESILIENCE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIGH_RESILIENCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESILIENCE_MODE_UNSPECIFIED"),
+                Self::HighResilience => std::option::Option::Some("HIGH_RESILIENCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESILIENCE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESILIENCE_MODE_UNSPECIFIED)
-                }
-                "HIGH_RESILIENCE" => std::option::Option::Some(Self::HIGH_RESILIENCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResilienceMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResilienceMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResilienceMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResilienceMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HighResilience,
+                _ => Self::UnknownValue(resilience_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResilienceMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESILIENCE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "HIGH_RESILIENCE" => Self::HighResilience,
+                _ => Self::UnknownValue(resilience_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResilienceMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HighResilience => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResilienceMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResilienceMode>::new(
+                ".google.cloud.orchestration.airflow.service.v1.EnvironmentConfig.ResilienceMode",
+            ))
         }
     }
 }
@@ -3377,62 +3629,121 @@ pub mod software_config {
     use super::*;
 
     /// Web server plugins mode of the Cloud Composer environment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WebServerPluginsMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WebServerPluginsMode {
+        /// Default mode.
+        Unspecified,
+        /// Web server plugins are not supported.
+        PluginsDisabled,
+        /// Web server plugins are supported.
+        PluginsEnabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WebServerPluginsMode::value] or
+        /// [WebServerPluginsMode::name].
+        UnknownValue(web_server_plugins_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod web_server_plugins_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WebServerPluginsMode {
-        /// Default mode.
-        pub const WEB_SERVER_PLUGINS_MODE_UNSPECIFIED: WebServerPluginsMode =
-            WebServerPluginsMode::new(0);
-
-        /// Web server plugins are not supported.
-        pub const PLUGINS_DISABLED: WebServerPluginsMode = WebServerPluginsMode::new(1);
-
-        /// Web server plugins are supported.
-        pub const PLUGINS_ENABLED: WebServerPluginsMode = WebServerPluginsMode::new(2);
-
-        /// Creates a new WebServerPluginsMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PluginsDisabled => std::option::Option::Some(1),
+                Self::PluginsEnabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WEB_SERVER_PLUGINS_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PLUGINS_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("PLUGINS_ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WEB_SERVER_PLUGINS_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WEB_SERVER_PLUGINS_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("WEB_SERVER_PLUGINS_MODE_UNSPECIFIED")
                 }
-                "PLUGINS_DISABLED" => std::option::Option::Some(Self::PLUGINS_DISABLED),
-                "PLUGINS_ENABLED" => std::option::Option::Some(Self::PLUGINS_ENABLED),
-                _ => std::option::Option::None,
+                Self::PluginsDisabled => std::option::Option::Some("PLUGINS_DISABLED"),
+                Self::PluginsEnabled => std::option::Option::Some("PLUGINS_ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for WebServerPluginsMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WebServerPluginsMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WebServerPluginsMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WebServerPluginsMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PluginsDisabled,
+                2 => Self::PluginsEnabled,
+                _ => Self::UnknownValue(web_server_plugins_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WebServerPluginsMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WEB_SERVER_PLUGINS_MODE_UNSPECIFIED" => Self::Unspecified,
+                "PLUGINS_DISABLED" => Self::PluginsDisabled,
+                "PLUGINS_ENABLED" => Self::PluginsEnabled,
+                _ => Self::UnknownValue(web_server_plugins_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WebServerPluginsMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PluginsDisabled => serializer.serialize_i32(1),
+                Self::PluginsEnabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WebServerPluginsMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WebServerPluginsMode>::new(
+                ".google.cloud.orchestration.airflow.service.v1.SoftwareConfig.WebServerPluginsMode"))
         }
     }
 }
@@ -4069,66 +4380,123 @@ pub mod networking_config {
     /// Represents connection type between Composer environment in Customer
     /// Project and the corresponding Tenant project, from a predefined list
     /// of available connection modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectionType(i32);
-
-    impl ConnectionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConnectionType {
         /// No specific connection type was requested, so the environment uses
         /// the default value corresponding to the rest of its configuration.
-        pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
-
+        Unspecified,
         /// Requests the use of VPC peerings for connecting the Customer and Tenant
         /// projects.
-        pub const VPC_PEERING: ConnectionType = ConnectionType::new(1);
-
+        VpcPeering,
         /// Requests the use of Private Service Connect for connecting the Customer
         /// and Tenant projects.
-        pub const PRIVATE_SERVICE_CONNECT: ConnectionType = ConnectionType::new(2);
+        PrivateServiceConnect,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConnectionType::value] or
+        /// [ConnectionType::name].
+        UnknownValue(connection_type::UnknownValue),
+    }
 
-        /// Creates a new ConnectionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod connection_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConnectionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VpcPeering => std::option::Option::Some(1),
+                Self::PrivateServiceConnect => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VPC_PEERING"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_CONNECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONNECTION_TYPE_UNSPECIFIED"),
+                Self::VpcPeering => std::option::Option::Some("VPC_PEERING"),
+                Self::PrivateServiceConnect => std::option::Option::Some("PRIVATE_SERVICE_CONNECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONNECTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
-                }
-                "VPC_PEERING" => std::option::Option::Some(Self::VPC_PEERING),
-                "PRIVATE_SERVICE_CONNECT" => {
-                    std::option::Option::Some(Self::PRIVATE_SERVICE_CONNECT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConnectionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConnectionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConnectionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VpcPeering,
+                2 => Self::PrivateServiceConnect,
+                _ => Self::UnknownValue(connection_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConnectionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONNECTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "VPC_PEERING" => Self::VpcPeering,
+                "PRIVATE_SERVICE_CONNECT" => Self::PrivateServiceConnect,
+                _ => Self::UnknownValue(connection_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConnectionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VpcPeering => serializer.serialize_i32(1),
+                Self::PrivateServiceConnect => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConnectionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionType>::new(
+                ".google.cloud.orchestration.airflow.service.v1.NetworkingConfig.ConnectionType",
+            ))
         }
     }
 }
@@ -5169,75 +5537,142 @@ pub mod environment {
     use super::*;
 
     /// State of the environment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state of the environment is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The environment is in the process of being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The environment is currently running and healthy. It is ready for use.
-        pub const RUNNING: State = State::new(2);
-
+        Running,
         /// The environment is being updated. It remains usable but cannot receive
         /// additional update requests or be deleted at this time.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The environment is undergoing deletion. It cannot be used.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The environment has encountered an error and cannot be used.
-        pub const ERROR: State = State::new(5);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Running,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "RUNNING" => Self::Running,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.orchestration.airflow.service.v1.Environment.State",
+            ))
         }
     }
 }
@@ -5403,61 +5838,119 @@ pub mod check_upgrade_response {
     use super::*;
 
     /// Whether there were python modules conflict during image build.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConflictResult(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConflictResult {
+        /// It is unknown whether build had conflicts or not.
+        Unspecified,
+        /// There were python packages conflicts.
+        Conflict,
+        /// There were no python packages conflicts.
+        NoConflict,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConflictResult::value] or
+        /// [ConflictResult::name].
+        UnknownValue(conflict_result::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod conflict_result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConflictResult {
-        /// It is unknown whether build had conflicts or not.
-        pub const CONFLICT_RESULT_UNSPECIFIED: ConflictResult = ConflictResult::new(0);
-
-        /// There were python packages conflicts.
-        pub const CONFLICT: ConflictResult = ConflictResult::new(1);
-
-        /// There were no python packages conflicts.
-        pub const NO_CONFLICT: ConflictResult = ConflictResult::new(2);
-
-        /// Creates a new ConflictResult instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Conflict => std::option::Option::Some(1),
+                Self::NoConflict => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONFLICT_RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFLICT"),
-                2 => std::borrow::Cow::Borrowed("NO_CONFLICT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONFLICT_RESULT_UNSPECIFIED"),
+                Self::Conflict => std::option::Option::Some("CONFLICT"),
+                Self::NoConflict => std::option::Option::Some("NO_CONFLICT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONFLICT_RESULT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONFLICT_RESULT_UNSPECIFIED)
-                }
-                "CONFLICT" => std::option::Option::Some(Self::CONFLICT),
-                "NO_CONFLICT" => std::option::Option::Some(Self::NO_CONFLICT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConflictResult {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConflictResult {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConflictResult {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConflictResult {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Conflict,
+                2 => Self::NoConflict,
+                _ => Self::UnknownValue(conflict_result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConflictResult {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONFLICT_RESULT_UNSPECIFIED" => Self::Unspecified,
+                "CONFLICT" => Self::Conflict,
+                "NO_CONFLICT" => Self::NoConflict,
+                _ => Self::UnknownValue(conflict_result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConflictResult {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Conflict => serializer.serialize_i32(1),
+                Self::NoConflict => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConflictResult {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConflictResult>::new(
+                ".google.cloud.orchestration.airflow.service.v1.CheckUpgradeResponse.ConflictResult"))
         }
     }
 }
@@ -5557,66 +6050,124 @@ pub mod task_logs_retention_config {
     use super::*;
 
     /// The definition of task_logs_storage_mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TaskLogsStorageMode(i32);
-
-    impl TaskLogsStorageMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TaskLogsStorageMode {
         /// This configuration is not specified by the user.
-        pub const TASK_LOGS_STORAGE_MODE_UNSPECIFIED: TaskLogsStorageMode =
-            TaskLogsStorageMode::new(0);
-
+        Unspecified,
         /// Store task logs in Cloud Logging and in the environment's Cloud Storage
         /// bucket.
-        pub const CLOUD_LOGGING_AND_CLOUD_STORAGE: TaskLogsStorageMode =
-            TaskLogsStorageMode::new(1);
-
+        CloudLoggingAndCloudStorage,
         /// Store task logs in Cloud Logging only.
-        pub const CLOUD_LOGGING_ONLY: TaskLogsStorageMode = TaskLogsStorageMode::new(2);
+        CloudLoggingOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TaskLogsStorageMode::value] or
+        /// [TaskLogsStorageMode::name].
+        UnknownValue(task_logs_storage_mode::UnknownValue),
+    }
 
-        /// Creates a new TaskLogsStorageMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod task_logs_storage_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TaskLogsStorageMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CloudLoggingAndCloudStorage => std::option::Option::Some(1),
+                Self::CloudLoggingOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TASK_LOGS_STORAGE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_LOGGING_AND_CLOUD_STORAGE"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_LOGGING_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TASK_LOGS_STORAGE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TASK_LOGS_STORAGE_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("TASK_LOGS_STORAGE_MODE_UNSPECIFIED")
                 }
-                "CLOUD_LOGGING_AND_CLOUD_STORAGE" => {
-                    std::option::Option::Some(Self::CLOUD_LOGGING_AND_CLOUD_STORAGE)
+                Self::CloudLoggingAndCloudStorage => {
+                    std::option::Option::Some("CLOUD_LOGGING_AND_CLOUD_STORAGE")
                 }
-                "CLOUD_LOGGING_ONLY" => std::option::Option::Some(Self::CLOUD_LOGGING_ONLY),
-                _ => std::option::Option::None,
+                Self::CloudLoggingOnly => std::option::Option::Some("CLOUD_LOGGING_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TaskLogsStorageMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TaskLogsStorageMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TaskLogsStorageMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TaskLogsStorageMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CloudLoggingAndCloudStorage,
+                2 => Self::CloudLoggingOnly,
+                _ => Self::UnknownValue(task_logs_storage_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TaskLogsStorageMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TASK_LOGS_STORAGE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "CLOUD_LOGGING_AND_CLOUD_STORAGE" => Self::CloudLoggingAndCloudStorage,
+                "CLOUD_LOGGING_ONLY" => Self::CloudLoggingOnly,
+                _ => Self::UnknownValue(task_logs_storage_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TaskLogsStorageMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CloudLoggingAndCloudStorage => serializer.serialize_i32(1),
+                Self::CloudLoggingOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TaskLogsStorageMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TaskLogsStorageMode>::new(
+                ".google.cloud.orchestration.airflow.service.v1.TaskLogsRetentionConfig.TaskLogsStorageMode"))
         }
     }
 }
@@ -5673,63 +6224,119 @@ pub mod airflow_metadata_retention_policy_config {
     use super::*;
 
     /// Describes retention policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetentionMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RetentionMode {
+        /// Default mode doesn't change environment parameters.
+        Unspecified,
+        /// Retention policy is enabled.
+        Enabled,
+        /// Retention policy is disabled.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RetentionMode::value] or
+        /// [RetentionMode::name].
+        UnknownValue(retention_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod retention_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RetentionMode {
-        /// Default mode doesn't change environment parameters.
-        pub const RETENTION_MODE_UNSPECIFIED: RetentionMode = RetentionMode::new(0);
-
-        /// Retention policy is enabled.
-        pub const RETENTION_MODE_ENABLED: RetentionMode = RetentionMode::new(1);
-
-        /// Retention policy is disabled.
-        pub const RETENTION_MODE_DISABLED: RetentionMode = RetentionMode::new(2);
-
-        /// Creates a new RetentionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RETENTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RETENTION_MODE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("RETENTION_MODE_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RETENTION_MODE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("RETENTION_MODE_ENABLED"),
+                Self::Disabled => std::option::Option::Some("RETENTION_MODE_DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RETENTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RETENTION_MODE_UNSPECIFIED)
-                }
-                "RETENTION_MODE_ENABLED" => std::option::Option::Some(Self::RETENTION_MODE_ENABLED),
-                "RETENTION_MODE_DISABLED" => {
-                    std::option::Option::Some(Self::RETENTION_MODE_DISABLED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RetentionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RetentionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RetentionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RetentionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(retention_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RetentionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RETENTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "RETENTION_MODE_ENABLED" => Self::Enabled,
+                "RETENTION_MODE_DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(retention_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RetentionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RetentionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RetentionMode>::new(
+                ".google.cloud.orchestration.airflow.service.v1.AirflowMetadataRetentionPolicyConfig.RetentionMode"))
         }
     }
 }
@@ -6054,155 +6661,293 @@ pub mod operation_metadata {
     use super::*;
 
     /// An enum describing the overall state of an operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unused.
+        Unspecified,
+        /// The operation has been created but is not yet started.
+        Pending,
+        /// The operation is underway.
+        Running,
+        /// The operation completed successfully.
+        Succeeded,
+        Successful,
+        /// The operation is no longer running but did not succeed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The operation has been created but is not yet started.
-        pub const PENDING: State = State::new(1);
-
-        /// The operation is underway.
-        pub const RUNNING: State = State::new(2);
-
-        /// The operation completed successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
-        pub const SUCCESSFUL: State = State::new(3);
-
-        /// The operation is no longer running but did not succeed.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Successful => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Successful => std::option::Option::Some("SUCCESSFUL"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "SUCCESSFUL" => Self::Successful,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Successful => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.orchestration.airflow.service.v1.OperationMetadata.State",
+            ))
         }
     }
 
     /// Type of longrunning operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Unused.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// A resource creation operation.
-        pub const CREATE: Type = Type::new(1);
-
+        Create,
         /// A resource deletion operation.
-        pub const DELETE: Type = Type::new(2);
-
+        Delete,
         /// A resource update operation.
-        pub const UPDATE: Type = Type::new(3);
-
+        Update,
         /// A resource check operation.
-        pub const CHECK: Type = Type::new(4);
-
+        Check,
         /// Saves snapshot of the resource operation.
-        pub const SAVE_SNAPSHOT: Type = Type::new(5);
-
+        SaveSnapshot,
         /// Loads snapshot of the resource operation.
-        pub const LOAD_SNAPSHOT: Type = Type::new(6);
-
+        LoadSnapshot,
         /// Triggers failover of environment's Cloud SQL instance (only for highly
         /// resilient environments).
-        pub const DATABASE_FAILOVER: Type = Type::new(7);
+        DatabaseFailover,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Delete => std::option::Option::Some(2),
+                Self::Update => std::option::Option::Some(3),
+                Self::Check => std::option::Option::Some(4),
+                Self::SaveSnapshot => std::option::Option::Some(5),
+                Self::LoadSnapshot => std::option::Option::Some(6),
+                Self::DatabaseFailover => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("DELETE"),
-                3 => std::borrow::Cow::Borrowed("UPDATE"),
-                4 => std::borrow::Cow::Borrowed("CHECK"),
-                5 => std::borrow::Cow::Borrowed("SAVE_SNAPSHOT"),
-                6 => std::borrow::Cow::Borrowed("LOAD_SNAPSHOT"),
-                7 => std::borrow::Cow::Borrowed("DATABASE_FAILOVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Check => std::option::Option::Some("CHECK"),
+                Self::SaveSnapshot => std::option::Option::Some("SAVE_SNAPSHOT"),
+                Self::LoadSnapshot => std::option::Option::Some("LOAD_SNAPSHOT"),
+                Self::DatabaseFailover => std::option::Option::Some("DATABASE_FAILOVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "CHECK" => std::option::Option::Some(Self::CHECK),
-                "SAVE_SNAPSHOT" => std::option::Option::Some(Self::SAVE_SNAPSHOT),
-                "LOAD_SNAPSHOT" => std::option::Option::Some(Self::LOAD_SNAPSHOT),
-                "DATABASE_FAILOVER" => std::option::Option::Some(Self::DATABASE_FAILOVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Delete,
+                3 => Self::Update,
+                4 => Self::Check,
+                5 => Self::SaveSnapshot,
+                6 => Self::LoadSnapshot,
+                7 => Self::DatabaseFailover,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "DELETE" => Self::Delete,
+                "UPDATE" => Self::Update,
+                "CHECK" => Self::Check,
+                "SAVE_SNAPSHOT" => Self::SaveSnapshot,
+                "LOAD_SNAPSHOT" => Self::LoadSnapshot,
+                "DATABASE_FAILOVER" => Self::DatabaseFailover,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Delete => serializer.serialize_i32(2),
+                Self::Update => serializer.serialize_i32(3),
+                Self::Check => serializer.serialize_i32(4),
+                Self::SaveSnapshot => serializer.serialize_i32(5),
+                Self::LoadSnapshot => serializer.serialize_i32(6),
+                Self::DatabaseFailover => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.orchestration.airflow.service.v1.OperationMetadata.Type",
+            ))
         }
     }
 }

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -456,61 +456,123 @@ pub mod policy {
         /// set to either `ALLOW` or `DENY,  `allowed_values` and `denied_values`
         /// must be unset. Setting this to `ALL_VALUES_UNSPECIFIED` allows for
         /// setting `allowed_values` and `denied_values`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AllValues(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum AllValues {
+            /// Indicates that allowed_values or denied_values must be set.
+            Unspecified,
+            /// A policy with this set allows all values.
+            Allow,
+            /// A policy with this set denies all values.
+            Deny,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [AllValues::value] or
+            /// [AllValues::name].
+            UnknownValue(all_values::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod all_values {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl AllValues {
-            /// Indicates that allowed_values or denied_values must be set.
-            pub const ALL_VALUES_UNSPECIFIED: AllValues = AllValues::new(0);
-
-            /// A policy with this set allows all values.
-            pub const ALLOW: AllValues = AllValues::new(1);
-
-            /// A policy with this set denies all values.
-            pub const DENY: AllValues = AllValues::new(2);
-
-            /// Creates a new AllValues instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Allow => std::option::Option::Some(1),
+                    Self::Deny => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ALL_VALUES_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ALLOW"),
-                    2 => std::borrow::Cow::Borrowed("DENY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ALL_VALUES_UNSPECIFIED"),
+                    Self::Allow => std::option::Option::Some("ALLOW"),
+                    Self::Deny => std::option::Option::Some("DENY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ALL_VALUES_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ALL_VALUES_UNSPECIFIED)
-                    }
-                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                    "DENY" => std::option::Option::Some(Self::DENY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for AllValues {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for AllValues {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for AllValues {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for AllValues {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Allow,
+                    2 => Self::Deny,
+                    _ => Self::UnknownValue(all_values::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for AllValues {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ALL_VALUES_UNSPECIFIED" => Self::Unspecified,
+                    "ALLOW" => Self::Allow,
+                    "DENY" => Self::Deny,
+                    _ => Self::UnknownValue(all_values::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for AllValues {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Allow => serializer.serialize_i32(1),
+                    Self::Deny => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for AllValues {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AllValues>::new(
+                    ".google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues",
+                ))
             }
         }
     }

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -555,65 +555,130 @@ pub mod constraint {
             }
 
             /// All valid types of parameter.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(i32);
-
-            impl Type {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Type {
                 /// This is only used for distinguishing unset values and should never be
                 /// used. Results in an error.
-                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+                Unspecified,
                 /// List parameter type.
-                pub const LIST: Type = Type::new(1);
-
+                List,
                 /// String parameter type.
-                pub const STRING: Type = Type::new(2);
-
+                String,
                 /// Boolean parameter type.
-                pub const BOOLEAN: Type = Type::new(3);
+                Boolean,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Type::value] or
+                /// [Type::name].
+                UnknownValue(r#type::UnknownValue),
+            }
 
-                /// Creates a new Type instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod r#type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl Type {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::List => std::option::Option::Some(1),
+                        Self::String => std::option::Option::Some(2),
+                        Self::Boolean => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("LIST"),
-                        2 => std::borrow::Cow::Borrowed("STRING"),
-                        3 => std::borrow::Cow::Borrowed("BOOLEAN"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                        Self::List => std::option::Option::Some("LIST"),
+                        Self::String => std::option::Option::Some("STRING"),
+                        Self::Boolean => std::option::Option::Some("BOOLEAN"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                        "LIST" => std::option::Option::Some(Self::LIST),
-                        "STRING" => std::option::Option::Some(Self::STRING),
-                        "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Type {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Type {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::List,
+                        2 => Self::String,
+                        3 => Self::Boolean,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Type {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "LIST" => Self::List,
+                        "STRING" => Self::String,
+                        "BOOLEAN" => Self::Boolean,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Type {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::List => serializer.serialize_i32(1),
+                        Self::String => serializer.serialize_i32(2),
+                        Self::Boolean => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Type {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                        ".google.cloud.orgpolicy.v2.Constraint.CustomConstraintDefinition.Parameter.Type"))
                 }
             }
         }
@@ -625,138 +690,268 @@ pub mod constraint {
         ///
         /// `UPDATE`-only custom constraints are not supported. Use `CREATE` or
         /// `CREATE, UPDATE`.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct MethodType(i32);
-
-        impl MethodType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum MethodType {
             /// This is only used for distinguishing unset values and should never be
             /// used. Results in an error.
-            pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
-
+            Unspecified,
             /// Constraint applied when creating the resource.
-            pub const CREATE: MethodType = MethodType::new(1);
-
+            Create,
             /// Constraint applied when updating the resource.
-            pub const UPDATE: MethodType = MethodType::new(2);
-
+            Update,
             /// Constraint applied when deleting the resource.
             /// Not currently supported.
-            pub const DELETE: MethodType = MethodType::new(3);
-
+            Delete,
             /// Constraint applied when removing an IAM grant.
-            pub const REMOVE_GRANT: MethodType = MethodType::new(4);
-
+            RemoveGrant,
             /// Constraint applied when enforcing forced tagging.
-            pub const GOVERN_TAGS: MethodType = MethodType::new(5);
+            GovernTags,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [MethodType::value] or
+            /// [MethodType::name].
+            UnknownValue(method_type::UnknownValue),
+        }
 
-            /// Creates a new MethodType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod method_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl MethodType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Create => std::option::Option::Some(1),
+                    Self::Update => std::option::Option::Some(2),
+                    Self::Delete => std::option::Option::Some(3),
+                    Self::RemoveGrant => std::option::Option::Some(4),
+                    Self::GovernTags => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CREATE"),
-                    2 => std::borrow::Cow::Borrowed("UPDATE"),
-                    3 => std::borrow::Cow::Borrowed("DELETE"),
-                    4 => std::borrow::Cow::Borrowed("REMOVE_GRANT"),
-                    5 => std::borrow::Cow::Borrowed("GOVERN_TAGS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("METHOD_TYPE_UNSPECIFIED"),
+                    Self::Create => std::option::Option::Some("CREATE"),
+                    Self::Update => std::option::Option::Some("UPDATE"),
+                    Self::Delete => std::option::Option::Some("DELETE"),
+                    Self::RemoveGrant => std::option::Option::Some("REMOVE_GRANT"),
+                    Self::GovernTags => std::option::Option::Some("GOVERN_TAGS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "METHOD_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
-                    }
-                    "CREATE" => std::option::Option::Some(Self::CREATE),
-                    "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                    "DELETE" => std::option::Option::Some(Self::DELETE),
-                    "REMOVE_GRANT" => std::option::Option::Some(Self::REMOVE_GRANT),
-                    "GOVERN_TAGS" => std::option::Option::Some(Self::GOVERN_TAGS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for MethodType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for MethodType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for MethodType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for MethodType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Create,
+                    2 => Self::Update,
+                    3 => Self::Delete,
+                    4 => Self::RemoveGrant,
+                    5 => Self::GovernTags,
+                    _ => Self::UnknownValue(method_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for MethodType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "METHOD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "CREATE" => Self::Create,
+                    "UPDATE" => Self::Update,
+                    "DELETE" => Self::Delete,
+                    "REMOVE_GRANT" => Self::RemoveGrant,
+                    "GOVERN_TAGS" => Self::GovernTags,
+                    _ => Self::UnknownValue(method_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for MethodType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Create => serializer.serialize_i32(1),
+                    Self::Update => serializer.serialize_i32(2),
+                    Self::Delete => serializer.serialize_i32(3),
+                    Self::RemoveGrant => serializer.serialize_i32(4),
+                    Self::GovernTags => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for MethodType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<MethodType>::new(
+                    ".google.cloud.orgpolicy.v2.Constraint.CustomConstraintDefinition.MethodType",
+                ))
             }
         }
 
         /// Allow or deny type.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ActionType(i32);
-
-        impl ActionType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ActionType {
             /// This is only used for distinguishing unset values and should never be
             /// used. Results in an error.
-            pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
-
+            Unspecified,
             /// Allowed action type.
-            pub const ALLOW: ActionType = ActionType::new(1);
-
+            Allow,
             /// Deny action type.
-            pub const DENY: ActionType = ActionType::new(2);
+            Deny,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ActionType::value] or
+            /// [ActionType::name].
+            UnknownValue(action_type::UnknownValue),
+        }
 
-            /// Creates a new ActionType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod action_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ActionType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Allow => std::option::Option::Some(1),
+                    Self::Deny => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ALLOW"),
-                    2 => std::borrow::Cow::Borrowed("DENY"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ACTION_TYPE_UNSPECIFIED"),
+                    Self::Allow => std::option::Option::Some("ALLOW"),
+                    Self::Deny => std::option::Option::Some("DENY"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ACTION_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
-                    }
-                    "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                    "DENY" => std::option::Option::Some(Self::DENY),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ActionType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ActionType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ActionType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ActionType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Allow,
+                    2 => Self::Deny,
+                    _ => Self::UnknownValue(action_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ActionType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ACTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "ALLOW" => Self::Allow,
+                    "DENY" => Self::Deny,
+                    _ => Self::UnknownValue(action_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ActionType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Allow => serializer.serialize_i32(1),
+                    Self::Deny => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ActionType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ActionType>::new(
+                    ".google.cloud.orgpolicy.v2.Constraint.CustomConstraintDefinition.ActionType",
+                ))
             }
         }
     }
@@ -811,64 +1006,123 @@ pub mod constraint {
     /// constraint. This must not be `CONSTRAINT_DEFAULT_UNSPECIFIED`.
     ///
     /// Immutable after creation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConstraintDefault(i32);
-
-    impl ConstraintDefault {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConstraintDefault {
         /// This is only used for distinguishing unset values and should never be
         /// used. Results in an error.
-        pub const CONSTRAINT_DEFAULT_UNSPECIFIED: ConstraintDefault = ConstraintDefault::new(0);
-
+        Unspecified,
         /// Indicate that all values are allowed for list constraints.
         /// Indicate that enforcement is off for boolean constraints.
-        pub const ALLOW: ConstraintDefault = ConstraintDefault::new(1);
-
+        Allow,
         /// Indicate that all values are denied for list constraints.
         /// Indicate that enforcement is on for boolean constraints.
-        pub const DENY: ConstraintDefault = ConstraintDefault::new(2);
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConstraintDefault::value] or
+        /// [ConstraintDefault::name].
+        UnknownValue(constraint_default::UnknownValue),
+    }
 
-        /// Creates a new ConstraintDefault instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod constraint_default {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConstraintDefault {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONSTRAINT_DEFAULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONSTRAINT_DEFAULT_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONSTRAINT_DEFAULT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONSTRAINT_DEFAULT_UNSPECIFIED)
-                }
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConstraintDefault {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConstraintDefault {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConstraintDefault {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConstraintDefault {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(constraint_default::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConstraintDefault {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONSTRAINT_DEFAULT_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(constraint_default::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConstraintDefault {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConstraintDefault {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConstraintDefault>::new(
+                ".google.cloud.orgpolicy.v2.Constraint.ConstraintDefault",
+            ))
         }
     }
 
@@ -1040,138 +1294,262 @@ pub mod custom_constraint {
     ///
     /// `UPDATE` only custom constraints are not supported. Use `CREATE` or
     /// `CREATE, UPDATE`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MethodType(i32);
-
-    impl MethodType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MethodType {
         /// This is only used for distinguishing unset values and should never be
         /// used. Results in an error.
-        pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
-
+        Unspecified,
         /// Constraint applied when creating the resource.
-        pub const CREATE: MethodType = MethodType::new(1);
-
+        Create,
         /// Constraint applied when updating the resource.
-        pub const UPDATE: MethodType = MethodType::new(2);
-
+        Update,
         /// Constraint applied when deleting the resource.
         /// Not currently supported.
-        pub const DELETE: MethodType = MethodType::new(3);
-
+        Delete,
         /// Constraint applied when removing an IAM grant.
-        pub const REMOVE_GRANT: MethodType = MethodType::new(4);
-
+        RemoveGrant,
         /// Constraint applied when enforcing forced tagging.
-        pub const GOVERN_TAGS: MethodType = MethodType::new(5);
+        GovernTags,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MethodType::value] or
+        /// [MethodType::name].
+        UnknownValue(method_type::UnknownValue),
+    }
 
-        /// Creates a new MethodType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod method_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MethodType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::RemoveGrant => std::option::Option::Some(4),
+                Self::GovernTags => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                4 => std::borrow::Cow::Borrowed("REMOVE_GRANT"),
-                5 => std::borrow::Cow::Borrowed("GOVERN_TAGS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METHOD_TYPE_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::RemoveGrant => std::option::Option::Some("REMOVE_GRANT"),
+                Self::GovernTags => std::option::Option::Some("GOVERN_TAGS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METHOD_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
-                }
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "REMOVE_GRANT" => std::option::Option::Some(Self::REMOVE_GRANT),
-                "GOVERN_TAGS" => std::option::Option::Some(Self::GOVERN_TAGS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MethodType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MethodType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MethodType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MethodType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                4 => Self::RemoveGrant,
+                5 => Self::GovernTags,
+                _ => Self::UnknownValue(method_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MethodType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METHOD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                "REMOVE_GRANT" => Self::RemoveGrant,
+                "GOVERN_TAGS" => Self::GovernTags,
+                _ => Self::UnknownValue(method_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MethodType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::RemoveGrant => serializer.serialize_i32(4),
+                Self::GovernTags => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MethodType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MethodType>::new(
+                ".google.cloud.orgpolicy.v2.CustomConstraint.MethodType",
+            ))
         }
     }
 
     /// Allow or deny type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ActionType(i32);
-
-    impl ActionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ActionType {
         /// This is only used for distinguishing unset values and should never be
         /// used. Results in an error.
-        pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
-
+        Unspecified,
         /// Allowed action type.
-        pub const ALLOW: ActionType = ActionType::new(1);
-
+        Allow,
         /// Deny action type.
-        pub const DENY: ActionType = ActionType::new(2);
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ActionType::value] or
+        /// [ActionType::name].
+        UnknownValue(action_type::UnknownValue),
+    }
 
-        /// Creates a new ActionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod action_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ActionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_TYPE_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
-                }
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ActionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ActionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ActionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ActionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(action_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ActionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(action_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ActionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ActionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ActionType>::new(
+                ".google.cloud.orgpolicy.v2.CustomConstraint.ActionType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -418,114 +418,238 @@ pub mod inventory {
         use super::*;
 
         /// The origin of a specific inventory item.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct OriginType(i32);
-
-        impl OriginType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum OriginType {
             /// Invalid. An origin type must be specified.
-            pub const ORIGIN_TYPE_UNSPECIFIED: OriginType = OriginType::new(0);
-
+            Unspecified,
             /// This inventory item was discovered as the result of the agent
             /// reporting inventory via the reporting API.
-            pub const INVENTORY_REPORT: OriginType = OriginType::new(1);
+            InventoryReport,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [OriginType::value] or
+            /// [OriginType::name].
+            UnknownValue(origin_type::UnknownValue),
+        }
 
-            /// Creates a new OriginType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod origin_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl OriginType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::InventoryReport => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ORIGIN_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("INVENTORY_REPORT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ORIGIN_TYPE_UNSPECIFIED"),
+                    Self::InventoryReport => std::option::Option::Some("INVENTORY_REPORT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ORIGIN_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ORIGIN_TYPE_UNSPECIFIED)
-                    }
-                    "INVENTORY_REPORT" => std::option::Option::Some(Self::INVENTORY_REPORT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for OriginType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for OriginType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for OriginType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for OriginType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::InventoryReport,
+                    _ => Self::UnknownValue(origin_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for OriginType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ORIGIN_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "INVENTORY_REPORT" => Self::InventoryReport,
+                    _ => Self::UnknownValue(origin_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for OriginType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::InventoryReport => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for OriginType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<OriginType>::new(
+                    ".google.cloud.osconfig.v1.Inventory.Item.OriginType",
+                ))
             }
         }
 
         /// The different types of inventory that are tracked on a VM.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Invalid. An type must be specified.
+            Unspecified,
+            /// This represents a package that is installed on the VM.
+            InstalledPackage,
+            /// This represents an update that is available for a package.
+            AvailablePackage,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Invalid. An type must be specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// This represents a package that is installed on the VM.
-            pub const INSTALLED_PACKAGE: Type = Type::new(1);
-
-            /// This represents an update that is available for a package.
-            pub const AVAILABLE_PACKAGE: Type = Type::new(2);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::InstalledPackage => std::option::Option::Some(1),
+                    Self::AvailablePackage => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("INSTALLED_PACKAGE"),
-                    2 => std::borrow::Cow::Borrowed("AVAILABLE_PACKAGE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::InstalledPackage => std::option::Option::Some("INSTALLED_PACKAGE"),
+                    Self::AvailablePackage => std::option::Option::Some("AVAILABLE_PACKAGE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "INSTALLED_PACKAGE" => std::option::Option::Some(Self::INSTALLED_PACKAGE),
-                    "AVAILABLE_PACKAGE" => std::option::Option::Some(Self::AVAILABLE_PACKAGE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::InstalledPackage,
+                    2 => Self::AvailablePackage,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "INSTALLED_PACKAGE" => Self::InstalledPackage,
+                    "AVAILABLE_PACKAGE" => Self::AvailablePackage,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::InstalledPackage => serializer.serialize_i32(1),
+                    Self::AvailablePackage => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.osconfig.v1.Inventory.Item.Type",
+                ))
             }
         }
 
@@ -2866,62 +2990,124 @@ pub mod os_policy {
             }
 
             /// The desired state that the OS Config agent maintains on the VM.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct DesiredState(i32);
-
-            impl DesiredState {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum DesiredState {
                 /// Unspecified is invalid.
-                pub const DESIRED_STATE_UNSPECIFIED: DesiredState = DesiredState::new(0);
-
+                Unspecified,
                 /// Ensure that the package is installed.
-                pub const INSTALLED: DesiredState = DesiredState::new(1);
-
+                Installed,
                 /// The agent ensures that the package is not installed and
                 /// uninstalls it if detected.
-                pub const REMOVED: DesiredState = DesiredState::new(2);
+                Removed,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [DesiredState::value] or
+                /// [DesiredState::name].
+                UnknownValue(desired_state::UnknownValue),
+            }
 
-                /// Creates a new DesiredState instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod desired_state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl DesiredState {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Installed => std::option::Option::Some(1),
+                        Self::Removed => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("DESIRED_STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("INSTALLED"),
-                        2 => std::borrow::Cow::Borrowed("REMOVED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("DESIRED_STATE_UNSPECIFIED"),
+                        Self::Installed => std::option::Option::Some("INSTALLED"),
+                        Self::Removed => std::option::Option::Some("REMOVED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "DESIRED_STATE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::DESIRED_STATE_UNSPECIFIED)
-                        }
-                        "INSTALLED" => std::option::Option::Some(Self::INSTALLED),
-                        "REMOVED" => std::option::Option::Some(Self::REMOVED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for DesiredState {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for DesiredState {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for DesiredState {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for DesiredState {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Installed,
+                        2 => Self::Removed,
+                        _ => Self::UnknownValue(desired_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for DesiredState {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "DESIRED_STATE_UNSPECIFIED" => Self::Unspecified,
+                        "INSTALLED" => Self::Installed,
+                        "REMOVED" => Self::Removed,
+                        _ => Self::UnknownValue(desired_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for DesiredState {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Installed => serializer.serialize_i32(1),
+                        Self::Removed => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for DesiredState {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<DesiredState>::new(
+                        ".google.cloud.osconfig.v1.OSPolicy.Resource.PackageResource.DesiredState",
+                    ))
                 }
             }
 
@@ -3254,61 +3440,124 @@ pub mod os_policy {
                 use super::*;
 
                 /// Type of archive.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct ArchiveType(i32);
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum ArchiveType {
+                    /// Unspecified is invalid.
+                    Unspecified,
+                    /// Deb indicates that the archive contains binary files.
+                    Deb,
+                    /// Deb-src indicates that the archive contains source files.
+                    DebSrc,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [ArchiveType::value] or
+                    /// [ArchiveType::name].
+                    UnknownValue(archive_type::UnknownValue),
+                }
+
+                #[doc(hidden)]
+                pub mod archive_type {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
                 impl ArchiveType {
-                    /// Unspecified is invalid.
-                    pub const ARCHIVE_TYPE_UNSPECIFIED: ArchiveType = ArchiveType::new(0);
-
-                    /// Deb indicates that the archive contains binary files.
-                    pub const DEB: ArchiveType = ArchiveType::new(1);
-
-                    /// Deb-src indicates that the archive contains source files.
-                    pub const DEB_SRC: ArchiveType = ArchiveType::new(2);
-
-                    /// Creates a new ArchiveType instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
-
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::Deb => std::option::Option::Some(1),
+                            Self::DebSrc => std::option::Option::Some(2),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("ARCHIVE_TYPE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("DEB"),
-                            2 => std::borrow::Cow::Borrowed("DEB_SRC"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "ARCHIVE_TYPE_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::ARCHIVE_TYPE_UNSPECIFIED)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => {
+                                std::option::Option::Some("ARCHIVE_TYPE_UNSPECIFIED")
                             }
-                            "DEB" => std::option::Option::Some(Self::DEB),
-                            "DEB_SRC" => std::option::Option::Some(Self::DEB_SRC),
-                            _ => std::option::Option::None,
+                            Self::Deb => std::option::Option::Some("DEB"),
+                            Self::DebSrc => std::option::Option::Some("DEB_SRC"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for ArchiveType {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for ArchiveType {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for ArchiveType {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for ArchiveType {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::Deb,
+                            2 => Self::DebSrc,
+                            _ => Self::UnknownValue(archive_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for ArchiveType {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "ARCHIVE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                            "DEB" => Self::Deb,
+                            "DEB_SRC" => Self::DebSrc,
+                            _ => Self::UnknownValue(archive_type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for ArchiveType {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::Deb => serializer.serialize_i32(1),
+                            Self::DebSrc => serializer.serialize_i32(2),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for ArchiveType {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ArchiveType>::new(
+                            ".google.cloud.osconfig.v1.OSPolicy.Resource.RepositoryResource.AptRepository.ArchiveType"))
                     }
                 }
             }
@@ -3808,71 +4057,136 @@ pub mod os_policy {
                 use super::*;
 
                 /// The interpreter to use.
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Interpreter(i32);
-
-                impl Interpreter {
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum Interpreter {
                     /// Invalid value, the request will return validation error.
-                    pub const INTERPRETER_UNSPECIFIED: Interpreter = Interpreter::new(0);
-
+                    Unspecified,
                     /// If an interpreter is not specified, the
                     /// source is executed directly. This execution, without an
                     /// interpreter, only succeeds for executables and scripts that have <a
                     /// href="https://en.wikipedia.org/wiki/Shebang_(Unix)"
                     /// class="external"\>shebang lines</a>.
-                    pub const NONE: Interpreter = Interpreter::new(1);
-
+                    None,
                     /// Indicates that the script runs with `/bin/sh` on Linux and
                     /// `cmd.exe` on Windows.
-                    pub const SHELL: Interpreter = Interpreter::new(2);
-
+                    Shell,
                     /// Indicates that the script runs with PowerShell.
-                    pub const POWERSHELL: Interpreter = Interpreter::new(3);
+                    Powershell,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [Interpreter::value] or
+                    /// [Interpreter::name].
+                    UnknownValue(interpreter::UnknownValue),
+                }
 
-                    /// Creates a new Interpreter instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
+                #[doc(hidden)]
+                pub mod interpreter {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
+                impl Interpreter {
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::None => std::option::Option::Some(1),
+                            Self::Shell => std::option::Option::Some(2),
+                            Self::Powershell => std::option::Option::Some(3),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("INTERPRETER_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("NONE"),
-                            2 => std::borrow::Cow::Borrowed("SHELL"),
-                            3 => std::borrow::Cow::Borrowed("POWERSHELL"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "INTERPRETER_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::INTERPRETER_UNSPECIFIED)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => {
+                                std::option::Option::Some("INTERPRETER_UNSPECIFIED")
                             }
-                            "NONE" => std::option::Option::Some(Self::NONE),
-                            "SHELL" => std::option::Option::Some(Self::SHELL),
-                            "POWERSHELL" => std::option::Option::Some(Self::POWERSHELL),
-                            _ => std::option::Option::None,
+                            Self::None => std::option::Option::Some("NONE"),
+                            Self::Shell => std::option::Option::Some("SHELL"),
+                            Self::Powershell => std::option::Option::Some("POWERSHELL"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for Interpreter {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Interpreter {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for Interpreter {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for Interpreter {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::None,
+                            2 => Self::Shell,
+                            3 => Self::Powershell,
+                            _ => Self::UnknownValue(interpreter::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for Interpreter {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "INTERPRETER_UNSPECIFIED" => Self::Unspecified,
+                            "NONE" => Self::None,
+                            "SHELL" => Self::Shell,
+                            "POWERSHELL" => Self::Powershell,
+                            _ => Self::UnknownValue(interpreter::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for Interpreter {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::None => serializer.serialize_i32(1),
+                            Self::Shell => serializer.serialize_i32(2),
+                            Self::Powershell => serializer.serialize_i32(3),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for Interpreter {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Interpreter>::new(
+                            ".google.cloud.osconfig.v1.OSPolicy.Resource.ExecResource.Exec.Interpreter"))
                     }
                 }
 
@@ -4048,67 +4362,131 @@ pub mod os_policy {
             use super::*;
 
             /// Desired state of the file.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct DesiredState(i32);
-
-            impl DesiredState {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum DesiredState {
                 /// Unspecified is invalid.
-                pub const DESIRED_STATE_UNSPECIFIED: DesiredState = DesiredState::new(0);
-
+                Unspecified,
                 /// Ensure file at path is present.
-                pub const PRESENT: DesiredState = DesiredState::new(1);
-
+                Present,
                 /// Ensure file at path is absent.
-                pub const ABSENT: DesiredState = DesiredState::new(2);
-
+                Absent,
                 /// Ensure the contents of the file at path matches. If the file does
                 /// not exist it will be created.
-                pub const CONTENTS_MATCH: DesiredState = DesiredState::new(3);
+                ContentsMatch,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [DesiredState::value] or
+                /// [DesiredState::name].
+                UnknownValue(desired_state::UnknownValue),
+            }
 
-                /// Creates a new DesiredState instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod desired_state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl DesiredState {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Present => std::option::Option::Some(1),
+                        Self::Absent => std::option::Option::Some(2),
+                        Self::ContentsMatch => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("DESIRED_STATE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("PRESENT"),
-                        2 => std::borrow::Cow::Borrowed("ABSENT"),
-                        3 => std::borrow::Cow::Borrowed("CONTENTS_MATCH"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("DESIRED_STATE_UNSPECIFIED"),
+                        Self::Present => std::option::Option::Some("PRESENT"),
+                        Self::Absent => std::option::Option::Some("ABSENT"),
+                        Self::ContentsMatch => std::option::Option::Some("CONTENTS_MATCH"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "DESIRED_STATE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::DESIRED_STATE_UNSPECIFIED)
-                        }
-                        "PRESENT" => std::option::Option::Some(Self::PRESENT),
-                        "ABSENT" => std::option::Option::Some(Self::ABSENT),
-                        "CONTENTS_MATCH" => std::option::Option::Some(Self::CONTENTS_MATCH),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for DesiredState {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for DesiredState {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for DesiredState {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for DesiredState {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Present,
+                        2 => Self::Absent,
+                        3 => Self::ContentsMatch,
+                        _ => Self::UnknownValue(desired_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for DesiredState {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "DESIRED_STATE_UNSPECIFIED" => Self::Unspecified,
+                        "PRESENT" => Self::Present,
+                        "ABSENT" => Self::Absent,
+                        "CONTENTS_MATCH" => Self::ContentsMatch,
+                        _ => Self::UnknownValue(desired_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for DesiredState {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Present => serializer.serialize_i32(1),
+                        Self::Absent => serializer.serialize_i32(2),
+                        Self::ContentsMatch => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for DesiredState {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<DesiredState>::new(
+                        ".google.cloud.osconfig.v1.OSPolicy.Resource.FileResource.DesiredState",
+                    ))
                 }
             }
 
@@ -4214,62 +4592,123 @@ pub mod os_policy {
     }
 
     /// Policy mode
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
-
-    impl Mode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
         /// Invalid mode
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+        Unspecified,
         /// This mode checks if the configuration resources in the policy are in
         /// their desired state. No actions are performed if they are not in the
         /// desired state. This mode is used for reporting purposes.
-        pub const VALIDATION: Mode = Mode::new(1);
-
+        Validation,
         /// This mode checks if the configuration resources in the policy are in
         /// their desired state, and if not, enforces the desired state.
-        pub const ENFORCEMENT: Mode = Mode::new(2);
+        Enforcement,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
 
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Mode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Validation => std::option::Option::Some(1),
+                Self::Enforcement => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VALIDATION"),
-                2 => std::borrow::Cow::Borrowed("ENFORCEMENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Validation => std::option::Option::Some("VALIDATION"),
+                Self::Enforcement => std::option::Option::Some("ENFORCEMENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "VALIDATION" => std::option::Option::Some(Self::VALIDATION),
-                "ENFORCEMENT" => std::option::Option::Some(Self::ENFORCEMENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Validation,
+                2 => Self::Enforcement,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "VALIDATION" => Self::Validation,
+                "ENFORCEMENT" => Self::Enforcement,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Validation => serializer.serialize_i32(1),
+                Self::Enforcement => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.osconfig.v1.OSPolicy.Mode",
+            ))
         }
     }
 }
@@ -4857,23 +5296,18 @@ pub mod os_policy_assignment_report {
                 use super::*;
 
                 /// Supported configuration step types
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct Type(i32);
-
-                impl Type {
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum Type {
                     /// Default value. This value is unused.
-                    pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+                    Unspecified,
                     /// Checks for resource conflicts such as schema errors.
-                    pub const VALIDATION: Type = Type::new(1);
-
+                    Validation,
                     /// Checks the current status of the desired state for a resource.
-                    pub const DESIRED_STATE_CHECK: Type = Type::new(2);
-
+                    DesiredStateCheck,
                     /// Enforces the desired state for a resource that is not in desired
                     /// state.
-                    pub const DESIRED_STATE_ENFORCEMENT: Type = Type::new(3);
-
+                    DesiredStateEnforcement,
                     /// Re-checks the status of the desired state. This check is done
                     /// for a resource after the enforcement of all OS policies.
                     ///
@@ -4881,58 +5315,132 @@ pub mod os_policy_assignment_report {
                     /// the resource. It accounts for any resources that might have drifted
                     /// from their desired state due to side effects from executing other
                     /// resources.
-                    pub const DESIRED_STATE_CHECK_POST_ENFORCEMENT: Type = Type::new(4);
+                    DesiredStateCheckPostEnforcement,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [Type::value] or
+                    /// [Type::name].
+                    UnknownValue(r#type::UnknownValue),
+                }
 
-                    /// Creates a new Type instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
+                #[doc(hidden)]
+                pub mod r#type {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
+                impl Type {
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::Validation => std::option::Option::Some(1),
+                            Self::DesiredStateCheck => std::option::Option::Some(2),
+                            Self::DesiredStateEnforcement => std::option::Option::Some(3),
+                            Self::DesiredStateCheckPostEnforcement => std::option::Option::Some(4),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("VALIDATION"),
-                            2 => std::borrow::Cow::Borrowed("DESIRED_STATE_CHECK"),
-                            3 => std::borrow::Cow::Borrowed("DESIRED_STATE_ENFORCEMENT"),
-                            4 => std::borrow::Cow::Borrowed("DESIRED_STATE_CHECK_POST_ENFORCEMENT"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                            "VALIDATION" => std::option::Option::Some(Self::VALIDATION),
-                            "DESIRED_STATE_CHECK" => {
-                                std::option::Option::Some(Self::DESIRED_STATE_CHECK)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                            Self::Validation => std::option::Option::Some("VALIDATION"),
+                            Self::DesiredStateCheck => {
+                                std::option::Option::Some("DESIRED_STATE_CHECK")
                             }
-                            "DESIRED_STATE_ENFORCEMENT" => {
-                                std::option::Option::Some(Self::DESIRED_STATE_ENFORCEMENT)
+                            Self::DesiredStateEnforcement => {
+                                std::option::Option::Some("DESIRED_STATE_ENFORCEMENT")
                             }
-                            "DESIRED_STATE_CHECK_POST_ENFORCEMENT" => std::option::Option::Some(
-                                Self::DESIRED_STATE_CHECK_POST_ENFORCEMENT,
-                            ),
-                            _ => std::option::Option::None,
+                            Self::DesiredStateCheckPostEnforcement => {
+                                std::option::Option::Some("DESIRED_STATE_CHECK_POST_ENFORCEMENT")
+                            }
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for Type {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for Type {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for Type {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for Type {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::Validation,
+                            2 => Self::DesiredStateCheck,
+                            3 => Self::DesiredStateEnforcement,
+                            4 => Self::DesiredStateCheckPostEnforcement,
+                            _ => Self::UnknownValue(r#type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for Type {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "TYPE_UNSPECIFIED" => Self::Unspecified,
+                            "VALIDATION" => Self::Validation,
+                            "DESIRED_STATE_CHECK" => Self::DesiredStateCheck,
+                            "DESIRED_STATE_ENFORCEMENT" => Self::DesiredStateEnforcement,
+                            "DESIRED_STATE_CHECK_POST_ENFORCEMENT" => {
+                                Self::DesiredStateCheckPostEnforcement
+                            }
+                            _ => Self::UnknownValue(r#type::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for Type {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::Validation => serializer.serialize_i32(1),
+                            Self::DesiredStateCheck => serializer.serialize_i32(2),
+                            Self::DesiredStateEnforcement => serializer.serialize_i32(3),
+                            Self::DesiredStateCheckPostEnforcement => serializer.serialize_i32(4),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for Type {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                            ".google.cloud.osconfig.v1.OSPolicyAssignmentReport.OSPolicyCompliance.OSPolicyResourceCompliance.OSPolicyResourceConfigStep.Type"))
                     }
                 }
             }
@@ -4975,62 +5483,125 @@ pub mod os_policy_assignment_report {
             }
 
             /// Possible compliance states for a resource.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ComplianceState(i32);
-
-            impl ComplianceState {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ComplianceState {
                 /// The resource is in an unknown compliance state.
                 ///
                 /// To get more details about why the policy is in this state, review
                 /// the output of the `compliance_state_reason` field.
-                pub const UNKNOWN: ComplianceState = ComplianceState::new(0);
-
+                Unknown,
                 /// Resource is compliant.
-                pub const COMPLIANT: ComplianceState = ComplianceState::new(1);
-
+                Compliant,
                 /// Resource is non-compliant.
-                pub const NON_COMPLIANT: ComplianceState = ComplianceState::new(2);
+                NonCompliant,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ComplianceState::value] or
+                /// [ComplianceState::name].
+                UnknownValue(compliance_state::UnknownValue),
+            }
 
-                /// Creates a new ComplianceState instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod compliance_state {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl ComplianceState {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unknown => std::option::Option::Some(0),
+                        Self::Compliant => std::option::Option::Some(1),
+                        Self::NonCompliant => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                        1 => std::borrow::Cow::Borrowed("COMPLIANT"),
-                        2 => std::borrow::Cow::Borrowed("NON_COMPLIANT"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                        Self::Compliant => std::option::Option::Some("COMPLIANT"),
+                        Self::NonCompliant => std::option::Option::Some("NON_COMPLIANT"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                        "COMPLIANT" => std::option::Option::Some(Self::COMPLIANT),
-                        "NON_COMPLIANT" => std::option::Option::Some(Self::NON_COMPLIANT),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for ComplianceState {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ComplianceState {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ComplianceState {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ComplianceState {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unknown,
+                        1 => Self::Compliant,
+                        2 => Self::NonCompliant,
+                        _ => Self::UnknownValue(compliance_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ComplianceState {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "UNKNOWN" => Self::Unknown,
+                        "COMPLIANT" => Self::Compliant,
+                        "NON_COMPLIANT" => Self::NonCompliant,
+                        _ => Self::UnknownValue(compliance_state::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ComplianceState {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unknown => serializer.serialize_i32(0),
+                        Self::Compliant => serializer.serialize_i32(1),
+                        Self::NonCompliant => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ComplianceState {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComplianceState>::new(
+                        ".google.cloud.osconfig.v1.OSPolicyAssignmentReport.OSPolicyCompliance.OSPolicyResourceCompliance.ComplianceState"))
                 }
             }
 
@@ -5045,68 +5616,131 @@ pub mod os_policy_assignment_report {
         }
 
         /// Possible compliance states for an os policy.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ComplianceState(i32);
-
-        impl ComplianceState {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ComplianceState {
             /// The policy is in an unknown compliance state.
             ///
             /// Refer to the field `compliance_state_reason` to learn the exact reason
             /// for the policy to be in this compliance state.
-            pub const UNKNOWN: ComplianceState = ComplianceState::new(0);
-
+            Unknown,
             /// Policy is compliant.
             ///
             /// The policy is compliant if all the underlying resources are also
             /// compliant.
-            pub const COMPLIANT: ComplianceState = ComplianceState::new(1);
-
+            Compliant,
             /// Policy is non-compliant.
             ///
             /// The policy is non-compliant if one or more underlying resources are
             /// non-compliant.
-            pub const NON_COMPLIANT: ComplianceState = ComplianceState::new(2);
+            NonCompliant,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ComplianceState::value] or
+            /// [ComplianceState::name].
+            UnknownValue(compliance_state::UnknownValue),
+        }
 
-            /// Creates a new ComplianceState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod compliance_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ComplianceState {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unknown => std::option::Option::Some(0),
+                    Self::Compliant => std::option::Option::Some(1),
+                    Self::NonCompliant => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                    1 => std::borrow::Cow::Borrowed("COMPLIANT"),
-                    2 => std::borrow::Cow::Borrowed("NON_COMPLIANT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                    Self::Compliant => std::option::Option::Some("COMPLIANT"),
+                    Self::NonCompliant => std::option::Option::Some("NON_COMPLIANT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                    "COMPLIANT" => std::option::Option::Some(Self::COMPLIANT),
-                    "NON_COMPLIANT" => std::option::Option::Some(Self::NON_COMPLIANT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ComplianceState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ComplianceState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ComplianceState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ComplianceState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unknown,
+                    1 => Self::Compliant,
+                    2 => Self::NonCompliant,
+                    _ => Self::UnknownValue(compliance_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ComplianceState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNKNOWN" => Self::Unknown,
+                    "COMPLIANT" => Self::Compliant,
+                    "NON_COMPLIANT" => Self::NonCompliant,
+                    _ => Self::UnknownValue(compliance_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ComplianceState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unknown => serializer.serialize_i32(0),
+                    Self::Compliant => serializer.serialize_i32(1),
+                    Self::NonCompliant => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ComplianceState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComplianceState>::new(
+                    ".google.cloud.osconfig.v1.OSPolicyAssignmentReport.OSPolicyCompliance.ComplianceState"))
             }
         }
     }
@@ -5584,71 +6218,134 @@ pub mod os_policy_assignment {
     }
 
     /// OS policy assignment rollout state
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolloutState {
+        /// Invalid value
+        Unspecified,
+        /// The rollout is in progress.
+        InProgress,
+        /// The rollout is being cancelled.
+        Cancelling,
+        /// The rollout is cancelled.
+        Cancelled,
+        /// The rollout has completed successfully.
+        Succeeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolloutState::value] or
+        /// [RolloutState::name].
+        UnknownValue(rollout_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod rollout_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RolloutState {
-        /// Invalid value
-        pub const ROLLOUT_STATE_UNSPECIFIED: RolloutState = RolloutState::new(0);
-
-        /// The rollout is in progress.
-        pub const IN_PROGRESS: RolloutState = RolloutState::new(1);
-
-        /// The rollout is being cancelled.
-        pub const CANCELLING: RolloutState = RolloutState::new(2);
-
-        /// The rollout is cancelled.
-        pub const CANCELLED: RolloutState = RolloutState::new(3);
-
-        /// The rollout has completed successfully.
-        pub const SUCCEEDED: RolloutState = RolloutState::new(4);
-
-        /// Creates a new RolloutState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Cancelling => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLLOUT_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("CANCELLING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLLOUT_STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLLOUT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLLOUT_STATE_UNSPECIFIED)
-                }
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolloutState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolloutState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolloutState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Cancelling,
+                3 => Self::Cancelled,
+                4 => Self::Succeeded,
+                _ => Self::UnknownValue(rollout_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolloutState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLLOUT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "SUCCEEDED" => Self::Succeeded,
+                _ => Self::UnknownValue(rollout_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolloutState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Cancelling => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolloutState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolloutState>::new(
+                ".google.cloud.osconfig.v1.OSPolicyAssignment.RolloutState",
+            ))
         }
     }
 }
@@ -5752,133 +6449,259 @@ pub mod os_policy_assignment_operation_metadata {
     use super::*;
 
     /// The OS policy assignment API method.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct APIMethod(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum APIMethod {
+        /// Invalid value
+        Unspecified,
+        /// Create OS policy assignment API method
+        Create,
+        /// Update OS policy assignment API method
+        Update,
+        /// Delete OS policy assignment API method
+        Delete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [APIMethod::value] or
+        /// [APIMethod::name].
+        UnknownValue(api_method::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod api_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl APIMethod {
-        /// Invalid value
-        pub const API_METHOD_UNSPECIFIED: APIMethod = APIMethod::new(0);
-
-        /// Create OS policy assignment API method
-        pub const CREATE: APIMethod = APIMethod::new(1);
-
-        /// Update OS policy assignment API method
-        pub const UPDATE: APIMethod = APIMethod::new(2);
-
-        /// Delete OS policy assignment API method
-        pub const DELETE: APIMethod = APIMethod::new(3);
-
-        /// Creates a new APIMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("API_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("API_METHOD_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "API_METHOD_UNSPECIFIED" => std::option::Option::Some(Self::API_METHOD_UNSPECIFIED),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for APIMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for APIMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for APIMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for APIMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                _ => Self::UnknownValue(api_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for APIMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "API_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                _ => Self::UnknownValue(api_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for APIMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for APIMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<APIMethod>::new(
+                ".google.cloud.osconfig.v1.OSPolicyAssignmentOperationMetadata.APIMethod",
+            ))
         }
     }
 
     /// State of the rollout
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolloutState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolloutState {
+        /// Invalid value
+        Unspecified,
+        /// The rollout is in progress.
+        InProgress,
+        /// The rollout is being cancelled.
+        Cancelling,
+        /// The rollout is cancelled.
+        Cancelled,
+        /// The rollout has completed successfully.
+        Succeeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolloutState::value] or
+        /// [RolloutState::name].
+        UnknownValue(rollout_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod rollout_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RolloutState {
-        /// Invalid value
-        pub const ROLLOUT_STATE_UNSPECIFIED: RolloutState = RolloutState::new(0);
-
-        /// The rollout is in progress.
-        pub const IN_PROGRESS: RolloutState = RolloutState::new(1);
-
-        /// The rollout is being cancelled.
-        pub const CANCELLING: RolloutState = RolloutState::new(2);
-
-        /// The rollout is cancelled.
-        pub const CANCELLED: RolloutState = RolloutState::new(3);
-
-        /// The rollout has completed successfully.
-        pub const SUCCEEDED: RolloutState = RolloutState::new(4);
-
-        /// Creates a new RolloutState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Cancelling => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLLOUT_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("CANCELLING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLLOUT_STATE_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLLOUT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLLOUT_STATE_UNSPECIFIED)
-                }
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolloutState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolloutState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolloutState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolloutState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Cancelling,
+                3 => Self::Cancelled,
+                4 => Self::Succeeded,
+                _ => Self::UnknownValue(rollout_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolloutState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLLOUT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                "SUCCEEDED" => Self::Succeeded,
+                _ => Self::UnknownValue(rollout_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolloutState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Cancelling => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolloutState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolloutState>::new(
+                ".google.cloud.osconfig.v1.OSPolicyAssignmentOperationMetadata.RolloutState",
+            ))
         }
     }
 }
@@ -6653,60 +7476,121 @@ pub mod patch_deployment {
     use super::*;
 
     /// Represents state of patch peployment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Active value means that patch deployment generates Patch Jobs.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Paused value means that patch deployment does not generate
         /// Patch jobs. Requires user action to move in and out from this state.
-        pub const PAUSED: State = State::new(2);
+        Paused,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Paused,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "PAUSED" => Self::Paused,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.osconfig.v1.PatchDeployment.State",
+            ))
         }
     }
 
@@ -6954,67 +7838,130 @@ pub mod recurring_schedule {
     use super::*;
 
     /// Specifies the frequency of the recurring patch deployments.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Frequency(i32);
-
-    impl Frequency {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Frequency {
         /// Invalid. A frequency must be specified.
-        pub const FREQUENCY_UNSPECIFIED: Frequency = Frequency::new(0);
-
+        Unspecified,
         /// Indicates that the frequency of recurrence should be expressed in terms
         /// of weeks.
-        pub const WEEKLY: Frequency = Frequency::new(1);
-
+        Weekly,
         /// Indicates that the frequency of recurrence should be expressed in terms
         /// of months.
-        pub const MONTHLY: Frequency = Frequency::new(2);
-
+        Monthly,
         /// Indicates that the frequency of recurrence should be expressed in terms
         /// of days.
-        pub const DAILY: Frequency = Frequency::new(3);
+        Daily,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Frequency::value] or
+        /// [Frequency::name].
+        UnknownValue(frequency::UnknownValue),
+    }
 
-        /// Creates a new Frequency instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod frequency {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Frequency {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Weekly => std::option::Option::Some(1),
+                Self::Monthly => std::option::Option::Some(2),
+                Self::Daily => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FREQUENCY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WEEKLY"),
-                2 => std::borrow::Cow::Borrowed("MONTHLY"),
-                3 => std::borrow::Cow::Borrowed("DAILY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FREQUENCY_UNSPECIFIED"),
+                Self::Weekly => std::option::Option::Some("WEEKLY"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FREQUENCY_UNSPECIFIED" => std::option::Option::Some(Self::FREQUENCY_UNSPECIFIED),
-                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Frequency {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Frequency {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Frequency {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Frequency {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Weekly,
+                2 => Self::Monthly,
+                3 => Self::Daily,
+                _ => Self::UnknownValue(frequency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Frequency {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FREQUENCY_UNSPECIFIED" => Self::Unspecified,
+                "WEEKLY" => Self::Weekly,
+                "MONTHLY" => Self::Monthly,
+                "DAILY" => Self::Daily,
+                _ => Self::UnknownValue(frequency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Frequency {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Weekly => serializer.serialize_i32(1),
+                Self::Monthly => serializer.serialize_i32(2),
+                Self::Daily => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Frequency {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Frequency>::new(
+                ".google.cloud.osconfig.v1.RecurringSchedule.Frequency",
+            ))
         }
     }
 
@@ -8531,84 +9478,155 @@ pub mod patch_job {
 
     /// Enumeration of the various states a patch job passes through as it
     /// executes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State must be specified.
+        Unspecified,
+        /// The patch job was successfully initiated.
+        Started,
+        /// The patch job is looking up instances to run the patch on.
+        InstanceLookup,
+        /// Instances are being patched.
+        Patching,
+        /// Patch job completed successfully.
+        Succeeded,
+        /// Patch job completed but there were errors.
+        CompletedWithErrors,
+        /// The patch job was canceled.
+        Canceled,
+        /// The patch job timed out.
+        TimedOut,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State must be specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The patch job was successfully initiated.
-        pub const STARTED: State = State::new(1);
-
-        /// The patch job is looking up instances to run the patch on.
-        pub const INSTANCE_LOOKUP: State = State::new(2);
-
-        /// Instances are being patched.
-        pub const PATCHING: State = State::new(3);
-
-        /// Patch job completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
-        /// Patch job completed but there were errors.
-        pub const COMPLETED_WITH_ERRORS: State = State::new(5);
-
-        /// The patch job was canceled.
-        pub const CANCELED: State = State::new(6);
-
-        /// The patch job timed out.
-        pub const TIMED_OUT: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Started => std::option::Option::Some(1),
+                Self::InstanceLookup => std::option::Option::Some(2),
+                Self::Patching => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::CompletedWithErrors => std::option::Option::Some(5),
+                Self::Canceled => std::option::Option::Some(6),
+                Self::TimedOut => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STARTED"),
-                2 => std::borrow::Cow::Borrowed("INSTANCE_LOOKUP"),
-                3 => std::borrow::Cow::Borrowed("PATCHING"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("COMPLETED_WITH_ERRORS"),
-                6 => std::borrow::Cow::Borrowed("CANCELED"),
-                7 => std::borrow::Cow::Borrowed("TIMED_OUT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Started => std::option::Option::Some("STARTED"),
+                Self::InstanceLookup => std::option::Option::Some("INSTANCE_LOOKUP"),
+                Self::Patching => std::option::Option::Some("PATCHING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::CompletedWithErrors => std::option::Option::Some("COMPLETED_WITH_ERRORS"),
+                Self::Canceled => std::option::Option::Some("CANCELED"),
+                Self::TimedOut => std::option::Option::Some("TIMED_OUT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STARTED" => std::option::Option::Some(Self::STARTED),
-                "INSTANCE_LOOKUP" => std::option::Option::Some(Self::INSTANCE_LOOKUP),
-                "PATCHING" => std::option::Option::Some(Self::PATCHING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "COMPLETED_WITH_ERRORS" => std::option::Option::Some(Self::COMPLETED_WITH_ERRORS),
-                "CANCELED" => std::option::Option::Some(Self::CANCELED),
-                "TIMED_OUT" => std::option::Option::Some(Self::TIMED_OUT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Started,
+                2 => Self::InstanceLookup,
+                3 => Self::Patching,
+                4 => Self::Succeeded,
+                5 => Self::CompletedWithErrors,
+                6 => Self::Canceled,
+                7 => Self::TimedOut,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STARTED" => Self::Started,
+                "INSTANCE_LOOKUP" => Self::InstanceLookup,
+                "PATCHING" => Self::Patching,
+                "SUCCEEDED" => Self::Succeeded,
+                "COMPLETED_WITH_ERRORS" => Self::CompletedWithErrors,
+                "CANCELED" => Self::Canceled,
+                "TIMED_OUT" => Self::TimedOut,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Started => serializer.serialize_i32(1),
+                Self::InstanceLookup => serializer.serialize_i32(2),
+                Self::Patching => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::CompletedWithErrors => serializer.serialize_i32(5),
+                Self::Canceled => serializer.serialize_i32(6),
+                Self::TimedOut => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.osconfig.v1.PatchJob.State",
+            ))
         }
     }
 }
@@ -8761,69 +9779,130 @@ pub mod patch_config {
     use super::*;
 
     /// Post-patch reboot settings.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RebootConfig(i32);
-
-    impl RebootConfig {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RebootConfig {
         /// The default behavior is DEFAULT.
-        pub const REBOOT_CONFIG_UNSPECIFIED: RebootConfig = RebootConfig::new(0);
-
+        Unspecified,
         /// The agent decides if a reboot is necessary by checking signals such as
         /// registry keys on Windows or `/var/run/reboot-required` on APT based
         /// systems. On RPM based systems, a set of core system package install times
         /// are compared with system boot time.
-        pub const DEFAULT: RebootConfig = RebootConfig::new(1);
-
+        Default,
         /// Always reboot the machine after the update completes.
-        pub const ALWAYS: RebootConfig = RebootConfig::new(2);
-
+        Always,
         /// Never reboot the machine after the update completes.
-        pub const NEVER: RebootConfig = RebootConfig::new(3);
+        Never,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RebootConfig::value] or
+        /// [RebootConfig::name].
+        UnknownValue(reboot_config::UnknownValue),
+    }
 
-        /// Creates a new RebootConfig instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reboot_config {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RebootConfig {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::Always => std::option::Option::Some(2),
+                Self::Never => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REBOOT_CONFIG_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("ALWAYS"),
-                3 => std::borrow::Cow::Borrowed("NEVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REBOOT_CONFIG_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Always => std::option::Option::Some("ALWAYS"),
+                Self::Never => std::option::Option::Some("NEVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REBOOT_CONFIG_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REBOOT_CONFIG_UNSPECIFIED)
-                }
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
-                "NEVER" => std::option::Option::Some(Self::NEVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RebootConfig {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RebootConfig {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RebootConfig {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RebootConfig {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::Always,
+                3 => Self::Never,
+                _ => Self::UnknownValue(reboot_config::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RebootConfig {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REBOOT_CONFIG_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "ALWAYS" => Self::Always,
+                "NEVER" => Self::Never,
+                _ => Self::UnknownValue(reboot_config::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RebootConfig {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::Always => serializer.serialize_i32(2),
+                Self::Never => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RebootConfig {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RebootConfig>::new(
+                ".google.cloud.osconfig.v1.PatchConfig.RebootConfig",
+            ))
         }
     }
 }
@@ -8856,132 +9935,215 @@ pub mod instance {
     use super::*;
 
     /// Patch state of an instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PatchState(i32);
-
-    impl PatchState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PatchState {
         /// Unspecified.
-        pub const PATCH_STATE_UNSPECIFIED: PatchState = PatchState::new(0);
-
+        Unspecified,
         /// The instance is not yet notified.
-        pub const PENDING: PatchState = PatchState::new(1);
-
+        Pending,
         /// Instance is inactive and cannot be patched.
-        pub const INACTIVE: PatchState = PatchState::new(2);
-
+        Inactive,
         /// The instance is notified that it should be patched.
-        pub const NOTIFIED: PatchState = PatchState::new(3);
-
+        Notified,
         /// The instance has started the patching process.
-        pub const STARTED: PatchState = PatchState::new(4);
-
+        Started,
         /// The instance is downloading patches.
-        pub const DOWNLOADING_PATCHES: PatchState = PatchState::new(5);
-
+        DownloadingPatches,
         /// The instance is applying patches.
-        pub const APPLYING_PATCHES: PatchState = PatchState::new(6);
-
+        ApplyingPatches,
         /// The instance is rebooting.
-        pub const REBOOTING: PatchState = PatchState::new(7);
-
+        Rebooting,
         /// The instance has completed applying patches.
-        pub const SUCCEEDED: PatchState = PatchState::new(8);
-
+        Succeeded,
         /// The instance has completed applying patches but a reboot is required.
-        pub const SUCCEEDED_REBOOT_REQUIRED: PatchState = PatchState::new(9);
-
+        SucceededRebootRequired,
         /// The instance has failed to apply the patch.
-        pub const FAILED: PatchState = PatchState::new(10);
-
+        Failed,
         /// The instance acked the notification and will start shortly.
-        pub const ACKED: PatchState = PatchState::new(11);
-
+        Acked,
         /// The instance exceeded the time out while applying the patch.
-        pub const TIMED_OUT: PatchState = PatchState::new(12);
-
+        TimedOut,
         /// The instance is running the pre-patch step.
-        pub const RUNNING_PRE_PATCH_STEP: PatchState = PatchState::new(13);
-
+        RunningPrePatchStep,
         /// The instance is running the post-patch step.
-        pub const RUNNING_POST_PATCH_STEP: PatchState = PatchState::new(14);
-
+        RunningPostPatchStep,
         /// The service could not detect the presence of the agent. Check to ensure
         /// that the agent is installed, running, and able to communicate with the
         /// service.
-        pub const NO_AGENT_DETECTED: PatchState = PatchState::new(15);
+        NoAgentDetected,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PatchState::value] or
+        /// [PatchState::name].
+        UnknownValue(patch_state::UnknownValue),
+    }
 
-        /// Creates a new PatchState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod patch_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PatchState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Inactive => std::option::Option::Some(2),
+                Self::Notified => std::option::Option::Some(3),
+                Self::Started => std::option::Option::Some(4),
+                Self::DownloadingPatches => std::option::Option::Some(5),
+                Self::ApplyingPatches => std::option::Option::Some(6),
+                Self::Rebooting => std::option::Option::Some(7),
+                Self::Succeeded => std::option::Option::Some(8),
+                Self::SucceededRebootRequired => std::option::Option::Some(9),
+                Self::Failed => std::option::Option::Some(10),
+                Self::Acked => std::option::Option::Some(11),
+                Self::TimedOut => std::option::Option::Some(12),
+                Self::RunningPrePatchStep => std::option::Option::Some(13),
+                Self::RunningPostPatchStep => std::option::Option::Some(14),
+                Self::NoAgentDetected => std::option::Option::Some(15),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PATCH_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("INACTIVE"),
-                3 => std::borrow::Cow::Borrowed("NOTIFIED"),
-                4 => std::borrow::Cow::Borrowed("STARTED"),
-                5 => std::borrow::Cow::Borrowed("DOWNLOADING_PATCHES"),
-                6 => std::borrow::Cow::Borrowed("APPLYING_PATCHES"),
-                7 => std::borrow::Cow::Borrowed("REBOOTING"),
-                8 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                9 => std::borrow::Cow::Borrowed("SUCCEEDED_REBOOT_REQUIRED"),
-                10 => std::borrow::Cow::Borrowed("FAILED"),
-                11 => std::borrow::Cow::Borrowed("ACKED"),
-                12 => std::borrow::Cow::Borrowed("TIMED_OUT"),
-                13 => std::borrow::Cow::Borrowed("RUNNING_PRE_PATCH_STEP"),
-                14 => std::borrow::Cow::Borrowed("RUNNING_POST_PATCH_STEP"),
-                15 => std::borrow::Cow::Borrowed("NO_AGENT_DETECTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PATCH_STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Notified => std::option::Option::Some("NOTIFIED"),
+                Self::Started => std::option::Option::Some("STARTED"),
+                Self::DownloadingPatches => std::option::Option::Some("DOWNLOADING_PATCHES"),
+                Self::ApplyingPatches => std::option::Option::Some("APPLYING_PATCHES"),
+                Self::Rebooting => std::option::Option::Some("REBOOTING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::SucceededRebootRequired => {
+                    std::option::Option::Some("SUCCEEDED_REBOOT_REQUIRED")
+                }
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Acked => std::option::Option::Some("ACKED"),
+                Self::TimedOut => std::option::Option::Some("TIMED_OUT"),
+                Self::RunningPrePatchStep => std::option::Option::Some("RUNNING_PRE_PATCH_STEP"),
+                Self::RunningPostPatchStep => std::option::Option::Some("RUNNING_POST_PATCH_STEP"),
+                Self::NoAgentDetected => std::option::Option::Some("NO_AGENT_DETECTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PATCH_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PATCH_STATE_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "NOTIFIED" => std::option::Option::Some(Self::NOTIFIED),
-                "STARTED" => std::option::Option::Some(Self::STARTED),
-                "DOWNLOADING_PATCHES" => std::option::Option::Some(Self::DOWNLOADING_PATCHES),
-                "APPLYING_PATCHES" => std::option::Option::Some(Self::APPLYING_PATCHES),
-                "REBOOTING" => std::option::Option::Some(Self::REBOOTING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "SUCCEEDED_REBOOT_REQUIRED" => {
-                    std::option::Option::Some(Self::SUCCEEDED_REBOOT_REQUIRED)
-                }
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ACKED" => std::option::Option::Some(Self::ACKED),
-                "TIMED_OUT" => std::option::Option::Some(Self::TIMED_OUT),
-                "RUNNING_PRE_PATCH_STEP" => std::option::Option::Some(Self::RUNNING_PRE_PATCH_STEP),
-                "RUNNING_POST_PATCH_STEP" => {
-                    std::option::Option::Some(Self::RUNNING_POST_PATCH_STEP)
-                }
-                "NO_AGENT_DETECTED" => std::option::Option::Some(Self::NO_AGENT_DETECTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PatchState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PatchState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PatchState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PatchState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Inactive,
+                3 => Self::Notified,
+                4 => Self::Started,
+                5 => Self::DownloadingPatches,
+                6 => Self::ApplyingPatches,
+                7 => Self::Rebooting,
+                8 => Self::Succeeded,
+                9 => Self::SucceededRebootRequired,
+                10 => Self::Failed,
+                11 => Self::Acked,
+                12 => Self::TimedOut,
+                13 => Self::RunningPrePatchStep,
+                14 => Self::RunningPostPatchStep,
+                15 => Self::NoAgentDetected,
+                _ => Self::UnknownValue(patch_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PatchState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PATCH_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "INACTIVE" => Self::Inactive,
+                "NOTIFIED" => Self::Notified,
+                "STARTED" => Self::Started,
+                "DOWNLOADING_PATCHES" => Self::DownloadingPatches,
+                "APPLYING_PATCHES" => Self::ApplyingPatches,
+                "REBOOTING" => Self::Rebooting,
+                "SUCCEEDED" => Self::Succeeded,
+                "SUCCEEDED_REBOOT_REQUIRED" => Self::SucceededRebootRequired,
+                "FAILED" => Self::Failed,
+                "ACKED" => Self::Acked,
+                "TIMED_OUT" => Self::TimedOut,
+                "RUNNING_PRE_PATCH_STEP" => Self::RunningPrePatchStep,
+                "RUNNING_POST_PATCH_STEP" => Self::RunningPostPatchStep,
+                "NO_AGENT_DETECTED" => Self::NoAgentDetected,
+                _ => Self::UnknownValue(patch_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PatchState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Inactive => serializer.serialize_i32(2),
+                Self::Notified => serializer.serialize_i32(3),
+                Self::Started => serializer.serialize_i32(4),
+                Self::DownloadingPatches => serializer.serialize_i32(5),
+                Self::ApplyingPatches => serializer.serialize_i32(6),
+                Self::Rebooting => serializer.serialize_i32(7),
+                Self::Succeeded => serializer.serialize_i32(8),
+                Self::SucceededRebootRequired => serializer.serialize_i32(9),
+                Self::Failed => serializer.serialize_i32(10),
+                Self::Acked => serializer.serialize_i32(11),
+                Self::TimedOut => serializer.serialize_i32(12),
+                Self::RunningPrePatchStep => serializer.serialize_i32(13),
+                Self::RunningPostPatchStep => serializer.serialize_i32(14),
+                Self::NoAgentDetected => serializer.serialize_i32(15),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PatchState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PatchState>::new(
+                ".google.cloud.osconfig.v1.Instance.PatchState",
+            ))
         }
     }
 }
@@ -9094,59 +10256,120 @@ pub mod apt_settings {
     use super::*;
 
     /// Apt patch type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// By default, upgrade will be performed.
+        Unspecified,
+        /// Runs `apt-get dist-upgrade`.
+        Dist,
+        /// Runs `apt-get upgrade`.
+        Upgrade,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// By default, upgrade will be performed.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Runs `apt-get dist-upgrade`.
-        pub const DIST: Type = Type::new(1);
-
-        /// Runs `apt-get upgrade`.
-        pub const UPGRADE: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Dist => std::option::Option::Some(1),
+                Self::Upgrade => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIST"),
-                2 => std::borrow::Cow::Borrowed("UPGRADE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Dist => std::option::Option::Some("DIST"),
+                Self::Upgrade => std::option::Option::Some("UPGRADE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "DIST" => std::option::Option::Some(Self::DIST),
-                "UPGRADE" => std::option::Option::Some(Self::UPGRADE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Dist,
+                2 => Self::Upgrade,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DIST" => Self::Dist,
+                "UPGRADE" => Self::Upgrade,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Dist => serializer.serialize_i32(1),
+                Self::Upgrade => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.osconfig.v1.AptSettings.Type",
+            ))
         }
     }
 }
@@ -9438,113 +10661,186 @@ pub mod windows_update_settings {
     /// Microsoft Windows update classifications as defined in
     /// [1]
     /// <https://support.microsoft.com/en-us/help/824684/description-of-the-standard-terminology-that-is-used-to-describe-micro>
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Classification(i32);
-
-    impl Classification {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Classification {
         /// Invalid. If classifications are included, they must be specified.
-        pub const CLASSIFICATION_UNSPECIFIED: Classification = Classification::new(0);
-
+        Unspecified,
         /// "A widely released fix for a specific problem that addresses a critical,
         /// non-security-related bug." [1]
-        pub const CRITICAL: Classification = Classification::new(1);
-
+        Critical,
         /// "A widely released fix for a product-specific, security-related
         /// vulnerability. Security vulnerabilities are rated by their severity. The
         /// severity rating is indicated in the Microsoft security bulletin as
         /// critical, important, moderate, or low." [1]
-        pub const SECURITY: Classification = Classification::new(2);
-
+        Security,
         /// "A widely released and frequent software update that contains additions
         /// to a product's definition database. Definition databases are often used
         /// to detect objects that have specific attributes, such as malicious code,
         /// phishing websites, or junk mail." [1]
-        pub const DEFINITION: Classification = Classification::new(3);
-
+        Definition,
         /// "Software that controls the input and output of a device." [1]
-        pub const DRIVER: Classification = Classification::new(4);
-
+        Driver,
         /// "New product functionality that is first distributed outside the context
         /// of a product release and that is typically included in the next full
         /// product release." [1]
-        pub const FEATURE_PACK: Classification = Classification::new(5);
-
+        FeaturePack,
         /// "A tested, cumulative set of all hotfixes, security updates, critical
         /// updates, and updates. Additionally, service packs may contain additional
         /// fixes for problems that are found internally since the release of the
         /// product. Service packs my also contain a limited number of
         /// customer-requested design changes or features." [1]
-        pub const SERVICE_PACK: Classification = Classification::new(6);
-
+        ServicePack,
         /// "A utility or feature that helps complete a task or set of tasks." [1]
-        pub const TOOL: Classification = Classification::new(7);
-
+        Tool,
         /// "A tested, cumulative set of hotfixes, security updates, critical
         /// updates, and updates that are packaged together for easy deployment. A
         /// rollup generally targets a specific area, such as security, or a
         /// component of a product, such as Internet Information Services (IIS)." [1]
-        pub const UPDATE_ROLLUP: Classification = Classification::new(8);
-
+        UpdateRollup,
         /// "A widely released fix for a specific problem. An update addresses a
         /// noncritical, non-security-related bug." [1]
-        pub const UPDATE: Classification = Classification::new(9);
+        Update,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Classification::value] or
+        /// [Classification::name].
+        UnknownValue(classification::UnknownValue),
+    }
 
-        /// Creates a new Classification instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod classification {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Classification {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Critical => std::option::Option::Some(1),
+                Self::Security => std::option::Option::Some(2),
+                Self::Definition => std::option::Option::Some(3),
+                Self::Driver => std::option::Option::Some(4),
+                Self::FeaturePack => std::option::Option::Some(5),
+                Self::ServicePack => std::option::Option::Some(6),
+                Self::Tool => std::option::Option::Some(7),
+                Self::UpdateRollup => std::option::Option::Some(8),
+                Self::Update => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLASSIFICATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CRITICAL"),
-                2 => std::borrow::Cow::Borrowed("SECURITY"),
-                3 => std::borrow::Cow::Borrowed("DEFINITION"),
-                4 => std::borrow::Cow::Borrowed("DRIVER"),
-                5 => std::borrow::Cow::Borrowed("FEATURE_PACK"),
-                6 => std::borrow::Cow::Borrowed("SERVICE_PACK"),
-                7 => std::borrow::Cow::Borrowed("TOOL"),
-                8 => std::borrow::Cow::Borrowed("UPDATE_ROLLUP"),
-                9 => std::borrow::Cow::Borrowed("UPDATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CLASSIFICATION_UNSPECIFIED"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::Security => std::option::Option::Some("SECURITY"),
+                Self::Definition => std::option::Option::Some("DEFINITION"),
+                Self::Driver => std::option::Option::Some("DRIVER"),
+                Self::FeaturePack => std::option::Option::Some("FEATURE_PACK"),
+                Self::ServicePack => std::option::Option::Some("SERVICE_PACK"),
+                Self::Tool => std::option::Option::Some("TOOL"),
+                Self::UpdateRollup => std::option::Option::Some("UPDATE_ROLLUP"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLASSIFICATION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLASSIFICATION_UNSPECIFIED)
-                }
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                "SECURITY" => std::option::Option::Some(Self::SECURITY),
-                "DEFINITION" => std::option::Option::Some(Self::DEFINITION),
-                "DRIVER" => std::option::Option::Some(Self::DRIVER),
-                "FEATURE_PACK" => std::option::Option::Some(Self::FEATURE_PACK),
-                "SERVICE_PACK" => std::option::Option::Some(Self::SERVICE_PACK),
-                "TOOL" => std::option::Option::Some(Self::TOOL),
-                "UPDATE_ROLLUP" => std::option::Option::Some(Self::UPDATE_ROLLUP),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Classification {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Classification {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Classification {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Classification {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Critical,
+                2 => Self::Security,
+                3 => Self::Definition,
+                4 => Self::Driver,
+                5 => Self::FeaturePack,
+                6 => Self::ServicePack,
+                7 => Self::Tool,
+                8 => Self::UpdateRollup,
+                9 => Self::Update,
+                _ => Self::UnknownValue(classification::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Classification {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLASSIFICATION_UNSPECIFIED" => Self::Unspecified,
+                "CRITICAL" => Self::Critical,
+                "SECURITY" => Self::Security,
+                "DEFINITION" => Self::Definition,
+                "DRIVER" => Self::Driver,
+                "FEATURE_PACK" => Self::FeaturePack,
+                "SERVICE_PACK" => Self::ServicePack,
+                "TOOL" => Self::Tool,
+                "UPDATE_ROLLUP" => Self::UpdateRollup,
+                "UPDATE" => Self::Update,
+                _ => Self::UnknownValue(classification::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Classification {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Critical => serializer.serialize_i32(1),
+                Self::Security => serializer.serialize_i32(2),
+                Self::Definition => serializer.serialize_i32(3),
+                Self::Driver => serializer.serialize_i32(4),
+                Self::FeaturePack => serializer.serialize_i32(5),
+                Self::ServicePack => serializer.serialize_i32(6),
+                Self::Tool => serializer.serialize_i32(7),
+                Self::UpdateRollup => serializer.serialize_i32(8),
+                Self::Update => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Classification {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Classification>::new(
+                ".google.cloud.osconfig.v1.WindowsUpdateSettings.Classification",
+            ))
         }
     }
 }
@@ -9731,65 +11027,124 @@ pub mod exec_step_config {
     use super::*;
 
     /// The interpreter used to execute the a file.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Interpreter(i32);
-
-    impl Interpreter {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Interpreter {
         /// Invalid for a Windows ExecStepConfig. For a Linux ExecStepConfig, the
         /// interpreter will be parsed from the shebang line of the script if
         /// unspecified.
-        pub const INTERPRETER_UNSPECIFIED: Interpreter = Interpreter::new(0);
-
+        Unspecified,
         /// Indicates that the script is run with `/bin/sh` on Linux and `cmd`
         /// on Windows.
-        pub const SHELL: Interpreter = Interpreter::new(1);
-
+        Shell,
         /// Indicates that the file is run with PowerShell flags
         /// `-NonInteractive`, `-NoProfile`, and `-ExecutionPolicy Bypass`.
-        pub const POWERSHELL: Interpreter = Interpreter::new(2);
+        Powershell,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Interpreter::value] or
+        /// [Interpreter::name].
+        UnknownValue(interpreter::UnknownValue),
+    }
 
-        /// Creates a new Interpreter instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod interpreter {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Interpreter {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Shell => std::option::Option::Some(1),
+                Self::Powershell => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INTERPRETER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SHELL"),
-                2 => std::borrow::Cow::Borrowed("POWERSHELL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INTERPRETER_UNSPECIFIED"),
+                Self::Shell => std::option::Option::Some("SHELL"),
+                Self::Powershell => std::option::Option::Some("POWERSHELL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INTERPRETER_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INTERPRETER_UNSPECIFIED)
-                }
-                "SHELL" => std::option::Option::Some(Self::SHELL),
-                "POWERSHELL" => std::option::Option::Some(Self::POWERSHELL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Interpreter {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Interpreter {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Interpreter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Interpreter {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Shell,
+                2 => Self::Powershell,
+                _ => Self::UnknownValue(interpreter::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Interpreter {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INTERPRETER_UNSPECIFIED" => Self::Unspecified,
+                "SHELL" => Self::Shell,
+                "POWERSHELL" => Self::Powershell,
+                _ => Self::UnknownValue(interpreter::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Interpreter {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Shell => serializer.serialize_i32(1),
+                Self::Powershell => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Interpreter {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Interpreter>::new(
+                ".google.cloud.osconfig.v1.ExecStepConfig.Interpreter",
+            ))
         }
     }
 
@@ -10092,64 +11447,125 @@ pub mod patch_rollout {
     use super::*;
 
     /// Type of the rollout.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
-
-    impl Mode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
         /// Mode must be specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+        Unspecified,
         /// Patches are applied one zone at a time. The patch job begins in the
         /// region with the lowest number of targeted VMs. Within the region,
         /// patching begins in the zone with the lowest number of targeted VMs. If
         /// multiple regions (or zones within a region) have the same number of
         /// targeted VMs, a tie-breaker is achieved by sorting the regions or zones
         /// in alphabetical order.
-        pub const ZONE_BY_ZONE: Mode = Mode::new(1);
-
+        ZoneByZone,
         /// Patches are applied to VMs in all zones at the same time.
-        pub const CONCURRENT_ZONES: Mode = Mode::new(2);
+        ConcurrentZones,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
 
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Mode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ZoneByZone => std::option::Option::Some(1),
+                Self::ConcurrentZones => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ZONE_BY_ZONE"),
-                2 => std::borrow::Cow::Borrowed("CONCURRENT_ZONES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::ZoneByZone => std::option::Option::Some("ZONE_BY_ZONE"),
+                Self::ConcurrentZones => std::option::Option::Some("CONCURRENT_ZONES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "ZONE_BY_ZONE" => std::option::Option::Some(Self::ZONE_BY_ZONE),
-                "CONCURRENT_ZONES" => std::option::Option::Some(Self::CONCURRENT_ZONES),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ZoneByZone,
+                2 => Self::ConcurrentZones,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "ZONE_BY_ZONE" => Self::ZoneByZone,
+                "CONCURRENT_ZONES" => Self::ConcurrentZones,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ZoneByZone => serializer.serialize_i32(1),
+                Self::ConcurrentZones => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.cloud.osconfig.v1.PatchRollout.Mode",
+            ))
         }
     }
 }
@@ -10937,468 +12353,885 @@ pub mod cvs_sv_3 {
 
     /// This metric reflects the context by which vulnerability exploitation is
     /// possible.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(i32);
-
-    impl AttackVector {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackVector {
         /// Invalid value.
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
-
+        Unspecified,
         /// The vulnerable component is bound to the network stack and the set of
         /// possible attackers extends beyond the other options listed below, up to
         /// and including the entire Internet.
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
-
+        Network,
         /// The vulnerable component is bound to the network stack, but the attack is
         /// limited at the protocol level to a logically adjacent topology.
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
-
+        Adjacent,
         /// The vulnerable component is not bound to the network stack and the
         /// attacker's path is via read/write/execute capabilities.
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
-
+        Local,
         /// The attack requires the attacker to physically touch or manipulate the
         /// vulnerable component.
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
+        Physical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackVector::value] or
+        /// [AttackVector::name].
+        UnknownValue(attack_vector::UnknownValue),
+    }
 
-        /// Creates a new AttackVector instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attack_vector {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttackVector {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Network => std::option::Option::Some(1),
+                Self::Adjacent => std::option::Option::Some(2),
+                Self::Local => std::option::Option::Some(3),
+                Self::Physical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
-                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
-                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_VECTOR_UNSPECIFIED"),
+                Self::Network => std::option::Option::Some("ATTACK_VECTOR_NETWORK"),
+                Self::Adjacent => std::option::Option::Some("ATTACK_VECTOR_ADJACENT"),
+                Self::Local => std::option::Option::Some("ATTACK_VECTOR_LOCAL"),
+                Self::Physical => std::option::Option::Some("ATTACK_VECTOR_PHYSICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_VECTOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
-                }
-                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
-                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
-                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
-                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackVector {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttackVector {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Network,
+                2 => Self::Adjacent,
+                3 => Self::Local,
+                4 => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackVector {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_VECTOR_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_VECTOR_NETWORK" => Self::Network,
+                "ATTACK_VECTOR_ADJACENT" => Self::Adjacent,
+                "ATTACK_VECTOR_LOCAL" => Self::Local,
+                "ATTACK_VECTOR_PHYSICAL" => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackVector {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Network => serializer.serialize_i32(1),
+                Self::Adjacent => serializer.serialize_i32(2),
+                Self::Local => serializer.serialize_i32(3),
+                Self::Physical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackVector {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackVector>::new(
+                ".google.cloud.osconfig.v1.CVSSv3.AttackVector",
+            ))
         }
     }
 
     /// This metric describes the conditions beyond the attacker's control that
     /// must exist in order to exploit the vulnerability.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(i32);
-
-    impl AttackComplexity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackComplexity {
         /// Invalid value.
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
-
+        Unspecified,
         /// Specialized access conditions or extenuating circumstances do not exist.
         /// An attacker can expect repeatable success when attacking the vulnerable
         /// component.
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
-
+        Low,
         /// A successful attack depends on conditions beyond the attacker's control.
         /// That is, a successful attack cannot be accomplished at will, but requires
         /// the attacker to invest in some measurable amount of effort in preparation
         /// or execution against the vulnerable component before a successful attack
         /// can be expected.
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackComplexity::value] or
+        /// [AttackComplexity::name].
+        UnknownValue(attack_complexity::UnknownValue),
+    }
 
-        /// Creates a new AttackComplexity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attack_complexity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttackComplexity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("ATTACK_COMPLEXITY_LOW"),
+                Self::High => std::option::Option::Some("ATTACK_COMPLEXITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
-                }
-                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
-                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackComplexity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttackComplexity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::High,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackComplexity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_COMPLEXITY_LOW" => Self::Low,
+                "ATTACK_COMPLEXITY_HIGH" => Self::High,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackComplexity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackComplexity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackComplexity>::new(
+                ".google.cloud.osconfig.v1.CVSSv3.AttackComplexity",
+            ))
         }
     }
 
     /// This metric describes the level of privileges an attacker must possess
     /// before successfully exploiting the vulnerability.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(i32);
-
-    impl PrivilegesRequired {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PrivilegesRequired {
         /// Invalid value.
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
-
+        Unspecified,
         /// The attacker is unauthorized prior to attack, and therefore does not
         /// require any access to settings or files of the vulnerable system to
         /// carry out an attack.
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
-
+        None,
         /// The attacker requires privileges that provide basic user capabilities
         /// that could normally affect only settings and files owned by a user.
         /// Alternatively, an attacker with Low privileges has the ability to access
         /// only non-sensitive resources.
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
-
+        Low,
         /// The attacker requires privileges that provide significant (e.g.,
         /// administrative) control over the vulnerable component allowing access to
         /// component-wide settings and files.
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PrivilegesRequired::value] or
+        /// [PrivilegesRequired::name].
+        UnknownValue(privileges_required::UnknownValue),
+    }
 
-        /// Creates a new PrivilegesRequired instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod privileges_required {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PrivilegesRequired {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
-                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
-                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("PRIVILEGES_REQUIRED_NONE"),
+                Self::Low => std::option::Option::Some("PRIVILEGES_REQUIRED_LOW"),
+                Self::High => std::option::Option::Some("PRIVILEGES_REQUIRED_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
-                }
-                "PRIVILEGES_REQUIRED_NONE" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
-                }
-                "PRIVILEGES_REQUIRED_LOW" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
-                }
-                "PRIVILEGES_REQUIRED_HIGH" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PrivilegesRequired {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PrivilegesRequired {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Low,
+                3 => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PrivilegesRequired {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => Self::Unspecified,
+                "PRIVILEGES_REQUIRED_NONE" => Self::None,
+                "PRIVILEGES_REQUIRED_LOW" => Self::Low,
+                "PRIVILEGES_REQUIRED_HIGH" => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PrivilegesRequired {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PrivilegesRequired {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PrivilegesRequired>::new(
+                ".google.cloud.osconfig.v1.CVSSv3.PrivilegesRequired",
+            ))
         }
     }
 
     /// This metric captures the requirement for a human user, other than the
     /// attacker, to participate in the successful compromise of the vulnerable
     /// component.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(i32);
-
-    impl UserInteraction {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserInteraction {
         /// Invalid value.
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
-
+        Unspecified,
         /// The vulnerable system can be exploited without interaction from any user.
-        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
-
+        None,
         /// Successful exploitation of this vulnerability requires a user to take
         /// some action before the vulnerability can be exploited.
-        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
+        Required,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserInteraction::value] or
+        /// [UserInteraction::name].
+        UnknownValue(user_interaction::UnknownValue),
+    }
 
-        /// Creates a new UserInteraction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod user_interaction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl UserInteraction {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Required => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
-                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("USER_INTERACTION_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("USER_INTERACTION_NONE"),
+                Self::Required => std::option::Option::Some("USER_INTERACTION_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_INTERACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
-                }
-                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
-                "USER_INTERACTION_REQUIRED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UserInteraction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UserInteraction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserInteraction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_INTERACTION_UNSPECIFIED" => Self::Unspecified,
+                "USER_INTERACTION_NONE" => Self::None,
+                "USER_INTERACTION_REQUIRED" => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserInteraction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Required => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserInteraction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserInteraction>::new(
+                ".google.cloud.osconfig.v1.CVSSv3.UserInteraction",
+            ))
         }
     }
 
     /// The Scope metric captures whether a vulnerability in one vulnerable
     /// component impacts resources in components beyond its security scope.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
-
-    impl Scope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
         /// Invalid value.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
-
+        Unspecified,
         /// An exploited vulnerability can only affect resources managed by the same
         /// security authority.
-        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
-
+        Unchanged,
         /// An exploited vulnerability can affect resources beyond the security scope
         /// managed by the security authority of the vulnerable component.
-        pub const SCOPE_CHANGED: Scope = Scope::new(2);
+        Changed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
 
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Scope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unchanged => std::option::Option::Some(1),
+                Self::Changed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
-                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCOPE_UNSPECIFIED"),
+                Self::Unchanged => std::option::Option::Some("SCOPE_UNCHANGED"),
+                Self::Changed => std::option::Option::Some("SCOPE_CHANGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
-                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
-                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unchanged,
+                2 => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "SCOPE_UNCHANGED" => Self::Unchanged,
+                "SCOPE_CHANGED" => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unchanged => serializer.serialize_i32(1),
+                Self::Changed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".google.cloud.osconfig.v1.CVSSv3.Scope",
+            ))
         }
     }
 
     /// The Impact metrics capture the effects of a successfully exploited
     /// vulnerability on the component that suffers the worst outcome that is most
     /// directly and predictably associated with the attack.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Impact {
+        /// Invalid value.
+        Unspecified,
+        /// High impact.
+        High,
+        /// Low impact.
+        Low,
+        /// No impact.
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Impact::value] or
+        /// [Impact::name].
+        UnknownValue(impact::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod impact {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Impact {
-        /// Invalid value.
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
-
-        /// High impact.
-        pub const IMPACT_HIGH: Impact = Impact::new(1);
-
-        /// Low impact.
-        pub const IMPACT_LOW: Impact = Impact::new(2);
-
-        /// No impact.
-        pub const IMPACT_NONE: Impact = Impact::new(3);
-
-        /// Creates a new Impact instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
-                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
-                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPACT_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("IMPACT_HIGH"),
+                Self::Low => std::option::Option::Some("IMPACT_LOW"),
+                Self::None => std::option::Option::Some("IMPACT_NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
-                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
-                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
-                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Impact {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Impact {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::Low,
+                3 => Self::None,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Impact {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPACT_UNSPECIFIED" => Self::Unspecified,
+                "IMPACT_HIGH" => Self::High,
+                "IMPACT_LOW" => Self::Low,
+                "IMPACT_NONE" => Self::None,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Impact {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Impact {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Impact>::new(
+                ".google.cloud.osconfig.v1.CVSSv3.Impact",
+            ))
         }
     }
 }
 
 /// The view for inventory objects.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InventoryView(i32);
-
-impl InventoryView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum InventoryView {
     /// The default value.
     /// The API defaults to the BASIC view.
-    pub const INVENTORY_VIEW_UNSPECIFIED: InventoryView = InventoryView::new(0);
-
+    Unspecified,
     /// Returns the basic inventory information that includes `os_info`.
-    pub const BASIC: InventoryView = InventoryView::new(1);
-
+    Basic,
     /// Returns all fields.
-    pub const FULL: InventoryView = InventoryView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [InventoryView::value] or
+    /// [InventoryView::name].
+    UnknownValue(inventory_view::UnknownValue),
+}
 
-    /// Creates a new InventoryView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod inventory_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl InventoryView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INVENTORY_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INVENTORY_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INVENTORY_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INVENTORY_VIEW_UNSPECIFIED)
-            }
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for InventoryView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for InventoryView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for InventoryView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for InventoryView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(inventory_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for InventoryView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INVENTORY_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(inventory_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for InventoryView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for InventoryView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<InventoryView>::new(
+            ".google.cloud.osconfig.v1.InventoryView",
+        ))
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -566,7 +566,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -589,7 +589,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -272,80 +272,149 @@ pub mod instance {
     use super::*;
 
     /// The possible states of a Parallelstore instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The instance is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The instance is available for use.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The instance is being deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// The instance is not usable.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// The instance is being upgraded.
-        pub const UPGRADING: State = State::new(5);
-
+        Upgrading,
         /// The instance is being repaired. This should only be used by instances
         /// using the `PERSISTENT` deployment type.
-        pub const REPAIRING: State = State::new(6);
+        Repairing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Upgrading => std::option::Option::Some(5),
+                Self::Repairing => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("UPGRADING"),
-                6 => std::borrow::Cow::Borrowed("REPAIRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Upgrading => std::option::Option::Some("UPGRADING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Failed,
+                5 => Self::Upgrading,
+                6 => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                "UPGRADING" => Self::Upgrading,
+                "REPAIRING" => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Upgrading => serializer.serialize_i32(5),
+                Self::Repairing => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.parallelstore.v1.Instance.State",
+            ))
         }
     }
 }
@@ -2153,257 +2222,488 @@ impl wkt::message::Message for TransferCounters {
 }
 
 /// Type of transfer that occurred.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransferType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransferType {
+    /// Zero is an illegal value.
+    Unspecified,
+    /// Imports to Parallelstore.
+    Import,
+    /// Exports from Parallelstore.
+    Export,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransferType::value] or
+    /// [TransferType::name].
+    UnknownValue(transfer_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod transfer_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TransferType {
-    /// Zero is an illegal value.
-    pub const TRANSFER_TYPE_UNSPECIFIED: TransferType = TransferType::new(0);
-
-    /// Imports to Parallelstore.
-    pub const IMPORT: TransferType = TransferType::new(1);
-
-    /// Exports from Parallelstore.
-    pub const EXPORT: TransferType = TransferType::new(2);
-
-    /// Creates a new TransferType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Import => std::option::Option::Some(1),
+            Self::Export => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFER_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IMPORT"),
-            2 => std::borrow::Cow::Borrowed("EXPORT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFER_TYPE_UNSPECIFIED"),
+            Self::Import => std::option::Option::Some("IMPORT"),
+            Self::Export => std::option::Option::Some("EXPORT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFER_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFER_TYPE_UNSPECIFIED)
-            }
-            "IMPORT" => std::option::Option::Some(Self::IMPORT),
-            "EXPORT" => std::option::Option::Some(Self::EXPORT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransferType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransferType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransferType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransferType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Import,
+            2 => Self::Export,
+            _ => Self::UnknownValue(transfer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransferType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFER_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "IMPORT" => Self::Import,
+            "EXPORT" => Self::Export,
+            _ => Self::UnknownValue(transfer_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransferType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Import => serializer.serialize_i32(1),
+            Self::Export => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransferType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransferType>::new(
+            ".google.cloud.parallelstore.v1.TransferType",
+        ))
     }
 }
 
 /// Represents the striping options for files.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FileStripeLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FileStripeLevel {
+    /// If not set, FileStripeLevel will default to FILE_STRIPE_LEVEL_BALANCED
+    Unspecified,
+    /// Minimum file striping
+    Min,
+    /// Medium file striping
+    Balanced,
+    /// Maximum file striping
+    Max,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FileStripeLevel::value] or
+    /// [FileStripeLevel::name].
+    UnknownValue(file_stripe_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod file_stripe_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl FileStripeLevel {
-    /// If not set, FileStripeLevel will default to FILE_STRIPE_LEVEL_BALANCED
-    pub const FILE_STRIPE_LEVEL_UNSPECIFIED: FileStripeLevel = FileStripeLevel::new(0);
-
-    /// Minimum file striping
-    pub const FILE_STRIPE_LEVEL_MIN: FileStripeLevel = FileStripeLevel::new(1);
-
-    /// Medium file striping
-    pub const FILE_STRIPE_LEVEL_BALANCED: FileStripeLevel = FileStripeLevel::new(2);
-
-    /// Maximum file striping
-    pub const FILE_STRIPE_LEVEL_MAX: FileStripeLevel = FileStripeLevel::new(3);
-
-    /// Creates a new FileStripeLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Min => std::option::Option::Some(1),
+            Self::Balanced => std::option::Option::Some(2),
+            Self::Max => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_MIN"),
-            2 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_BALANCED"),
-            3 => std::borrow::Cow::Borrowed("FILE_STRIPE_LEVEL_MAX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FILE_STRIPE_LEVEL_UNSPECIFIED"),
+            Self::Min => std::option::Option::Some("FILE_STRIPE_LEVEL_MIN"),
+            Self::Balanced => std::option::Option::Some("FILE_STRIPE_LEVEL_BALANCED"),
+            Self::Max => std::option::Option::Some("FILE_STRIPE_LEVEL_MAX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FILE_STRIPE_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FILE_STRIPE_LEVEL_UNSPECIFIED)
-            }
-            "FILE_STRIPE_LEVEL_MIN" => std::option::Option::Some(Self::FILE_STRIPE_LEVEL_MIN),
-            "FILE_STRIPE_LEVEL_BALANCED" => {
-                std::option::Option::Some(Self::FILE_STRIPE_LEVEL_BALANCED)
-            }
-            "FILE_STRIPE_LEVEL_MAX" => std::option::Option::Some(Self::FILE_STRIPE_LEVEL_MAX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FileStripeLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FileStripeLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FileStripeLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FileStripeLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Min,
+            2 => Self::Balanced,
+            3 => Self::Max,
+            _ => Self::UnknownValue(file_stripe_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FileStripeLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FILE_STRIPE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "FILE_STRIPE_LEVEL_MIN" => Self::Min,
+            "FILE_STRIPE_LEVEL_BALANCED" => Self::Balanced,
+            "FILE_STRIPE_LEVEL_MAX" => Self::Max,
+            _ => Self::UnknownValue(file_stripe_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FileStripeLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Min => serializer.serialize_i32(1),
+            Self::Balanced => serializer.serialize_i32(2),
+            Self::Max => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FileStripeLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileStripeLevel>::new(
+            ".google.cloud.parallelstore.v1.FileStripeLevel",
+        ))
     }
 }
 
 /// Represents the striping options for directories.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DirectoryStripeLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DirectoryStripeLevel {
+    /// If not set, DirectoryStripeLevel will default to DIRECTORY_STRIPE_LEVEL_MAX
+    Unspecified,
+    /// Minimum directory striping
+    Min,
+    /// Medium directory striping
+    Balanced,
+    /// Maximum directory striping
+    Max,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DirectoryStripeLevel::value] or
+    /// [DirectoryStripeLevel::name].
+    UnknownValue(directory_stripe_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod directory_stripe_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DirectoryStripeLevel {
-    /// If not set, DirectoryStripeLevel will default to DIRECTORY_STRIPE_LEVEL_MAX
-    pub const DIRECTORY_STRIPE_LEVEL_UNSPECIFIED: DirectoryStripeLevel =
-        DirectoryStripeLevel::new(0);
-
-    /// Minimum directory striping
-    pub const DIRECTORY_STRIPE_LEVEL_MIN: DirectoryStripeLevel = DirectoryStripeLevel::new(1);
-
-    /// Medium directory striping
-    pub const DIRECTORY_STRIPE_LEVEL_BALANCED: DirectoryStripeLevel = DirectoryStripeLevel::new(2);
-
-    /// Maximum directory striping
-    pub const DIRECTORY_STRIPE_LEVEL_MAX: DirectoryStripeLevel = DirectoryStripeLevel::new(3);
-
-    /// Creates a new DirectoryStripeLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Min => std::option::Option::Some(1),
+            Self::Balanced => std::option::Option::Some(2),
+            Self::Max => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_MIN"),
-            2 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_BALANCED"),
-            3 => std::borrow::Cow::Borrowed("DIRECTORY_STRIPE_LEVEL_MAX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"),
+            Self::Min => std::option::Option::Some("DIRECTORY_STRIPE_LEVEL_MIN"),
+            Self::Balanced => std::option::Option::Some("DIRECTORY_STRIPE_LEVEL_BALANCED"),
+            Self::Max => std::option::Option::Some("DIRECTORY_STRIPE_LEVEL_MAX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DIRECTORY_STRIPE_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_UNSPECIFIED)
-            }
-            "DIRECTORY_STRIPE_LEVEL_MIN" => {
-                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_MIN)
-            }
-            "DIRECTORY_STRIPE_LEVEL_BALANCED" => {
-                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_BALANCED)
-            }
-            "DIRECTORY_STRIPE_LEVEL_MAX" => {
-                std::option::Option::Some(Self::DIRECTORY_STRIPE_LEVEL_MAX)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DirectoryStripeLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DirectoryStripeLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DirectoryStripeLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DirectoryStripeLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Min,
+            2 => Self::Balanced,
+            3 => Self::Max,
+            _ => Self::UnknownValue(directory_stripe_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DirectoryStripeLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DIRECTORY_STRIPE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "DIRECTORY_STRIPE_LEVEL_MIN" => Self::Min,
+            "DIRECTORY_STRIPE_LEVEL_BALANCED" => Self::Balanced,
+            "DIRECTORY_STRIPE_LEVEL_MAX" => Self::Max,
+            _ => Self::UnknownValue(directory_stripe_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DirectoryStripeLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Min => serializer.serialize_i32(1),
+            Self::Balanced => serializer.serialize_i32(2),
+            Self::Max => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DirectoryStripeLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DirectoryStripeLevel>::new(
+            ".google.cloud.parallelstore.v1.DirectoryStripeLevel",
+        ))
     }
 }
 
 /// Represents the deployment type for the instance.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentType(i32);
-
-impl DeploymentType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DeploymentType {
     /// Default Deployment Type
     /// It is equivalent to SCRATCH
-    pub const DEPLOYMENT_TYPE_UNSPECIFIED: DeploymentType = DeploymentType::new(0);
-
+    Unspecified,
     /// Scratch
-    pub const SCRATCH: DeploymentType = DeploymentType::new(1);
-
+    Scratch,
     /// Persistent
-    pub const PERSISTENT: DeploymentType = DeploymentType::new(2);
+    Persistent,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DeploymentType::value] or
+    /// [DeploymentType::name].
+    UnknownValue(deployment_type::UnknownValue),
+}
 
-    /// Creates a new DeploymentType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod deployment_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DeploymentType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Scratch => std::option::Option::Some(1),
+            Self::Persistent => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SCRATCH"),
-            2 => std::borrow::Cow::Borrowed("PERSISTENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DEPLOYMENT_TYPE_UNSPECIFIED"),
+            Self::Scratch => std::option::Option::Some("SCRATCH"),
+            Self::Persistent => std::option::Option::Some("PERSISTENT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DEPLOYMENT_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DEPLOYMENT_TYPE_UNSPECIFIED)
-            }
-            "SCRATCH" => std::option::Option::Some(Self::SCRATCH),
-            "PERSISTENT" => std::option::Option::Some(Self::PERSISTENT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DeploymentType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DeploymentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DeploymentType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Scratch,
+            2 => Self::Persistent,
+            _ => Self::UnknownValue(deployment_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DeploymentType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DEPLOYMENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SCRATCH" => Self::Scratch,
+            "PERSISTENT" => Self::Persistent,
+            _ => Self::UnknownValue(deployment_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DeploymentType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Scratch => serializer.serialize_i32(1),
+            Self::Persistent => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DeploymentType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeploymentType>::new(
+            ".google.cloud.parallelstore.v1.DeploymentType",
+        ))
     }
 }

--- a/src/generated/cloud/parametermanager/v1/src/model.rs
+++ b/src/generated/cloud/parametermanager/v1/src/model.rs
@@ -1191,126 +1191,248 @@ impl wkt::message::Message for DeleteParameterVersionRequest {
 /// Option to specify the format of a Parameter resource (UNFORMATTED / YAML /
 /// JSON). This option is user specified at the time of creation of the resource
 /// and is immutable.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ParameterFormat(i32);
-
-impl ParameterFormat {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ParameterFormat {
     /// The default / unset value.
     /// The API will default to the UNFORMATTED format.
-    pub const PARAMETER_FORMAT_UNSPECIFIED: ParameterFormat = ParameterFormat::new(0);
-
+    Unspecified,
     /// Unformatted.
-    pub const UNFORMATTED: ParameterFormat = ParameterFormat::new(1);
-
+    Unformatted,
     /// YAML format.
-    pub const YAML: ParameterFormat = ParameterFormat::new(2);
-
+    Yaml,
     /// JSON format.
-    pub const JSON: ParameterFormat = ParameterFormat::new(3);
+    Json,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ParameterFormat::value] or
+    /// [ParameterFormat::name].
+    UnknownValue(parameter_format::UnknownValue),
+}
 
-    /// Creates a new ParameterFormat instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod parameter_format {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ParameterFormat {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Unformatted => std::option::Option::Some(1),
+            Self::Yaml => std::option::Option::Some(2),
+            Self::Json => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PARAMETER_FORMAT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("UNFORMATTED"),
-            2 => std::borrow::Cow::Borrowed("YAML"),
-            3 => std::borrow::Cow::Borrowed("JSON"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PARAMETER_FORMAT_UNSPECIFIED"),
+            Self::Unformatted => std::option::Option::Some("UNFORMATTED"),
+            Self::Yaml => std::option::Option::Some("YAML"),
+            Self::Json => std::option::Option::Some("JSON"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PARAMETER_FORMAT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PARAMETER_FORMAT_UNSPECIFIED)
-            }
-            "UNFORMATTED" => std::option::Option::Some(Self::UNFORMATTED),
-            "YAML" => std::option::Option::Some(Self::YAML),
-            "JSON" => std::option::Option::Some(Self::JSON),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ParameterFormat {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ParameterFormat {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ParameterFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ParameterFormat {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Unformatted,
+            2 => Self::Yaml,
+            3 => Self::Json,
+            _ => Self::UnknownValue(parameter_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ParameterFormat {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PARAMETER_FORMAT_UNSPECIFIED" => Self::Unspecified,
+            "UNFORMATTED" => Self::Unformatted,
+            "YAML" => Self::Yaml,
+            "JSON" => Self::Json,
+            _ => Self::UnknownValue(parameter_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ParameterFormat {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Unformatted => serializer.serialize_i32(1),
+            Self::Yaml => serializer.serialize_i32(2),
+            Self::Json => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ParameterFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ParameterFormat>::new(
+            ".google.cloud.parametermanager.v1.ParameterFormat",
+        ))
     }
 }
 
 /// Option for requesting only metadata, or user provided payload
 /// of a ParameterVersion resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct View(i32);
-
-impl View {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum View {
     /// The default / unset value.
     /// The API will default to the FULL view..
-    pub const VIEW_UNSPECIFIED: View = View::new(0);
-
+    Unspecified,
     /// Include only the metadata for the resource.
-    pub const BASIC: View = View::new(1);
-
+    Basic,
     /// Include metadata & other relevant payload data as well.
     /// This is the default view.
-    pub const FULL: View = View::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [View::value] or
+    /// [View::name].
+    UnknownValue(view::UnknownValue),
+}
 
-    /// Creates a new View instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl View {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for View {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for View {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for View {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for View {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for View {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(view::UnknownValue(wkt::internal::UnknownEnumValue::String(
+                value.to_string(),
+            ))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for View {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for View {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<View>::new(
+            ".google.cloud.parametermanager.v1.View",
+        ))
     }
 }

--- a/src/generated/cloud/parametermanager/v1/src/transport.rs
+++ b/src/generated/cloud/parametermanager/v1/src/transport.rs
@@ -205,7 +205,7 @@ impl super::stub::ParameterManager for ParameterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -437,87 +437,142 @@ pub mod binding_explanation {
     }
 
     /// Whether a role includes a specific permission.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolePermission(i32);
-
-    impl RolePermission {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolePermission {
         /// Default value. This value is unused.
-        pub const ROLE_PERMISSION_UNSPECIFIED: RolePermission = RolePermission::new(0);
-
+        Unspecified,
         /// The permission is included in the role.
-        pub const ROLE_PERMISSION_INCLUDED: RolePermission = RolePermission::new(1);
-
+        Included,
         /// The permission is not included in the role.
-        pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermission = RolePermission::new(2);
-
+        NotIncluded,
         /// The user who created the
         /// [Replay][google.cloud.policysimulator.v1.Replay] is not
         /// allowed to access the binding.
         ///
         /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-        pub const ROLE_PERMISSION_UNKNOWN_INFO_DENIED: RolePermission = RolePermission::new(3);
+        UnknownInfoDenied,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolePermission::value] or
+        /// [RolePermission::name].
+        UnknownValue(role_permission::UnknownValue),
+    }
 
-        /// Creates a new RolePermission instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod role_permission {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RolePermission {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Included => std::option::Option::Some(1),
+                Self::NotIncluded => std::option::Option::Some(2),
+                Self::UnknownInfoDenied => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUDED"),
-                2 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_NOT_INCLUDED"),
-                3 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNKNOWN_INFO_DENIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_PERMISSION_UNSPECIFIED"),
+                Self::Included => std::option::Option::Some("ROLE_PERMISSION_INCLUDED"),
+                Self::NotIncluded => std::option::Option::Some("ROLE_PERMISSION_NOT_INCLUDED"),
+                Self::UnknownInfoDenied => {
+                    std::option::Option::Some("ROLE_PERMISSION_UNKNOWN_INFO_DENIED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_PERMISSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_UNSPECIFIED)
-                }
-                "ROLE_PERMISSION_INCLUDED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_INCLUDED)
-                }
-                "ROLE_PERMISSION_NOT_INCLUDED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_NOT_INCLUDED)
-                }
-                "ROLE_PERMISSION_UNKNOWN_INFO_DENIED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_UNKNOWN_INFO_DENIED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolePermission {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolePermission {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolePermission {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolePermission {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Included,
+                2 => Self::NotIncluded,
+                3 => Self::UnknownInfoDenied,
+                _ => Self::UnknownValue(role_permission::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolePermission {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_PERMISSION_UNSPECIFIED" => Self::Unspecified,
+                "ROLE_PERMISSION_INCLUDED" => Self::Included,
+                "ROLE_PERMISSION_NOT_INCLUDED" => Self::NotIncluded,
+                "ROLE_PERMISSION_UNKNOWN_INFO_DENIED" => Self::UnknownInfoDenied,
+                _ => Self::UnknownValue(role_permission::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolePermission {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Included => serializer.serialize_i32(1),
+                Self::NotIncluded => serializer.serialize_i32(2),
+                Self::UnknownInfoDenied => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolePermission {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolePermission>::new(
+                ".google.cloud.policysimulator.v1.BindingExplanation.RolePermission",
+            ))
         }
     }
 
     /// Whether the binding includes the principal.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Membership(i32);
-
-    impl Membership {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Membership {
         /// Default value. This value is unused.
-        pub const MEMBERSHIP_UNSPECIFIED: Membership = Membership::new(0);
-
+        Unspecified,
         /// The binding includes the principal. The principal can be included
         /// directly or indirectly. For example:
         ///
@@ -525,72 +580,137 @@ pub mod binding_explanation {
         ///   binding.
         /// * A principal is included indirectly if that principal is in a Google
         ///   group or Google Workspace domain that is listed in the binding.
-        pub const MEMBERSHIP_INCLUDED: Membership = Membership::new(1);
-
+        Included,
         /// The binding does not include the principal.
-        pub const MEMBERSHIP_NOT_INCLUDED: Membership = Membership::new(2);
-
+        NotIncluded,
         /// The user who created the
         /// [Replay][google.cloud.policysimulator.v1.Replay] is not
         /// allowed to access the binding.
         ///
         /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-        pub const MEMBERSHIP_UNKNOWN_INFO_DENIED: Membership = Membership::new(3);
-
+        UnknownInfoDenied,
         /// The principal is an unsupported type. Only Google Accounts and service
         /// accounts are supported.
-        pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: Membership = Membership::new(4);
+        UnknownUnsupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Membership::value] or
+        /// [Membership::name].
+        UnknownValue(membership::UnknownValue),
+    }
 
-        /// Creates a new Membership instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod membership {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Membership {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Included => std::option::Option::Some(1),
+                Self::NotIncluded => std::option::Option::Some(2),
+                Self::UnknownInfoDenied => std::option::Option::Some(3),
+                Self::UnknownUnsupported => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MEMBERSHIP_INCLUDED"),
-                2 => std::borrow::Cow::Borrowed("MEMBERSHIP_NOT_INCLUDED"),
-                3 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_INFO_DENIED"),
-                4 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_UNSUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MEMBERSHIP_UNSPECIFIED"),
+                Self::Included => std::option::Option::Some("MEMBERSHIP_INCLUDED"),
+                Self::NotIncluded => std::option::Option::Some("MEMBERSHIP_NOT_INCLUDED"),
+                Self::UnknownInfoDenied => {
+                    std::option::Option::Some("MEMBERSHIP_UNKNOWN_INFO_DENIED")
+                }
+                Self::UnknownUnsupported => {
+                    std::option::Option::Some("MEMBERSHIP_UNKNOWN_UNSUPPORTED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MEMBERSHIP_UNSPECIFIED" => std::option::Option::Some(Self::MEMBERSHIP_UNSPECIFIED),
-                "MEMBERSHIP_INCLUDED" => std::option::Option::Some(Self::MEMBERSHIP_INCLUDED),
-                "MEMBERSHIP_NOT_INCLUDED" => {
-                    std::option::Option::Some(Self::MEMBERSHIP_NOT_INCLUDED)
-                }
-                "MEMBERSHIP_UNKNOWN_INFO_DENIED" => {
-                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_INFO_DENIED)
-                }
-                "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_UNSUPPORTED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Membership {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Membership {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Membership {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Membership {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Included,
+                2 => Self::NotIncluded,
+                3 => Self::UnknownInfoDenied,
+                4 => Self::UnknownUnsupported,
+                _ => Self::UnknownValue(membership::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Membership {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MEMBERSHIP_UNSPECIFIED" => Self::Unspecified,
+                "MEMBERSHIP_INCLUDED" => Self::Included,
+                "MEMBERSHIP_NOT_INCLUDED" => Self::NotIncluded,
+                "MEMBERSHIP_UNKNOWN_INFO_DENIED" => Self::UnknownInfoDenied,
+                "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => Self::UnknownUnsupported,
+                _ => Self::UnknownValue(membership::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Membership {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Included => serializer.serialize_i32(1),
+                Self::NotIncluded => serializer.serialize_i32(2),
+                Self::UnknownInfoDenied => serializer.serialize_i32(3),
+                Self::UnknownUnsupported => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Membership {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Membership>::new(
+                ".google.cloud.policysimulator.v1.BindingExplanation.Membership",
+            ))
         }
     }
 }
@@ -770,69 +890,134 @@ pub mod replay {
     /// The current state of the [Replay][google.cloud.policysimulator.v1.Replay].
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// The `Replay` has not started yet.
+        Pending,
+        /// The `Replay` is currently running.
+        Running,
+        /// The `Replay` has successfully completed.
+        Succeeded,
+        /// The `Replay` has finished with an error.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The `Replay` has not started yet.
-        pub const PENDING: State = State::new(1);
-
-        /// The `Replay` is currently running.
-        pub const RUNNING: State = State::new(2);
-
-        /// The `Replay` has successfully completed.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// The `Replay` has finished with an error.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.policysimulator.v1.Replay.State",
+            ))
         }
     }
 }
@@ -1379,60 +1564,119 @@ pub mod replay_config {
     /// [Replay][google.cloud.policysimulator.v1.Replay].
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSource(i32);
-
-    impl LogSource {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogSource {
         /// An unspecified log source.
         /// If the log source is unspecified, the
         /// [Replay][google.cloud.policysimulator.v1.Replay] defaults to using
         /// `RECENT_ACCESSES`.
         ///
         /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-        pub const LOG_SOURCE_UNSPECIFIED: LogSource = LogSource::new(0);
-
+        Unspecified,
         /// All access logs from the last 90 days. These logs may not include logs
         /// from the most recent 7 days.
-        pub const RECENT_ACCESSES: LogSource = LogSource::new(1);
+        RecentAccesses,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogSource::value] or
+        /// [LogSource::name].
+        UnknownValue(log_source::UnknownValue),
+    }
 
-        /// Creates a new LogSource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod log_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LogSource {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RecentAccesses => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_SOURCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RECENT_ACCESSES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_SOURCE_UNSPECIFIED"),
+                Self::RecentAccesses => std::option::Option::Some("RECENT_ACCESSES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_SOURCE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_SOURCE_UNSPECIFIED),
-                "RECENT_ACCESSES" => std::option::Option::Some(Self::RECENT_ACCESSES),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LogSource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LogSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LogSource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RecentAccesses,
+                _ => Self::UnknownValue(log_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LogSource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "RECENT_ACCESSES" => Self::RecentAccesses,
+                _ => Self::UnknownValue(log_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LogSource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RecentAccesses => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LogSource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogSource>::new(
+                ".google.cloud.policysimulator.v1.ReplayConfig.LogSource",
+            ))
         }
     }
 }
@@ -1569,31 +1813,25 @@ pub mod access_state_diff {
 
     /// How the principal's access, specified in the AccessState field, changed
     /// between the current (baseline) policies and proposed (simulated) policies.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccessChangeType(i32);
-
-    impl AccessChangeType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AccessChangeType {
         /// Default value. This value is unused.
-        pub const ACCESS_CHANGE_TYPE_UNSPECIFIED: AccessChangeType = AccessChangeType::new(0);
-
+        Unspecified,
         /// The principal's access did not change.
         /// This includes the case where both baseline and simulated are UNKNOWN,
         /// but the unknown information is equivalent.
-        pub const NO_CHANGE: AccessChangeType = AccessChangeType::new(1);
-
+        NoChange,
         /// The principal's access under both the current policies and the proposed
         /// policies is `UNKNOWN`, but the unknown information differs between them.
-        pub const UNKNOWN_CHANGE: AccessChangeType = AccessChangeType::new(2);
-
+        UnknownChange,
         /// The principal had access under the current policies (`GRANTED`), but will
         /// no longer have access after the proposed changes (`NOT_GRANTED`).
-        pub const ACCESS_REVOKED: AccessChangeType = AccessChangeType::new(3);
-
+        AccessRevoked,
         /// The principal did not have access under the current policies
         /// (`NOT_GRANTED`), but will have access after the proposed changes
         /// (`GRANTED`).
-        pub const ACCESS_GAINED: AccessChangeType = AccessChangeType::new(4);
-
+        AccessGained,
         /// This result can occur for the following reasons:
         ///
         /// * The principal had access under the current policies (`GRANTED`), but
@@ -1603,8 +1841,7 @@ pub mod access_state_diff {
         ///   they
         ///   will not have access after the proposed changes (`NOT_GRANTED`).
         ///
-        pub const ACCESS_MAYBE_REVOKED: AccessChangeType = AccessChangeType::new(5);
-
+        AccessMaybeRevoked,
         /// This result can occur for the following reasons:
         ///
         /// * The principal did not have access under the current policies
@@ -1614,58 +1851,132 @@ pub mod access_state_diff {
         /// * The principal's access under the current policies is `UNKNOWN`, but
         ///   they will have access after the proposed changes (`GRANTED`).
         ///
-        pub const ACCESS_MAYBE_GAINED: AccessChangeType = AccessChangeType::new(6);
+        AccessMaybeGained,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AccessChangeType::value] or
+        /// [AccessChangeType::name].
+        UnknownValue(access_change_type::UnknownValue),
+    }
 
-        /// Creates a new AccessChangeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod access_change_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AccessChangeType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoChange => std::option::Option::Some(1),
+                Self::UnknownChange => std::option::Option::Some(2),
+                Self::AccessRevoked => std::option::Option::Some(3),
+                Self::AccessGained => std::option::Option::Some(4),
+                Self::AccessMaybeRevoked => std::option::Option::Some(5),
+                Self::AccessMaybeGained => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCESS_CHANGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_CHANGE"),
-                2 => std::borrow::Cow::Borrowed("UNKNOWN_CHANGE"),
-                3 => std::borrow::Cow::Borrowed("ACCESS_REVOKED"),
-                4 => std::borrow::Cow::Borrowed("ACCESS_GAINED"),
-                5 => std::borrow::Cow::Borrowed("ACCESS_MAYBE_REVOKED"),
-                6 => std::borrow::Cow::Borrowed("ACCESS_MAYBE_GAINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACCESS_CHANGE_TYPE_UNSPECIFIED"),
+                Self::NoChange => std::option::Option::Some("NO_CHANGE"),
+                Self::UnknownChange => std::option::Option::Some("UNKNOWN_CHANGE"),
+                Self::AccessRevoked => std::option::Option::Some("ACCESS_REVOKED"),
+                Self::AccessGained => std::option::Option::Some("ACCESS_GAINED"),
+                Self::AccessMaybeRevoked => std::option::Option::Some("ACCESS_MAYBE_REVOKED"),
+                Self::AccessMaybeGained => std::option::Option::Some("ACCESS_MAYBE_GAINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCESS_CHANGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCESS_CHANGE_TYPE_UNSPECIFIED)
-                }
-                "NO_CHANGE" => std::option::Option::Some(Self::NO_CHANGE),
-                "UNKNOWN_CHANGE" => std::option::Option::Some(Self::UNKNOWN_CHANGE),
-                "ACCESS_REVOKED" => std::option::Option::Some(Self::ACCESS_REVOKED),
-                "ACCESS_GAINED" => std::option::Option::Some(Self::ACCESS_GAINED),
-                "ACCESS_MAYBE_REVOKED" => std::option::Option::Some(Self::ACCESS_MAYBE_REVOKED),
-                "ACCESS_MAYBE_GAINED" => std::option::Option::Some(Self::ACCESS_MAYBE_GAINED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AccessChangeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AccessChangeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AccessChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AccessChangeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoChange,
+                2 => Self::UnknownChange,
+                3 => Self::AccessRevoked,
+                4 => Self::AccessGained,
+                5 => Self::AccessMaybeRevoked,
+                6 => Self::AccessMaybeGained,
+                _ => Self::UnknownValue(access_change_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AccessChangeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCESS_CHANGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NO_CHANGE" => Self::NoChange,
+                "UNKNOWN_CHANGE" => Self::UnknownChange,
+                "ACCESS_REVOKED" => Self::AccessRevoked,
+                "ACCESS_GAINED" => Self::AccessGained,
+                "ACCESS_MAYBE_REVOKED" => Self::AccessMaybeRevoked,
+                "ACCESS_MAYBE_GAINED" => Self::AccessMaybeGained,
+                _ => Self::UnknownValue(access_change_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AccessChangeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoChange => serializer.serialize_i32(1),
+                Self::UnknownChange => serializer.serialize_i32(2),
+                Self::AccessRevoked => serializer.serialize_i32(3),
+                Self::AccessGained => serializer.serialize_i32(4),
+                Self::AccessMaybeRevoked => serializer.serialize_i32(5),
+                Self::AccessMaybeGained => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AccessChangeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessChangeType>::new(
+                ".google.cloud.policysimulator.v1.AccessStateDiff.AccessChangeType",
+            ))
         }
     }
 }
@@ -1755,136 +2066,260 @@ impl wkt::message::Message for ExplainedAccess {
 }
 
 /// Whether a principal has a permission for a resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessState(i32);
-
-impl AccessState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AccessState {
     /// Default value. This value is unused.
-    pub const ACCESS_STATE_UNSPECIFIED: AccessState = AccessState::new(0);
-
+    Unspecified,
     /// The principal has the permission.
-    pub const GRANTED: AccessState = AccessState::new(1);
-
+    Granted,
     /// The principal does not have the permission.
-    pub const NOT_GRANTED: AccessState = AccessState::new(2);
-
+    NotGranted,
     /// The principal has the permission only if a condition expression evaluates
     /// to `true`.
-    pub const UNKNOWN_CONDITIONAL: AccessState = AccessState::new(3);
-
+    UnknownConditional,
     /// The user who created the
     /// [Replay][google.cloud.policysimulator.v1.Replay] does not have
     /// access to all of the policies that Policy Simulator needs to evaluate.
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
-    pub const UNKNOWN_INFO_DENIED: AccessState = AccessState::new(4);
+    UnknownInfoDenied,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AccessState::value] or
+    /// [AccessState::name].
+    UnknownValue(access_state::UnknownValue),
+}
 
-    /// Creates a new AccessState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod access_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AccessState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Granted => std::option::Option::Some(1),
+            Self::NotGranted => std::option::Option::Some(2),
+            Self::UnknownConditional => std::option::Option::Some(3),
+            Self::UnknownInfoDenied => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ACCESS_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GRANTED"),
-            2 => std::borrow::Cow::Borrowed("NOT_GRANTED"),
-            3 => std::borrow::Cow::Borrowed("UNKNOWN_CONDITIONAL"),
-            4 => std::borrow::Cow::Borrowed("UNKNOWN_INFO_DENIED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ACCESS_STATE_UNSPECIFIED"),
+            Self::Granted => std::option::Option::Some("GRANTED"),
+            Self::NotGranted => std::option::Option::Some("NOT_GRANTED"),
+            Self::UnknownConditional => std::option::Option::Some("UNKNOWN_CONDITIONAL"),
+            Self::UnknownInfoDenied => std::option::Option::Some("UNKNOWN_INFO_DENIED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ACCESS_STATE_UNSPECIFIED" => std::option::Option::Some(Self::ACCESS_STATE_UNSPECIFIED),
-            "GRANTED" => std::option::Option::Some(Self::GRANTED),
-            "NOT_GRANTED" => std::option::Option::Some(Self::NOT_GRANTED),
-            "UNKNOWN_CONDITIONAL" => std::option::Option::Some(Self::UNKNOWN_CONDITIONAL),
-            "UNKNOWN_INFO_DENIED" => std::option::Option::Some(Self::UNKNOWN_INFO_DENIED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AccessState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AccessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AccessState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Granted,
+            2 => Self::NotGranted,
+            3 => Self::UnknownConditional,
+            4 => Self::UnknownInfoDenied,
+            _ => Self::UnknownValue(access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AccessState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ACCESS_STATE_UNSPECIFIED" => Self::Unspecified,
+            "GRANTED" => Self::Granted,
+            "NOT_GRANTED" => Self::NotGranted,
+            "UNKNOWN_CONDITIONAL" => Self::UnknownConditional,
+            "UNKNOWN_INFO_DENIED" => Self::UnknownInfoDenied,
+            _ => Self::UnknownValue(access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AccessState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Granted => serializer.serialize_i32(1),
+            Self::NotGranted => serializer.serialize_i32(2),
+            Self::UnknownConditional => serializer.serialize_i32(3),
+            Self::UnknownInfoDenied => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AccessState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessState>::new(
+            ".google.cloud.policysimulator.v1.AccessState",
+        ))
     }
 }
 
 /// The extent to which a single data point, such as the existence of a binding
 /// or whether a binding includes a specific principal, contributes to an overall
 /// determination.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HeuristicRelevance(i32);
-
-impl HeuristicRelevance {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HeuristicRelevance {
     /// Default value. This value is unused.
-    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance = HeuristicRelevance::new(0);
-
+    Unspecified,
     /// The data point has a limited effect on the result. Changing the data point
     /// is unlikely to affect the overall determination.
-    pub const NORMAL: HeuristicRelevance = HeuristicRelevance::new(1);
-
+    Normal,
     /// The data point has a strong effect on the result. Changing the data point
     /// is likely to affect the overall determination.
-    pub const HIGH: HeuristicRelevance = HeuristicRelevance::new(2);
+    High,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HeuristicRelevance::value] or
+    /// [HeuristicRelevance::name].
+    UnknownValue(heuristic_relevance::UnknownValue),
+}
 
-    /// Creates a new HeuristicRelevance instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod heuristic_relevance {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl HeuristicRelevance {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Normal => std::option::Option::Some(1),
+            Self::High => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NORMAL"),
-            2 => std::borrow::Cow::Borrowed("HIGH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HEURISTIC_RELEVANCE_UNSPECIFIED"),
+            Self::Normal => std::option::Option::Some("NORMAL"),
+            Self::High => std::option::Option::Some("HIGH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HEURISTIC_RELEVANCE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_UNSPECIFIED)
-            }
-            "NORMAL" => std::option::Option::Some(Self::NORMAL),
-            "HIGH" => std::option::Option::Some(Self::HIGH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HeuristicRelevance {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HeuristicRelevance {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HeuristicRelevance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HeuristicRelevance {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Normal,
+            2 => Self::High,
+            _ => Self::UnknownValue(heuristic_relevance::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HeuristicRelevance {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HEURISTIC_RELEVANCE_UNSPECIFIED" => Self::Unspecified,
+            "NORMAL" => Self::Normal,
+            "HIGH" => Self::High,
+            _ => Self::UnknownValue(heuristic_relevance::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HeuristicRelevance {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Normal => serializer.serialize_i32(1),
+            Self::High => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HeuristicRelevance {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HeuristicRelevance>::new(
+            ".google.cloud.policysimulator.v1.HeuristicRelevance",
+        ))
     }
 }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -170,74 +170,136 @@ pub mod troubleshoot_iam_policy_response {
     use super::*;
 
     /// Whether the principal has the permission on the resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OverallAccessState(i32);
-
-    impl OverallAccessState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OverallAccessState {
         /// Not specified.
-        pub const OVERALL_ACCESS_STATE_UNSPECIFIED: OverallAccessState = OverallAccessState::new(0);
-
+        Unspecified,
         /// The principal has the permission.
-        pub const CAN_ACCESS: OverallAccessState = OverallAccessState::new(1);
-
+        CanAccess,
         /// The principal doesn't have the permission.
-        pub const CANNOT_ACCESS: OverallAccessState = OverallAccessState::new(2);
-
+        CannotAccess,
         /// The principal might have the permission, but the sender can't access all
         /// of the information needed to fully evaluate the principal's access.
-        pub const UNKNOWN_INFO: OverallAccessState = OverallAccessState::new(3);
-
+        UnknownInfo,
         /// The principal might have the permission, but Policy Troubleshooter can't
         /// fully evaluate the principal's access because the sender didn't provide
         /// the required context to evaluate the condition.
-        pub const UNKNOWN_CONDITIONAL: OverallAccessState = OverallAccessState::new(4);
+        UnknownConditional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OverallAccessState::value] or
+        /// [OverallAccessState::name].
+        UnknownValue(overall_access_state::UnknownValue),
+    }
 
-        /// Creates a new OverallAccessState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod overall_access_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OverallAccessState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CanAccess => std::option::Option::Some(1),
+                Self::CannotAccess => std::option::Option::Some(2),
+                Self::UnknownInfo => std::option::Option::Some(3),
+                Self::UnknownConditional => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OVERALL_ACCESS_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CAN_ACCESS"),
-                2 => std::borrow::Cow::Borrowed("CANNOT_ACCESS"),
-                3 => std::borrow::Cow::Borrowed("UNKNOWN_INFO"),
-                4 => std::borrow::Cow::Borrowed("UNKNOWN_CONDITIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OVERALL_ACCESS_STATE_UNSPECIFIED"),
+                Self::CanAccess => std::option::Option::Some("CAN_ACCESS"),
+                Self::CannotAccess => std::option::Option::Some("CANNOT_ACCESS"),
+                Self::UnknownInfo => std::option::Option::Some("UNKNOWN_INFO"),
+                Self::UnknownConditional => std::option::Option::Some("UNKNOWN_CONDITIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OVERALL_ACCESS_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OVERALL_ACCESS_STATE_UNSPECIFIED)
-                }
-                "CAN_ACCESS" => std::option::Option::Some(Self::CAN_ACCESS),
-                "CANNOT_ACCESS" => std::option::Option::Some(Self::CANNOT_ACCESS),
-                "UNKNOWN_INFO" => std::option::Option::Some(Self::UNKNOWN_INFO),
-                "UNKNOWN_CONDITIONAL" => std::option::Option::Some(Self::UNKNOWN_CONDITIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OverallAccessState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OverallAccessState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OverallAccessState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OverallAccessState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CanAccess,
+                2 => Self::CannotAccess,
+                3 => Self::UnknownInfo,
+                4 => Self::UnknownConditional,
+                _ => Self::UnknownValue(overall_access_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OverallAccessState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OVERALL_ACCESS_STATE_UNSPECIFIED" => Self::Unspecified,
+                "CAN_ACCESS" => Self::CanAccess,
+                "CANNOT_ACCESS" => Self::CannotAccess,
+                "UNKNOWN_INFO" => Self::UnknownInfo,
+                "UNKNOWN_CONDITIONAL" => Self::UnknownConditional,
+                _ => Self::UnknownValue(overall_access_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OverallAccessState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CanAccess => serializer.serialize_i32(1),
+                Self::CannotAccess => serializer.serialize_i32(2),
+                Self::UnknownInfo => serializer.serialize_i32(3),
+                Self::UnknownConditional => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OverallAccessState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OverallAccessState>::new(
+                ".google.cloud.policytroubleshooter.iam.v3.TroubleshootIamPolicyResponse.OverallAccessState"))
         }
     }
 }
@@ -1943,312 +2005,546 @@ pub mod condition_explanation {
 }
 
 /// Whether IAM allow policies gives the principal the permission.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AllowAccessState(i32);
-
-impl AllowAccessState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AllowAccessState {
     /// Not specified.
-    pub const ALLOW_ACCESS_STATE_UNSPECIFIED: AllowAccessState = AllowAccessState::new(0);
-
+    Unspecified,
     /// The allow policy gives the principal the permission.
-    pub const ALLOW_ACCESS_STATE_GRANTED: AllowAccessState = AllowAccessState::new(1);
-
+    Granted,
     /// The allow policy doesn't give the principal the permission.
-    pub const ALLOW_ACCESS_STATE_NOT_GRANTED: AllowAccessState = AllowAccessState::new(2);
-
+    NotGranted,
     /// The allow policy gives the principal the permission if a condition
     /// expression evaluate to `true`. However, the sender of the request didn't
     /// provide enough context for Policy Troubleshooter to evaluate the condition
     /// expression.
-    pub const ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL: AllowAccessState = AllowAccessState::new(3);
-
+    UnknownConditional,
     /// The sender of the request doesn't have access to all of the allow policies
     /// that Policy Troubleshooter needs to evaluate the principal's access.
-    pub const ALLOW_ACCESS_STATE_UNKNOWN_INFO: AllowAccessState = AllowAccessState::new(4);
+    UnknownInfo,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AllowAccessState::value] or
+    /// [AllowAccessState::name].
+    UnknownValue(allow_access_state::UnknownValue),
+}
 
-    /// Creates a new AllowAccessState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod allow_access_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AllowAccessState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Granted => std::option::Option::Some(1),
+            Self::NotGranted => std::option::Option::Some(2),
+            Self::UnknownConditional => std::option::Option::Some(3),
+            Self::UnknownInfo => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_GRANTED"),
-            2 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_NOT_GRANTED"),
-            3 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL"),
-            4 => std::borrow::Cow::Borrowed("ALLOW_ACCESS_STATE_UNKNOWN_INFO"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ALLOW_ACCESS_STATE_UNSPECIFIED"),
+            Self::Granted => std::option::Option::Some("ALLOW_ACCESS_STATE_GRANTED"),
+            Self::NotGranted => std::option::Option::Some("ALLOW_ACCESS_STATE_NOT_GRANTED"),
+            Self::UnknownConditional => {
+                std::option::Option::Some("ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL")
+            }
+            Self::UnknownInfo => std::option::Option::Some("ALLOW_ACCESS_STATE_UNKNOWN_INFO"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ALLOW_ACCESS_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_UNSPECIFIED)
-            }
-            "ALLOW_ACCESS_STATE_GRANTED" => {
-                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_GRANTED)
-            }
-            "ALLOW_ACCESS_STATE_NOT_GRANTED" => {
-                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_NOT_GRANTED)
-            }
-            "ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL" => {
-                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL)
-            }
-            "ALLOW_ACCESS_STATE_UNKNOWN_INFO" => {
-                std::option::Option::Some(Self::ALLOW_ACCESS_STATE_UNKNOWN_INFO)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AllowAccessState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AllowAccessState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AllowAccessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AllowAccessState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Granted,
+            2 => Self::NotGranted,
+            3 => Self::UnknownConditional,
+            4 => Self::UnknownInfo,
+            _ => Self::UnknownValue(allow_access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AllowAccessState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ALLOW_ACCESS_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ALLOW_ACCESS_STATE_GRANTED" => Self::Granted,
+            "ALLOW_ACCESS_STATE_NOT_GRANTED" => Self::NotGranted,
+            "ALLOW_ACCESS_STATE_UNKNOWN_CONDITIONAL" => Self::UnknownConditional,
+            "ALLOW_ACCESS_STATE_UNKNOWN_INFO" => Self::UnknownInfo,
+            _ => Self::UnknownValue(allow_access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AllowAccessState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Granted => serializer.serialize_i32(1),
+            Self::NotGranted => serializer.serialize_i32(2),
+            Self::UnknownConditional => serializer.serialize_i32(3),
+            Self::UnknownInfo => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AllowAccessState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AllowAccessState>::new(
+            ".google.cloud.policytroubleshooter.iam.v3.AllowAccessState",
+        ))
     }
 }
 
 /// Whether IAM deny policies deny the principal the permission.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DenyAccessState(i32);
-
-impl DenyAccessState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DenyAccessState {
     /// Not specified.
-    pub const DENY_ACCESS_STATE_UNSPECIFIED: DenyAccessState = DenyAccessState::new(0);
-
+    Unspecified,
     /// The deny policy denies the principal the permission.
-    pub const DENY_ACCESS_STATE_DENIED: DenyAccessState = DenyAccessState::new(1);
-
+    Denied,
     /// The deny policy doesn't deny the principal the permission.
-    pub const DENY_ACCESS_STATE_NOT_DENIED: DenyAccessState = DenyAccessState::new(2);
-
+    NotDenied,
     /// The deny policy denies the principal the permission if a condition
     /// expression evaluates to `true`. However, the sender of the request didn't
     /// provide enough context for Policy Troubleshooter to evaluate the condition
     /// expression.
-    pub const DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL: DenyAccessState = DenyAccessState::new(3);
-
+    UnknownConditional,
     /// The sender of the request does not have access to all of the deny policies
     /// that Policy Troubleshooter needs to evaluate the principal's access.
-    pub const DENY_ACCESS_STATE_UNKNOWN_INFO: DenyAccessState = DenyAccessState::new(4);
+    UnknownInfo,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DenyAccessState::value] or
+    /// [DenyAccessState::name].
+    UnknownValue(deny_access_state::UnknownValue),
+}
 
-    /// Creates a new DenyAccessState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod deny_access_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DenyAccessState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Denied => std::option::Option::Some(1),
+            Self::NotDenied => std::option::Option::Some(2),
+            Self::UnknownConditional => std::option::Option::Some(3),
+            Self::UnknownInfo => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_DENIED"),
-            2 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_NOT_DENIED"),
-            3 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL"),
-            4 => std::borrow::Cow::Borrowed("DENY_ACCESS_STATE_UNKNOWN_INFO"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DENY_ACCESS_STATE_UNSPECIFIED"),
+            Self::Denied => std::option::Option::Some("DENY_ACCESS_STATE_DENIED"),
+            Self::NotDenied => std::option::Option::Some("DENY_ACCESS_STATE_NOT_DENIED"),
+            Self::UnknownConditional => {
+                std::option::Option::Some("DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL")
+            }
+            Self::UnknownInfo => std::option::Option::Some("DENY_ACCESS_STATE_UNKNOWN_INFO"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DENY_ACCESS_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DENY_ACCESS_STATE_UNSPECIFIED)
-            }
-            "DENY_ACCESS_STATE_DENIED" => std::option::Option::Some(Self::DENY_ACCESS_STATE_DENIED),
-            "DENY_ACCESS_STATE_NOT_DENIED" => {
-                std::option::Option::Some(Self::DENY_ACCESS_STATE_NOT_DENIED)
-            }
-            "DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL" => {
-                std::option::Option::Some(Self::DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL)
-            }
-            "DENY_ACCESS_STATE_UNKNOWN_INFO" => {
-                std::option::Option::Some(Self::DENY_ACCESS_STATE_UNKNOWN_INFO)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DenyAccessState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DenyAccessState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DenyAccessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DenyAccessState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Denied,
+            2 => Self::NotDenied,
+            3 => Self::UnknownConditional,
+            4 => Self::UnknownInfo,
+            _ => Self::UnknownValue(deny_access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DenyAccessState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DENY_ACCESS_STATE_UNSPECIFIED" => Self::Unspecified,
+            "DENY_ACCESS_STATE_DENIED" => Self::Denied,
+            "DENY_ACCESS_STATE_NOT_DENIED" => Self::NotDenied,
+            "DENY_ACCESS_STATE_UNKNOWN_CONDITIONAL" => Self::UnknownConditional,
+            "DENY_ACCESS_STATE_UNKNOWN_INFO" => Self::UnknownInfo,
+            _ => Self::UnknownValue(deny_access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DenyAccessState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Denied => serializer.serialize_i32(1),
+            Self::NotDenied => serializer.serialize_i32(2),
+            Self::UnknownConditional => serializer.serialize_i32(3),
+            Self::UnknownInfo => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DenyAccessState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DenyAccessState>::new(
+            ".google.cloud.policytroubleshooter.iam.v3.DenyAccessState",
+        ))
     }
 }
 
 /// Whether a role includes a specific permission.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RolePermissionInclusionState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RolePermissionInclusionState {
+    /// Not specified.
+    Unspecified,
+    /// The permission is included in the role.
+    RolePermissionIncluded,
+    /// The permission is not included in the role.
+    RolePermissionNotIncluded,
+    /// The sender of the request is not allowed to access the role definition.
+    RolePermissionUnknownInfo,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RolePermissionInclusionState::value] or
+    /// [RolePermissionInclusionState::name].
+    UnknownValue(role_permission_inclusion_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod role_permission_inclusion_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RolePermissionInclusionState {
-    /// Not specified.
-    pub const ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED: RolePermissionInclusionState =
-        RolePermissionInclusionState::new(0);
-
-    /// The permission is included in the role.
-    pub const ROLE_PERMISSION_INCLUDED: RolePermissionInclusionState =
-        RolePermissionInclusionState::new(1);
-
-    /// The permission is not included in the role.
-    pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermissionInclusionState =
-        RolePermissionInclusionState::new(2);
-
-    /// The sender of the request is not allowed to access the role definition.
-    pub const ROLE_PERMISSION_UNKNOWN_INFO: RolePermissionInclusionState =
-        RolePermissionInclusionState::new(3);
-
-    /// Creates a new RolePermissionInclusionState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RolePermissionIncluded => std::option::Option::Some(1),
+            Self::RolePermissionNotIncluded => std::option::Option::Some(2),
+            Self::RolePermissionUnknownInfo => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUDED"),
-            2 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_NOT_INCLUDED"),
-            3 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNKNOWN_INFO"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED")
+            }
+            Self::RolePermissionIncluded => std::option::Option::Some("ROLE_PERMISSION_INCLUDED"),
+            Self::RolePermissionNotIncluded => {
+                std::option::Option::Some("ROLE_PERMISSION_NOT_INCLUDED")
+            }
+            Self::RolePermissionUnknownInfo => {
+                std::option::Option::Some("ROLE_PERMISSION_UNKNOWN_INFO")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED)
-            }
-            "ROLE_PERMISSION_INCLUDED" => std::option::Option::Some(Self::ROLE_PERMISSION_INCLUDED),
-            "ROLE_PERMISSION_NOT_INCLUDED" => {
-                std::option::Option::Some(Self::ROLE_PERMISSION_NOT_INCLUDED)
-            }
-            "ROLE_PERMISSION_UNKNOWN_INFO" => {
-                std::option::Option::Some(Self::ROLE_PERMISSION_UNKNOWN_INFO)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RolePermissionInclusionState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RolePermissionInclusionState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RolePermissionInclusionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RolePermissionInclusionState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RolePermissionIncluded,
+            2 => Self::RolePermissionNotIncluded,
+            3 => Self::RolePermissionUnknownInfo,
+            _ => Self::UnknownValue(role_permission_inclusion_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RolePermissionInclusionState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ROLE_PERMISSION_INCLUSION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ROLE_PERMISSION_INCLUDED" => Self::RolePermissionIncluded,
+            "ROLE_PERMISSION_NOT_INCLUDED" => Self::RolePermissionNotIncluded,
+            "ROLE_PERMISSION_UNKNOWN_INFO" => Self::RolePermissionUnknownInfo,
+            _ => Self::UnknownValue(role_permission_inclusion_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RolePermissionInclusionState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RolePermissionIncluded => serializer.serialize_i32(1),
+            Self::RolePermissionNotIncluded => serializer.serialize_i32(2),
+            Self::RolePermissionUnknownInfo => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RolePermissionInclusionState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<RolePermissionInclusionState>::new(
+                ".google.cloud.policytroubleshooter.iam.v3.RolePermissionInclusionState",
+            ),
+        )
     }
 }
 
 /// Whether the permission in the request matches the permission in the policy.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PermissionPatternMatchingState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PermissionPatternMatchingState {
+    /// Not specified.
+    Unspecified,
+    /// The permission in the request matches the permission in the policy.
+    PermissionPatternMatched,
+    /// The permission in the request matches the permission in the policy.
+    PermissionPatternNotMatched,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PermissionPatternMatchingState::value] or
+    /// [PermissionPatternMatchingState::name].
+    UnknownValue(permission_pattern_matching_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod permission_pattern_matching_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl PermissionPatternMatchingState {
-    /// Not specified.
-    pub const PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED: PermissionPatternMatchingState =
-        PermissionPatternMatchingState::new(0);
-
-    /// The permission in the request matches the permission in the policy.
-    pub const PERMISSION_PATTERN_MATCHED: PermissionPatternMatchingState =
-        PermissionPatternMatchingState::new(1);
-
-    /// The permission in the request matches the permission in the policy.
-    pub const PERMISSION_PATTERN_NOT_MATCHED: PermissionPatternMatchingState =
-        PermissionPatternMatchingState::new(2);
-
-    /// Creates a new PermissionPatternMatchingState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PermissionPatternMatched => std::option::Option::Some(1),
+            Self::PermissionPatternNotMatched => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PERMISSION_PATTERN_MATCHED"),
-            2 => std::borrow::Cow::Borrowed("PERMISSION_PATTERN_NOT_MATCHED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED")
+            }
+            Self::PermissionPatternMatched => {
+                std::option::Option::Some("PERMISSION_PATTERN_MATCHED")
+            }
+            Self::PermissionPatternNotMatched => {
+                std::option::Option::Some("PERMISSION_PATTERN_NOT_MATCHED")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED)
-            }
-            "PERMISSION_PATTERN_MATCHED" => {
-                std::option::Option::Some(Self::PERMISSION_PATTERN_MATCHED)
-            }
-            "PERMISSION_PATTERN_NOT_MATCHED" => {
-                std::option::Option::Some(Self::PERMISSION_PATTERN_NOT_MATCHED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PermissionPatternMatchingState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PermissionPatternMatchingState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PermissionPatternMatchingState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PermissionPatternMatchingState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PermissionPatternMatched,
+            2 => Self::PermissionPatternNotMatched,
+            _ => Self::UnknownValue(permission_pattern_matching_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PermissionPatternMatchingState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PERMISSION_PATTERN_MATCHING_STATE_UNSPECIFIED" => Self::Unspecified,
+            "PERMISSION_PATTERN_MATCHED" => Self::PermissionPatternMatched,
+            "PERMISSION_PATTERN_NOT_MATCHED" => Self::PermissionPatternNotMatched,
+            _ => Self::UnknownValue(permission_pattern_matching_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PermissionPatternMatchingState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PermissionPatternMatched => serializer.serialize_i32(1),
+            Self::PermissionPatternNotMatched => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PermissionPatternMatchingState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<PermissionPatternMatchingState>::new(
+                ".google.cloud.policytroubleshooter.iam.v3.PermissionPatternMatchingState",
+            ),
+        )
     }
 }
 
 /// Whether the principal in the request matches the principal in the policy.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MembershipMatchingState(i32);
-
-impl MembershipMatchingState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MembershipMatchingState {
     /// Not specified.
-    pub const MEMBERSHIP_MATCHING_STATE_UNSPECIFIED: MembershipMatchingState =
-        MembershipMatchingState::new(0);
-
+    Unspecified,
     /// The principal in the request matches the principal in the policy. The
     /// principal can be included directly or indirectly:
     ///
@@ -2257,131 +2553,252 @@ impl MembershipMatchingState {
     /// * A principal is included indirectly if that principal is in a Google
     ///   group, Google Workspace account, or Cloud Identity domain that is listed
     ///   in the policy.
-    pub const MEMBERSHIP_MATCHED: MembershipMatchingState = MembershipMatchingState::new(1);
-
+    MembershipMatched,
     /// The principal in the request doesn't match the principal in the policy.
-    pub const MEMBERSHIP_NOT_MATCHED: MembershipMatchingState = MembershipMatchingState::new(2);
-
+    MembershipNotMatched,
     /// The principal in the policy is a group or domain, and the sender of the
     /// request doesn't have permission to view whether the principal in the
     /// request is a member of the group or domain.
-    pub const MEMBERSHIP_UNKNOWN_INFO: MembershipMatchingState = MembershipMatchingState::new(3);
-
+    MembershipUnknownInfo,
     /// The principal is an unsupported type.
-    pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: MembershipMatchingState =
-        MembershipMatchingState::new(4);
+    MembershipUnknownUnsupported,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MembershipMatchingState::value] or
+    /// [MembershipMatchingState::name].
+    UnknownValue(membership_matching_state::UnknownValue),
+}
 
-    /// Creates a new MembershipMatchingState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod membership_matching_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl MembershipMatchingState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::MembershipMatched => std::option::Option::Some(1),
+            Self::MembershipNotMatched => std::option::Option::Some(2),
+            Self::MembershipUnknownInfo => std::option::Option::Some(3),
+            Self::MembershipUnknownUnsupported => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MEMBERSHIP_MATCHING_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MEMBERSHIP_MATCHED"),
-            2 => std::borrow::Cow::Borrowed("MEMBERSHIP_NOT_MATCHED"),
-            3 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_INFO"),
-            4 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_UNSUPPORTED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MEMBERSHIP_MATCHING_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MEMBERSHIP_MATCHING_STATE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MEMBERSHIP_MATCHING_STATE_UNSPECIFIED"),
+            Self::MembershipMatched => std::option::Option::Some("MEMBERSHIP_MATCHED"),
+            Self::MembershipNotMatched => std::option::Option::Some("MEMBERSHIP_NOT_MATCHED"),
+            Self::MembershipUnknownInfo => std::option::Option::Some("MEMBERSHIP_UNKNOWN_INFO"),
+            Self::MembershipUnknownUnsupported => {
+                std::option::Option::Some("MEMBERSHIP_UNKNOWN_UNSUPPORTED")
             }
-            "MEMBERSHIP_MATCHED" => std::option::Option::Some(Self::MEMBERSHIP_MATCHED),
-            "MEMBERSHIP_NOT_MATCHED" => std::option::Option::Some(Self::MEMBERSHIP_NOT_MATCHED),
-            "MEMBERSHIP_UNKNOWN_INFO" => std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_INFO),
-            "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => {
-                std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_UNSUPPORTED)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for MembershipMatchingState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MembershipMatchingState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MembershipMatchingState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MembershipMatchingState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::MembershipMatched,
+            2 => Self::MembershipNotMatched,
+            3 => Self::MembershipUnknownInfo,
+            4 => Self::MembershipUnknownUnsupported,
+            _ => Self::UnknownValue(membership_matching_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MembershipMatchingState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MEMBERSHIP_MATCHING_STATE_UNSPECIFIED" => Self::Unspecified,
+            "MEMBERSHIP_MATCHED" => Self::MembershipMatched,
+            "MEMBERSHIP_NOT_MATCHED" => Self::MembershipNotMatched,
+            "MEMBERSHIP_UNKNOWN_INFO" => Self::MembershipUnknownInfo,
+            "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => Self::MembershipUnknownUnsupported,
+            _ => Self::UnknownValue(membership_matching_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MembershipMatchingState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::MembershipMatched => serializer.serialize_i32(1),
+            Self::MembershipNotMatched => serializer.serialize_i32(2),
+            Self::MembershipUnknownInfo => serializer.serialize_i32(3),
+            Self::MembershipUnknownUnsupported => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MembershipMatchingState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MembershipMatchingState>::new(
+            ".google.cloud.policytroubleshooter.iam.v3.MembershipMatchingState",
+        ))
     }
 }
 
 /// The extent to which a single data point contributes to an overall
 /// determination.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HeuristicRelevance(i32);
-
-impl HeuristicRelevance {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HeuristicRelevance {
     /// Not specified.
-    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance = HeuristicRelevance::new(0);
-
+    Unspecified,
     /// The data point has a limited effect on the result. Changing the data point
     /// is unlikely to affect the overall determination.
-    pub const HEURISTIC_RELEVANCE_NORMAL: HeuristicRelevance = HeuristicRelevance::new(1);
-
+    Normal,
     /// The data point has a strong effect on the result. Changing the data point
     /// is likely to affect the overall determination.
-    pub const HEURISTIC_RELEVANCE_HIGH: HeuristicRelevance = HeuristicRelevance::new(2);
+    High,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HeuristicRelevance::value] or
+    /// [HeuristicRelevance::name].
+    UnknownValue(heuristic_relevance::UnknownValue),
+}
 
-    /// Creates a new HeuristicRelevance instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod heuristic_relevance {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl HeuristicRelevance {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Normal => std::option::Option::Some(1),
+            Self::High => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_NORMAL"),
-            2 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_HIGH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HEURISTIC_RELEVANCE_UNSPECIFIED"),
+            Self::Normal => std::option::Option::Some("HEURISTIC_RELEVANCE_NORMAL"),
+            Self::High => std::option::Option::Some("HEURISTIC_RELEVANCE_HIGH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HEURISTIC_RELEVANCE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_UNSPECIFIED)
-            }
-            "HEURISTIC_RELEVANCE_NORMAL" => {
-                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_NORMAL)
-            }
-            "HEURISTIC_RELEVANCE_HIGH" => std::option::Option::Some(Self::HEURISTIC_RELEVANCE_HIGH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HeuristicRelevance {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HeuristicRelevance {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HeuristicRelevance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HeuristicRelevance {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Normal,
+            2 => Self::High,
+            _ => Self::UnknownValue(heuristic_relevance::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HeuristicRelevance {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HEURISTIC_RELEVANCE_UNSPECIFIED" => Self::Unspecified,
+            "HEURISTIC_RELEVANCE_NORMAL" => Self::Normal,
+            "HEURISTIC_RELEVANCE_HIGH" => Self::High,
+            _ => Self::UnknownValue(heuristic_relevance::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HeuristicRelevance {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Normal => serializer.serialize_i32(1),
+            Self::High => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HeuristicRelevance {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HeuristicRelevance>::new(
+            ".google.cloud.policytroubleshooter.iam.v3.HeuristicRelevance",
+        ))
     }
 }

--- a/src/generated/cloud/policytroubleshooter/v1/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/model.rs
@@ -538,83 +538,138 @@ pub mod binding_explanation {
     }
 
     /// Whether a role includes a specific permission.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RolePermission(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RolePermission {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// The permission is included in the role.
+        Included,
+        /// The permission is not included in the role.
+        NotIncluded,
+        /// The sender of the request is not allowed to access the binding.
+        UnknownInfoDenied,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RolePermission::value] or
+        /// [RolePermission::name].
+        UnknownValue(role_permission::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod role_permission {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RolePermission {
-        /// Default value. This value is unused.
-        pub const ROLE_PERMISSION_UNSPECIFIED: RolePermission = RolePermission::new(0);
-
-        /// The permission is included in the role.
-        pub const ROLE_PERMISSION_INCLUDED: RolePermission = RolePermission::new(1);
-
-        /// The permission is not included in the role.
-        pub const ROLE_PERMISSION_NOT_INCLUDED: RolePermission = RolePermission::new(2);
-
-        /// The sender of the request is not allowed to access the binding.
-        pub const ROLE_PERMISSION_UNKNOWN_INFO_DENIED: RolePermission = RolePermission::new(3);
-
-        /// Creates a new RolePermission instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Included => std::option::Option::Some(1),
+                Self::NotIncluded => std::option::Option::Some(2),
+                Self::UnknownInfoDenied => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_INCLUDED"),
-                2 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_NOT_INCLUDED"),
-                3 => std::borrow::Cow::Borrowed("ROLE_PERMISSION_UNKNOWN_INFO_DENIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROLE_PERMISSION_UNSPECIFIED"),
+                Self::Included => std::option::Option::Some("ROLE_PERMISSION_INCLUDED"),
+                Self::NotIncluded => std::option::Option::Some("ROLE_PERMISSION_NOT_INCLUDED"),
+                Self::UnknownInfoDenied => {
+                    std::option::Option::Some("ROLE_PERMISSION_UNKNOWN_INFO_DENIED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROLE_PERMISSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_UNSPECIFIED)
-                }
-                "ROLE_PERMISSION_INCLUDED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_INCLUDED)
-                }
-                "ROLE_PERMISSION_NOT_INCLUDED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_NOT_INCLUDED)
-                }
-                "ROLE_PERMISSION_UNKNOWN_INFO_DENIED" => {
-                    std::option::Option::Some(Self::ROLE_PERMISSION_UNKNOWN_INFO_DENIED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RolePermission {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RolePermission {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RolePermission {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RolePermission {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Included,
+                2 => Self::NotIncluded,
+                3 => Self::UnknownInfoDenied,
+                _ => Self::UnknownValue(role_permission::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RolePermission {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROLE_PERMISSION_UNSPECIFIED" => Self::Unspecified,
+                "ROLE_PERMISSION_INCLUDED" => Self::Included,
+                "ROLE_PERMISSION_NOT_INCLUDED" => Self::NotIncluded,
+                "ROLE_PERMISSION_UNKNOWN_INFO_DENIED" => Self::UnknownInfoDenied,
+                _ => Self::UnknownValue(role_permission::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RolePermission {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Included => serializer.serialize_i32(1),
+                Self::NotIncluded => serializer.serialize_i32(2),
+                Self::UnknownInfoDenied => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RolePermission {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RolePermission>::new(
+                ".google.cloud.policytroubleshooter.v1.BindingExplanation.RolePermission",
+            ))
         }
     }
 
     /// Whether the binding includes the principal.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Membership(i32);
-
-    impl Membership {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Membership {
         /// Default value. This value is unused.
-        pub const MEMBERSHIP_UNSPECIFIED: Membership = Membership::new(0);
-
+        Unspecified,
         /// The binding includes the principal. The principal can be included
         /// directly or indirectly. For example:
         ///
@@ -622,200 +677,389 @@ pub mod binding_explanation {
         ///   binding.
         /// * A principal is included indirectly if that principal is in a Google
         ///   group or Google Workspace domain that is listed in the binding.
-        pub const MEMBERSHIP_INCLUDED: Membership = Membership::new(1);
-
+        Included,
         /// The binding does not include the principal.
-        pub const MEMBERSHIP_NOT_INCLUDED: Membership = Membership::new(2);
-
+        NotIncluded,
         /// The sender of the request is not allowed to access the binding.
-        pub const MEMBERSHIP_UNKNOWN_INFO_DENIED: Membership = Membership::new(3);
-
+        UnknownInfoDenied,
         /// The principal is an unsupported type. Only Google Accounts and service
         /// accounts are supported.
-        pub const MEMBERSHIP_UNKNOWN_UNSUPPORTED: Membership = Membership::new(4);
+        UnknownUnsupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Membership::value] or
+        /// [Membership::name].
+        UnknownValue(membership::UnknownValue),
+    }
 
-        /// Creates a new Membership instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod membership {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Membership {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Included => std::option::Option::Some(1),
+                Self::NotIncluded => std::option::Option::Some(2),
+                Self::UnknownInfoDenied => std::option::Option::Some(3),
+                Self::UnknownUnsupported => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MEMBERSHIP_INCLUDED"),
-                2 => std::borrow::Cow::Borrowed("MEMBERSHIP_NOT_INCLUDED"),
-                3 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_INFO_DENIED"),
-                4 => std::borrow::Cow::Borrowed("MEMBERSHIP_UNKNOWN_UNSUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MEMBERSHIP_UNSPECIFIED"),
+                Self::Included => std::option::Option::Some("MEMBERSHIP_INCLUDED"),
+                Self::NotIncluded => std::option::Option::Some("MEMBERSHIP_NOT_INCLUDED"),
+                Self::UnknownInfoDenied => {
+                    std::option::Option::Some("MEMBERSHIP_UNKNOWN_INFO_DENIED")
+                }
+                Self::UnknownUnsupported => {
+                    std::option::Option::Some("MEMBERSHIP_UNKNOWN_UNSUPPORTED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MEMBERSHIP_UNSPECIFIED" => std::option::Option::Some(Self::MEMBERSHIP_UNSPECIFIED),
-                "MEMBERSHIP_INCLUDED" => std::option::Option::Some(Self::MEMBERSHIP_INCLUDED),
-                "MEMBERSHIP_NOT_INCLUDED" => {
-                    std::option::Option::Some(Self::MEMBERSHIP_NOT_INCLUDED)
-                }
-                "MEMBERSHIP_UNKNOWN_INFO_DENIED" => {
-                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_INFO_DENIED)
-                }
-                "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::MEMBERSHIP_UNKNOWN_UNSUPPORTED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Membership {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Membership {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Membership {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Membership {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Included,
+                2 => Self::NotIncluded,
+                3 => Self::UnknownInfoDenied,
+                4 => Self::UnknownUnsupported,
+                _ => Self::UnknownValue(membership::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Membership {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MEMBERSHIP_UNSPECIFIED" => Self::Unspecified,
+                "MEMBERSHIP_INCLUDED" => Self::Included,
+                "MEMBERSHIP_NOT_INCLUDED" => Self::NotIncluded,
+                "MEMBERSHIP_UNKNOWN_INFO_DENIED" => Self::UnknownInfoDenied,
+                "MEMBERSHIP_UNKNOWN_UNSUPPORTED" => Self::UnknownUnsupported,
+                _ => Self::UnknownValue(membership::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Membership {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Included => serializer.serialize_i32(1),
+                Self::NotIncluded => serializer.serialize_i32(2),
+                Self::UnknownInfoDenied => serializer.serialize_i32(3),
+                Self::UnknownUnsupported => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Membership {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Membership>::new(
+                ".google.cloud.policytroubleshooter.v1.BindingExplanation.Membership",
+            ))
         }
     }
 }
 
 /// Whether a principal has a permission for a resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AccessState(i32);
-
-impl AccessState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AccessState {
     /// Default value. This value is unused.
-    pub const ACCESS_STATE_UNSPECIFIED: AccessState = AccessState::new(0);
-
+    Unspecified,
     /// The principal has the permission.
-    pub const GRANTED: AccessState = AccessState::new(1);
-
+    Granted,
     /// The principal does not have the permission.
-    pub const NOT_GRANTED: AccessState = AccessState::new(2);
-
+    NotGranted,
     /// The principal has the permission only if a condition expression evaluates
     /// to `true`.
-    pub const UNKNOWN_CONDITIONAL: AccessState = AccessState::new(3);
-
+    UnknownConditional,
     /// The sender of the request does not have access to all of the policies that
     /// Policy Troubleshooter needs to evaluate.
-    pub const UNKNOWN_INFO_DENIED: AccessState = AccessState::new(4);
+    UnknownInfoDenied,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AccessState::value] or
+    /// [AccessState::name].
+    UnknownValue(access_state::UnknownValue),
+}
 
-    /// Creates a new AccessState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod access_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AccessState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Granted => std::option::Option::Some(1),
+            Self::NotGranted => std::option::Option::Some(2),
+            Self::UnknownConditional => std::option::Option::Some(3),
+            Self::UnknownInfoDenied => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ACCESS_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GRANTED"),
-            2 => std::borrow::Cow::Borrowed("NOT_GRANTED"),
-            3 => std::borrow::Cow::Borrowed("UNKNOWN_CONDITIONAL"),
-            4 => std::borrow::Cow::Borrowed("UNKNOWN_INFO_DENIED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ACCESS_STATE_UNSPECIFIED"),
+            Self::Granted => std::option::Option::Some("GRANTED"),
+            Self::NotGranted => std::option::Option::Some("NOT_GRANTED"),
+            Self::UnknownConditional => std::option::Option::Some("UNKNOWN_CONDITIONAL"),
+            Self::UnknownInfoDenied => std::option::Option::Some("UNKNOWN_INFO_DENIED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ACCESS_STATE_UNSPECIFIED" => std::option::Option::Some(Self::ACCESS_STATE_UNSPECIFIED),
-            "GRANTED" => std::option::Option::Some(Self::GRANTED),
-            "NOT_GRANTED" => std::option::Option::Some(Self::NOT_GRANTED),
-            "UNKNOWN_CONDITIONAL" => std::option::Option::Some(Self::UNKNOWN_CONDITIONAL),
-            "UNKNOWN_INFO_DENIED" => std::option::Option::Some(Self::UNKNOWN_INFO_DENIED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AccessState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AccessState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AccessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AccessState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Granted,
+            2 => Self::NotGranted,
+            3 => Self::UnknownConditional,
+            4 => Self::UnknownInfoDenied,
+            _ => Self::UnknownValue(access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AccessState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ACCESS_STATE_UNSPECIFIED" => Self::Unspecified,
+            "GRANTED" => Self::Granted,
+            "NOT_GRANTED" => Self::NotGranted,
+            "UNKNOWN_CONDITIONAL" => Self::UnknownConditional,
+            "UNKNOWN_INFO_DENIED" => Self::UnknownInfoDenied,
+            _ => Self::UnknownValue(access_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AccessState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Granted => serializer.serialize_i32(1),
+            Self::NotGranted => serializer.serialize_i32(2),
+            Self::UnknownConditional => serializer.serialize_i32(3),
+            Self::UnknownInfoDenied => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AccessState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccessState>::new(
+            ".google.cloud.policytroubleshooter.v1.AccessState",
+        ))
     }
 }
 
 /// The extent to which a single data point, such as the existence of a binding
 /// or whether a binding includes a specific principal, contributes to an overall
 /// determination.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HeuristicRelevance(i32);
-
-impl HeuristicRelevance {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HeuristicRelevance {
     /// Default value. This value is unused.
-    pub const HEURISTIC_RELEVANCE_UNSPECIFIED: HeuristicRelevance = HeuristicRelevance::new(0);
-
+    Unspecified,
     /// The data point has a limited effect on the result. Changing the data point
     /// is unlikely to affect the overall determination.
-    pub const NORMAL: HeuristicRelevance = HeuristicRelevance::new(1);
-
+    Normal,
     /// The data point has a strong effect on the result. Changing the data point
     /// is likely to affect the overall determination.
-    pub const HIGH: HeuristicRelevance = HeuristicRelevance::new(2);
+    High,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HeuristicRelevance::value] or
+    /// [HeuristicRelevance::name].
+    UnknownValue(heuristic_relevance::UnknownValue),
+}
 
-    /// Creates a new HeuristicRelevance instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod heuristic_relevance {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl HeuristicRelevance {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Normal => std::option::Option::Some(1),
+            Self::High => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HEURISTIC_RELEVANCE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NORMAL"),
-            2 => std::borrow::Cow::Borrowed("HIGH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HEURISTIC_RELEVANCE_UNSPECIFIED"),
+            Self::Normal => std::option::Option::Some("NORMAL"),
+            Self::High => std::option::Option::Some("HIGH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HEURISTIC_RELEVANCE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HEURISTIC_RELEVANCE_UNSPECIFIED)
-            }
-            "NORMAL" => std::option::Option::Some(Self::NORMAL),
-            "HIGH" => std::option::Option::Some(Self::HIGH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HeuristicRelevance {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HeuristicRelevance {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HeuristicRelevance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HeuristicRelevance {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Normal,
+            2 => Self::High,
+            _ => Self::UnknownValue(heuristic_relevance::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HeuristicRelevance {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HEURISTIC_RELEVANCE_UNSPECIFIED" => Self::Unspecified,
+            "NORMAL" => Self::Normal,
+            "HIGH" => Self::High,
+            _ => Self::UnknownValue(heuristic_relevance::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HeuristicRelevance {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Normal => serializer.serialize_i32(1),
+            Self::High => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HeuristicRelevance {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HeuristicRelevance>::new(
+            ".google.cloud.policytroubleshooter.v1.HeuristicRelevance",
+        ))
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -714,74 +714,141 @@ pub mod entitlement {
     }
 
     /// Different states an entitlement can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state. This value is never returned by the server.
+        Unspecified,
+        /// The entitlement is being created.
+        Creating,
+        /// The entitlement is available for requesting access.
+        Available,
+        /// The entitlement is being deleted.
+        Deleting,
+        /// The entitlement has been deleted.
+        Deleted,
+        /// The entitlement is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state. This value is never returned by the server.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The entitlement is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The entitlement is available for requesting access.
-        pub const AVAILABLE: State = State::new(2);
-
-        /// The entitlement is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The entitlement has been deleted.
-        pub const DELETED: State = State::new(4);
-
-        /// The entitlement is being updated.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Available => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Available,
+                3 => Self::Deleting,
+                4 => Self::Deleted,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "AVAILABLE" => Self::Available,
+                "DELETING" => Self::Deleting,
+                "DELETED" => Self::Deleted,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Available => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.privilegedaccessmanager.v1.Entitlement.State",
+            ))
         }
     }
 }
@@ -1488,62 +1555,120 @@ pub mod search_entitlements_request {
     use super::*;
 
     /// Different types of access a user can have on the entitlement resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallerAccessType(i32);
-
-    impl CallerAccessType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CallerAccessType {
         /// Unspecified access type.
-        pub const CALLER_ACCESS_TYPE_UNSPECIFIED: CallerAccessType = CallerAccessType::new(0);
-
+        Unspecified,
         /// The user has access to create grants using this entitlement.
-        pub const GRANT_REQUESTER: CallerAccessType = CallerAccessType::new(1);
-
+        GrantRequester,
         /// The user has access to approve/deny grants created under this
         /// entitlement.
-        pub const GRANT_APPROVER: CallerAccessType = CallerAccessType::new(2);
+        GrantApprover,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CallerAccessType::value] or
+        /// [CallerAccessType::name].
+        UnknownValue(caller_access_type::UnknownValue),
+    }
 
-        /// Creates a new CallerAccessType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod caller_access_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CallerAccessType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GrantRequester => std::option::Option::Some(1),
+                Self::GrantApprover => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CALLER_ACCESS_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GRANT_REQUESTER"),
-                2 => std::borrow::Cow::Borrowed("GRANT_APPROVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CALLER_ACCESS_TYPE_UNSPECIFIED"),
+                Self::GrantRequester => std::option::Option::Some("GRANT_REQUESTER"),
+                Self::GrantApprover => std::option::Option::Some("GRANT_APPROVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CALLER_ACCESS_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CALLER_ACCESS_TYPE_UNSPECIFIED)
-                }
-                "GRANT_REQUESTER" => std::option::Option::Some(Self::GRANT_REQUESTER),
-                "GRANT_APPROVER" => std::option::Option::Some(Self::GRANT_APPROVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CallerAccessType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CallerAccessType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CallerAccessType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CallerAccessType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GrantRequester,
+                2 => Self::GrantApprover,
+                _ => Self::UnknownValue(caller_access_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CallerAccessType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CALLER_ACCESS_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GRANT_REQUESTER" => Self::GrantRequester,
+                "GRANT_APPROVER" => Self::GrantApprover,
+                _ => Self::UnknownValue(caller_access_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CallerAccessType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GrantRequester => serializer.serialize_i32(1),
+                Self::GrantApprover => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CallerAccessType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CallerAccessType>::new(
+                ".google.cloud.privilegedaccessmanager.v1.SearchEntitlementsRequest.CallerAccessType"))
         }
     }
 }
@@ -2936,105 +3061,182 @@ pub mod grant {
     }
 
     /// Different states a grant can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state. This value is never returned by the server.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The entitlement had an approval workflow configured and this grant is
         /// waiting for the workflow to complete.
-        pub const APPROVAL_AWAITED: State = State::new(1);
-
+        ApprovalAwaited,
         /// The approval workflow completed with a denied result. No access is
         /// granted for this grant. This is a terminal state.
-        pub const DENIED: State = State::new(3);
-
+        Denied,
         /// The approval workflow completed successfully with an approved result or
         /// none was configured. Access is provided at an appropriate time.
-        pub const SCHEDULED: State = State::new(4);
-
+        Scheduled,
         /// Access is being given.
-        pub const ACTIVATING: State = State::new(5);
-
+        Activating,
         /// Access was successfully given and is currently active.
-        pub const ACTIVE: State = State::new(6);
-
+        Active,
         /// The system could not give access due to a non-retriable error. This is a
         /// terminal state.
-        pub const ACTIVATION_FAILED: State = State::new(7);
-
+        ActivationFailed,
         /// Expired after waiting for the approval workflow to complete. This is a
         /// terminal state.
-        pub const EXPIRED: State = State::new(8);
-
+        Expired,
         /// Access is being revoked.
-        pub const REVOKING: State = State::new(9);
-
+        Revoking,
         /// Access was revoked by a user. This is a terminal state.
-        pub const REVOKED: State = State::new(10);
-
+        Revoked,
         /// System took back access as the requested duration was over. This is a
         /// terminal state.
-        pub const ENDED: State = State::new(11);
+        Ended,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ApprovalAwaited => std::option::Option::Some(1),
+                Self::Denied => std::option::Option::Some(3),
+                Self::Scheduled => std::option::Option::Some(4),
+                Self::Activating => std::option::Option::Some(5),
+                Self::Active => std::option::Option::Some(6),
+                Self::ActivationFailed => std::option::Option::Some(7),
+                Self::Expired => std::option::Option::Some(8),
+                Self::Revoking => std::option::Option::Some(9),
+                Self::Revoked => std::option::Option::Some(10),
+                Self::Ended => std::option::Option::Some(11),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("APPROVAL_AWAITED"),
-                3 => std::borrow::Cow::Borrowed("DENIED"),
-                4 => std::borrow::Cow::Borrowed("SCHEDULED"),
-                5 => std::borrow::Cow::Borrowed("ACTIVATING"),
-                6 => std::borrow::Cow::Borrowed("ACTIVE"),
-                7 => std::borrow::Cow::Borrowed("ACTIVATION_FAILED"),
-                8 => std::borrow::Cow::Borrowed("EXPIRED"),
-                9 => std::borrow::Cow::Borrowed("REVOKING"),
-                10 => std::borrow::Cow::Borrowed("REVOKED"),
-                11 => std::borrow::Cow::Borrowed("ENDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::ApprovalAwaited => std::option::Option::Some("APPROVAL_AWAITED"),
+                Self::Denied => std::option::Option::Some("DENIED"),
+                Self::Scheduled => std::option::Option::Some("SCHEDULED"),
+                Self::Activating => std::option::Option::Some("ACTIVATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::ActivationFailed => std::option::Option::Some("ACTIVATION_FAILED"),
+                Self::Expired => std::option::Option::Some("EXPIRED"),
+                Self::Revoking => std::option::Option::Some("REVOKING"),
+                Self::Revoked => std::option::Option::Some("REVOKED"),
+                Self::Ended => std::option::Option::Some("ENDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "APPROVAL_AWAITED" => std::option::Option::Some(Self::APPROVAL_AWAITED),
-                "DENIED" => std::option::Option::Some(Self::DENIED),
-                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
-                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "ACTIVATION_FAILED" => std::option::Option::Some(Self::ACTIVATION_FAILED),
-                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
-                "REVOKING" => std::option::Option::Some(Self::REVOKING),
-                "REVOKED" => std::option::Option::Some(Self::REVOKED),
-                "ENDED" => std::option::Option::Some(Self::ENDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ApprovalAwaited,
+                3 => Self::Denied,
+                4 => Self::Scheduled,
+                5 => Self::Activating,
+                6 => Self::Active,
+                7 => Self::ActivationFailed,
+                8 => Self::Expired,
+                9 => Self::Revoking,
+                10 => Self::Revoked,
+                11 => Self::Ended,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "APPROVAL_AWAITED" => Self::ApprovalAwaited,
+                "DENIED" => Self::Denied,
+                "SCHEDULED" => Self::Scheduled,
+                "ACTIVATING" => Self::Activating,
+                "ACTIVE" => Self::Active,
+                "ACTIVATION_FAILED" => Self::ActivationFailed,
+                "EXPIRED" => Self::Expired,
+                "REVOKING" => Self::Revoking,
+                "REVOKED" => Self::Revoked,
+                "ENDED" => Self::Ended,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ApprovalAwaited => serializer.serialize_i32(1),
+                Self::Denied => serializer.serialize_i32(3),
+                Self::Scheduled => serializer.serialize_i32(4),
+                Self::Activating => serializer.serialize_i32(5),
+                Self::Active => serializer.serialize_i32(6),
+                Self::ActivationFailed => serializer.serialize_i32(7),
+                Self::Expired => serializer.serialize_i32(8),
+                Self::Revoking => serializer.serialize_i32(9),
+                Self::Revoked => serializer.serialize_i32(10),
+                Self::Ended => serializer.serialize_i32(11),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.privilegedaccessmanager.v1.Grant.State",
+            ))
         }
     }
 }
@@ -3354,68 +3556,129 @@ pub mod search_grants_request {
     use super::*;
 
     /// Different types of relationships a user can have with a grant.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallerRelationshipType(i32);
-
-    impl CallerRelationshipType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CallerRelationshipType {
         /// Unspecified caller relationship type.
-        pub const CALLER_RELATIONSHIP_TYPE_UNSPECIFIED: CallerRelationshipType =
-            CallerRelationshipType::new(0);
-
+        Unspecified,
         /// The user created this grant by calling `CreateGrant` earlier.
-        pub const HAD_CREATED: CallerRelationshipType = CallerRelationshipType::new(1);
-
+        HadCreated,
         /// The user is an approver for the entitlement that this grant is parented
         /// under and can currently approve/deny it.
-        pub const CAN_APPROVE: CallerRelationshipType = CallerRelationshipType::new(2);
-
+        CanApprove,
         /// The caller had successfully approved/denied this grant earlier.
-        pub const HAD_APPROVED: CallerRelationshipType = CallerRelationshipType::new(3);
+        HadApproved,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CallerRelationshipType::value] or
+        /// [CallerRelationshipType::name].
+        UnknownValue(caller_relationship_type::UnknownValue),
+    }
 
-        /// Creates a new CallerRelationshipType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod caller_relationship_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CallerRelationshipType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::HadCreated => std::option::Option::Some(1),
+                Self::CanApprove => std::option::Option::Some(2),
+                Self::HadApproved => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CALLER_RELATIONSHIP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HAD_CREATED"),
-                2 => std::borrow::Cow::Borrowed("CAN_APPROVE"),
-                3 => std::borrow::Cow::Borrowed("HAD_APPROVED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CALLER_RELATIONSHIP_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CALLER_RELATIONSHIP_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CALLER_RELATIONSHIP_TYPE_UNSPECIFIED")
                 }
-                "HAD_CREATED" => std::option::Option::Some(Self::HAD_CREATED),
-                "CAN_APPROVE" => std::option::Option::Some(Self::CAN_APPROVE),
-                "HAD_APPROVED" => std::option::Option::Some(Self::HAD_APPROVED),
-                _ => std::option::Option::None,
+                Self::HadCreated => std::option::Option::Some("HAD_CREATED"),
+                Self::CanApprove => std::option::Option::Some("CAN_APPROVE"),
+                Self::HadApproved => std::option::Option::Some("HAD_APPROVED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CallerRelationshipType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CallerRelationshipType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CallerRelationshipType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CallerRelationshipType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::HadCreated,
+                2 => Self::CanApprove,
+                3 => Self::HadApproved,
+                _ => Self::UnknownValue(caller_relationship_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CallerRelationshipType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CALLER_RELATIONSHIP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "HAD_CREATED" => Self::HadCreated,
+                "CAN_APPROVE" => Self::CanApprove,
+                "HAD_APPROVED" => Self::HadApproved,
+                _ => Self::UnknownValue(caller_relationship_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CallerRelationshipType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::HadCreated => serializer.serialize_i32(1),
+                Self::CanApprove => serializer.serialize_i32(2),
+                Self::HadApproved => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CallerRelationshipType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CallerRelationshipType>::new(
+                ".google.cloud.privilegedaccessmanager.v1.SearchGrantsRequest.CallerRelationshipType"))
         }
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -105,7 +105,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("callerAccessType", &req.caller_access_type.value())]);
+        let builder = builder.query(&[("callerAccessType", &req.caller_access_type)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
@@ -252,7 +252,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("callerRelationship", &req.caller_relationship.value())]);
+        let builder = builder.query(&[("callerRelationship", &req.caller_relationship)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -306,91 +306,164 @@ pub mod collector {
     /// States are used for internal purposes and named to keep
     /// convention of legacy product:
     /// <https://cloud.google.com/migrate/stratozone/docs/about-stratoprobe>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Collector state is not recognized.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Collector started to create, but hasn't been completed MC source creation
         /// and db object creation.
-        pub const STATE_INITIALIZING: State = State::new(1);
-
+        Initializing,
         /// Collector has been created, MC source creation and db object creation
         /// completed.
-        pub const STATE_READY_TO_USE: State = State::new(2);
-
+        ReadyToUse,
         /// Collector client has been registered with client.
-        pub const STATE_REGISTERED: State = State::new(3);
-
+        Registered,
         /// Collector client is actively scanning.
-        pub const STATE_ACTIVE: State = State::new(4);
-
+        Active,
         /// Collector is not actively scanning.
-        pub const STATE_PAUSED: State = State::new(5);
-
+        Paused,
         /// Collector is starting background job for deletion.
-        pub const STATE_DELETING: State = State::new(6);
-
+        Deleting,
         /// Collector completed all tasks for deletion.
-        pub const STATE_DECOMMISSIONED: State = State::new(7);
-
+        Decommissioned,
         /// Collector is in error state.
-        pub const STATE_ERROR: State = State::new(8);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Initializing => std::option::Option::Some(1),
+                Self::ReadyToUse => std::option::Option::Some(2),
+                Self::Registered => std::option::Option::Some(3),
+                Self::Active => std::option::Option::Some(4),
+                Self::Paused => std::option::Option::Some(5),
+                Self::Deleting => std::option::Option::Some(6),
+                Self::Decommissioned => std::option::Option::Some(7),
+                Self::Error => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATE_INITIALIZING"),
-                2 => std::borrow::Cow::Borrowed("STATE_READY_TO_USE"),
-                3 => std::borrow::Cow::Borrowed("STATE_REGISTERED"),
-                4 => std::borrow::Cow::Borrowed("STATE_ACTIVE"),
-                5 => std::borrow::Cow::Borrowed("STATE_PAUSED"),
-                6 => std::borrow::Cow::Borrowed("STATE_DELETING"),
-                7 => std::borrow::Cow::Borrowed("STATE_DECOMMISSIONED"),
-                8 => std::borrow::Cow::Borrowed("STATE_ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Initializing => std::option::Option::Some("STATE_INITIALIZING"),
+                Self::ReadyToUse => std::option::Option::Some("STATE_READY_TO_USE"),
+                Self::Registered => std::option::Option::Some("STATE_REGISTERED"),
+                Self::Active => std::option::Option::Some("STATE_ACTIVE"),
+                Self::Paused => std::option::Option::Some("STATE_PAUSED"),
+                Self::Deleting => std::option::Option::Some("STATE_DELETING"),
+                Self::Decommissioned => std::option::Option::Some("STATE_DECOMMISSIONED"),
+                Self::Error => std::option::Option::Some("STATE_ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STATE_INITIALIZING" => std::option::Option::Some(Self::STATE_INITIALIZING),
-                "STATE_READY_TO_USE" => std::option::Option::Some(Self::STATE_READY_TO_USE),
-                "STATE_REGISTERED" => std::option::Option::Some(Self::STATE_REGISTERED),
-                "STATE_ACTIVE" => std::option::Option::Some(Self::STATE_ACTIVE),
-                "STATE_PAUSED" => std::option::Option::Some(Self::STATE_PAUSED),
-                "STATE_DELETING" => std::option::Option::Some(Self::STATE_DELETING),
-                "STATE_DECOMMISSIONED" => std::option::Option::Some(Self::STATE_DECOMMISSIONED),
-                "STATE_ERROR" => std::option::Option::Some(Self::STATE_ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Initializing,
+                2 => Self::ReadyToUse,
+                3 => Self::Registered,
+                4 => Self::Active,
+                5 => Self::Paused,
+                6 => Self::Deleting,
+                7 => Self::Decommissioned,
+                8 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STATE_INITIALIZING" => Self::Initializing,
+                "STATE_READY_TO_USE" => Self::ReadyToUse,
+                "STATE_REGISTERED" => Self::Registered,
+                "STATE_ACTIVE" => Self::Active,
+                "STATE_PAUSED" => Self::Paused,
+                "STATE_DELETING" => Self::Deleting,
+                "STATE_DECOMMISSIONED" => Self::Decommissioned,
+                "STATE_ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Initializing => serializer.serialize_i32(1),
+                Self::ReadyToUse => serializer.serialize_i32(2),
+                Self::Registered => serializer.serialize_i32(3),
+                Self::Active => serializer.serialize_i32(4),
+                Self::Paused => serializer.serialize_i32(5),
+                Self::Deleting => serializer.serialize_i32(6),
+                Self::Decommissioned => serializer.serialize_i32(7),
+                Self::Error => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.rapidmigrationassessment.v1.Collector.State",
+            ))
         }
     }
 }
@@ -485,61 +558,122 @@ pub mod annotation {
     use super::*;
 
     /// Types for project level setting.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unknown type
+        Unspecified,
+        /// Indicates that this project has opted into StratoZone export.
+        LegacyExportConsent,
+        /// Indicates that this project is created by Qwiklab.
+        Qwiklab,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unknown type
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Indicates that this project has opted into StratoZone export.
-        pub const TYPE_LEGACY_EXPORT_CONSENT: Type = Type::new(1);
-
-        /// Indicates that this project is created by Qwiklab.
-        pub const TYPE_QWIKLAB: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LegacyExportConsent => std::option::Option::Some(1),
+                Self::Qwiklab => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TYPE_LEGACY_EXPORT_CONSENT"),
-                2 => std::borrow::Cow::Borrowed("TYPE_QWIKLAB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TYPE_LEGACY_EXPORT_CONSENT" => {
-                    std::option::Option::Some(Self::TYPE_LEGACY_EXPORT_CONSENT)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::LegacyExportConsent => {
+                    std::option::Option::Some("TYPE_LEGACY_EXPORT_CONSENT")
                 }
-                "TYPE_QWIKLAB" => std::option::Option::Some(Self::TYPE_QWIKLAB),
-                _ => std::option::Option::None,
+                Self::Qwiklab => std::option::Option::Some("TYPE_QWIKLAB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LegacyExportConsent,
+                2 => Self::Qwiklab,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TYPE_LEGACY_EXPORT_CONSENT" => Self::LegacyExportConsent,
+                "TYPE_QWIKLAB" => Self::Qwiklab,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LegacyExportConsent => serializer.serialize_i32(1),
+                Self::Qwiklab => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.rapidmigrationassessment.v1.Annotation.Type",
+            ))
         }
     }
 }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -157,184 +157,274 @@ pub mod transaction_event {
     use super::*;
 
     /// Enum that represents an event in the payment transaction lifecycle.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransactionEventType(i32);
-
-    impl TransactionEventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TransactionEventType {
         /// Default, unspecified event type.
-        pub const TRANSACTION_EVENT_TYPE_UNSPECIFIED: TransactionEventType =
-            TransactionEventType::new(0);
-
+        Unspecified,
         /// Indicates that the transaction is approved by the merchant. The
         /// accompanying reasons can include terms such as 'INHOUSE', 'ACCERTIFY',
         /// 'CYBERSOURCE', or 'MANUAL_REVIEW'.
-        pub const MERCHANT_APPROVE: TransactionEventType = TransactionEventType::new(1);
-
+        MerchantApprove,
         /// Indicates that the transaction is denied and concluded due to risks
         /// detected by the merchant. The accompanying reasons can include terms such
         /// as 'INHOUSE',  'ACCERTIFY',  'CYBERSOURCE', or 'MANUAL_REVIEW'.
-        pub const MERCHANT_DENY: TransactionEventType = TransactionEventType::new(2);
-
+        MerchantDeny,
         /// Indicates that the transaction is being evaluated by a human, due to
         /// suspicion or risk.
-        pub const MANUAL_REVIEW: TransactionEventType = TransactionEventType::new(3);
-
+        ManualReview,
         /// Indicates that the authorization attempt with the card issuer succeeded.
-        pub const AUTHORIZATION: TransactionEventType = TransactionEventType::new(4);
-
+        Authorization,
         /// Indicates that the authorization attempt with the card issuer failed.
         /// The accompanying reasons can include Visa's '54' indicating that the card
         /// is expired, or '82' indicating that the CVV is incorrect.
-        pub const AUTHORIZATION_DECLINE: TransactionEventType = TransactionEventType::new(5);
-
+        AuthorizationDecline,
         /// Indicates that the transaction is completed because the funds were
         /// settled.
-        pub const PAYMENT_CAPTURE: TransactionEventType = TransactionEventType::new(6);
-
+        PaymentCapture,
         /// Indicates that the transaction could not be completed because the funds
         /// were not settled.
-        pub const PAYMENT_CAPTURE_DECLINE: TransactionEventType = TransactionEventType::new(7);
-
+        PaymentCaptureDecline,
         /// Indicates that the transaction has been canceled. Specify the reason
         /// for the cancellation. For example, 'INSUFFICIENT_INVENTORY'.
-        pub const CANCEL: TransactionEventType = TransactionEventType::new(8);
-
+        Cancel,
         /// Indicates that the merchant has received a chargeback inquiry due to
         /// fraud for the transaction, requesting additional information before a
         /// fraud chargeback is officially issued and a formal chargeback
         /// notification is sent.
-        pub const CHARGEBACK_INQUIRY: TransactionEventType = TransactionEventType::new(9);
-
+        ChargebackInquiry,
         /// Indicates that the merchant has received a chargeback alert due to fraud
         /// for the transaction. The process of resolving the dispute without
         /// involving the payment network is started.
-        pub const CHARGEBACK_ALERT: TransactionEventType = TransactionEventType::new(10);
-
+        ChargebackAlert,
         /// Indicates that a fraud notification is issued for the transaction, sent
         /// by the payment instrument's issuing bank because the transaction appears
         /// to be fraudulent. We recommend including TC40 or SAFE data in the
         /// `reason` field for this event type. For partial chargebacks, we recommend
         /// that you include an amount in the `value` field.
-        pub const FRAUD_NOTIFICATION: TransactionEventType = TransactionEventType::new(11);
-
+        FraudNotification,
         /// Indicates that the merchant is informed by the payment network that the
         /// transaction has entered the chargeback process due to fraud. Reason code
         /// examples include Discover's '6005' and '6041'. For partial chargebacks,
         /// we recommend that you include an amount in the `value` field.
-        pub const CHARGEBACK: TransactionEventType = TransactionEventType::new(12);
-
+        Chargeback,
         /// Indicates that the transaction has entered the chargeback process due to
         /// fraud, and that the merchant has chosen to enter representment. Reason
         /// examples include Discover's '6005' and '6041'. For partial chargebacks,
         /// we recommend that you include an amount in the `value` field.
-        pub const CHARGEBACK_REPRESENTMENT: TransactionEventType = TransactionEventType::new(13);
-
+        ChargebackRepresentment,
         /// Indicates that the transaction has had a fraud chargeback which was
         /// illegitimate and was reversed as a result. For partial chargebacks, we
         /// recommend that you include an amount in the `value` field.
-        pub const CHARGEBACK_REVERSE: TransactionEventType = TransactionEventType::new(14);
-
+        ChargebackReverse,
         /// Indicates that the merchant has received a refund for a completed
         /// transaction. For partial refunds, we recommend that you include an amount
         /// in the `value` field. Reason example: 'TAX_EXEMPT' (partial refund of
         /// exempt tax)
-        pub const REFUND_REQUEST: TransactionEventType = TransactionEventType::new(15);
-
+        RefundRequest,
         /// Indicates that the merchant has received a refund request for this
         /// transaction, but that they have declined it. For partial refunds, we
         /// recommend that you include an amount in the `value` field. Reason
         /// example: 'TAX_EXEMPT' (partial refund of exempt tax)
-        pub const REFUND_DECLINE: TransactionEventType = TransactionEventType::new(16);
-
+        RefundDecline,
         /// Indicates that the completed transaction was refunded by the merchant.
         /// For partial refunds, we recommend that you include an amount in the
         /// `value` field. Reason example: 'TAX_EXEMPT' (partial refund of exempt
         /// tax)
-        pub const REFUND: TransactionEventType = TransactionEventType::new(17);
-
+        Refund,
         /// Indicates that the completed transaction was refunded by the merchant,
         /// and that this refund was reversed. For partial refunds, we recommend that
         /// you include an amount in the `value` field.
-        pub const REFUND_REVERSE: TransactionEventType = TransactionEventType::new(18);
+        RefundReverse,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TransactionEventType::value] or
+        /// [TransactionEventType::name].
+        UnknownValue(transaction_event_type::UnknownValue),
+    }
 
-        /// Creates a new TransactionEventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod transaction_event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TransactionEventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MerchantApprove => std::option::Option::Some(1),
+                Self::MerchantDeny => std::option::Option::Some(2),
+                Self::ManualReview => std::option::Option::Some(3),
+                Self::Authorization => std::option::Option::Some(4),
+                Self::AuthorizationDecline => std::option::Option::Some(5),
+                Self::PaymentCapture => std::option::Option::Some(6),
+                Self::PaymentCaptureDecline => std::option::Option::Some(7),
+                Self::Cancel => std::option::Option::Some(8),
+                Self::ChargebackInquiry => std::option::Option::Some(9),
+                Self::ChargebackAlert => std::option::Option::Some(10),
+                Self::FraudNotification => std::option::Option::Some(11),
+                Self::Chargeback => std::option::Option::Some(12),
+                Self::ChargebackRepresentment => std::option::Option::Some(13),
+                Self::ChargebackReverse => std::option::Option::Some(14),
+                Self::RefundRequest => std::option::Option::Some(15),
+                Self::RefundDecline => std::option::Option::Some(16),
+                Self::Refund => std::option::Option::Some(17),
+                Self::RefundReverse => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRANSACTION_EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MERCHANT_APPROVE"),
-                2 => std::borrow::Cow::Borrowed("MERCHANT_DENY"),
-                3 => std::borrow::Cow::Borrowed("MANUAL_REVIEW"),
-                4 => std::borrow::Cow::Borrowed("AUTHORIZATION"),
-                5 => std::borrow::Cow::Borrowed("AUTHORIZATION_DECLINE"),
-                6 => std::borrow::Cow::Borrowed("PAYMENT_CAPTURE"),
-                7 => std::borrow::Cow::Borrowed("PAYMENT_CAPTURE_DECLINE"),
-                8 => std::borrow::Cow::Borrowed("CANCEL"),
-                9 => std::borrow::Cow::Borrowed("CHARGEBACK_INQUIRY"),
-                10 => std::borrow::Cow::Borrowed("CHARGEBACK_ALERT"),
-                11 => std::borrow::Cow::Borrowed("FRAUD_NOTIFICATION"),
-                12 => std::borrow::Cow::Borrowed("CHARGEBACK"),
-                13 => std::borrow::Cow::Borrowed("CHARGEBACK_REPRESENTMENT"),
-                14 => std::borrow::Cow::Borrowed("CHARGEBACK_REVERSE"),
-                15 => std::borrow::Cow::Borrowed("REFUND_REQUEST"),
-                16 => std::borrow::Cow::Borrowed("REFUND_DECLINE"),
-                17 => std::borrow::Cow::Borrowed("REFUND"),
-                18 => std::borrow::Cow::Borrowed("REFUND_REVERSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("TRANSACTION_EVENT_TYPE_UNSPECIFIED")
+                }
+                Self::MerchantApprove => std::option::Option::Some("MERCHANT_APPROVE"),
+                Self::MerchantDeny => std::option::Option::Some("MERCHANT_DENY"),
+                Self::ManualReview => std::option::Option::Some("MANUAL_REVIEW"),
+                Self::Authorization => std::option::Option::Some("AUTHORIZATION"),
+                Self::AuthorizationDecline => std::option::Option::Some("AUTHORIZATION_DECLINE"),
+                Self::PaymentCapture => std::option::Option::Some("PAYMENT_CAPTURE"),
+                Self::PaymentCaptureDecline => std::option::Option::Some("PAYMENT_CAPTURE_DECLINE"),
+                Self::Cancel => std::option::Option::Some("CANCEL"),
+                Self::ChargebackInquiry => std::option::Option::Some("CHARGEBACK_INQUIRY"),
+                Self::ChargebackAlert => std::option::Option::Some("CHARGEBACK_ALERT"),
+                Self::FraudNotification => std::option::Option::Some("FRAUD_NOTIFICATION"),
+                Self::Chargeback => std::option::Option::Some("CHARGEBACK"),
+                Self::ChargebackRepresentment => {
+                    std::option::Option::Some("CHARGEBACK_REPRESENTMENT")
+                }
+                Self::ChargebackReverse => std::option::Option::Some("CHARGEBACK_REVERSE"),
+                Self::RefundRequest => std::option::Option::Some("REFUND_REQUEST"),
+                Self::RefundDecline => std::option::Option::Some("REFUND_DECLINE"),
+                Self::Refund => std::option::Option::Some("REFUND"),
+                Self::RefundReverse => std::option::Option::Some("REFUND_REVERSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRANSACTION_EVENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRANSACTION_EVENT_TYPE_UNSPECIFIED)
-                }
-                "MERCHANT_APPROVE" => std::option::Option::Some(Self::MERCHANT_APPROVE),
-                "MERCHANT_DENY" => std::option::Option::Some(Self::MERCHANT_DENY),
-                "MANUAL_REVIEW" => std::option::Option::Some(Self::MANUAL_REVIEW),
-                "AUTHORIZATION" => std::option::Option::Some(Self::AUTHORIZATION),
-                "AUTHORIZATION_DECLINE" => std::option::Option::Some(Self::AUTHORIZATION_DECLINE),
-                "PAYMENT_CAPTURE" => std::option::Option::Some(Self::PAYMENT_CAPTURE),
-                "PAYMENT_CAPTURE_DECLINE" => {
-                    std::option::Option::Some(Self::PAYMENT_CAPTURE_DECLINE)
-                }
-                "CANCEL" => std::option::Option::Some(Self::CANCEL),
-                "CHARGEBACK_INQUIRY" => std::option::Option::Some(Self::CHARGEBACK_INQUIRY),
-                "CHARGEBACK_ALERT" => std::option::Option::Some(Self::CHARGEBACK_ALERT),
-                "FRAUD_NOTIFICATION" => std::option::Option::Some(Self::FRAUD_NOTIFICATION),
-                "CHARGEBACK" => std::option::Option::Some(Self::CHARGEBACK),
-                "CHARGEBACK_REPRESENTMENT" => {
-                    std::option::Option::Some(Self::CHARGEBACK_REPRESENTMENT)
-                }
-                "CHARGEBACK_REVERSE" => std::option::Option::Some(Self::CHARGEBACK_REVERSE),
-                "REFUND_REQUEST" => std::option::Option::Some(Self::REFUND_REQUEST),
-                "REFUND_DECLINE" => std::option::Option::Some(Self::REFUND_DECLINE),
-                "REFUND" => std::option::Option::Some(Self::REFUND),
-                "REFUND_REVERSE" => std::option::Option::Some(Self::REFUND_REVERSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TransactionEventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TransactionEventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TransactionEventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TransactionEventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MerchantApprove,
+                2 => Self::MerchantDeny,
+                3 => Self::ManualReview,
+                4 => Self::Authorization,
+                5 => Self::AuthorizationDecline,
+                6 => Self::PaymentCapture,
+                7 => Self::PaymentCaptureDecline,
+                8 => Self::Cancel,
+                9 => Self::ChargebackInquiry,
+                10 => Self::ChargebackAlert,
+                11 => Self::FraudNotification,
+                12 => Self::Chargeback,
+                13 => Self::ChargebackRepresentment,
+                14 => Self::ChargebackReverse,
+                15 => Self::RefundRequest,
+                16 => Self::RefundDecline,
+                17 => Self::Refund,
+                18 => Self::RefundReverse,
+                _ => Self::UnknownValue(transaction_event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TransactionEventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRANSACTION_EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MERCHANT_APPROVE" => Self::MerchantApprove,
+                "MERCHANT_DENY" => Self::MerchantDeny,
+                "MANUAL_REVIEW" => Self::ManualReview,
+                "AUTHORIZATION" => Self::Authorization,
+                "AUTHORIZATION_DECLINE" => Self::AuthorizationDecline,
+                "PAYMENT_CAPTURE" => Self::PaymentCapture,
+                "PAYMENT_CAPTURE_DECLINE" => Self::PaymentCaptureDecline,
+                "CANCEL" => Self::Cancel,
+                "CHARGEBACK_INQUIRY" => Self::ChargebackInquiry,
+                "CHARGEBACK_ALERT" => Self::ChargebackAlert,
+                "FRAUD_NOTIFICATION" => Self::FraudNotification,
+                "CHARGEBACK" => Self::Chargeback,
+                "CHARGEBACK_REPRESENTMENT" => Self::ChargebackRepresentment,
+                "CHARGEBACK_REVERSE" => Self::ChargebackReverse,
+                "REFUND_REQUEST" => Self::RefundRequest,
+                "REFUND_DECLINE" => Self::RefundDecline,
+                "REFUND" => Self::Refund,
+                "REFUND_REVERSE" => Self::RefundReverse,
+                _ => Self::UnknownValue(transaction_event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TransactionEventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MerchantApprove => serializer.serialize_i32(1),
+                Self::MerchantDeny => serializer.serialize_i32(2),
+                Self::ManualReview => serializer.serialize_i32(3),
+                Self::Authorization => serializer.serialize_i32(4),
+                Self::AuthorizationDecline => serializer.serialize_i32(5),
+                Self::PaymentCapture => serializer.serialize_i32(6),
+                Self::PaymentCaptureDecline => serializer.serialize_i32(7),
+                Self::Cancel => serializer.serialize_i32(8),
+                Self::ChargebackInquiry => serializer.serialize_i32(9),
+                Self::ChargebackAlert => serializer.serialize_i32(10),
+                Self::FraudNotification => serializer.serialize_i32(11),
+                Self::Chargeback => serializer.serialize_i32(12),
+                Self::ChargebackRepresentment => serializer.serialize_i32(13),
+                Self::ChargebackReverse => serializer.serialize_i32(14),
+                Self::RefundRequest => serializer.serialize_i32(15),
+                Self::RefundDecline => serializer.serialize_i32(16),
+                Self::Refund => serializer.serialize_i32(17),
+                Self::RefundReverse => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TransactionEventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransactionEventType>::new(
+                ".google.cloud.recaptchaenterprise.v1.TransactionEvent.TransactionEventType",
+            ))
         }
     }
 }
@@ -451,207 +541,357 @@ pub mod annotate_assessment_request {
     use super::*;
 
     /// Enum that represents the types of annotations.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Annotation(i32);
-
-    impl Annotation {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Annotation {
         /// Default unspecified type.
-        pub const ANNOTATION_UNSPECIFIED: Annotation = Annotation::new(0);
-
+        Unspecified,
         /// Provides information that the event turned out to be legitimate.
-        pub const LEGITIMATE: Annotation = Annotation::new(1);
-
+        Legitimate,
         /// Provides information that the event turned out to be fraudulent.
-        pub const FRAUDULENT: Annotation = Annotation::new(2);
-
+        Fraudulent,
         /// Provides information that the event was related to a login event in which
         /// the user typed the correct password. Deprecated, prefer indicating
         /// CORRECT_PASSWORD through the reasons field instead.
-        pub const PASSWORD_CORRECT: Annotation = Annotation::new(3);
-
+        PasswordCorrect,
         /// Provides information that the event was related to a login event in which
         /// the user typed the incorrect password. Deprecated, prefer indicating
         /// INCORRECT_PASSWORD through the reasons field instead.
-        pub const PASSWORD_INCORRECT: Annotation = Annotation::new(4);
+        PasswordIncorrect,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Annotation::value] or
+        /// [Annotation::name].
+        UnknownValue(annotation::UnknownValue),
+    }
 
-        /// Creates a new Annotation instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod annotation {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Annotation {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Legitimate => std::option::Option::Some(1),
+                Self::Fraudulent => std::option::Option::Some(2),
+                Self::PasswordCorrect => std::option::Option::Some(3),
+                Self::PasswordIncorrect => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANNOTATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LEGITIMATE"),
-                2 => std::borrow::Cow::Borrowed("FRAUDULENT"),
-                3 => std::borrow::Cow::Borrowed("PASSWORD_CORRECT"),
-                4 => std::borrow::Cow::Borrowed("PASSWORD_INCORRECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANNOTATION_UNSPECIFIED"),
+                Self::Legitimate => std::option::Option::Some("LEGITIMATE"),
+                Self::Fraudulent => std::option::Option::Some("FRAUDULENT"),
+                Self::PasswordCorrect => std::option::Option::Some("PASSWORD_CORRECT"),
+                Self::PasswordIncorrect => std::option::Option::Some("PASSWORD_INCORRECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANNOTATION_UNSPECIFIED" => std::option::Option::Some(Self::ANNOTATION_UNSPECIFIED),
-                "LEGITIMATE" => std::option::Option::Some(Self::LEGITIMATE),
-                "FRAUDULENT" => std::option::Option::Some(Self::FRAUDULENT),
-                "PASSWORD_CORRECT" => std::option::Option::Some(Self::PASSWORD_CORRECT),
-                "PASSWORD_INCORRECT" => std::option::Option::Some(Self::PASSWORD_INCORRECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Annotation {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Annotation {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Annotation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Annotation {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Legitimate,
+                2 => Self::Fraudulent,
+                3 => Self::PasswordCorrect,
+                4 => Self::PasswordIncorrect,
+                _ => Self::UnknownValue(annotation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Annotation {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANNOTATION_UNSPECIFIED" => Self::Unspecified,
+                "LEGITIMATE" => Self::Legitimate,
+                "FRAUDULENT" => Self::Fraudulent,
+                "PASSWORD_CORRECT" => Self::PasswordCorrect,
+                "PASSWORD_INCORRECT" => Self::PasswordIncorrect,
+                _ => Self::UnknownValue(annotation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Annotation {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Legitimate => serializer.serialize_i32(1),
+                Self::Fraudulent => serializer.serialize_i32(2),
+                Self::PasswordCorrect => serializer.serialize_i32(3),
+                Self::PasswordIncorrect => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Annotation {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Annotation>::new(
+                ".google.cloud.recaptchaenterprise.v1.AnnotateAssessmentRequest.Annotation",
+            ))
         }
     }
 
     /// Enum that represents potential reasons for annotating an assessment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reason(i32);
-
-    impl Reason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Reason {
         /// Unspecified reason. Do not use.
-        pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
-
+        Unspecified,
         /// Indicates that the transaction had a chargeback issued with no other
         /// details. When possible, specify the type by using CHARGEBACK_FRAUD or
         /// CHARGEBACK_DISPUTE instead.
-        pub const CHARGEBACK: Reason = Reason::new(1);
-
+        Chargeback,
         /// Indicates that the transaction had a chargeback issued related to an
         /// alleged unauthorized transaction from the cardholder's perspective (for
         /// example, the card number was stolen).
-        pub const CHARGEBACK_FRAUD: Reason = Reason::new(8);
-
+        ChargebackFraud,
         /// Indicates that the transaction had a chargeback issued related to the
         /// cardholder having provided their card details but allegedly not being
         /// satisfied with the purchase (for example, misrepresentation, attempted
         /// cancellation).
-        pub const CHARGEBACK_DISPUTE: Reason = Reason::new(9);
-
+        ChargebackDispute,
         /// Indicates that the completed payment transaction was refunded by the
         /// seller.
-        pub const REFUND: Reason = Reason::new(10);
-
+        Refund,
         /// Indicates that the completed payment transaction was determined to be
         /// fraudulent by the seller, and was cancelled and refunded as a result.
-        pub const REFUND_FRAUD: Reason = Reason::new(11);
-
+        RefundFraud,
         /// Indicates that the payment transaction was accepted, and the user was
         /// charged.
-        pub const TRANSACTION_ACCEPTED: Reason = Reason::new(12);
-
+        TransactionAccepted,
         /// Indicates that the payment transaction was declined, for example due to
         /// invalid card details.
-        pub const TRANSACTION_DECLINED: Reason = Reason::new(13);
-
+        TransactionDeclined,
         /// Indicates the transaction associated with the assessment is suspected of
         /// being fraudulent based on the payment method, billing details, shipping
         /// address or other transaction information.
-        pub const PAYMENT_HEURISTICS: Reason = Reason::new(2);
-
+        PaymentHeuristics,
         /// Indicates that the user was served a 2FA challenge. An old assessment
         /// with `ENUM_VALUES.INITIATED_TWO_FACTOR` reason that has not been
         /// overwritten with `PASSED_TWO_FACTOR` is treated as an abandoned 2FA flow.
         /// This is equivalent to `FAILED_TWO_FACTOR`.
-        pub const INITIATED_TWO_FACTOR: Reason = Reason::new(7);
-
+        InitiatedTwoFactor,
         /// Indicates that the user passed a 2FA challenge.
-        pub const PASSED_TWO_FACTOR: Reason = Reason::new(3);
-
+        PassedTwoFactor,
         /// Indicates that the user failed a 2FA challenge.
-        pub const FAILED_TWO_FACTOR: Reason = Reason::new(4);
-
+        FailedTwoFactor,
         /// Indicates the user provided the correct password.
-        pub const CORRECT_PASSWORD: Reason = Reason::new(5);
-
+        CorrectPassword,
         /// Indicates the user provided an incorrect password.
-        pub const INCORRECT_PASSWORD: Reason = Reason::new(6);
-
+        IncorrectPassword,
         /// Indicates that the user sent unwanted and abusive messages to other users
         /// of the platform, such as spam, scams, phishing, or social engineering.
-        pub const SOCIAL_SPAM: Reason = Reason::new(14);
+        SocialSpam,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Reason::value] or
+        /// [Reason::name].
+        UnknownValue(reason::UnknownValue),
+    }
 
-        /// Creates a new Reason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Reason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Chargeback => std::option::Option::Some(1),
+                Self::ChargebackFraud => std::option::Option::Some(8),
+                Self::ChargebackDispute => std::option::Option::Some(9),
+                Self::Refund => std::option::Option::Some(10),
+                Self::RefundFraud => std::option::Option::Some(11),
+                Self::TransactionAccepted => std::option::Option::Some(12),
+                Self::TransactionDeclined => std::option::Option::Some(13),
+                Self::PaymentHeuristics => std::option::Option::Some(2),
+                Self::InitiatedTwoFactor => std::option::Option::Some(7),
+                Self::PassedTwoFactor => std::option::Option::Some(3),
+                Self::FailedTwoFactor => std::option::Option::Some(4),
+                Self::CorrectPassword => std::option::Option::Some(5),
+                Self::IncorrectPassword => std::option::Option::Some(6),
+                Self::SocialSpam => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CHARGEBACK"),
-                2 => std::borrow::Cow::Borrowed("PAYMENT_HEURISTICS"),
-                3 => std::borrow::Cow::Borrowed("PASSED_TWO_FACTOR"),
-                4 => std::borrow::Cow::Borrowed("FAILED_TWO_FACTOR"),
-                5 => std::borrow::Cow::Borrowed("CORRECT_PASSWORD"),
-                6 => std::borrow::Cow::Borrowed("INCORRECT_PASSWORD"),
-                7 => std::borrow::Cow::Borrowed("INITIATED_TWO_FACTOR"),
-                8 => std::borrow::Cow::Borrowed("CHARGEBACK_FRAUD"),
-                9 => std::borrow::Cow::Borrowed("CHARGEBACK_DISPUTE"),
-                10 => std::borrow::Cow::Borrowed("REFUND"),
-                11 => std::borrow::Cow::Borrowed("REFUND_FRAUD"),
-                12 => std::borrow::Cow::Borrowed("TRANSACTION_ACCEPTED"),
-                13 => std::borrow::Cow::Borrowed("TRANSACTION_DECLINED"),
-                14 => std::borrow::Cow::Borrowed("SOCIAL_SPAM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REASON_UNSPECIFIED"),
+                Self::Chargeback => std::option::Option::Some("CHARGEBACK"),
+                Self::ChargebackFraud => std::option::Option::Some("CHARGEBACK_FRAUD"),
+                Self::ChargebackDispute => std::option::Option::Some("CHARGEBACK_DISPUTE"),
+                Self::Refund => std::option::Option::Some("REFUND"),
+                Self::RefundFraud => std::option::Option::Some("REFUND_FRAUD"),
+                Self::TransactionAccepted => std::option::Option::Some("TRANSACTION_ACCEPTED"),
+                Self::TransactionDeclined => std::option::Option::Some("TRANSACTION_DECLINED"),
+                Self::PaymentHeuristics => std::option::Option::Some("PAYMENT_HEURISTICS"),
+                Self::InitiatedTwoFactor => std::option::Option::Some("INITIATED_TWO_FACTOR"),
+                Self::PassedTwoFactor => std::option::Option::Some("PASSED_TWO_FACTOR"),
+                Self::FailedTwoFactor => std::option::Option::Some("FAILED_TWO_FACTOR"),
+                Self::CorrectPassword => std::option::Option::Some("CORRECT_PASSWORD"),
+                Self::IncorrectPassword => std::option::Option::Some("INCORRECT_PASSWORD"),
+                Self::SocialSpam => std::option::Option::Some("SOCIAL_SPAM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
-                "CHARGEBACK" => std::option::Option::Some(Self::CHARGEBACK),
-                "CHARGEBACK_FRAUD" => std::option::Option::Some(Self::CHARGEBACK_FRAUD),
-                "CHARGEBACK_DISPUTE" => std::option::Option::Some(Self::CHARGEBACK_DISPUTE),
-                "REFUND" => std::option::Option::Some(Self::REFUND),
-                "REFUND_FRAUD" => std::option::Option::Some(Self::REFUND_FRAUD),
-                "TRANSACTION_ACCEPTED" => std::option::Option::Some(Self::TRANSACTION_ACCEPTED),
-                "TRANSACTION_DECLINED" => std::option::Option::Some(Self::TRANSACTION_DECLINED),
-                "PAYMENT_HEURISTICS" => std::option::Option::Some(Self::PAYMENT_HEURISTICS),
-                "INITIATED_TWO_FACTOR" => std::option::Option::Some(Self::INITIATED_TWO_FACTOR),
-                "PASSED_TWO_FACTOR" => std::option::Option::Some(Self::PASSED_TWO_FACTOR),
-                "FAILED_TWO_FACTOR" => std::option::Option::Some(Self::FAILED_TWO_FACTOR),
-                "CORRECT_PASSWORD" => std::option::Option::Some(Self::CORRECT_PASSWORD),
-                "INCORRECT_PASSWORD" => std::option::Option::Some(Self::INCORRECT_PASSWORD),
-                "SOCIAL_SPAM" => std::option::Option::Some(Self::SOCIAL_SPAM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Reason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Reason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Reason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Chargeback,
+                2 => Self::PaymentHeuristics,
+                3 => Self::PassedTwoFactor,
+                4 => Self::FailedTwoFactor,
+                5 => Self::CorrectPassword,
+                6 => Self::IncorrectPassword,
+                7 => Self::InitiatedTwoFactor,
+                8 => Self::ChargebackFraud,
+                9 => Self::ChargebackDispute,
+                10 => Self::Refund,
+                11 => Self::RefundFraud,
+                12 => Self::TransactionAccepted,
+                13 => Self::TransactionDeclined,
+                14 => Self::SocialSpam,
+                _ => Self::UnknownValue(reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Reason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REASON_UNSPECIFIED" => Self::Unspecified,
+                "CHARGEBACK" => Self::Chargeback,
+                "CHARGEBACK_FRAUD" => Self::ChargebackFraud,
+                "CHARGEBACK_DISPUTE" => Self::ChargebackDispute,
+                "REFUND" => Self::Refund,
+                "REFUND_FRAUD" => Self::RefundFraud,
+                "TRANSACTION_ACCEPTED" => Self::TransactionAccepted,
+                "TRANSACTION_DECLINED" => Self::TransactionDeclined,
+                "PAYMENT_HEURISTICS" => Self::PaymentHeuristics,
+                "INITIATED_TWO_FACTOR" => Self::InitiatedTwoFactor,
+                "PASSED_TWO_FACTOR" => Self::PassedTwoFactor,
+                "FAILED_TWO_FACTOR" => Self::FailedTwoFactor,
+                "CORRECT_PASSWORD" => Self::CorrectPassword,
+                "INCORRECT_PASSWORD" => Self::IncorrectPassword,
+                "SOCIAL_SPAM" => Self::SocialSpam,
+                _ => Self::UnknownValue(reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Reason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Chargeback => serializer.serialize_i32(1),
+                Self::ChargebackFraud => serializer.serialize_i32(8),
+                Self::ChargebackDispute => serializer.serialize_i32(9),
+                Self::Refund => serializer.serialize_i32(10),
+                Self::RefundFraud => serializer.serialize_i32(11),
+                Self::TransactionAccepted => serializer.serialize_i32(12),
+                Self::TransactionDeclined => serializer.serialize_i32(13),
+                Self::PaymentHeuristics => serializer.serialize_i32(2),
+                Self::InitiatedTwoFactor => serializer.serialize_i32(7),
+                Self::PassedTwoFactor => serializer.serialize_i32(3),
+                Self::FailedTwoFactor => serializer.serialize_i32(4),
+                Self::CorrectPassword => serializer.serialize_i32(5),
+                Self::IncorrectPassword => serializer.serialize_i32(6),
+                Self::SocialSpam => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Reason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Reason>::new(
+                ".google.cloud.recaptchaenterprise.v1.AnnotateAssessmentRequest.Reason",
+            ))
         }
     }
 }
@@ -891,117 +1131,188 @@ pub mod account_verification_info {
 
     /// Result of the account verification as contained in the verdict token issued
     /// at the end of the verification flow.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(i32);
-
-    impl Result {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Result {
         /// No information about the latest account verification.
-        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
-
+        Unspecified,
         /// The user was successfully verified. This means the account verification
         /// challenge was successfully completed.
-        pub const SUCCESS_USER_VERIFIED: Result = Result::new(1);
-
+        SuccessUserVerified,
         /// The user failed the verification challenge.
-        pub const ERROR_USER_NOT_VERIFIED: Result = Result::new(2);
-
+        ErrorUserNotVerified,
         /// The site is not properly onboarded to use the account verification
         /// feature.
-        pub const ERROR_SITE_ONBOARDING_INCOMPLETE: Result = Result::new(3);
-
+        ErrorSiteOnboardingIncomplete,
         /// The recipient is not allowed for account verification. This can occur
         /// during integration but should not occur in production.
-        pub const ERROR_RECIPIENT_NOT_ALLOWED: Result = Result::new(4);
-
+        ErrorRecipientNotAllowed,
         /// The recipient has already been sent too many verification codes in a
         /// short amount of time.
-        pub const ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED: Result = Result::new(5);
-
+        ErrorRecipientAbuseLimitExhausted,
         /// The verification flow could not be completed due to a critical internal
         /// error.
-        pub const ERROR_CRITICAL_INTERNAL: Result = Result::new(6);
-
+        ErrorCriticalInternal,
         /// The client has exceeded their two factor request quota for this period of
         /// time.
-        pub const ERROR_CUSTOMER_QUOTA_EXHAUSTED: Result = Result::new(7);
-
+        ErrorCustomerQuotaExhausted,
         /// The request cannot be processed at the time because of an incident. This
         /// bypass can be restricted to a problematic destination email domain, a
         /// customer, or could affect the entire service.
-        pub const ERROR_VERIFICATION_BYPASSED: Result = Result::new(8);
-
+        ErrorVerificationBypassed,
         /// The request parameters do not match with the token provided and cannot be
         /// processed.
-        pub const ERROR_VERDICT_MISMATCH: Result = Result::new(9);
+        ErrorVerdictMismatch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Result::value] or
+        /// [Result::name].
+        UnknownValue(result::UnknownValue),
+    }
 
-        /// Creates a new Result instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Result {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SuccessUserVerified => std::option::Option::Some(1),
+                Self::ErrorUserNotVerified => std::option::Option::Some(2),
+                Self::ErrorSiteOnboardingIncomplete => std::option::Option::Some(3),
+                Self::ErrorRecipientNotAllowed => std::option::Option::Some(4),
+                Self::ErrorRecipientAbuseLimitExhausted => std::option::Option::Some(5),
+                Self::ErrorCriticalInternal => std::option::Option::Some(6),
+                Self::ErrorCustomerQuotaExhausted => std::option::Option::Some(7),
+                Self::ErrorVerificationBypassed => std::option::Option::Some(8),
+                Self::ErrorVerdictMismatch => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCESS_USER_VERIFIED"),
-                2 => std::borrow::Cow::Borrowed("ERROR_USER_NOT_VERIFIED"),
-                3 => std::borrow::Cow::Borrowed("ERROR_SITE_ONBOARDING_INCOMPLETE"),
-                4 => std::borrow::Cow::Borrowed("ERROR_RECIPIENT_NOT_ALLOWED"),
-                5 => std::borrow::Cow::Borrowed("ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED"),
-                6 => std::borrow::Cow::Borrowed("ERROR_CRITICAL_INTERNAL"),
-                7 => std::borrow::Cow::Borrowed("ERROR_CUSTOMER_QUOTA_EXHAUSTED"),
-                8 => std::borrow::Cow::Borrowed("ERROR_VERIFICATION_BYPASSED"),
-                9 => std::borrow::Cow::Borrowed("ERROR_VERDICT_MISMATCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESULT_UNSPECIFIED"),
+                Self::SuccessUserVerified => std::option::Option::Some("SUCCESS_USER_VERIFIED"),
+                Self::ErrorUserNotVerified => std::option::Option::Some("ERROR_USER_NOT_VERIFIED"),
+                Self::ErrorSiteOnboardingIncomplete => {
+                    std::option::Option::Some("ERROR_SITE_ONBOARDING_INCOMPLETE")
+                }
+                Self::ErrorRecipientNotAllowed => {
+                    std::option::Option::Some("ERROR_RECIPIENT_NOT_ALLOWED")
+                }
+                Self::ErrorRecipientAbuseLimitExhausted => {
+                    std::option::Option::Some("ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED")
+                }
+                Self::ErrorCriticalInternal => std::option::Option::Some("ERROR_CRITICAL_INTERNAL"),
+                Self::ErrorCustomerQuotaExhausted => {
+                    std::option::Option::Some("ERROR_CUSTOMER_QUOTA_EXHAUSTED")
+                }
+                Self::ErrorVerificationBypassed => {
+                    std::option::Option::Some("ERROR_VERIFICATION_BYPASSED")
+                }
+                Self::ErrorVerdictMismatch => std::option::Option::Some("ERROR_VERDICT_MISMATCH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
-                "SUCCESS_USER_VERIFIED" => std::option::Option::Some(Self::SUCCESS_USER_VERIFIED),
-                "ERROR_USER_NOT_VERIFIED" => {
-                    std::option::Option::Some(Self::ERROR_USER_NOT_VERIFIED)
-                }
-                "ERROR_SITE_ONBOARDING_INCOMPLETE" => {
-                    std::option::Option::Some(Self::ERROR_SITE_ONBOARDING_INCOMPLETE)
-                }
-                "ERROR_RECIPIENT_NOT_ALLOWED" => {
-                    std::option::Option::Some(Self::ERROR_RECIPIENT_NOT_ALLOWED)
-                }
-                "ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED" => {
-                    std::option::Option::Some(Self::ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED)
-                }
-                "ERROR_CRITICAL_INTERNAL" => {
-                    std::option::Option::Some(Self::ERROR_CRITICAL_INTERNAL)
-                }
-                "ERROR_CUSTOMER_QUOTA_EXHAUSTED" => {
-                    std::option::Option::Some(Self::ERROR_CUSTOMER_QUOTA_EXHAUSTED)
-                }
-                "ERROR_VERIFICATION_BYPASSED" => {
-                    std::option::Option::Some(Self::ERROR_VERIFICATION_BYPASSED)
-                }
-                "ERROR_VERDICT_MISMATCH" => std::option::Option::Some(Self::ERROR_VERDICT_MISMATCH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Result {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SuccessUserVerified,
+                2 => Self::ErrorUserNotVerified,
+                3 => Self::ErrorSiteOnboardingIncomplete,
+                4 => Self::ErrorRecipientNotAllowed,
+                5 => Self::ErrorRecipientAbuseLimitExhausted,
+                6 => Self::ErrorCriticalInternal,
+                7 => Self::ErrorCustomerQuotaExhausted,
+                8 => Self::ErrorVerificationBypassed,
+                9 => Self::ErrorVerdictMismatch,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Result {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESULT_UNSPECIFIED" => Self::Unspecified,
+                "SUCCESS_USER_VERIFIED" => Self::SuccessUserVerified,
+                "ERROR_USER_NOT_VERIFIED" => Self::ErrorUserNotVerified,
+                "ERROR_SITE_ONBOARDING_INCOMPLETE" => Self::ErrorSiteOnboardingIncomplete,
+                "ERROR_RECIPIENT_NOT_ALLOWED" => Self::ErrorRecipientNotAllowed,
+                "ERROR_RECIPIENT_ABUSE_LIMIT_EXHAUSTED" => Self::ErrorRecipientAbuseLimitExhausted,
+                "ERROR_CRITICAL_INTERNAL" => Self::ErrorCriticalInternal,
+                "ERROR_CUSTOMER_QUOTA_EXHAUSTED" => Self::ErrorCustomerQuotaExhausted,
+                "ERROR_VERIFICATION_BYPASSED" => Self::ErrorVerificationBypassed,
+                "ERROR_VERDICT_MISMATCH" => Self::ErrorVerdictMismatch,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Result {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SuccessUserVerified => serializer.serialize_i32(1),
+                Self::ErrorUserNotVerified => serializer.serialize_i32(2),
+                Self::ErrorSiteOnboardingIncomplete => serializer.serialize_i32(3),
+                Self::ErrorRecipientNotAllowed => serializer.serialize_i32(4),
+                Self::ErrorRecipientAbuseLimitExhausted => serializer.serialize_i32(5),
+                Self::ErrorCriticalInternal => serializer.serialize_i32(6),
+                Self::ErrorCustomerQuotaExhausted => serializer.serialize_i32(7),
+                Self::ErrorVerificationBypassed => serializer.serialize_i32(8),
+                Self::ErrorVerdictMismatch => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Result {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Result>::new(
+                ".google.cloud.recaptchaenterprise.v1.AccountVerificationInfo.Result",
+            ))
         }
     }
 }
@@ -1523,65 +1834,124 @@ pub mod event {
     use super::*;
 
     /// Setting that controls Fraud Prevention assessments.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FraudPrevention(i32);
-
-    impl FraudPrevention {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FraudPrevention {
         /// Default, unspecified setting. `fraud_prevention_assessment` is returned
         /// if `transaction_data` is present in `Event` and Fraud Prevention is
         /// enabled in the Google Cloud console.
-        pub const FRAUD_PREVENTION_UNSPECIFIED: FraudPrevention = FraudPrevention::new(0);
-
+        Unspecified,
         /// Enable Fraud Prevention for this assessment, if Fraud Prevention is
         /// enabled in the Google Cloud console.
-        pub const ENABLED: FraudPrevention = FraudPrevention::new(1);
-
+        Enabled,
         /// Disable Fraud Prevention for this assessment, regardless of the Google
         /// Cloud console settings.
-        pub const DISABLED: FraudPrevention = FraudPrevention::new(2);
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FraudPrevention::value] or
+        /// [FraudPrevention::name].
+        UnknownValue(fraud_prevention::UnknownValue),
+    }
 
-        /// Creates a new FraudPrevention instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod fraud_prevention {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FraudPrevention {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FRAUD_PREVENTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FRAUD_PREVENTION_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FRAUD_PREVENTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FRAUD_PREVENTION_UNSPECIFIED)
-                }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FraudPrevention {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FraudPrevention {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FraudPrevention {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FraudPrevention {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(fraud_prevention::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FraudPrevention {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FRAUD_PREVENTION_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(fraud_prevention::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FraudPrevention {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FraudPrevention {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FraudPrevention>::new(
+                ".google.cloud.recaptchaenterprise.v1.Event.FraudPrevention",
+            ))
         }
     }
 }
@@ -2392,154 +2762,285 @@ pub mod risk_analysis {
     use super::*;
 
     /// Reasons contributing to the risk analysis verdict.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClassificationReason(i32);
-
-    impl ClassificationReason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ClassificationReason {
         /// Default unspecified type.
-        pub const CLASSIFICATION_REASON_UNSPECIFIED: ClassificationReason =
-            ClassificationReason::new(0);
-
+        Unspecified,
         /// Interactions matched the behavior of an automated agent.
-        pub const AUTOMATION: ClassificationReason = ClassificationReason::new(1);
-
+        Automation,
         /// The event originated from an illegitimate environment.
-        pub const UNEXPECTED_ENVIRONMENT: ClassificationReason = ClassificationReason::new(2);
-
+        UnexpectedEnvironment,
         /// Traffic volume from the event source is higher than normal.
-        pub const TOO_MUCH_TRAFFIC: ClassificationReason = ClassificationReason::new(3);
-
+        TooMuchTraffic,
         /// Interactions with the site were significantly different than expected
         /// patterns.
-        pub const UNEXPECTED_USAGE_PATTERNS: ClassificationReason = ClassificationReason::new(4);
-
+        UnexpectedUsagePatterns,
         /// Too little traffic has been received from this site thus far to generate
         /// quality risk analysis.
-        pub const LOW_CONFIDENCE_SCORE: ClassificationReason = ClassificationReason::new(5);
-
+        LowConfidenceScore,
         /// The request matches behavioral characteristics of a carding attack.
-        pub const SUSPECTED_CARDING: ClassificationReason = ClassificationReason::new(6);
-
+        SuspectedCarding,
         /// The request matches behavioral characteristics of chargebacks for fraud.
-        pub const SUSPECTED_CHARGEBACK: ClassificationReason = ClassificationReason::new(7);
+        SuspectedChargeback,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ClassificationReason::value] or
+        /// [ClassificationReason::name].
+        UnknownValue(classification_reason::UnknownValue),
+    }
 
-        /// Creates a new ClassificationReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod classification_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ClassificationReason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automation => std::option::Option::Some(1),
+                Self::UnexpectedEnvironment => std::option::Option::Some(2),
+                Self::TooMuchTraffic => std::option::Option::Some(3),
+                Self::UnexpectedUsagePatterns => std::option::Option::Some(4),
+                Self::LowConfidenceScore => std::option::Option::Some(5),
+                Self::SuspectedCarding => std::option::Option::Some(6),
+                Self::SuspectedChargeback => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLASSIFICATION_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATION"),
-                2 => std::borrow::Cow::Borrowed("UNEXPECTED_ENVIRONMENT"),
-                3 => std::borrow::Cow::Borrowed("TOO_MUCH_TRAFFIC"),
-                4 => std::borrow::Cow::Borrowed("UNEXPECTED_USAGE_PATTERNS"),
-                5 => std::borrow::Cow::Borrowed("LOW_CONFIDENCE_SCORE"),
-                6 => std::borrow::Cow::Borrowed("SUSPECTED_CARDING"),
-                7 => std::borrow::Cow::Borrowed("SUSPECTED_CHARGEBACK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLASSIFICATION_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLASSIFICATION_REASON_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CLASSIFICATION_REASON_UNSPECIFIED"),
+                Self::Automation => std::option::Option::Some("AUTOMATION"),
+                Self::UnexpectedEnvironment => std::option::Option::Some("UNEXPECTED_ENVIRONMENT"),
+                Self::TooMuchTraffic => std::option::Option::Some("TOO_MUCH_TRAFFIC"),
+                Self::UnexpectedUsagePatterns => {
+                    std::option::Option::Some("UNEXPECTED_USAGE_PATTERNS")
                 }
-                "AUTOMATION" => std::option::Option::Some(Self::AUTOMATION),
-                "UNEXPECTED_ENVIRONMENT" => std::option::Option::Some(Self::UNEXPECTED_ENVIRONMENT),
-                "TOO_MUCH_TRAFFIC" => std::option::Option::Some(Self::TOO_MUCH_TRAFFIC),
-                "UNEXPECTED_USAGE_PATTERNS" => {
-                    std::option::Option::Some(Self::UNEXPECTED_USAGE_PATTERNS)
-                }
-                "LOW_CONFIDENCE_SCORE" => std::option::Option::Some(Self::LOW_CONFIDENCE_SCORE),
-                "SUSPECTED_CARDING" => std::option::Option::Some(Self::SUSPECTED_CARDING),
-                "SUSPECTED_CHARGEBACK" => std::option::Option::Some(Self::SUSPECTED_CHARGEBACK),
-                _ => std::option::Option::None,
+                Self::LowConfidenceScore => std::option::Option::Some("LOW_CONFIDENCE_SCORE"),
+                Self::SuspectedCarding => std::option::Option::Some("SUSPECTED_CARDING"),
+                Self::SuspectedChargeback => std::option::Option::Some("SUSPECTED_CHARGEBACK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ClassificationReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ClassificationReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ClassificationReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ClassificationReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automation,
+                2 => Self::UnexpectedEnvironment,
+                3 => Self::TooMuchTraffic,
+                4 => Self::UnexpectedUsagePatterns,
+                5 => Self::LowConfidenceScore,
+                6 => Self::SuspectedCarding,
+                7 => Self::SuspectedChargeback,
+                _ => Self::UnknownValue(classification_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ClassificationReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLASSIFICATION_REASON_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATION" => Self::Automation,
+                "UNEXPECTED_ENVIRONMENT" => Self::UnexpectedEnvironment,
+                "TOO_MUCH_TRAFFIC" => Self::TooMuchTraffic,
+                "UNEXPECTED_USAGE_PATTERNS" => Self::UnexpectedUsagePatterns,
+                "LOW_CONFIDENCE_SCORE" => Self::LowConfidenceScore,
+                "SUSPECTED_CARDING" => Self::SuspectedCarding,
+                "SUSPECTED_CHARGEBACK" => Self::SuspectedChargeback,
+                _ => Self::UnknownValue(classification_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ClassificationReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automation => serializer.serialize_i32(1),
+                Self::UnexpectedEnvironment => serializer.serialize_i32(2),
+                Self::TooMuchTraffic => serializer.serialize_i32(3),
+                Self::UnexpectedUsagePatterns => serializer.serialize_i32(4),
+                Self::LowConfidenceScore => serializer.serialize_i32(5),
+                Self::SuspectedCarding => serializer.serialize_i32(6),
+                Self::SuspectedChargeback => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ClassificationReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ClassificationReason>::new(
+                ".google.cloud.recaptchaenterprise.v1.RiskAnalysis.ClassificationReason",
+            ))
         }
     }
 
     /// Challenge information for SCORE_AND_CHALLENGE and INVISIBLE keys
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Challenge(i32);
-
-    impl Challenge {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Challenge {
         /// Default unspecified type.
-        pub const CHALLENGE_UNSPECIFIED: Challenge = Challenge::new(0);
-
+        Unspecified,
         /// No challenge was presented for solving.
-        pub const NOCAPTCHA: Challenge = Challenge::new(1);
-
+        Nocaptcha,
         /// A solution was submitted that was correct.
-        pub const PASSED: Challenge = Challenge::new(2);
-
+        Passed,
         /// A solution was submitted that was incorrect or otherwise
         /// deemed suspicious.
-        pub const FAILED: Challenge = Challenge::new(3);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Challenge::value] or
+        /// [Challenge::name].
+        UnknownValue(challenge::UnknownValue),
+    }
 
-        /// Creates a new Challenge instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod challenge {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Challenge {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Nocaptcha => std::option::Option::Some(1),
+                Self::Passed => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CHALLENGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOCAPTCHA"),
-                2 => std::borrow::Cow::Borrowed("PASSED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CHALLENGE_UNSPECIFIED"),
+                Self::Nocaptcha => std::option::Option::Some("NOCAPTCHA"),
+                Self::Passed => std::option::Option::Some("PASSED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CHALLENGE_UNSPECIFIED" => std::option::Option::Some(Self::CHALLENGE_UNSPECIFIED),
-                "NOCAPTCHA" => std::option::Option::Some(Self::NOCAPTCHA),
-                "PASSED" => std::option::Option::Some(Self::PASSED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Challenge {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Challenge {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Challenge {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Challenge {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Nocaptcha,
+                2 => Self::Passed,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(challenge::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Challenge {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CHALLENGE_UNSPECIFIED" => Self::Unspecified,
+                "NOCAPTCHA" => Self::Nocaptcha,
+                "PASSED" => Self::Passed,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(challenge::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Challenge {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Nocaptcha => serializer.serialize_i32(1),
+                Self::Passed => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Challenge {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Challenge>::new(
+                ".google.cloud.recaptchaenterprise.v1.RiskAnalysis.Challenge",
+            ))
         }
     }
 }
@@ -2659,82 +3160,149 @@ pub mod token_properties {
     use super::*;
 
     /// Enum that represents the types of invalid token reasons.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InvalidReason(i32);
-
-    impl InvalidReason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InvalidReason {
         /// Default unspecified type.
-        pub const INVALID_REASON_UNSPECIFIED: InvalidReason = InvalidReason::new(0);
-
+        Unspecified,
         /// If the failure reason was not accounted for.
-        pub const UNKNOWN_INVALID_REASON: InvalidReason = InvalidReason::new(1);
-
+        UnknownInvalidReason,
         /// The provided user verification token was malformed.
-        pub const MALFORMED: InvalidReason = InvalidReason::new(2);
-
+        Malformed,
         /// The user verification token had expired.
-        pub const EXPIRED: InvalidReason = InvalidReason::new(3);
-
+        Expired,
         /// The user verification had already been seen.
-        pub const DUPE: InvalidReason = InvalidReason::new(4);
-
+        Dupe,
         /// The user verification token was not present.
-        pub const MISSING: InvalidReason = InvalidReason::new(5);
-
+        Missing,
         /// A retriable error (such as network failure) occurred on the browser.
         /// Could easily be simulated by an attacker.
-        pub const BROWSER_ERROR: InvalidReason = InvalidReason::new(6);
+        BrowserError,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InvalidReason::value] or
+        /// [InvalidReason::name].
+        UnknownValue(invalid_reason::UnknownValue),
+    }
 
-        /// Creates a new InvalidReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod invalid_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl InvalidReason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UnknownInvalidReason => std::option::Option::Some(1),
+                Self::Malformed => std::option::Option::Some(2),
+                Self::Expired => std::option::Option::Some(3),
+                Self::Dupe => std::option::Option::Some(4),
+                Self::Missing => std::option::Option::Some(5),
+                Self::BrowserError => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INVALID_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN_INVALID_REASON"),
-                2 => std::borrow::Cow::Borrowed("MALFORMED"),
-                3 => std::borrow::Cow::Borrowed("EXPIRED"),
-                4 => std::borrow::Cow::Borrowed("DUPE"),
-                5 => std::borrow::Cow::Borrowed("MISSING"),
-                6 => std::borrow::Cow::Borrowed("BROWSER_ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INVALID_REASON_UNSPECIFIED"),
+                Self::UnknownInvalidReason => std::option::Option::Some("UNKNOWN_INVALID_REASON"),
+                Self::Malformed => std::option::Option::Some("MALFORMED"),
+                Self::Expired => std::option::Option::Some("EXPIRED"),
+                Self::Dupe => std::option::Option::Some("DUPE"),
+                Self::Missing => std::option::Option::Some("MISSING"),
+                Self::BrowserError => std::option::Option::Some("BROWSER_ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INVALID_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INVALID_REASON_UNSPECIFIED)
-                }
-                "UNKNOWN_INVALID_REASON" => std::option::Option::Some(Self::UNKNOWN_INVALID_REASON),
-                "MALFORMED" => std::option::Option::Some(Self::MALFORMED),
-                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
-                "DUPE" => std::option::Option::Some(Self::DUPE),
-                "MISSING" => std::option::Option::Some(Self::MISSING),
-                "BROWSER_ERROR" => std::option::Option::Some(Self::BROWSER_ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InvalidReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InvalidReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InvalidReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InvalidReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UnknownInvalidReason,
+                2 => Self::Malformed,
+                3 => Self::Expired,
+                4 => Self::Dupe,
+                5 => Self::Missing,
+                6 => Self::BrowserError,
+                _ => Self::UnknownValue(invalid_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InvalidReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INVALID_REASON_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN_INVALID_REASON" => Self::UnknownInvalidReason,
+                "MALFORMED" => Self::Malformed,
+                "EXPIRED" => Self::Expired,
+                "DUPE" => Self::Dupe,
+                "MISSING" => Self::Missing,
+                "BROWSER_ERROR" => Self::BrowserError,
+                _ => Self::UnknownValue(invalid_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InvalidReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UnknownInvalidReason => serializer.serialize_i32(1),
+                Self::Malformed => serializer.serialize_i32(2),
+                Self::Expired => serializer.serialize_i32(3),
+                Self::Dupe => serializer.serialize_i32(4),
+                Self::Missing => serializer.serialize_i32(5),
+                Self::BrowserError => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InvalidReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InvalidReason>::new(
+                ".google.cloud.recaptchaenterprise.v1.TokenProperties.InvalidReason",
+            ))
         }
     }
 }
@@ -3088,68 +3656,132 @@ pub mod fraud_signals {
 
         /// Risk labels describing the card being assessed, such as its funding
         /// mechanism.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct CardLabel(i32);
-
-        impl CardLabel {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum CardLabel {
             /// No label specified.
-            pub const CARD_LABEL_UNSPECIFIED: CardLabel = CardLabel::new(0);
-
+            Unspecified,
             /// This card has been detected as prepaid.
-            pub const PREPAID: CardLabel = CardLabel::new(1);
-
+            Prepaid,
             /// This card has been detected as virtual, such as a card number generated
             /// for a single transaction or merchant.
-            pub const VIRTUAL: CardLabel = CardLabel::new(2);
-
+            Virtual,
             /// This card has been detected as being used in an unexpected geographic
             /// location.
-            pub const UNEXPECTED_LOCATION: CardLabel = CardLabel::new(3);
+            UnexpectedLocation,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [CardLabel::value] or
+            /// [CardLabel::name].
+            UnknownValue(card_label::UnknownValue),
+        }
 
-            /// Creates a new CardLabel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod card_label {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl CardLabel {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Prepaid => std::option::Option::Some(1),
+                    Self::Virtual => std::option::Option::Some(2),
+                    Self::UnexpectedLocation => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CARD_LABEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PREPAID"),
-                    2 => std::borrow::Cow::Borrowed("VIRTUAL"),
-                    3 => std::borrow::Cow::Borrowed("UNEXPECTED_LOCATION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CARD_LABEL_UNSPECIFIED"),
+                    Self::Prepaid => std::option::Option::Some("PREPAID"),
+                    Self::Virtual => std::option::Option::Some("VIRTUAL"),
+                    Self::UnexpectedLocation => std::option::Option::Some("UNEXPECTED_LOCATION"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CARD_LABEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CARD_LABEL_UNSPECIFIED)
-                    }
-                    "PREPAID" => std::option::Option::Some(Self::PREPAID),
-                    "VIRTUAL" => std::option::Option::Some(Self::VIRTUAL),
-                    "UNEXPECTED_LOCATION" => std::option::Option::Some(Self::UNEXPECTED_LOCATION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for CardLabel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for CardLabel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for CardLabel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for CardLabel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Prepaid,
+                    2 => Self::Virtual,
+                    3 => Self::UnexpectedLocation,
+                    _ => Self::UnknownValue(card_label::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for CardLabel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CARD_LABEL_UNSPECIFIED" => Self::Unspecified,
+                    "PREPAID" => Self::Prepaid,
+                    "VIRTUAL" => Self::Virtual,
+                    "UNEXPECTED_LOCATION" => Self::UnexpectedLocation,
+                    _ => Self::UnknownValue(card_label::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for CardLabel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Prepaid => serializer.serialize_i32(1),
+                    Self::Virtual => serializer.serialize_i32(2),
+                    Self::UnexpectedLocation => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for CardLabel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<CardLabel>::new(
+                    ".google.cloud.recaptchaenterprise.v1.FraudSignals.CardSignals.CardLabel",
+                ))
             }
         }
     }
@@ -3209,57 +3841,113 @@ pub mod sms_toll_fraud_verdict {
     use super::*;
 
     /// Reasons contributing to the SMS toll fraud verdict.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SmsTollFraudReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SmsTollFraudReason {
+        /// Default unspecified reason
+        Unspecified,
+        /// The provided phone number was invalid
+        InvalidPhoneNumber,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SmsTollFraudReason::value] or
+        /// [SmsTollFraudReason::name].
+        UnknownValue(sms_toll_fraud_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sms_toll_fraud_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SmsTollFraudReason {
-        /// Default unspecified reason
-        pub const SMS_TOLL_FRAUD_REASON_UNSPECIFIED: SmsTollFraudReason =
-            SmsTollFraudReason::new(0);
-
-        /// The provided phone number was invalid
-        pub const INVALID_PHONE_NUMBER: SmsTollFraudReason = SmsTollFraudReason::new(1);
-
-        /// Creates a new SmsTollFraudReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InvalidPhoneNumber => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SMS_TOLL_FRAUD_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INVALID_PHONE_NUMBER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SMS_TOLL_FRAUD_REASON_UNSPECIFIED"),
+                Self::InvalidPhoneNumber => std::option::Option::Some("INVALID_PHONE_NUMBER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SMS_TOLL_FRAUD_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SMS_TOLL_FRAUD_REASON_UNSPECIFIED)
-                }
-                "INVALID_PHONE_NUMBER" => std::option::Option::Some(Self::INVALID_PHONE_NUMBER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SmsTollFraudReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SmsTollFraudReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SmsTollFraudReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SmsTollFraudReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InvalidPhoneNumber,
+                _ => Self::UnknownValue(sms_toll_fraud_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SmsTollFraudReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SMS_TOLL_FRAUD_REASON_UNSPECIFIED" => Self::Unspecified,
+                "INVALID_PHONE_NUMBER" => Self::InvalidPhoneNumber,
+                _ => Self::UnknownValue(sms_toll_fraud_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SmsTollFraudReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InvalidPhoneNumber => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SmsTollFraudReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SmsTollFraudReason>::new(
+                ".google.cloud.recaptchaenterprise.v1.SmsTollFraudVerdict.SmsTollFraudReason",
+            ))
         }
     }
 }
@@ -3344,82 +4032,145 @@ pub mod account_defender_assessment {
     use super::*;
 
     /// Labels returned by account defender for this request.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AccountDefenderLabel(i32);
-
-    impl AccountDefenderLabel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AccountDefenderLabel {
         /// Default unspecified type.
-        pub const ACCOUNT_DEFENDER_LABEL_UNSPECIFIED: AccountDefenderLabel =
-            AccountDefenderLabel::new(0);
-
+        Unspecified,
         /// The request matches a known good profile for the user.
-        pub const PROFILE_MATCH: AccountDefenderLabel = AccountDefenderLabel::new(1);
-
+        ProfileMatch,
         /// The request is potentially a suspicious login event and must be further
         /// verified either through multi-factor authentication or another system.
-        pub const SUSPICIOUS_LOGIN_ACTIVITY: AccountDefenderLabel = AccountDefenderLabel::new(2);
-
+        SuspiciousLoginActivity,
         /// The request matched a profile that previously had suspicious account
         /// creation behavior. This can mean that this is a fake account.
-        pub const SUSPICIOUS_ACCOUNT_CREATION: AccountDefenderLabel = AccountDefenderLabel::new(3);
-
+        SuspiciousAccountCreation,
         /// The account in the request has a high number of related accounts. It does
         /// not necessarily imply that the account is bad but can require further
         /// investigation.
-        pub const RELATED_ACCOUNTS_NUMBER_HIGH: AccountDefenderLabel = AccountDefenderLabel::new(4);
+        RelatedAccountsNumberHigh,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AccountDefenderLabel::value] or
+        /// [AccountDefenderLabel::name].
+        UnknownValue(account_defender_label::UnknownValue),
+    }
 
-        /// Creates a new AccountDefenderLabel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod account_defender_label {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AccountDefenderLabel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ProfileMatch => std::option::Option::Some(1),
+                Self::SuspiciousLoginActivity => std::option::Option::Some(2),
+                Self::SuspiciousAccountCreation => std::option::Option::Some(3),
+                Self::RelatedAccountsNumberHigh => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACCOUNT_DEFENDER_LABEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROFILE_MATCH"),
-                2 => std::borrow::Cow::Borrowed("SUSPICIOUS_LOGIN_ACTIVITY"),
-                3 => std::borrow::Cow::Borrowed("SUSPICIOUS_ACCOUNT_CREATION"),
-                4 => std::borrow::Cow::Borrowed("RELATED_ACCOUNTS_NUMBER_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("ACCOUNT_DEFENDER_LABEL_UNSPECIFIED")
+                }
+                Self::ProfileMatch => std::option::Option::Some("PROFILE_MATCH"),
+                Self::SuspiciousLoginActivity => {
+                    std::option::Option::Some("SUSPICIOUS_LOGIN_ACTIVITY")
+                }
+                Self::SuspiciousAccountCreation => {
+                    std::option::Option::Some("SUSPICIOUS_ACCOUNT_CREATION")
+                }
+                Self::RelatedAccountsNumberHigh => {
+                    std::option::Option::Some("RELATED_ACCOUNTS_NUMBER_HIGH")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACCOUNT_DEFENDER_LABEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACCOUNT_DEFENDER_LABEL_UNSPECIFIED)
-                }
-                "PROFILE_MATCH" => std::option::Option::Some(Self::PROFILE_MATCH),
-                "SUSPICIOUS_LOGIN_ACTIVITY" => {
-                    std::option::Option::Some(Self::SUSPICIOUS_LOGIN_ACTIVITY)
-                }
-                "SUSPICIOUS_ACCOUNT_CREATION" => {
-                    std::option::Option::Some(Self::SUSPICIOUS_ACCOUNT_CREATION)
-                }
-                "RELATED_ACCOUNTS_NUMBER_HIGH" => {
-                    std::option::Option::Some(Self::RELATED_ACCOUNTS_NUMBER_HIGH)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AccountDefenderLabel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AccountDefenderLabel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AccountDefenderLabel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AccountDefenderLabel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ProfileMatch,
+                2 => Self::SuspiciousLoginActivity,
+                3 => Self::SuspiciousAccountCreation,
+                4 => Self::RelatedAccountsNumberHigh,
+                _ => Self::UnknownValue(account_defender_label::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AccountDefenderLabel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACCOUNT_DEFENDER_LABEL_UNSPECIFIED" => Self::Unspecified,
+                "PROFILE_MATCH" => Self::ProfileMatch,
+                "SUSPICIOUS_LOGIN_ACTIVITY" => Self::SuspiciousLoginActivity,
+                "SUSPICIOUS_ACCOUNT_CREATION" => Self::SuspiciousAccountCreation,
+                "RELATED_ACCOUNTS_NUMBER_HIGH" => Self::RelatedAccountsNumberHigh,
+                _ => Self::UnknownValue(account_defender_label::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AccountDefenderLabel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ProfileMatch => serializer.serialize_i32(1),
+                Self::SuspiciousLoginActivity => serializer.serialize_i32(2),
+                Self::SuspiciousAccountCreation => serializer.serialize_i32(3),
+                Self::RelatedAccountsNumberHigh => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AccountDefenderLabel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AccountDefenderLabel>::new(
+                ".google.cloud.recaptchaenterprise.v1.AccountDefenderAssessment.AccountDefenderLabel"))
         }
     }
 }
@@ -4609,64 +5360,123 @@ pub mod testing_options {
 
     /// Enum that represents the challenge option for challenge-based (CHECKBOX,
     /// INVISIBLE) testing keys.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TestingChallenge(i32);
-
-    impl TestingChallenge {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TestingChallenge {
         /// Perform the normal risk analysis and return either nocaptcha or a
         /// challenge depending on risk and trust factors.
-        pub const TESTING_CHALLENGE_UNSPECIFIED: TestingChallenge = TestingChallenge::new(0);
-
+        Unspecified,
         /// Challenge requests for this key always return a nocaptcha, which
         /// does not require a solution.
-        pub const NOCAPTCHA: TestingChallenge = TestingChallenge::new(1);
-
+        Nocaptcha,
         /// Challenge requests for this key always return an unsolvable
         /// challenge.
-        pub const UNSOLVABLE_CHALLENGE: TestingChallenge = TestingChallenge::new(2);
+        UnsolvableChallenge,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TestingChallenge::value] or
+        /// [TestingChallenge::name].
+        UnknownValue(testing_challenge::UnknownValue),
+    }
 
-        /// Creates a new TestingChallenge instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod testing_challenge {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TestingChallenge {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Nocaptcha => std::option::Option::Some(1),
+                Self::UnsolvableChallenge => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TESTING_CHALLENGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOCAPTCHA"),
-                2 => std::borrow::Cow::Borrowed("UNSOLVABLE_CHALLENGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TESTING_CHALLENGE_UNSPECIFIED"),
+                Self::Nocaptcha => std::option::Option::Some("NOCAPTCHA"),
+                Self::UnsolvableChallenge => std::option::Option::Some("UNSOLVABLE_CHALLENGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TESTING_CHALLENGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TESTING_CHALLENGE_UNSPECIFIED)
-                }
-                "NOCAPTCHA" => std::option::Option::Some(Self::NOCAPTCHA),
-                "UNSOLVABLE_CHALLENGE" => std::option::Option::Some(Self::UNSOLVABLE_CHALLENGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TestingChallenge {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TestingChallenge {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TestingChallenge {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TestingChallenge {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Nocaptcha,
+                2 => Self::UnsolvableChallenge,
+                _ => Self::UnknownValue(testing_challenge::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TestingChallenge {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TESTING_CHALLENGE_UNSPECIFIED" => Self::Unspecified,
+                "NOCAPTCHA" => Self::Nocaptcha,
+                "UNSOLVABLE_CHALLENGE" => Self::UnsolvableChallenge,
+                _ => Self::UnknownValue(testing_challenge::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TestingChallenge {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Nocaptcha => serializer.serialize_i32(1),
+                Self::UnsolvableChallenge => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TestingChallenge {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TestingChallenge>::new(
+                ".google.cloud.recaptchaenterprise.v1.TestingOptions.TestingChallenge",
+            ))
         }
     }
 }
@@ -4768,137 +5578,259 @@ pub mod web_key_settings {
     use super::*;
 
     /// Enum that represents the integration types for web keys.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IntegrationType(i32);
-
-    impl IntegrationType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IntegrationType {
         /// Default type that indicates this enum hasn't been specified. This is not
         /// a valid IntegrationType, one of the other types must be specified
         /// instead.
-        pub const INTEGRATION_TYPE_UNSPECIFIED: IntegrationType = IntegrationType::new(0);
-
+        Unspecified,
         /// Only used to produce scores. It doesn't display the "I'm not a robot"
         /// checkbox and never shows captcha challenges.
-        pub const SCORE: IntegrationType = IntegrationType::new(1);
-
+        Score,
         /// Displays the "I'm not a robot" checkbox and may show captcha challenges
         /// after it is checked.
-        pub const CHECKBOX: IntegrationType = IntegrationType::new(2);
-
+        Checkbox,
         /// Doesn't display the "I'm not a robot" checkbox, but may show captcha
         /// challenges after risk analysis.
-        pub const INVISIBLE: IntegrationType = IntegrationType::new(3);
+        Invisible,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IntegrationType::value] or
+        /// [IntegrationType::name].
+        UnknownValue(integration_type::UnknownValue),
+    }
 
-        /// Creates a new IntegrationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod integration_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl IntegrationType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Score => std::option::Option::Some(1),
+                Self::Checkbox => std::option::Option::Some(2),
+                Self::Invisible => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INTEGRATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCORE"),
-                2 => std::borrow::Cow::Borrowed("CHECKBOX"),
-                3 => std::borrow::Cow::Borrowed("INVISIBLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INTEGRATION_TYPE_UNSPECIFIED"),
+                Self::Score => std::option::Option::Some("SCORE"),
+                Self::Checkbox => std::option::Option::Some("CHECKBOX"),
+                Self::Invisible => std::option::Option::Some("INVISIBLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INTEGRATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INTEGRATION_TYPE_UNSPECIFIED)
-                }
-                "SCORE" => std::option::Option::Some(Self::SCORE),
-                "CHECKBOX" => std::option::Option::Some(Self::CHECKBOX),
-                "INVISIBLE" => std::option::Option::Some(Self::INVISIBLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IntegrationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IntegrationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IntegrationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IntegrationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Score,
+                2 => Self::Checkbox,
+                3 => Self::Invisible,
+                _ => Self::UnknownValue(integration_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IntegrationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INTEGRATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SCORE" => Self::Score,
+                "CHECKBOX" => Self::Checkbox,
+                "INVISIBLE" => Self::Invisible,
+                _ => Self::UnknownValue(integration_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IntegrationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Score => serializer.serialize_i32(1),
+                Self::Checkbox => serializer.serialize_i32(2),
+                Self::Invisible => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IntegrationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IntegrationType>::new(
+                ".google.cloud.recaptchaenterprise.v1.WebKeySettings.IntegrationType",
+            ))
         }
     }
 
     /// Enum that represents the possible challenge frequency and difficulty
     /// configurations for a web key.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ChallengeSecurityPreference(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ChallengeSecurityPreference {
+        /// Default type that indicates this enum hasn't been specified.
+        Unspecified,
+        /// Key tends to show fewer and easier challenges.
+        Usability,
+        /// Key tends to show balanced (in amount and difficulty) challenges.
+        Balance,
+        /// Key tends to show more and harder challenges.
+        Security,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ChallengeSecurityPreference::value] or
+        /// [ChallengeSecurityPreference::name].
+        UnknownValue(challenge_security_preference::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod challenge_security_preference {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ChallengeSecurityPreference {
-        /// Default type that indicates this enum hasn't been specified.
-        pub const CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED: ChallengeSecurityPreference =
-            ChallengeSecurityPreference::new(0);
-
-        /// Key tends to show fewer and easier challenges.
-        pub const USABILITY: ChallengeSecurityPreference = ChallengeSecurityPreference::new(1);
-
-        /// Key tends to show balanced (in amount and difficulty) challenges.
-        pub const BALANCE: ChallengeSecurityPreference = ChallengeSecurityPreference::new(2);
-
-        /// Key tends to show more and harder challenges.
-        pub const SECURITY: ChallengeSecurityPreference = ChallengeSecurityPreference::new(3);
-
-        /// Creates a new ChallengeSecurityPreference instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Usability => std::option::Option::Some(1),
+                Self::Balance => std::option::Option::Some(2),
+                Self::Security => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USABILITY"),
-                2 => std::borrow::Cow::Borrowed("BALANCE"),
-                3 => std::borrow::Cow::Borrowed("SECURITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED")
                 }
-                "USABILITY" => std::option::Option::Some(Self::USABILITY),
-                "BALANCE" => std::option::Option::Some(Self::BALANCE),
-                "SECURITY" => std::option::Option::Some(Self::SECURITY),
-                _ => std::option::Option::None,
+                Self::Usability => std::option::Option::Some("USABILITY"),
+                Self::Balance => std::option::Option::Some("BALANCE"),
+                Self::Security => std::option::Option::Some("SECURITY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ChallengeSecurityPreference {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ChallengeSecurityPreference {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ChallengeSecurityPreference {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ChallengeSecurityPreference {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Usability,
+                2 => Self::Balance,
+                3 => Self::Security,
+                _ => Self::UnknownValue(challenge_security_preference::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ChallengeSecurityPreference {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED" => Self::Unspecified,
+                "USABILITY" => Self::Usability,
+                "BALANCE" => Self::Balance,
+                "SECURITY" => Self::Security,
+                _ => Self::UnknownValue(challenge_security_preference::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ChallengeSecurityPreference {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Usability => serializer.serialize_i32(1),
+                Self::Balance => serializer.serialize_i32(2),
+                Self::Security => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ChallengeSecurityPreference {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ChallengeSecurityPreference>::new(
+                ".google.cloud.recaptchaenterprise.v1.WebKeySettings.ChallengeSecurityPreference"))
         }
     }
 }
@@ -6672,142 +7604,268 @@ pub mod waf_settings {
 
     /// Supported WAF features. For more information, see
     /// <https://cloud.google.com/recaptcha/docs/usecase#comparison_of_features>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WafFeature(i32);
-
-    impl WafFeature {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WafFeature {
         /// Undefined feature.
-        pub const WAF_FEATURE_UNSPECIFIED: WafFeature = WafFeature::new(0);
-
+        Unspecified,
         /// Redirects suspicious traffic to reCAPTCHA.
-        pub const CHALLENGE_PAGE: WafFeature = WafFeature::new(1);
-
+        ChallengePage,
         /// Use reCAPTCHA session-tokens to protect the whole user session on the
         /// site's domain.
-        pub const SESSION_TOKEN: WafFeature = WafFeature::new(2);
-
+        SessionToken,
         /// Use reCAPTCHA action-tokens to protect user actions.
-        pub const ACTION_TOKEN: WafFeature = WafFeature::new(3);
-
+        ActionToken,
         /// Use reCAPTCHA WAF express protection to protect any content other than
         /// web pages, like APIs and IoT devices.
-        pub const EXPRESS: WafFeature = WafFeature::new(5);
+        Express,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WafFeature::value] or
+        /// [WafFeature::name].
+        UnknownValue(waf_feature::UnknownValue),
+    }
 
-        /// Creates a new WafFeature instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod waf_feature {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl WafFeature {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ChallengePage => std::option::Option::Some(1),
+                Self::SessionToken => std::option::Option::Some(2),
+                Self::ActionToken => std::option::Option::Some(3),
+                Self::Express => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WAF_FEATURE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CHALLENGE_PAGE"),
-                2 => std::borrow::Cow::Borrowed("SESSION_TOKEN"),
-                3 => std::borrow::Cow::Borrowed("ACTION_TOKEN"),
-                5 => std::borrow::Cow::Borrowed("EXPRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WAF_FEATURE_UNSPECIFIED"),
+                Self::ChallengePage => std::option::Option::Some("CHALLENGE_PAGE"),
+                Self::SessionToken => std::option::Option::Some("SESSION_TOKEN"),
+                Self::ActionToken => std::option::Option::Some("ACTION_TOKEN"),
+                Self::Express => std::option::Option::Some("EXPRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WAF_FEATURE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WAF_FEATURE_UNSPECIFIED)
-                }
-                "CHALLENGE_PAGE" => std::option::Option::Some(Self::CHALLENGE_PAGE),
-                "SESSION_TOKEN" => std::option::Option::Some(Self::SESSION_TOKEN),
-                "ACTION_TOKEN" => std::option::Option::Some(Self::ACTION_TOKEN),
-                "EXPRESS" => std::option::Option::Some(Self::EXPRESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WafFeature {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WafFeature {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WafFeature {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WafFeature {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ChallengePage,
+                2 => Self::SessionToken,
+                3 => Self::ActionToken,
+                5 => Self::Express,
+                _ => Self::UnknownValue(waf_feature::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WafFeature {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WAF_FEATURE_UNSPECIFIED" => Self::Unspecified,
+                "CHALLENGE_PAGE" => Self::ChallengePage,
+                "SESSION_TOKEN" => Self::SessionToken,
+                "ACTION_TOKEN" => Self::ActionToken,
+                "EXPRESS" => Self::Express,
+                _ => Self::UnknownValue(waf_feature::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WafFeature {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ChallengePage => serializer.serialize_i32(1),
+                Self::SessionToken => serializer.serialize_i32(2),
+                Self::ActionToken => serializer.serialize_i32(3),
+                Self::Express => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WafFeature {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WafFeature>::new(
+                ".google.cloud.recaptchaenterprise.v1.WafSettings.WafFeature",
+            ))
         }
     }
 
     /// Web Application Firewalls supported by reCAPTCHA.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WafService(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WafService {
+        /// Undefined WAF
+        Unspecified,
+        /// Cloud Armor
+        Ca,
+        /// Fastly
+        Fastly,
+        /// Cloudflare
+        Cloudflare,
+        /// Akamai
+        Akamai,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WafService::value] or
+        /// [WafService::name].
+        UnknownValue(waf_service::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod waf_service {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WafService {
-        /// Undefined WAF
-        pub const WAF_SERVICE_UNSPECIFIED: WafService = WafService::new(0);
-
-        /// Cloud Armor
-        pub const CA: WafService = WafService::new(1);
-
-        /// Fastly
-        pub const FASTLY: WafService = WafService::new(3);
-
-        /// Cloudflare
-        pub const CLOUDFLARE: WafService = WafService::new(4);
-
-        /// Akamai
-        pub const AKAMAI: WafService = WafService::new(5);
-
-        /// Creates a new WafService instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ca => std::option::Option::Some(1),
+                Self::Fastly => std::option::Option::Some(3),
+                Self::Cloudflare => std::option::Option::Some(4),
+                Self::Akamai => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WAF_SERVICE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CA"),
-                3 => std::borrow::Cow::Borrowed("FASTLY"),
-                4 => std::borrow::Cow::Borrowed("CLOUDFLARE"),
-                5 => std::borrow::Cow::Borrowed("AKAMAI"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WAF_SERVICE_UNSPECIFIED"),
+                Self::Ca => std::option::Option::Some("CA"),
+                Self::Fastly => std::option::Option::Some("FASTLY"),
+                Self::Cloudflare => std::option::Option::Some("CLOUDFLARE"),
+                Self::Akamai => std::option::Option::Some("AKAMAI"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WAF_SERVICE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WAF_SERVICE_UNSPECIFIED)
-                }
-                "CA" => std::option::Option::Some(Self::CA),
-                "FASTLY" => std::option::Option::Some(Self::FASTLY),
-                "CLOUDFLARE" => std::option::Option::Some(Self::CLOUDFLARE),
-                "AKAMAI" => std::option::Option::Some(Self::AKAMAI),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WafService {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WafService {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WafService {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WafService {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ca,
+                3 => Self::Fastly,
+                4 => Self::Cloudflare,
+                5 => Self::Akamai,
+                _ => Self::UnknownValue(waf_service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WafService {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WAF_SERVICE_UNSPECIFIED" => Self::Unspecified,
+                "CA" => Self::Ca,
+                "FASTLY" => Self::Fastly,
+                "CLOUDFLARE" => Self::Cloudflare,
+                "AKAMAI" => Self::Akamai,
+                _ => Self::UnknownValue(waf_service::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WafService {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ca => serializer.serialize_i32(1),
+                Self::Fastly => serializer.serialize_i32(3),
+                Self::Cloudflare => serializer.serialize_i32(4),
+                Self::Akamai => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WafService {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WafService>::new(
+                ".google.cloud.recaptchaenterprise.v1.WafSettings.WafService",
+            ))
         }
     }
 }
@@ -6920,57 +7978,114 @@ pub mod ip_override_data {
     use super::*;
 
     /// Enum that represents the type of IP override.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OverrideType(i32);
-
-    impl OverrideType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OverrideType {
         /// Default override type that indicates this enum hasn't been specified.
-        pub const OVERRIDE_TYPE_UNSPECIFIED: OverrideType = OverrideType::new(0);
-
+        Unspecified,
         /// Allowlist the IP address; i.e. give a `risk_analysis.score` of 0.9 for
         /// all valid assessments.
-        pub const ALLOW: OverrideType = OverrideType::new(1);
+        Allow,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OverrideType::value] or
+        /// [OverrideType::name].
+        UnknownValue(override_type::UnknownValue),
+    }
 
-        /// Creates a new OverrideType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod override_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OverrideType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OVERRIDE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OVERRIDE_TYPE_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OVERRIDE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OVERRIDE_TYPE_UNSPECIFIED)
-                }
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OverrideType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OverrideType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OverrideType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OverrideType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                _ => Self::UnknownValue(override_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OverrideType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OVERRIDE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                _ => Self::UnknownValue(override_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OverrideType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OverrideType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OverrideType>::new(
+                ".google.cloud.recaptchaenterprise.v1.IpOverrideData.OverrideType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -249,146 +249,280 @@ pub mod insight {
     }
 
     /// Insight category.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Category {
+        /// Unspecified category.
+        Unspecified,
+        /// The insight is related to cost.
+        Cost,
+        /// The insight is related to security.
+        Security,
+        /// The insight is related to performance.
+        Performance,
+        /// This insight is related to manageability.
+        Manageability,
+        /// The insight is related to sustainability.
+        Sustainability,
+        /// This insight is related to reliability.
+        Reliability,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Category::value] or
+        /// [Category::name].
+        UnknownValue(category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Category {
-        /// Unspecified category.
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
-
-        /// The insight is related to cost.
-        pub const COST: Category = Category::new(1);
-
-        /// The insight is related to security.
-        pub const SECURITY: Category = Category::new(2);
-
-        /// The insight is related to performance.
-        pub const PERFORMANCE: Category = Category::new(3);
-
-        /// This insight is related to manageability.
-        pub const MANAGEABILITY: Category = Category::new(4);
-
-        /// The insight is related to sustainability.
-        pub const SUSTAINABILITY: Category = Category::new(5);
-
-        /// This insight is related to reliability.
-        pub const RELIABILITY: Category = Category::new(6);
-
-        /// Creates a new Category instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Cost => std::option::Option::Some(1),
+                Self::Security => std::option::Option::Some(2),
+                Self::Performance => std::option::Option::Some(3),
+                Self::Manageability => std::option::Option::Some(4),
+                Self::Sustainability => std::option::Option::Some(5),
+                Self::Reliability => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COST"),
-                2 => std::borrow::Cow::Borrowed("SECURITY"),
-                3 => std::borrow::Cow::Borrowed("PERFORMANCE"),
-                4 => std::borrow::Cow::Borrowed("MANAGEABILITY"),
-                5 => std::borrow::Cow::Borrowed("SUSTAINABILITY"),
-                6 => std::borrow::Cow::Borrowed("RELIABILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CATEGORY_UNSPECIFIED"),
+                Self::Cost => std::option::Option::Some("COST"),
+                Self::Security => std::option::Option::Some("SECURITY"),
+                Self::Performance => std::option::Option::Some("PERFORMANCE"),
+                Self::Manageability => std::option::Option::Some("MANAGEABILITY"),
+                Self::Sustainability => std::option::Option::Some("SUSTAINABILITY"),
+                Self::Reliability => std::option::Option::Some("RELIABILITY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
-                "COST" => std::option::Option::Some(Self::COST),
-                "SECURITY" => std::option::Option::Some(Self::SECURITY),
-                "PERFORMANCE" => std::option::Option::Some(Self::PERFORMANCE),
-                "MANAGEABILITY" => std::option::Option::Some(Self::MANAGEABILITY),
-                "SUSTAINABILITY" => std::option::Option::Some(Self::SUSTAINABILITY),
-                "RELIABILITY" => std::option::Option::Some(Self::RELIABILITY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Category {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Category {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Cost,
+                2 => Self::Security,
+                3 => Self::Performance,
+                4 => Self::Manageability,
+                5 => Self::Sustainability,
+                6 => Self::Reliability,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Category {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "COST" => Self::Cost,
+                "SECURITY" => Self::Security,
+                "PERFORMANCE" => Self::Performance,
+                "MANAGEABILITY" => Self::Manageability,
+                "SUSTAINABILITY" => Self::Sustainability,
+                "RELIABILITY" => Self::Reliability,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Category {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Cost => serializer.serialize_i32(1),
+                Self::Security => serializer.serialize_i32(2),
+                Self::Performance => serializer.serialize_i32(3),
+                Self::Manageability => serializer.serialize_i32(4),
+                Self::Sustainability => serializer.serialize_i32(5),
+                Self::Reliability => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Category {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Category>::new(
+                ".google.cloud.recommender.v1.Insight.Category",
+            ))
         }
     }
 
     /// Insight severity levels.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Insight has unspecified severity.
+        Unspecified,
+        /// Insight has low severity.
+        Low,
+        /// Insight has medium severity.
+        Medium,
+        /// Insight has high severity.
+        High,
+        /// Insight has critical severity.
+        Critical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Insight has unspecified severity.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// Insight has low severity.
-        pub const LOW: Severity = Severity::new(1);
-
-        /// Insight has medium severity.
-        pub const MEDIUM: Severity = Severity::new(2);
-
-        /// Insight has high severity.
-        pub const HIGH: Severity = Severity::new(3);
-
-        /// Insight has critical severity.
-        pub const CRITICAL: Severity = Severity::new(4);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::Medium => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::Critical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOW"),
-                2 => std::borrow::Cow::Borrowed("MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("HIGH"),
-                4 => std::borrow::Cow::Borrowed("CRITICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::Medium,
+                3 => Self::High,
+                4 => Self::Critical,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                "CRITICAL" => Self::Critical,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::Medium => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::Critical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.recommender.v1.Insight.Severity",
+            ))
         }
     }
 }
@@ -449,70 +583,133 @@ pub mod insight_state_info {
     use super::*;
 
     /// Represents insight state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Insight is active. Content for ACTIVE insights can be updated by Google.
         /// ACTIVE insights can be marked DISMISSED OR ACCEPTED.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Some action has been taken based on this insight. Insights become
         /// accepted when a recommendation derived from the insight has been marked
         /// CLAIMED, SUCCEEDED, or FAILED. ACTIVE insights can also be marked
         /// ACCEPTED explicitly. Content for ACCEPTED insights is immutable. ACCEPTED
         /// insights can only be marked ACCEPTED (which may update state metadata).
-        pub const ACCEPTED: State = State::new(2);
-
+        Accepted,
         /// Insight is dismissed. Content for DISMISSED insights can be updated by
         /// Google. DISMISSED insights can be marked as ACTIVE.
-        pub const DISMISSED: State = State::new(3);
+        Dismissed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Accepted => std::option::Option::Some(2),
+                Self::Dismissed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("ACCEPTED"),
-                3 => std::borrow::Cow::Borrowed("DISMISSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Accepted => std::option::Option::Some("ACCEPTED"),
+                Self::Dismissed => std::option::Option::Some("DISMISSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "ACCEPTED" => std::option::Option::Some(Self::ACCEPTED),
-                "DISMISSED" => std::option::Option::Some(Self::DISMISSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Accepted,
+                3 => Self::Dismissed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "ACCEPTED" => Self::Accepted,
+                "DISMISSED" => Self::Dismissed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Accepted => serializer.serialize_i32(2),
+                Self::Dismissed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.recommender.v1.InsightStateInfo.State",
+            ))
         }
     }
 }
@@ -906,69 +1103,134 @@ pub mod recommendation {
     }
 
     /// Recommendation priority levels.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Priority {
+        /// Recommendation has unspecified priority.
+        Unspecified,
+        /// Recommendation has P4 priority (lowest priority).
+        P4,
+        /// Recommendation has P3 priority (second lowest priority).
+        P3,
+        /// Recommendation has P2 priority (second highest priority).
+        P2,
+        /// Recommendation has P1 priority (highest priority).
+        P1,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Priority::value] or
+        /// [Priority::name].
+        UnknownValue(priority::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod priority {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Priority {
-        /// Recommendation has unspecified priority.
-        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
-
-        /// Recommendation has P4 priority (lowest priority).
-        pub const P4: Priority = Priority::new(1);
-
-        /// Recommendation has P3 priority (second lowest priority).
-        pub const P3: Priority = Priority::new(2);
-
-        /// Recommendation has P2 priority (second highest priority).
-        pub const P2: Priority = Priority::new(3);
-
-        /// Recommendation has P1 priority (highest priority).
-        pub const P1: Priority = Priority::new(4);
-
-        /// Creates a new Priority instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::P4 => std::option::Option::Some(1),
+                Self::P3 => std::option::Option::Some(2),
+                Self::P2 => std::option::Option::Some(3),
+                Self::P1 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("P4"),
-                2 => std::borrow::Cow::Borrowed("P3"),
-                3 => std::borrow::Cow::Borrowed("P2"),
-                4 => std::borrow::Cow::Borrowed("P1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIORITY_UNSPECIFIED"),
+                Self::P4 => std::option::Option::Some("P4"),
+                Self::P3 => std::option::Option::Some("P3"),
+                Self::P2 => std::option::Option::Some("P2"),
+                Self::P1 => std::option::Option::Some("P1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
-                "P4" => std::option::Option::Some(Self::P4),
-                "P3" => std::option::Option::Some(Self::P3),
-                "P2" => std::option::Option::Some(Self::P2),
-                "P1" => std::option::Option::Some(Self::P1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Priority {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Priority {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::P4,
+                2 => Self::P3,
+                3 => Self::P2,
+                4 => Self::P1,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Priority {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIORITY_UNSPECIFIED" => Self::Unspecified,
+                "P4" => Self::P4,
+                "P3" => Self::P3,
+                "P2" => Self::P2,
+                "P1" => Self::P1,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Priority {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::P4 => serializer.serialize_i32(1),
+                Self::P3 => serializer.serialize_i32(2),
+                Self::P2 => serializer.serialize_i32(3),
+                Self::P1 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Priority {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Priority>::new(
+                ".google.cloud.recommender.v1.Recommendation.Priority",
+            ))
         }
     }
 }
@@ -1611,65 +1873,128 @@ pub mod reliability_projection {
     use super::*;
 
     /// The risk associated with the reliability issue.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RiskType(i32);
-
-    impl RiskType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RiskType {
         /// Default unspecified risk. Don't use directly.
-        pub const RISK_TYPE_UNSPECIFIED: RiskType = RiskType::new(0);
-
+        Unspecified,
         /// Potential service downtime.
-        pub const SERVICE_DISRUPTION: RiskType = RiskType::new(1);
-
+        ServiceDisruption,
         /// Potential data loss.
-        pub const DATA_LOSS: RiskType = RiskType::new(2);
-
+        DataLoss,
         /// Potential access denial. The service is still up but some or all clients
         /// can't access it.
-        pub const ACCESS_DENY: RiskType = RiskType::new(3);
+        AccessDeny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RiskType::value] or
+        /// [RiskType::name].
+        UnknownValue(risk_type::UnknownValue),
+    }
 
-        /// Creates a new RiskType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod risk_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RiskType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ServiceDisruption => std::option::Option::Some(1),
+                Self::DataLoss => std::option::Option::Some(2),
+                Self::AccessDeny => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RISK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVICE_DISRUPTION"),
-                2 => std::borrow::Cow::Borrowed("DATA_LOSS"),
-                3 => std::borrow::Cow::Borrowed("ACCESS_DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RISK_TYPE_UNSPECIFIED"),
+                Self::ServiceDisruption => std::option::Option::Some("SERVICE_DISRUPTION"),
+                Self::DataLoss => std::option::Option::Some("DATA_LOSS"),
+                Self::AccessDeny => std::option::Option::Some("ACCESS_DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RISK_TYPE_UNSPECIFIED),
-                "SERVICE_DISRUPTION" => std::option::Option::Some(Self::SERVICE_DISRUPTION),
-                "DATA_LOSS" => std::option::Option::Some(Self::DATA_LOSS),
-                "ACCESS_DENY" => std::option::Option::Some(Self::ACCESS_DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RiskType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RiskType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RiskType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RiskType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ServiceDisruption,
+                2 => Self::DataLoss,
+                3 => Self::AccessDeny,
+                _ => Self::UnknownValue(risk_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RiskType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SERVICE_DISRUPTION" => Self::ServiceDisruption,
+                "DATA_LOSS" => Self::DataLoss,
+                "ACCESS_DENY" => Self::AccessDeny,
+                _ => Self::UnknownValue(risk_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RiskType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ServiceDisruption => serializer.serialize_i32(1),
+                Self::DataLoss => serializer.serialize_i32(2),
+                Self::AccessDeny => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RiskType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RiskType>::new(
+                ".google.cloud.recommender.v1.ReliabilityProjection.RiskType",
+            ))
         }
     }
 }
@@ -1855,79 +2180,148 @@ pub mod impact {
     use super::*;
 
     /// The category of the impact.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Category(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Category {
+        /// Default unspecified category. Don't use directly.
+        Unspecified,
+        /// Indicates a potential increase or decrease in cost.
+        Cost,
+        /// Indicates a potential increase or decrease in security.
+        Security,
+        /// Indicates a potential increase or decrease in performance.
+        Performance,
+        /// Indicates a potential increase or decrease in manageability.
+        Manageability,
+        /// Indicates a potential increase or decrease in sustainability.
+        Sustainability,
+        /// Indicates a potential increase or decrease in reliability.
+        Reliability,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Category::value] or
+        /// [Category::name].
+        UnknownValue(category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Category {
-        /// Default unspecified category. Don't use directly.
-        pub const CATEGORY_UNSPECIFIED: Category = Category::new(0);
-
-        /// Indicates a potential increase or decrease in cost.
-        pub const COST: Category = Category::new(1);
-
-        /// Indicates a potential increase or decrease in security.
-        pub const SECURITY: Category = Category::new(2);
-
-        /// Indicates a potential increase or decrease in performance.
-        pub const PERFORMANCE: Category = Category::new(3);
-
-        /// Indicates a potential increase or decrease in manageability.
-        pub const MANAGEABILITY: Category = Category::new(4);
-
-        /// Indicates a potential increase or decrease in sustainability.
-        pub const SUSTAINABILITY: Category = Category::new(5);
-
-        /// Indicates a potential increase or decrease in reliability.
-        pub const RELIABILITY: Category = Category::new(6);
-
-        /// Creates a new Category instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Cost => std::option::Option::Some(1),
+                Self::Security => std::option::Option::Some(2),
+                Self::Performance => std::option::Option::Some(3),
+                Self::Manageability => std::option::Option::Some(4),
+                Self::Sustainability => std::option::Option::Some(5),
+                Self::Reliability => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COST"),
-                2 => std::borrow::Cow::Borrowed("SECURITY"),
-                3 => std::borrow::Cow::Borrowed("PERFORMANCE"),
-                4 => std::borrow::Cow::Borrowed("MANAGEABILITY"),
-                5 => std::borrow::Cow::Borrowed("SUSTAINABILITY"),
-                6 => std::borrow::Cow::Borrowed("RELIABILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CATEGORY_UNSPECIFIED"),
+                Self::Cost => std::option::Option::Some("COST"),
+                Self::Security => std::option::Option::Some("SECURITY"),
+                Self::Performance => std::option::Option::Some("PERFORMANCE"),
+                Self::Manageability => std::option::Option::Some("MANAGEABILITY"),
+                Self::Sustainability => std::option::Option::Some("SUSTAINABILITY"),
+                Self::Reliability => std::option::Option::Some("RELIABILITY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::CATEGORY_UNSPECIFIED),
-                "COST" => std::option::Option::Some(Self::COST),
-                "SECURITY" => std::option::Option::Some(Self::SECURITY),
-                "PERFORMANCE" => std::option::Option::Some(Self::PERFORMANCE),
-                "MANAGEABILITY" => std::option::Option::Some(Self::MANAGEABILITY),
-                "SUSTAINABILITY" => std::option::Option::Some(Self::SUSTAINABILITY),
-                "RELIABILITY" => std::option::Option::Some(Self::RELIABILITY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Category {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Category {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Category {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Category {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Cost,
+                2 => Self::Security,
+                3 => Self::Performance,
+                4 => Self::Manageability,
+                5 => Self::Sustainability,
+                6 => Self::Reliability,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Category {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "COST" => Self::Cost,
+                "SECURITY" => Self::Security,
+                "PERFORMANCE" => Self::Performance,
+                "MANAGEABILITY" => Self::Manageability,
+                "SUSTAINABILITY" => Self::Sustainability,
+                "RELIABILITY" => Self::Reliability,
+                _ => Self::UnknownValue(category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Category {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Cost => serializer.serialize_i32(1),
+                Self::Security => serializer.serialize_i32(2),
+                Self::Performance => serializer.serialize_i32(3),
+                Self::Manageability => serializer.serialize_i32(4),
+                Self::Sustainability => serializer.serialize_i32(5),
+                Self::Reliability => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Category {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Category>::new(
+                ".google.cloud.recommender.v1.Impact.Category",
+            ))
         }
     }
 
@@ -2003,89 +2397,156 @@ pub mod recommendation_state_info {
     use super::*;
 
     /// Represents Recommendation State.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default state. Don't use directly.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Recommendation is active and can be applied. Recommendations content can
         /// be updated by Google.
         ///
         /// ACTIVE recommendations can be marked as CLAIMED, SUCCEEDED, or FAILED.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Recommendation is in claimed state. Recommendations content is
         /// immutable and cannot be updated by Google.
         ///
         /// CLAIMED recommendations can be marked as CLAIMED, SUCCEEDED, or FAILED.
-        pub const CLAIMED: State = State::new(6);
-
+        Claimed,
         /// Recommendation is in succeeded state. Recommendations content is
         /// immutable and cannot be updated by Google.
         ///
         /// SUCCEEDED recommendations can be marked as SUCCEEDED, or FAILED.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// Recommendation is in failed state. Recommendations content is immutable
         /// and cannot be updated by Google.
         ///
         /// FAILED recommendations can be marked as SUCCEEDED, or FAILED.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// Recommendation is in dismissed state. Recommendation content can be
         /// updated by Google.
         ///
         /// DISMISSED recommendations can be marked as ACTIVE.
-        pub const DISMISSED: State = State::new(5);
+        Dismissed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Claimed => std::option::Option::Some(6),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Dismissed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("DISMISSED"),
-                6 => std::borrow::Cow::Borrowed("CLAIMED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Claimed => std::option::Option::Some("CLAIMED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Dismissed => std::option::Option::Some("DISMISSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CLAIMED" => std::option::Option::Some(Self::CLAIMED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DISMISSED" => std::option::Option::Some(Self::DISMISSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Dismissed,
+                6 => Self::Claimed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CLAIMED" => Self::Claimed,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "DISMISSED" => Self::Dismissed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Claimed => serializer.serialize_i32(6),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Dismissed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.recommender.v1.RecommendationStateInfo.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -1701,69 +1701,134 @@ pub mod cluster {
     }
 
     /// Represents the different states of a Redis cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not set.
+        Unspecified,
+        /// Redis cluster is being created.
+        Creating,
+        /// Redis cluster has been created and is fully usable.
+        Active,
+        /// Redis cluster configuration is being updated.
+        Updating,
+        /// Redis cluster is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Redis cluster is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Redis cluster has been created and is fully usable.
-        pub const ACTIVE: State = State::new(2);
-
-        /// Redis cluster configuration is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// Redis cluster is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.redis.cluster.v1.Cluster.State",
+            ))
         }
     }
 
@@ -1933,62 +1998,120 @@ pub mod automated_backup_config {
     }
 
     /// The automated backup mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutomatedBackupMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AutomatedBackupMode {
+        /// Default value. Automated backup config is not specified.
+        Unspecified,
+        /// Automated backup config disabled.
+        Disabled,
+        /// Automated backup config enabled.
+        Enabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AutomatedBackupMode::value] or
+        /// [AutomatedBackupMode::name].
+        UnknownValue(automated_backup_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod automated_backup_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AutomatedBackupMode {
-        /// Default value. Automated backup config is not specified.
-        pub const AUTOMATED_BACKUP_MODE_UNSPECIFIED: AutomatedBackupMode =
-            AutomatedBackupMode::new(0);
-
-        /// Automated backup config disabled.
-        pub const DISABLED: AutomatedBackupMode = AutomatedBackupMode::new(1);
-
-        /// Automated backup config enabled.
-        pub const ENABLED: AutomatedBackupMode = AutomatedBackupMode::new(2);
-
-        /// Creates a new AutomatedBackupMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Enabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTOMATED_BACKUP_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTOMATED_BACKUP_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTOMATED_BACKUP_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTOMATED_BACKUP_MODE_UNSPECIFIED)
-                }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AutomatedBackupMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AutomatedBackupMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AutomatedBackupMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AutomatedBackupMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Enabled,
+                _ => Self::UnknownValue(automated_backup_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AutomatedBackupMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTOMATED_BACKUP_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "ENABLED" => Self::Enabled,
+                _ => Self::UnknownValue(automated_backup_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AutomatedBackupMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Enabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AutomatedBackupMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AutomatedBackupMode>::new(
+                ".google.cloud.redis.cluster.v1.AutomatedBackupConfig.AutomatedBackupMode",
+            ))
         }
     }
 
@@ -2277,129 +2400,253 @@ pub mod backup {
     use super::*;
 
     /// Type of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BackupType {
+        /// The default value, not set.
+        Unspecified,
+        /// On-demand backup.
+        OnDemand,
+        /// Automated backup.
+        Automated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BackupType::value] or
+        /// [BackupType::name].
+        UnknownValue(backup_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod backup_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BackupType {
-        /// The default value, not set.
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
-
-        /// On-demand backup.
-        pub const ON_DEMAND: BackupType = BackupType::new(1);
-
-        /// Automated backup.
-        pub const AUTOMATED: BackupType = BackupType::new(2);
-
-        /// Creates a new BackupType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OnDemand => std::option::Option::Some(1),
+                Self::Automated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BACKUP_TYPE_UNSPECIFIED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::Automated => std::option::Option::Some("AUTOMATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BACKUP_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED)
-                }
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BackupType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BackupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::OnDemand,
+                2 => Self::Automated,
+                _ => Self::UnknownValue(backup_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BackupType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BACKUP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ON_DEMAND" => Self::OnDemand,
+                "AUTOMATED" => Self::Automated,
+                _ => Self::UnknownValue(backup_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BackupType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OnDemand => serializer.serialize_i32(1),
+                Self::Automated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BackupType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupType>::new(
+                ".google.cloud.redis.cluster.v1.Backup.BackupType",
+            ))
         }
     }
 
     /// State of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value, not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The backup is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The backup is active to be used.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The backup is being deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// The backup is currently suspended due to reasons like project deletion,
         /// billing account closure, etc.
-        pub const SUSPENDED: State = State::new(4);
+        Suspended,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Suspended => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Suspended,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "SUSPENDED" => Self::Suspended,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Suspended => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.redis.cluster.v1.Backup.State",
+            ))
         }
     }
 }
@@ -2734,70 +2981,131 @@ pub mod cross_cluster_replication_config {
     }
 
     /// The role of the cluster in cross cluster replication.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterRole(i32);
-
-    impl ClusterRole {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ClusterRole {
         /// Cluster role is not set.
         /// The behavior is equivalent to NONE.
-        pub const CLUSTER_ROLE_UNSPECIFIED: ClusterRole = ClusterRole::new(0);
-
+        Unspecified,
         /// This cluster does not participate in cross cluster replication. It is an
         /// independent cluster and does not replicate to or from any other clusters.
-        pub const NONE: ClusterRole = ClusterRole::new(1);
-
+        None,
         /// A cluster that allows both reads and writes. Any data written to this
         /// cluster is also replicated to the attached secondary clusters.
-        pub const PRIMARY: ClusterRole = ClusterRole::new(2);
-
+        Primary,
         /// A cluster that allows only reads and replicates data from a primary
         /// cluster.
-        pub const SECONDARY: ClusterRole = ClusterRole::new(3);
+        Secondary,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ClusterRole::value] or
+        /// [ClusterRole::name].
+        UnknownValue(cluster_role::UnknownValue),
+    }
 
-        /// Creates a new ClusterRole instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cluster_role {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ClusterRole {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Primary => std::option::Option::Some(2),
+                Self::Secondary => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLUSTER_ROLE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("PRIMARY"),
-                3 => std::borrow::Cow::Borrowed("SECONDARY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CLUSTER_ROLE_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Primary => std::option::Option::Some("PRIMARY"),
+                Self::Secondary => std::option::Option::Some("SECONDARY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLUSTER_ROLE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLUSTER_ROLE_UNSPECIFIED)
-                }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-                "SECONDARY" => std::option::Option::Some(Self::SECONDARY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ClusterRole {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterRole {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ClusterRole {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ClusterRole {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Primary,
+                3 => Self::Secondary,
+                _ => Self::UnknownValue(cluster_role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ClusterRole {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLUSTER_ROLE_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "PRIMARY" => Self::Primary,
+                "SECONDARY" => Self::Secondary,
+                _ => Self::UnknownValue(cluster_role::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ClusterRole {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Primary => serializer.serialize_i32(2),
+                Self::Secondary => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ClusterRole {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ClusterRole>::new(
+                ".google.cloud.redis.cluster.v1.CrossClusterReplicationConfig.ClusterRole",
+            ))
         }
     }
 }
@@ -3896,71 +4204,136 @@ pub mod cluster_persistence_config {
         use super::*;
 
         /// Available snapshot periods.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SnapshotPeriod(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SnapshotPeriod {
+            /// Not set.
+            Unspecified,
+            /// One hour.
+            OneHour,
+            /// Six hours.
+            SixHours,
+            /// Twelve hours.
+            TwelveHours,
+            /// Twenty four hours.
+            TwentyFourHours,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SnapshotPeriod::value] or
+            /// [SnapshotPeriod::name].
+            UnknownValue(snapshot_period::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod snapshot_period {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SnapshotPeriod {
-            /// Not set.
-            pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod = SnapshotPeriod::new(0);
-
-            /// One hour.
-            pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new(1);
-
-            /// Six hours.
-            pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new(2);
-
-            /// Twelve hours.
-            pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new(3);
-
-            /// Twenty four hours.
-            pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new(4);
-
-            /// Creates a new SnapshotPeriod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::OneHour => std::option::Option::Some(1),
+                    Self::SixHours => std::option::Option::Some(2),
+                    Self::TwelveHours => std::option::Option::Some(3),
+                    Self::TwentyFourHours => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SNAPSHOT_PERIOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ONE_HOUR"),
-                    2 => std::borrow::Cow::Borrowed("SIX_HOURS"),
-                    3 => std::borrow::Cow::Borrowed("TWELVE_HOURS"),
-                    4 => std::borrow::Cow::Borrowed("TWENTY_FOUR_HOURS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SNAPSHOT_PERIOD_UNSPECIFIED"),
+                    Self::OneHour => std::option::Option::Some("ONE_HOUR"),
+                    Self::SixHours => std::option::Option::Some("SIX_HOURS"),
+                    Self::TwelveHours => std::option::Option::Some("TWELVE_HOURS"),
+                    Self::TwentyFourHours => std::option::Option::Some("TWENTY_FOUR_HOURS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SNAPSHOT_PERIOD_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SNAPSHOT_PERIOD_UNSPECIFIED)
-                    }
-                    "ONE_HOUR" => std::option::Option::Some(Self::ONE_HOUR),
-                    "SIX_HOURS" => std::option::Option::Some(Self::SIX_HOURS),
-                    "TWELVE_HOURS" => std::option::Option::Some(Self::TWELVE_HOURS),
-                    "TWENTY_FOUR_HOURS" => std::option::Option::Some(Self::TWENTY_FOUR_HOURS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SnapshotPeriod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SnapshotPeriod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SnapshotPeriod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SnapshotPeriod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::OneHour,
+                    2 => Self::SixHours,
+                    3 => Self::TwelveHours,
+                    4 => Self::TwentyFourHours,
+                    _ => Self::UnknownValue(snapshot_period::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SnapshotPeriod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SNAPSHOT_PERIOD_UNSPECIFIED" => Self::Unspecified,
+                    "ONE_HOUR" => Self::OneHour,
+                    "SIX_HOURS" => Self::SixHours,
+                    "TWELVE_HOURS" => Self::TwelveHours,
+                    "TWENTY_FOUR_HOURS" => Self::TwentyFourHours,
+                    _ => Self::UnknownValue(snapshot_period::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SnapshotPeriod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::OneHour => serializer.serialize_i32(1),
+                    Self::SixHours => serializer.serialize_i32(2),
+                    Self::TwelveHours => serializer.serialize_i32(3),
+                    Self::TwentyFourHours => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SnapshotPeriod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SnapshotPeriod>::new(
+                    ".google.cloud.redis.cluster.v1.ClusterPersistenceConfig.RDBConfig.SnapshotPeriod"))
             }
         }
     }
@@ -4007,134 +4380,259 @@ pub mod cluster_persistence_config {
         use super::*;
 
         /// Available fsync modes.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AppendFsync(i32);
-
-        impl AppendFsync {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum AppendFsync {
             /// Not set. Default: EVERYSEC
-            pub const APPEND_FSYNC_UNSPECIFIED: AppendFsync = AppendFsync::new(0);
-
+            Unspecified,
             /// Never fsync. Normally Linux will flush data every 30 seconds with this
             /// configuration, but it's up to the kernel's exact tuning.
-            pub const NO: AppendFsync = AppendFsync::new(1);
-
+            No,
             /// fsync every second. Fast enough, and you may lose 1 second of data if
             /// there is a disaster
-            pub const EVERYSEC: AppendFsync = AppendFsync::new(2);
-
+            Everysec,
             /// fsync every time new write commands are appended to the AOF. It has the
             /// best data loss protection at the cost of performance
-            pub const ALWAYS: AppendFsync = AppendFsync::new(3);
+            Always,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [AppendFsync::value] or
+            /// [AppendFsync::name].
+            UnknownValue(append_fsync::UnknownValue),
+        }
 
-            /// Creates a new AppendFsync instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod append_fsync {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl AppendFsync {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::No => std::option::Option::Some(1),
+                    Self::Everysec => std::option::Option::Some(2),
+                    Self::Always => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("APPEND_FSYNC_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NO"),
-                    2 => std::borrow::Cow::Borrowed("EVERYSEC"),
-                    3 => std::borrow::Cow::Borrowed("ALWAYS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("APPEND_FSYNC_UNSPECIFIED"),
+                    Self::No => std::option::Option::Some("NO"),
+                    Self::Everysec => std::option::Option::Some("EVERYSEC"),
+                    Self::Always => std::option::Option::Some("ALWAYS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "APPEND_FSYNC_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::APPEND_FSYNC_UNSPECIFIED)
-                    }
-                    "NO" => std::option::Option::Some(Self::NO),
-                    "EVERYSEC" => std::option::Option::Some(Self::EVERYSEC),
-                    "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for AppendFsync {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for AppendFsync {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for AppendFsync {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for AppendFsync {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::No,
+                    2 => Self::Everysec,
+                    3 => Self::Always,
+                    _ => Self::UnknownValue(append_fsync::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for AppendFsync {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "APPEND_FSYNC_UNSPECIFIED" => Self::Unspecified,
+                    "NO" => Self::No,
+                    "EVERYSEC" => Self::Everysec,
+                    "ALWAYS" => Self::Always,
+                    _ => Self::UnknownValue(append_fsync::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for AppendFsync {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::No => serializer.serialize_i32(1),
+                    Self::Everysec => serializer.serialize_i32(2),
+                    Self::Always => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for AppendFsync {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AppendFsync>::new(
+                    ".google.cloud.redis.cluster.v1.ClusterPersistenceConfig.AOFConfig.AppendFsync",
+                ))
             }
         }
     }
 
     /// Available persistence modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PersistenceMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PersistenceMode {
+        /// Not set.
+        Unspecified,
+        /// Persistence is disabled, and any snapshot data is deleted.
+        Disabled,
+        /// RDB based persistence is enabled.
+        Rdb,
+        /// AOF based persistence is enabled.
+        Aof,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PersistenceMode::value] or
+        /// [PersistenceMode::name].
+        UnknownValue(persistence_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod persistence_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PersistenceMode {
-        /// Not set.
-        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode = PersistenceMode::new(0);
-
-        /// Persistence is disabled, and any snapshot data is deleted.
-        pub const DISABLED: PersistenceMode = PersistenceMode::new(1);
-
-        /// RDB based persistence is enabled.
-        pub const RDB: PersistenceMode = PersistenceMode::new(2);
-
-        /// AOF based persistence is enabled.
-        pub const AOF: PersistenceMode = PersistenceMode::new(3);
-
-        /// Creates a new PersistenceMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Rdb => std::option::Option::Some(2),
+                Self::Aof => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERSISTENCE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("RDB"),
-                3 => std::borrow::Cow::Borrowed("AOF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERSISTENCE_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Rdb => std::option::Option::Some("RDB"),
+                Self::Aof => std::option::Option::Some("AOF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERSISTENCE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PERSISTENCE_MODE_UNSPECIFIED)
-                }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "RDB" => std::option::Option::Some(Self::RDB),
-                "AOF" => std::option::Option::Some(Self::AOF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PersistenceMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PersistenceMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PersistenceMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PersistenceMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Rdb,
+                3 => Self::Aof,
+                _ => Self::UnknownValue(persistence_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PersistenceMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERSISTENCE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "RDB" => Self::Rdb,
+                "AOF" => Self::Aof,
+                _ => Self::UnknownValue(persistence_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PersistenceMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Rdb => serializer.serialize_i32(2),
+                Self::Aof => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PersistenceMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PersistenceMode>::new(
+                ".google.cloud.redis.cluster.v1.ClusterPersistenceConfig.PersistenceMode",
+            ))
         }
     }
 }
@@ -4194,64 +4692,124 @@ pub mod zone_distribution_config {
     use super::*;
 
     /// Defines various modes of zone distribution.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ZoneDistributionMode(i32);
-
-    impl ZoneDistributionMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ZoneDistributionMode {
         /// Not Set. Default: MULTI_ZONE
-        pub const ZONE_DISTRIBUTION_MODE_UNSPECIFIED: ZoneDistributionMode =
-            ZoneDistributionMode::new(0);
-
+        Unspecified,
         /// Distribute all resources across 3 zones picked at random, within the
         /// region.
-        pub const MULTI_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(1);
-
+        MultiZone,
         /// Distribute all resources in a single zone. The zone field must be
         /// specified, when this mode is selected.
-        pub const SINGLE_ZONE: ZoneDistributionMode = ZoneDistributionMode::new(2);
+        SingleZone,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ZoneDistributionMode::value] or
+        /// [ZoneDistributionMode::name].
+        UnknownValue(zone_distribution_mode::UnknownValue),
+    }
 
-        /// Creates a new ZoneDistributionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod zone_distribution_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ZoneDistributionMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MultiZone => std::option::Option::Some(1),
+                Self::SingleZone => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ZONE_DISTRIBUTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MULTI_ZONE"),
-                2 => std::borrow::Cow::Borrowed("SINGLE_ZONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ZONE_DISTRIBUTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ZONE_DISTRIBUTION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("ZONE_DISTRIBUTION_MODE_UNSPECIFIED")
                 }
-                "MULTI_ZONE" => std::option::Option::Some(Self::MULTI_ZONE),
-                "SINGLE_ZONE" => std::option::Option::Some(Self::SINGLE_ZONE),
-                _ => std::option::Option::None,
+                Self::MultiZone => std::option::Option::Some("MULTI_ZONE"),
+                Self::SingleZone => std::option::Option::Some("SINGLE_ZONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ZoneDistributionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ZoneDistributionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ZoneDistributionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ZoneDistributionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MultiZone,
+                2 => Self::SingleZone,
+                _ => Self::UnknownValue(zone_distribution_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ZoneDistributionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ZONE_DISTRIBUTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "MULTI_ZONE" => Self::MultiZone,
+                "SINGLE_ZONE" => Self::SingleZone,
+                _ => Self::UnknownValue(zone_distribution_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ZoneDistributionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MultiZone => serializer.serialize_i32(1),
+                Self::SingleZone => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ZoneDistributionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ZoneDistributionMode>::new(
+                ".google.cloud.redis.cluster.v1.ZoneDistributionConfig.ZoneDistributionMode",
+            ))
         }
     }
 }
@@ -4326,61 +4884,120 @@ pub mod reschedule_cluster_maintenance_request {
     use super::*;
 
     /// Reschedule options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RescheduleType {
+        /// Not set.
+        Unspecified,
+        /// If the user wants to schedule the maintenance to happen now.
+        Immediate,
+        /// If the user wants to reschedule the maintenance to a specific time.
+        SpecificTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RescheduleType::value] or
+        /// [RescheduleType::name].
+        UnknownValue(reschedule_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod reschedule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RescheduleType {
-        /// Not set.
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
-
-        /// If the user wants to schedule the maintenance to happen now.
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
-
-        /// If the user wants to reschedule the maintenance to a specific time.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
-
-        /// Creates a new RescheduleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Immediate => std::option::Option::Some(1),
+                Self::SpecificTime => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESCHEDULE_TYPE_UNSPECIFIED"),
+                Self::Immediate => std::option::Option::Some("IMMEDIATE"),
+                Self::SpecificTime => std::option::Option::Some("SPECIFIC_TIME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESCHEDULE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED)
-                }
-                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
-                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RescheduleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RescheduleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Immediate,
+                3 => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RescheduleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMMEDIATE" => Self::Immediate,
+                "SPECIFIC_TIME" => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RescheduleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Immediate => serializer.serialize_i32(1),
+                Self::SpecificTime => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RescheduleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RescheduleType>::new(
+                ".google.cloud.redis.cluster.v1.RescheduleClusterMaintenanceRequest.RescheduleType",
+            ))
         }
     }
 }
@@ -4469,476 +5086,902 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Encryption type not specified. Defaults to GOOGLE_DEFAULT_ENCRYPTION.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The data is encrypted at rest with a key that is fully managed by Google.
         /// No key version will be populated. This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new(1);
-
+        GoogleDefaultEncryption,
         /// The data is encrypted at rest with a key that is managed by the customer.
         /// KMS key versions will be populated.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new(2);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(1),
+                Self::CustomerManagedEncryption => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
                 }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleDefaultEncryption,
+                2 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(1),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.redis.cluster.v1.EncryptionInfo.Type",
+            ))
         }
     }
 
     /// The state of the KMS key perceived by the system. Refer to the public
     /// documentation for the impact of each state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KmsKeyState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KmsKeyState {
+        /// The default value. This value is unused.
+        Unspecified,
+        /// The KMS key is enabled and correctly configured.
+        Enabled,
+        /// Permission denied on the KMS key.
+        PermissionDenied,
+        /// The KMS key is disabled.
+        Disabled,
+        /// The KMS key is destroyed.
+        Destroyed,
+        /// The KMS key is scheduled to be destroyed.
+        DestroyScheduled,
+        /// The EKM key is unreachable.
+        EkmKeyUnreachableDetected,
+        /// Billing is disabled for the project.
+        BillingDisabled,
+        /// All other unknown failures.
+        UnknownFailure,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KmsKeyState::value] or
+        /// [KmsKeyState::name].
+        UnknownValue(kms_key_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod kms_key_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl KmsKeyState {
-        /// The default value. This value is unused.
-        pub const KMS_KEY_STATE_UNSPECIFIED: KmsKeyState = KmsKeyState::new(0);
-
-        /// The KMS key is enabled and correctly configured.
-        pub const ENABLED: KmsKeyState = KmsKeyState::new(1);
-
-        /// Permission denied on the KMS key.
-        pub const PERMISSION_DENIED: KmsKeyState = KmsKeyState::new(2);
-
-        /// The KMS key is disabled.
-        pub const DISABLED: KmsKeyState = KmsKeyState::new(3);
-
-        /// The KMS key is destroyed.
-        pub const DESTROYED: KmsKeyState = KmsKeyState::new(4);
-
-        /// The KMS key is scheduled to be destroyed.
-        pub const DESTROY_SCHEDULED: KmsKeyState = KmsKeyState::new(5);
-
-        /// The EKM key is unreachable.
-        pub const EKM_KEY_UNREACHABLE_DETECTED: KmsKeyState = KmsKeyState::new(6);
-
-        /// Billing is disabled for the project.
-        pub const BILLING_DISABLED: KmsKeyState = KmsKeyState::new(7);
-
-        /// All other unknown failures.
-        pub const UNKNOWN_FAILURE: KmsKeyState = KmsKeyState::new(8);
-
-        /// Creates a new KmsKeyState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::PermissionDenied => std::option::Option::Some(2),
+                Self::Disabled => std::option::Option::Some(3),
+                Self::Destroyed => std::option::Option::Some(4),
+                Self::DestroyScheduled => std::option::Option::Some(5),
+                Self::EkmKeyUnreachableDetected => std::option::Option::Some(6),
+                Self::BillingDisabled => std::option::Option::Some(7),
+                Self::UnknownFailure => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KMS_KEY_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-                3 => std::borrow::Cow::Borrowed("DISABLED"),
-                4 => std::borrow::Cow::Borrowed("DESTROYED"),
-                5 => std::borrow::Cow::Borrowed("DESTROY_SCHEDULED"),
-                6 => std::borrow::Cow::Borrowed("EKM_KEY_UNREACHABLE_DETECTED"),
-                7 => std::borrow::Cow::Borrowed("BILLING_DISABLED"),
-                8 => std::borrow::Cow::Borrowed("UNKNOWN_FAILURE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KMS_KEY_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KMS_KEY_STATE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KMS_KEY_STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Destroyed => std::option::Option::Some("DESTROYED"),
+                Self::DestroyScheduled => std::option::Option::Some("DESTROY_SCHEDULED"),
+                Self::EkmKeyUnreachableDetected => {
+                    std::option::Option::Some("EKM_KEY_UNREACHABLE_DETECTED")
                 }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
-                "DESTROY_SCHEDULED" => std::option::Option::Some(Self::DESTROY_SCHEDULED),
-                "EKM_KEY_UNREACHABLE_DETECTED" => {
-                    std::option::Option::Some(Self::EKM_KEY_UNREACHABLE_DETECTED)
-                }
-                "BILLING_DISABLED" => std::option::Option::Some(Self::BILLING_DISABLED),
-                "UNKNOWN_FAILURE" => std::option::Option::Some(Self::UNKNOWN_FAILURE),
-                _ => std::option::Option::None,
+                Self::BillingDisabled => std::option::Option::Some("BILLING_DISABLED"),
+                Self::UnknownFailure => std::option::Option::Some("UNKNOWN_FAILURE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for KmsKeyState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KmsKeyState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KmsKeyState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KmsKeyState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::PermissionDenied,
+                3 => Self::Disabled,
+                4 => Self::Destroyed,
+                5 => Self::DestroyScheduled,
+                6 => Self::EkmKeyUnreachableDetected,
+                7 => Self::BillingDisabled,
+                8 => Self::UnknownFailure,
+                _ => Self::UnknownValue(kms_key_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KmsKeyState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KMS_KEY_STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "PERMISSION_DENIED" => Self::PermissionDenied,
+                "DISABLED" => Self::Disabled,
+                "DESTROYED" => Self::Destroyed,
+                "DESTROY_SCHEDULED" => Self::DestroyScheduled,
+                "EKM_KEY_UNREACHABLE_DETECTED" => Self::EkmKeyUnreachableDetected,
+                "BILLING_DISABLED" => Self::BillingDisabled,
+                "UNKNOWN_FAILURE" => Self::UnknownFailure,
+                _ => Self::UnknownValue(kms_key_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KmsKeyState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::PermissionDenied => serializer.serialize_i32(2),
+                Self::Disabled => serializer.serialize_i32(3),
+                Self::Destroyed => serializer.serialize_i32(4),
+                Self::DestroyScheduled => serializer.serialize_i32(5),
+                Self::EkmKeyUnreachableDetected => serializer.serialize_i32(6),
+                Self::BillingDisabled => serializer.serialize_i32(7),
+                Self::UnknownFailure => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KmsKeyState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KmsKeyState>::new(
+                ".google.cloud.redis.cluster.v1.EncryptionInfo.KmsKeyState",
+            ))
         }
     }
 }
 
 /// Status of the PSC connection.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PscConnectionStatus(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PscConnectionStatus {
+    /// PSC connection status is not specified.
+    Unspecified,
+    /// The connection is active
+    Active,
+    /// Connection not found
+    NotFound,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PscConnectionStatus::value] or
+    /// [PscConnectionStatus::name].
+    UnknownValue(psc_connection_status::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod psc_connection_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl PscConnectionStatus {
-    /// PSC connection status is not specified.
-    pub const PSC_CONNECTION_STATUS_UNSPECIFIED: PscConnectionStatus = PscConnectionStatus::new(0);
-
-    /// The connection is active
-    pub const PSC_CONNECTION_STATUS_ACTIVE: PscConnectionStatus = PscConnectionStatus::new(1);
-
-    /// Connection not found
-    pub const PSC_CONNECTION_STATUS_NOT_FOUND: PscConnectionStatus = PscConnectionStatus::new(2);
-
-    /// Creates a new PscConnectionStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Active => std::option::Option::Some(1),
+            Self::NotFound => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_ACTIVE"),
-            2 => std::borrow::Cow::Borrowed("PSC_CONNECTION_STATUS_NOT_FOUND"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PSC_CONNECTION_STATUS_UNSPECIFIED"),
+            Self::Active => std::option::Option::Some("PSC_CONNECTION_STATUS_ACTIVE"),
+            Self::NotFound => std::option::Option::Some("PSC_CONNECTION_STATUS_NOT_FOUND"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PSC_CONNECTION_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_UNSPECIFIED)
-            }
-            "PSC_CONNECTION_STATUS_ACTIVE" => {
-                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_ACTIVE)
-            }
-            "PSC_CONNECTION_STATUS_NOT_FOUND" => {
-                std::option::Option::Some(Self::PSC_CONNECTION_STATUS_NOT_FOUND)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PscConnectionStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PscConnectionStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PscConnectionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PscConnectionStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Active,
+            2 => Self::NotFound,
+            _ => Self::UnknownValue(psc_connection_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PscConnectionStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PSC_CONNECTION_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "PSC_CONNECTION_STATUS_ACTIVE" => Self::Active,
+            "PSC_CONNECTION_STATUS_NOT_FOUND" => Self::NotFound,
+            _ => Self::UnknownValue(psc_connection_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PscConnectionStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Active => serializer.serialize_i32(1),
+            Self::NotFound => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PscConnectionStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PscConnectionStatus>::new(
+            ".google.cloud.redis.cluster.v1.PscConnectionStatus",
+        ))
     }
 }
 
 /// Available authorization mode of a Redis cluster.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AuthorizationMode(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AuthorizationMode {
+    /// Not set.
+    AuthModeUnspecified,
+    /// IAM basic authorization mode
+    AuthModeIamAuth,
+    /// Authorization disabled mode
+    AuthModeDisabled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AuthorizationMode::value] or
+    /// [AuthorizationMode::name].
+    UnknownValue(authorization_mode::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod authorization_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl AuthorizationMode {
-    /// Not set.
-    pub const AUTH_MODE_UNSPECIFIED: AuthorizationMode = AuthorizationMode::new(0);
-
-    /// IAM basic authorization mode
-    pub const AUTH_MODE_IAM_AUTH: AuthorizationMode = AuthorizationMode::new(1);
-
-    /// Authorization disabled mode
-    pub const AUTH_MODE_DISABLED: AuthorizationMode = AuthorizationMode::new(2);
-
-    /// Creates a new AuthorizationMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::AuthModeUnspecified => std::option::Option::Some(0),
+            Self::AuthModeIamAuth => std::option::Option::Some(1),
+            Self::AuthModeDisabled => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUTH_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AUTH_MODE_IAM_AUTH"),
-            2 => std::borrow::Cow::Borrowed("AUTH_MODE_DISABLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::AuthModeUnspecified => std::option::Option::Some("AUTH_MODE_UNSPECIFIED"),
+            Self::AuthModeIamAuth => std::option::Option::Some("AUTH_MODE_IAM_AUTH"),
+            Self::AuthModeDisabled => std::option::Option::Some("AUTH_MODE_DISABLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUTH_MODE_UNSPECIFIED" => std::option::Option::Some(Self::AUTH_MODE_UNSPECIFIED),
-            "AUTH_MODE_IAM_AUTH" => std::option::Option::Some(Self::AUTH_MODE_IAM_AUTH),
-            "AUTH_MODE_DISABLED" => std::option::Option::Some(Self::AUTH_MODE_DISABLED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AuthorizationMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AuthorizationMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AuthorizationMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AuthorizationMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::AuthModeUnspecified,
+            1 => Self::AuthModeIamAuth,
+            2 => Self::AuthModeDisabled,
+            _ => Self::UnknownValue(authorization_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AuthorizationMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUTH_MODE_UNSPECIFIED" => Self::AuthModeUnspecified,
+            "AUTH_MODE_IAM_AUTH" => Self::AuthModeIamAuth,
+            "AUTH_MODE_DISABLED" => Self::AuthModeDisabled,
+            _ => Self::UnknownValue(authorization_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AuthorizationMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::AuthModeUnspecified => serializer.serialize_i32(0),
+            Self::AuthModeIamAuth => serializer.serialize_i32(1),
+            Self::AuthModeDisabled => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AuthorizationMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthorizationMode>::new(
+            ".google.cloud.redis.cluster.v1.AuthorizationMode",
+        ))
     }
 }
 
 /// NodeType of a redis cluster node,
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NodeType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NodeType {
+    /// Node type unspecified
+    Unspecified,
+    /// Redis shared core nano node_type.
+    RedisSharedCoreNano,
+    /// Redis highmem medium node_type.
+    RedisHighmemMedium,
+    /// Redis highmem xlarge node_type.
+    RedisHighmemXlarge,
+    /// Redis standard small node_type.
+    RedisStandardSmall,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NodeType::value] or
+    /// [NodeType::name].
+    UnknownValue(node_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod node_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl NodeType {
-    /// Node type unspecified
-    pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new(0);
-
-    /// Redis shared core nano node_type.
-    pub const REDIS_SHARED_CORE_NANO: NodeType = NodeType::new(1);
-
-    /// Redis highmem medium node_type.
-    pub const REDIS_HIGHMEM_MEDIUM: NodeType = NodeType::new(2);
-
-    /// Redis highmem xlarge node_type.
-    pub const REDIS_HIGHMEM_XLARGE: NodeType = NodeType::new(3);
-
-    /// Redis standard small node_type.
-    pub const REDIS_STANDARD_SMALL: NodeType = NodeType::new(4);
-
-    /// Creates a new NodeType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RedisSharedCoreNano => std::option::Option::Some(1),
+            Self::RedisHighmemMedium => std::option::Option::Some(2),
+            Self::RedisHighmemXlarge => std::option::Option::Some(3),
+            Self::RedisStandardSmall => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NODE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("REDIS_SHARED_CORE_NANO"),
-            2 => std::borrow::Cow::Borrowed("REDIS_HIGHMEM_MEDIUM"),
-            3 => std::borrow::Cow::Borrowed("REDIS_HIGHMEM_XLARGE"),
-            4 => std::borrow::Cow::Borrowed("REDIS_STANDARD_SMALL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NODE_TYPE_UNSPECIFIED"),
+            Self::RedisSharedCoreNano => std::option::Option::Some("REDIS_SHARED_CORE_NANO"),
+            Self::RedisHighmemMedium => std::option::Option::Some("REDIS_HIGHMEM_MEDIUM"),
+            Self::RedisHighmemXlarge => std::option::Option::Some("REDIS_HIGHMEM_XLARGE"),
+            Self::RedisStandardSmall => std::option::Option::Some("REDIS_STANDARD_SMALL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NODE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::NODE_TYPE_UNSPECIFIED),
-            "REDIS_SHARED_CORE_NANO" => std::option::Option::Some(Self::REDIS_SHARED_CORE_NANO),
-            "REDIS_HIGHMEM_MEDIUM" => std::option::Option::Some(Self::REDIS_HIGHMEM_MEDIUM),
-            "REDIS_HIGHMEM_XLARGE" => std::option::Option::Some(Self::REDIS_HIGHMEM_XLARGE),
-            "REDIS_STANDARD_SMALL" => std::option::Option::Some(Self::REDIS_STANDARD_SMALL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NodeType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NodeType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NodeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NodeType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RedisSharedCoreNano,
+            2 => Self::RedisHighmemMedium,
+            3 => Self::RedisHighmemXlarge,
+            4 => Self::RedisStandardSmall,
+            _ => Self::UnknownValue(node_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NodeType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NODE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "REDIS_SHARED_CORE_NANO" => Self::RedisSharedCoreNano,
+            "REDIS_HIGHMEM_MEDIUM" => Self::RedisHighmemMedium,
+            "REDIS_HIGHMEM_XLARGE" => Self::RedisHighmemXlarge,
+            "REDIS_STANDARD_SMALL" => Self::RedisStandardSmall,
+            _ => Self::UnknownValue(node_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NodeType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RedisSharedCoreNano => serializer.serialize_i32(1),
+            Self::RedisHighmemMedium => serializer.serialize_i32(2),
+            Self::RedisHighmemXlarge => serializer.serialize_i32(3),
+            Self::RedisStandardSmall => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NodeType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodeType>::new(
+            ".google.cloud.redis.cluster.v1.NodeType",
+        ))
     }
 }
 
 /// Available mode of in-transit encryption.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransitEncryptionMode(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransitEncryptionMode {
+    /// In-transit encryption not set.
+    Unspecified,
+    /// In-transit encryption disabled.
+    Disabled,
+    /// Use server managed encryption for in-transit encryption.
+    ServerAuthentication,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransitEncryptionMode::value] or
+    /// [TransitEncryptionMode::name].
+    UnknownValue(transit_encryption_mode::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod transit_encryption_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TransitEncryptionMode {
-    /// In-transit encryption not set.
-    pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
-        TransitEncryptionMode::new(0);
-
-    /// In-transit encryption disabled.
-    pub const TRANSIT_ENCRYPTION_MODE_DISABLED: TransitEncryptionMode =
-        TransitEncryptionMode::new(1);
-
-    /// Use server managed encryption for in-transit encryption.
-    pub const TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION: TransitEncryptionMode =
-        TransitEncryptionMode::new(2);
-
-    /// Creates a new TransitEncryptionMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Disabled => std::option::Option::Some(1),
+            Self::ServerAuthentication => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_DISABLED"),
-            2 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
+            Self::Disabled => std::option::Option::Some("TRANSIT_ENCRYPTION_MODE_DISABLED"),
+            Self::ServerAuthentication => {
+                std::option::Option::Some("TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED)
-            }
-            "TRANSIT_ENCRYPTION_MODE_DISABLED" => {
-                std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_DISABLED)
-            }
-            "TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION" => {
-                std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TransitEncryptionMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransitEncryptionMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransitEncryptionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransitEncryptionMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Disabled,
+            2 => Self::ServerAuthentication,
+            _ => Self::UnknownValue(transit_encryption_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransitEncryptionMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => Self::Unspecified,
+            "TRANSIT_ENCRYPTION_MODE_DISABLED" => Self::Disabled,
+            "TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION" => Self::ServerAuthentication,
+            _ => Self::UnknownValue(transit_encryption_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransitEncryptionMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Disabled => serializer.serialize_i32(1),
+            Self::ServerAuthentication => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransitEncryptionMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransitEncryptionMode>::new(
+            ".google.cloud.redis.cluster.v1.TransitEncryptionMode",
+        ))
     }
 }
 
 /// Type of a PSC connection, for cluster access purpose.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectionType {
+    /// Cluster endpoint Type is not set
+    Unspecified,
+    /// Cluster endpoint that will be used as for cluster topology discovery.
+    Discovery,
+    /// Cluster endpoint that will be used as primary endpoint to access primary.
+    Primary,
+    /// Cluster endpoint that will be used as reader endpoint to access replicas.
+    Reader,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConnectionType::value] or
+    /// [ConnectionType::name].
+    UnknownValue(connection_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod connection_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ConnectionType {
-    /// Cluster endpoint Type is not set
-    pub const CONNECTION_TYPE_UNSPECIFIED: ConnectionType = ConnectionType::new(0);
-
-    /// Cluster endpoint that will be used as for cluster topology discovery.
-    pub const CONNECTION_TYPE_DISCOVERY: ConnectionType = ConnectionType::new(1);
-
-    /// Cluster endpoint that will be used as primary endpoint to access primary.
-    pub const CONNECTION_TYPE_PRIMARY: ConnectionType = ConnectionType::new(2);
-
-    /// Cluster endpoint that will be used as reader endpoint to access replicas.
-    pub const CONNECTION_TYPE_READER: ConnectionType = ConnectionType::new(3);
-
-    /// Creates a new ConnectionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Discovery => std::option::Option::Some(1),
+            Self::Primary => std::option::Option::Some(2),
+            Self::Reader => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_DISCOVERY"),
-            2 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_PRIMARY"),
-            3 => std::borrow::Cow::Borrowed("CONNECTION_TYPE_READER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONNECTION_TYPE_UNSPECIFIED"),
+            Self::Discovery => std::option::Option::Some("CONNECTION_TYPE_DISCOVERY"),
+            Self::Primary => std::option::Option::Some("CONNECTION_TYPE_PRIMARY"),
+            Self::Reader => std::option::Option::Some("CONNECTION_TYPE_READER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONNECTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONNECTION_TYPE_UNSPECIFIED)
-            }
-            "CONNECTION_TYPE_DISCOVERY" => {
-                std::option::Option::Some(Self::CONNECTION_TYPE_DISCOVERY)
-            }
-            "CONNECTION_TYPE_PRIMARY" => std::option::Option::Some(Self::CONNECTION_TYPE_PRIMARY),
-            "CONNECTION_TYPE_READER" => std::option::Option::Some(Self::CONNECTION_TYPE_READER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConnectionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConnectionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConnectionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Discovery,
+            2 => Self::Primary,
+            3 => Self::Reader,
+            _ => Self::UnknownValue(connection_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConnectionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONNECTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "CONNECTION_TYPE_DISCOVERY" => Self::Discovery,
+            "CONNECTION_TYPE_PRIMARY" => Self::Primary,
+            "CONNECTION_TYPE_READER" => Self::Reader,
+            _ => Self::UnknownValue(connection_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConnectionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Discovery => serializer.serialize_i32(1),
+            Self::Primary => serializer.serialize_i32(2),
+            Self::Reader => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConnectionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionType>::new(
+            ".google.cloud.redis.cluster.v1.ConnectionType",
+        ))
     }
 }

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -623,387 +623,756 @@ pub mod instance {
     use super::*;
 
     /// Represents the different states of a Redis instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Redis instance is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Redis instance has been created and is fully usable.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// Redis instance configuration is being updated. Certain kinds of updates
         /// may cause the instance to become unusable while the update is in
         /// progress.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// Redis instance is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Redis instance is being repaired and may be unusable.
-        pub const REPAIRING: State = State::new(5);
-
+        Repairing,
         /// Maintenance is being performed on this Redis instance.
-        pub const MAINTENANCE: State = State::new(6);
-
+        Maintenance,
         /// Redis instance is importing data (availability may be affected).
-        pub const IMPORTING: State = State::new(8);
-
+        Importing,
         /// Redis instance is failing over (availability may be affected).
-        pub const FAILING_OVER: State = State::new(9);
+        FailingOver,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Repairing => std::option::Option::Some(5),
+                Self::Maintenance => std::option::Option::Some(6),
+                Self::Importing => std::option::Option::Some(8),
+                Self::FailingOver => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("REPAIRING"),
-                6 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                8 => std::borrow::Cow::Borrowed("IMPORTING"),
-                9 => std::borrow::Cow::Borrowed("FAILING_OVER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Importing => std::option::Option::Some("IMPORTING"),
+                Self::FailingOver => std::option::Option::Some("FAILING_OVER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "IMPORTING" => std::option::Option::Some(Self::IMPORTING),
-                "FAILING_OVER" => std::option::Option::Some(Self::FAILING_OVER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Repairing,
+                6 => Self::Maintenance,
+                8 => Self::Importing,
+                9 => Self::FailingOver,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "REPAIRING" => Self::Repairing,
+                "MAINTENANCE" => Self::Maintenance,
+                "IMPORTING" => Self::Importing,
+                "FAILING_OVER" => Self::FailingOver,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Repairing => serializer.serialize_i32(5),
+                Self::Maintenance => serializer.serialize_i32(6),
+                Self::Importing => serializer.serialize_i32(8),
+                Self::FailingOver => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.redis.v1.Instance.State",
+            ))
         }
     }
 
     /// Available service tiers to choose from
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
+        /// Not set.
+        Unspecified,
+        /// BASIC tier: standalone instance
+        Basic,
+        /// STANDARD_HA tier: highly available primary/replica instances
+        StandardHa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Tier {
-        /// Not set.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
-        /// BASIC tier: standalone instance
-        pub const BASIC: Tier = Tier::new(1);
-
-        /// STANDARD_HA tier: highly available primary/replica instances
-        pub const STANDARD_HA: Tier = Tier::new(3);
-
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::StandardHa => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                3 => std::borrow::Cow::Borrowed("STANDARD_HA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::StandardHa => std::option::Option::Some("STANDARD_HA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "STANDARD_HA" => std::option::Option::Some(Self::STANDARD_HA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                3 => Self::StandardHa,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "STANDARD_HA" => Self::StandardHa,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::StandardHa => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.redis.v1.Instance.Tier",
+            ))
         }
     }
 
     /// Available connection modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectMode(i32);
-
-    impl ConnectMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConnectMode {
         /// Not set.
-        pub const CONNECT_MODE_UNSPECIFIED: ConnectMode = ConnectMode::new(0);
-
+        Unspecified,
         /// Connect via direct peering to the Memorystore for Redis hosted service.
-        pub const DIRECT_PEERING: ConnectMode = ConnectMode::new(1);
-
+        DirectPeering,
         /// Connect your Memorystore for Redis instance using Private Service
         /// Access. Private services access provides an IP address range for multiple
         /// Google Cloud services, including Memorystore.
-        pub const PRIVATE_SERVICE_ACCESS: ConnectMode = ConnectMode::new(2);
+        PrivateServiceAccess,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConnectMode::value] or
+        /// [ConnectMode::name].
+        UnknownValue(connect_mode::UnknownValue),
+    }
 
-        /// Creates a new ConnectMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod connect_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConnectMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DirectPeering => std::option::Option::Some(1),
+                Self::PrivateServiceAccess => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONNECT_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIRECT_PEERING"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONNECT_MODE_UNSPECIFIED"),
+                Self::DirectPeering => std::option::Option::Some("DIRECT_PEERING"),
+                Self::PrivateServiceAccess => std::option::Option::Some("PRIVATE_SERVICE_ACCESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONNECT_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONNECT_MODE_UNSPECIFIED)
-                }
-                "DIRECT_PEERING" => std::option::Option::Some(Self::DIRECT_PEERING),
-                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConnectMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConnectMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConnectMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConnectMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DirectPeering,
+                2 => Self::PrivateServiceAccess,
+                _ => Self::UnknownValue(connect_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConnectMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONNECT_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DIRECT_PEERING" => Self::DirectPeering,
+                "PRIVATE_SERVICE_ACCESS" => Self::PrivateServiceAccess,
+                _ => Self::UnknownValue(connect_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConnectMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DirectPeering => serializer.serialize_i32(1),
+                Self::PrivateServiceAccess => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConnectMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectMode>::new(
+                ".google.cloud.redis.v1.Instance.ConnectMode",
+            ))
         }
     }
 
     /// Available TLS modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransitEncryptionMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TransitEncryptionMode {
+        /// Not set.
+        Unspecified,
+        /// Client to Server traffic encryption enabled with server authentication.
+        ServerAuthentication,
+        /// TLS is disabled for the instance.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TransitEncryptionMode::value] or
+        /// [TransitEncryptionMode::name].
+        UnknownValue(transit_encryption_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod transit_encryption_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TransitEncryptionMode {
-        /// Not set.
-        pub const TRANSIT_ENCRYPTION_MODE_UNSPECIFIED: TransitEncryptionMode =
-            TransitEncryptionMode::new(0);
-
-        /// Client to Server traffic encryption enabled with server authentication.
-        pub const SERVER_AUTHENTICATION: TransitEncryptionMode = TransitEncryptionMode::new(1);
-
-        /// TLS is disabled for the instance.
-        pub const DISABLED: TransitEncryptionMode = TransitEncryptionMode::new(2);
-
-        /// Creates a new TransitEncryptionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ServerAuthentication => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SERVER_AUTHENTICATION"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRANSIT_ENCRYPTION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("TRANSIT_ENCRYPTION_MODE_UNSPECIFIED")
                 }
-                "SERVER_AUTHENTICATION" => std::option::Option::Some(Self::SERVER_AUTHENTICATION),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
+                Self::ServerAuthentication => std::option::Option::Some("SERVER_AUTHENTICATION"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TransitEncryptionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TransitEncryptionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TransitEncryptionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TransitEncryptionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ServerAuthentication,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(transit_encryption_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TransitEncryptionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "SERVER_AUTHENTICATION" => Self::ServerAuthentication,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(transit_encryption_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TransitEncryptionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ServerAuthentication => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TransitEncryptionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransitEncryptionMode>::new(
+                ".google.cloud.redis.v1.Instance.TransitEncryptionMode",
+            ))
         }
     }
 
     /// Read replicas mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReadReplicasMode(i32);
-
-    impl ReadReplicasMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReadReplicasMode {
         /// If not set, Memorystore Redis backend will default to
         /// READ_REPLICAS_DISABLED.
-        pub const READ_REPLICAS_MODE_UNSPECIFIED: ReadReplicasMode = ReadReplicasMode::new(0);
-
+        Unspecified,
         /// If disabled, read endpoint will not be provided and the instance cannot
         /// scale up or down the number of replicas.
-        pub const READ_REPLICAS_DISABLED: ReadReplicasMode = ReadReplicasMode::new(1);
-
+        ReadReplicasDisabled,
         /// If enabled, read endpoint will be provided and the instance can scale
         /// up and down the number of replicas. Not valid for basic tier.
-        pub const READ_REPLICAS_ENABLED: ReadReplicasMode = ReadReplicasMode::new(2);
+        ReadReplicasEnabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReadReplicasMode::value] or
+        /// [ReadReplicasMode::name].
+        UnknownValue(read_replicas_mode::UnknownValue),
+    }
 
-        /// Creates a new ReadReplicasMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod read_replicas_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ReadReplicasMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReadReplicasDisabled => std::option::Option::Some(1),
+                Self::ReadReplicasEnabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("READ_REPLICAS_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_REPLICAS_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("READ_REPLICAS_ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("READ_REPLICAS_MODE_UNSPECIFIED"),
+                Self::ReadReplicasDisabled => std::option::Option::Some("READ_REPLICAS_DISABLED"),
+                Self::ReadReplicasEnabled => std::option::Option::Some("READ_REPLICAS_ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "READ_REPLICAS_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::READ_REPLICAS_MODE_UNSPECIFIED)
-                }
-                "READ_REPLICAS_DISABLED" => std::option::Option::Some(Self::READ_REPLICAS_DISABLED),
-                "READ_REPLICAS_ENABLED" => std::option::Option::Some(Self::READ_REPLICAS_ENABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReadReplicasMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReadReplicasMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReadReplicasMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReadReplicasMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReadReplicasDisabled,
+                2 => Self::ReadReplicasEnabled,
+                _ => Self::UnknownValue(read_replicas_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReadReplicasMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "READ_REPLICAS_MODE_UNSPECIFIED" => Self::Unspecified,
+                "READ_REPLICAS_DISABLED" => Self::ReadReplicasDisabled,
+                "READ_REPLICAS_ENABLED" => Self::ReadReplicasEnabled,
+                _ => Self::UnknownValue(read_replicas_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReadReplicasMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReadReplicasDisabled => serializer.serialize_i32(1),
+                Self::ReadReplicasEnabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReadReplicasMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReadReplicasMode>::new(
+                ".google.cloud.redis.v1.Instance.ReadReplicasMode",
+            ))
         }
     }
 
     /// Possible reasons for the instance to be in a "SUSPENDED" state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SuspensionReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SuspensionReason {
+        /// Not set.
+        Unspecified,
+        /// Something wrong with the CMEK key provided by customer.
+        CustomerManagedKeyIssue,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SuspensionReason::value] or
+        /// [SuspensionReason::name].
+        UnknownValue(suspension_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod suspension_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SuspensionReason {
-        /// Not set.
-        pub const SUSPENSION_REASON_UNSPECIFIED: SuspensionReason = SuspensionReason::new(0);
-
-        /// Something wrong with the CMEK key provided by customer.
-        pub const CUSTOMER_MANAGED_KEY_ISSUE: SuspensionReason = SuspensionReason::new(1);
-
-        /// Creates a new SuspensionReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CustomerManagedKeyIssue => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SUSPENSION_REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_KEY_ISSUE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SUSPENSION_REASON_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SUSPENSION_REASON_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SUSPENSION_REASON_UNSPECIFIED"),
+                Self::CustomerManagedKeyIssue => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_KEY_ISSUE")
                 }
-                "CUSTOMER_MANAGED_KEY_ISSUE" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_KEY_ISSUE)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SuspensionReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SuspensionReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SuspensionReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SuspensionReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CustomerManagedKeyIssue,
+                _ => Self::UnknownValue(suspension_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SuspensionReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SUSPENSION_REASON_UNSPECIFIED" => Self::Unspecified,
+                "CUSTOMER_MANAGED_KEY_ISSUE" => Self::CustomerManagedKeyIssue,
+                _ => Self::UnknownValue(suspension_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SuspensionReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CustomerManagedKeyIssue => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SuspensionReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SuspensionReason>::new(
+                ".google.cloud.redis.v1.Instance.SuspensionReason",
+            ))
         }
     }
 }
@@ -1102,131 +1471,253 @@ pub mod persistence_config {
     use super::*;
 
     /// Available Persistence modes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PersistenceMode(i32);
-
-    impl PersistenceMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PersistenceMode {
         /// Not set.
-        pub const PERSISTENCE_MODE_UNSPECIFIED: PersistenceMode = PersistenceMode::new(0);
-
+        Unspecified,
         /// Persistence is disabled for the instance,
         /// and any existing snapshots are deleted.
-        pub const DISABLED: PersistenceMode = PersistenceMode::new(1);
-
+        Disabled,
         /// RDB based Persistence is enabled.
-        pub const RDB: PersistenceMode = PersistenceMode::new(2);
+        Rdb,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PersistenceMode::value] or
+        /// [PersistenceMode::name].
+        UnknownValue(persistence_mode::UnknownValue),
+    }
 
-        /// Creates a new PersistenceMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod persistence_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PersistenceMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Rdb => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERSISTENCE_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("RDB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERSISTENCE_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Rdb => std::option::Option::Some("RDB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERSISTENCE_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PERSISTENCE_MODE_UNSPECIFIED)
-                }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "RDB" => std::option::Option::Some(Self::RDB),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PersistenceMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PersistenceMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PersistenceMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PersistenceMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Rdb,
+                _ => Self::UnknownValue(persistence_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PersistenceMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERSISTENCE_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "RDB" => Self::Rdb,
+                _ => Self::UnknownValue(persistence_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PersistenceMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Rdb => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PersistenceMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PersistenceMode>::new(
+                ".google.cloud.redis.v1.PersistenceConfig.PersistenceMode",
+            ))
         }
     }
 
     /// Available snapshot periods for scheduling.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SnapshotPeriod(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SnapshotPeriod {
+        /// Not set.
+        Unspecified,
+        /// Snapshot every 1 hour.
+        OneHour,
+        /// Snapshot every 6 hours.
+        SixHours,
+        /// Snapshot every 12 hours.
+        TwelveHours,
+        /// Snapshot every 24 hours.
+        TwentyFourHours,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SnapshotPeriod::value] or
+        /// [SnapshotPeriod::name].
+        UnknownValue(snapshot_period::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod snapshot_period {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SnapshotPeriod {
-        /// Not set.
-        pub const SNAPSHOT_PERIOD_UNSPECIFIED: SnapshotPeriod = SnapshotPeriod::new(0);
-
-        /// Snapshot every 1 hour.
-        pub const ONE_HOUR: SnapshotPeriod = SnapshotPeriod::new(3);
-
-        /// Snapshot every 6 hours.
-        pub const SIX_HOURS: SnapshotPeriod = SnapshotPeriod::new(4);
-
-        /// Snapshot every 12 hours.
-        pub const TWELVE_HOURS: SnapshotPeriod = SnapshotPeriod::new(5);
-
-        /// Snapshot every 24 hours.
-        pub const TWENTY_FOUR_HOURS: SnapshotPeriod = SnapshotPeriod::new(6);
-
-        /// Creates a new SnapshotPeriod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::OneHour => std::option::Option::Some(3),
+                Self::SixHours => std::option::Option::Some(4),
+                Self::TwelveHours => std::option::Option::Some(5),
+                Self::TwentyFourHours => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SNAPSHOT_PERIOD_UNSPECIFIED"),
-                3 => std::borrow::Cow::Borrowed("ONE_HOUR"),
-                4 => std::borrow::Cow::Borrowed("SIX_HOURS"),
-                5 => std::borrow::Cow::Borrowed("TWELVE_HOURS"),
-                6 => std::borrow::Cow::Borrowed("TWENTY_FOUR_HOURS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SNAPSHOT_PERIOD_UNSPECIFIED"),
+                Self::OneHour => std::option::Option::Some("ONE_HOUR"),
+                Self::SixHours => std::option::Option::Some("SIX_HOURS"),
+                Self::TwelveHours => std::option::Option::Some("TWELVE_HOURS"),
+                Self::TwentyFourHours => std::option::Option::Some("TWENTY_FOUR_HOURS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SNAPSHOT_PERIOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SNAPSHOT_PERIOD_UNSPECIFIED)
-                }
-                "ONE_HOUR" => std::option::Option::Some(Self::ONE_HOUR),
-                "SIX_HOURS" => std::option::Option::Some(Self::SIX_HOURS),
-                "TWELVE_HOURS" => std::option::Option::Some(Self::TWELVE_HOURS),
-                "TWENTY_FOUR_HOURS" => std::option::Option::Some(Self::TWENTY_FOUR_HOURS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SnapshotPeriod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SnapshotPeriod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SnapshotPeriod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SnapshotPeriod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                3 => Self::OneHour,
+                4 => Self::SixHours,
+                5 => Self::TwelveHours,
+                6 => Self::TwentyFourHours,
+                _ => Self::UnknownValue(snapshot_period::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SnapshotPeriod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SNAPSHOT_PERIOD_UNSPECIFIED" => Self::Unspecified,
+                "ONE_HOUR" => Self::OneHour,
+                "SIX_HOURS" => Self::SixHours,
+                "TWELVE_HOURS" => Self::TwelveHours,
+                "TWENTY_FOUR_HOURS" => Self::TwentyFourHours,
+                _ => Self::UnknownValue(snapshot_period::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SnapshotPeriod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::OneHour => serializer.serialize_i32(3),
+                Self::SixHours => serializer.serialize_i32(4),
+                Self::TwelveHours => serializer.serialize_i32(5),
+                Self::TwentyFourHours => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SnapshotPeriod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SnapshotPeriod>::new(
+                ".google.cloud.redis.v1.PersistenceConfig.SnapshotPeriod",
+            ))
         }
     }
 }
@@ -1304,67 +1795,128 @@ pub mod reschedule_maintenance_request {
     use super::*;
 
     /// Reschedule options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(i32);
-
-    impl RescheduleType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RescheduleType {
         /// Not set.
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
-
+        Unspecified,
         /// If the user wants to schedule the maintenance to happen now.
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
-
+        Immediate,
         /// If the user wants to use the existing maintenance policy to find the
         /// next available window.
-        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new(2);
-
+        NextAvailableWindow,
         /// If the user wants to reschedule the maintenance to a specific time.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
+        SpecificTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RescheduleType::value] or
+        /// [RescheduleType::name].
+        UnknownValue(reschedule_type::UnknownValue),
+    }
 
-        /// Creates a new RescheduleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reschedule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RescheduleType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Immediate => std::option::Option::Some(1),
+                Self::NextAvailableWindow => std::option::Option::Some(2),
+                Self::SpecificTime => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
-                2 => std::borrow::Cow::Borrowed("NEXT_AVAILABLE_WINDOW"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESCHEDULE_TYPE_UNSPECIFIED"),
+                Self::Immediate => std::option::Option::Some("IMMEDIATE"),
+                Self::NextAvailableWindow => std::option::Option::Some("NEXT_AVAILABLE_WINDOW"),
+                Self::SpecificTime => std::option::Option::Some("SPECIFIC_TIME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESCHEDULE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED)
-                }
-                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
-                "NEXT_AVAILABLE_WINDOW" => std::option::Option::Some(Self::NEXT_AVAILABLE_WINDOW),
-                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RescheduleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RescheduleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Immediate,
+                2 => Self::NextAvailableWindow,
+                3 => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RescheduleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMMEDIATE" => Self::Immediate,
+                "NEXT_AVAILABLE_WINDOW" => Self::NextAvailableWindow,
+                "SPECIFIC_TIME" => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RescheduleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Immediate => serializer.serialize_i32(1),
+                Self::NextAvailableWindow => serializer.serialize_i32(2),
+                Self::SpecificTime => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RescheduleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RescheduleType>::new(
+                ".google.cloud.redis.v1.RescheduleMaintenanceRequest.RescheduleType",
+            ))
         }
     }
 }
@@ -2447,65 +2999,124 @@ pub mod failover_instance_request {
     use super::*;
 
     /// Specifies different modes of operation in relation to the data retention.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataProtectionMode(i32);
-
-    impl DataProtectionMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataProtectionMode {
         /// Defaults to LIMITED_DATA_LOSS if a data protection mode is not
         /// specified.
-        pub const DATA_PROTECTION_MODE_UNSPECIFIED: DataProtectionMode = DataProtectionMode::new(0);
-
+        Unspecified,
         /// Instance failover will be protected with data loss control. More
         /// specifically, the failover will only be performed if the current
         /// replication offset diff between primary and replica is under a certain
         /// threshold.
-        pub const LIMITED_DATA_LOSS: DataProtectionMode = DataProtectionMode::new(1);
-
+        LimitedDataLoss,
         /// Instance failover will be performed without data loss control.
-        pub const FORCE_DATA_LOSS: DataProtectionMode = DataProtectionMode::new(2);
+        ForceDataLoss,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataProtectionMode::value] or
+        /// [DataProtectionMode::name].
+        UnknownValue(data_protection_mode::UnknownValue),
+    }
 
-        /// Creates a new DataProtectionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_protection_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataProtectionMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LimitedDataLoss => std::option::Option::Some(1),
+                Self::ForceDataLoss => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_PROTECTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LIMITED_DATA_LOSS"),
-                2 => std::borrow::Cow::Borrowed("FORCE_DATA_LOSS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_PROTECTION_MODE_UNSPECIFIED"),
+                Self::LimitedDataLoss => std::option::Option::Some("LIMITED_DATA_LOSS"),
+                Self::ForceDataLoss => std::option::Option::Some("FORCE_DATA_LOSS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_PROTECTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATA_PROTECTION_MODE_UNSPECIFIED)
-                }
-                "LIMITED_DATA_LOSS" => std::option::Option::Some(Self::LIMITED_DATA_LOSS),
-                "FORCE_DATA_LOSS" => std::option::Option::Some(Self::FORCE_DATA_LOSS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataProtectionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataProtectionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataProtectionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataProtectionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LimitedDataLoss,
+                2 => Self::ForceDataLoss,
+                _ => Self::UnknownValue(data_protection_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataProtectionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_PROTECTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "LIMITED_DATA_LOSS" => Self::LimitedDataLoss,
+                "FORCE_DATA_LOSS" => Self::ForceDataLoss,
+                _ => Self::UnknownValue(data_protection_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataProtectionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LimitedDataLoss => serializer.serialize_i32(1),
+                Self::ForceDataLoss => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataProtectionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataProtectionMode>::new(
+                ".google.cloud.redis.v1.FailoverInstanceRequest.DataProtectionMode",
+            ))
         }
     }
 }

--- a/src/generated/cloud/resourcemanager/v3/src/client.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/client.rs
@@ -279,8 +279,8 @@ impl Folders {
     /// The caller must have `resourcemanager.folders.delete` permission on the
     /// identified folder.
     ///
-    /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: crate::model::folder::state::ACTIVE
-    /// [google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]: crate::model::folder::state::DELETE_REQUESTED
+    /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: crate::model::folder::State::Active
+    /// [google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]: crate::model::folder::State::DeleteRequested
     ///
     /// # Long running operations
     ///
@@ -310,7 +310,7 @@ impl Folders {
     /// documentation. The caller must have `resourcemanager.folders.undelete`
     /// permission on the identified folder.
     ///
-    /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: crate::model::folder::state::ACTIVE
+    /// [google.cloud.resourcemanager.v3.Folder.State.ACTIVE]: crate::model::folder::State::Active
     /// [google.cloud.resourcemanager.v3.Folders.CreateFolder]: crate::client::Folders::create_folder
     ///
     /// # Long running operations
@@ -794,8 +794,8 @@ impl Projects {
     /// The caller must have `resourcemanager.projects.delete` permissions for this
     /// project.
     ///
-    /// [google.cloud.resourcemanager.v3.Project.State.ACTIVE]: crate::model::project::state::ACTIVE
-    /// [google.cloud.resourcemanager.v3.Project.State.DELETE_REQUESTED]: crate::model::project::state::DELETE_REQUESTED
+    /// [google.cloud.resourcemanager.v3.Project.State.ACTIVE]: crate::model::project::State::Active
+    /// [google.cloud.resourcemanager.v3.Project.State.DELETE_REQUESTED]: crate::model::project::State::DeleteRequested
     /// [google.cloud.resourcemanager.v3.Projects.SearchProjects]: crate::client::Projects::search_projects
     ///
     /// # Long running operations

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -169,59 +169,120 @@ pub mod folder {
     use super::*;
 
     /// Folder lifecycle states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// The normal and active state.
+        Active,
+        /// The folder has been marked for deletion by the user.
+        DeleteRequested,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The normal and active state.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The folder has been marked for deletion by the user.
-        pub const DELETE_REQUESTED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::DeleteRequested => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::DeleteRequested => std::option::Option::Some("DELETE_REQUESTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::DeleteRequested,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETE_REQUESTED" => Self::DeleteRequested,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::DeleteRequested => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.resourcemanager.v3.Folder.State",
+            ))
         }
     }
 }
@@ -292,7 +353,7 @@ pub struct ListFoldersRequest {
     /// [DELETE_REQUESTED][google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]
     /// state should be returned. Defaults to false.
     ///
-    /// [google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]: crate::model::folder::state::DELETE_REQUESTED
+    /// [google.cloud.resourcemanager.v3.Folder.State.DELETE_REQUESTED]: crate::model::folder::State::DeleteRequested
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub show_deleted: bool,
 
@@ -1091,59 +1152,120 @@ pub mod organization {
     use super::*;
 
     /// Organization lifecycle states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.  This is only useful for distinguishing unset values.
+        Unspecified,
+        /// The normal and active state.
+        Active,
+        /// The organization has been marked for deletion by the user.
+        DeleteRequested,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.  This is only useful for distinguishing unset values.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The normal and active state.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The organization has been marked for deletion by the user.
-        pub const DELETE_REQUESTED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::DeleteRequested => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::DeleteRequested => std::option::Option::Some("DELETE_REQUESTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::DeleteRequested,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETE_REQUESTED" => Self::DeleteRequested,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::DeleteRequested => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.resourcemanager.v3.Organization.State",
+            ))
         }
     }
 
@@ -1554,17 +1676,14 @@ pub mod project {
     use super::*;
 
     /// Project lifecycle states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.  This is only used/useful for distinguishing
         /// unset values.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The normal and active state.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The project has been marked for deletion by the user
         /// (by invoking
         /// [DeleteProject][google.cloud.resourcemanager.v3.Projects.DeleteProject])
@@ -1573,48 +1692,112 @@ pub mod project {
         /// [google.cloud.resourcemanager.v3.Projects.UndeleteProject].
         ///
         /// [google.cloud.resourcemanager.v3.Projects.DeleteProject]: crate::client::Projects::delete_project
-        pub const DELETE_REQUESTED: State = State::new(2);
+        DeleteRequested,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::DeleteRequested => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::DeleteRequested => std::option::Option::Some("DELETE_REQUESTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::DeleteRequested,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETE_REQUESTED" => Self::DeleteRequested,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::DeleteRequested => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.resourcemanager.v3.Project.State",
+            ))
         }
     }
 }
@@ -4436,13 +4619,11 @@ impl wkt::message::Message for DeleteTagValueMetadata {
 /// A purpose for each policy engine requiring such an integration. A single
 /// policy engine may have multiple purposes defined, however a TagKey may only
 /// specify a single purpose.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Purpose(i32);
-
-impl Purpose {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Purpose {
     /// Unspecified purpose.
-    pub const PURPOSE_UNSPECIFIED: Purpose = Purpose::new(0);
-
+    Unspecified,
     /// Purpose for Compute Engine firewalls.
     /// A corresponding `purpose_data` should be set for the network the tag is
     /// intended for. The key should be `network` and the value should be in
@@ -4459,45 +4640,106 @@ impl Purpose {
     /// `<https://www.googleapis.com/compute/staging_v1/projects/fail-closed-load-testing/global/networks/6992953698831725600>`
     ///
     /// - `fail-closed-load-testing/load-testing-network`
-    pub const GCE_FIREWALL: Purpose = Purpose::new(1);
+    GceFirewall,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Purpose::value] or
+    /// [Purpose::name].
+    UnknownValue(purpose::UnknownValue),
+}
 
-    /// Creates a new Purpose instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod purpose {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl Purpose {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::GceFirewall => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PURPOSE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GCE_FIREWALL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PURPOSE_UNSPECIFIED"),
+            Self::GceFirewall => std::option::Option::Some("GCE_FIREWALL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PURPOSE_UNSPECIFIED" => std::option::Option::Some(Self::PURPOSE_UNSPECIFIED),
-            "GCE_FIREWALL" => std::option::Option::Some(Self::GCE_FIREWALL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Purpose {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Purpose {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Purpose {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Purpose {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::GceFirewall,
+            _ => Self::UnknownValue(purpose::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Purpose {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PURPOSE_UNSPECIFIED" => Self::Unspecified,
+            "GCE_FIREWALL" => Self::GceFirewall,
+            _ => Self::UnknownValue(purpose::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Purpose {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::GceFirewall => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Purpose {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Purpose>::new(
+            ".google.cloud.resourcemanager.v3.Purpose",
+        ))
     }
 }

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -70,8 +70,8 @@ pub struct ProductLevelConfig {
     /// for more details.
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.Product.primary_product_id]: crate::model::Product::primary_product_id
     /// [google.cloud.retail.v2.ProductLevelConfig.merchant_center_product_id_field]: crate::model::ProductLevelConfig::merchant_center_product_id_field
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -246,14 +246,14 @@ pub struct CatalogAttribute {
     /// behavior defaults to
     /// [EXACT_SEARCHABLE_DISABLED][google.cloud.retail.v2.CatalogAttribute.ExactSearchableOption.EXACT_SEARCHABLE_DISABLED].
     ///
-    /// [google.cloud.retail.v2.CatalogAttribute.ExactSearchableOption.EXACT_SEARCHABLE_DISABLED]: crate::model::catalog_attribute::exact_searchable_option::EXACT_SEARCHABLE_DISABLED
+    /// [google.cloud.retail.v2.CatalogAttribute.ExactSearchableOption.EXACT_SEARCHABLE_DISABLED]: crate::model::catalog_attribute::ExactSearchableOption::ExactSearchableDisabled
     pub exact_searchable_option: crate::model::catalog_attribute::ExactSearchableOption,
 
     /// If RETRIEVABLE_ENABLED, attribute values are retrievable in the search
     /// results. If unset, the server behavior defaults to
     /// [RETRIEVABLE_DISABLED][google.cloud.retail.v2.CatalogAttribute.RetrievableOption.RETRIEVABLE_DISABLED].
     ///
-    /// [google.cloud.retail.v2.CatalogAttribute.RetrievableOption.RETRIEVABLE_DISABLED]: crate::model::catalog_attribute::retrievable_option::RETRIEVABLE_DISABLED
+    /// [google.cloud.retail.v2.CatalogAttribute.RetrievableOption.RETRIEVABLE_DISABLED]: crate::model::catalog_attribute::RetrievableOption::RetrievableDisabled
     pub retrievable_option: crate::model::catalog_attribute::RetrievableOption,
 
     /// Contains facet options.
@@ -759,371 +759,727 @@ pub mod catalog_attribute {
     }
 
     /// The type of an attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttributeType(i32);
-
-    impl AttributeType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttributeType {
         /// The type of the attribute is unknown.
         ///
         /// Used when type cannot be derived from attribute that is not
         /// [in_use][google.cloud.retail.v2.CatalogAttribute.in_use].
         ///
         /// [google.cloud.retail.v2.CatalogAttribute.in_use]: crate::model::CatalogAttribute::in_use
-        pub const UNKNOWN: AttributeType = AttributeType::new(0);
-
+        Unknown,
         /// Textual attribute.
-        pub const TEXTUAL: AttributeType = AttributeType::new(1);
-
+        Textual,
         /// Numerical attribute.
-        pub const NUMERICAL: AttributeType = AttributeType::new(2);
+        Numerical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttributeType::value] or
+        /// [AttributeType::name].
+        UnknownValue(attribute_type::UnknownValue),
+    }
 
-        /// Creates a new AttributeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attribute_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttributeType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Textual => std::option::Option::Some(1),
+                Self::Numerical => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("TEXTUAL"),
-                2 => std::borrow::Cow::Borrowed("NUMERICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Textual => std::option::Option::Some("TEXTUAL"),
+                Self::Numerical => std::option::Option::Some("NUMERICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "TEXTUAL" => std::option::Option::Some(Self::TEXTUAL),
-                "NUMERICAL" => std::option::Option::Some(Self::NUMERICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttributeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttributeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttributeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttributeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Textual,
+                2 => Self::Numerical,
+                _ => Self::UnknownValue(attribute_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttributeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "TEXTUAL" => Self::Textual,
+                "NUMERICAL" => Self::Numerical,
+                _ => Self::UnknownValue(attribute_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttributeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Textual => serializer.serialize_i32(1),
+                Self::Numerical => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttributeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttributeType>::new(
+                ".google.cloud.retail.v2.CatalogAttribute.AttributeType",
+            ))
         }
     }
 
     /// The status of the indexable option of a catalog attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndexableOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IndexableOption {
+        /// Value used when unset.
+        Unspecified,
+        /// Indexable option enabled for an attribute.
+        IndexableEnabled,
+        /// Indexable option disabled for an attribute.
+        IndexableDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IndexableOption::value] or
+        /// [IndexableOption::name].
+        UnknownValue(indexable_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod indexable_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IndexableOption {
-        /// Value used when unset.
-        pub const INDEXABLE_OPTION_UNSPECIFIED: IndexableOption = IndexableOption::new(0);
-
-        /// Indexable option enabled for an attribute.
-        pub const INDEXABLE_ENABLED: IndexableOption = IndexableOption::new(1);
-
-        /// Indexable option disabled for an attribute.
-        pub const INDEXABLE_DISABLED: IndexableOption = IndexableOption::new(2);
-
-        /// Creates a new IndexableOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::IndexableEnabled => std::option::Option::Some(1),
+                Self::IndexableDisabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INDEXABLE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INDEXABLE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("INDEXABLE_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INDEXABLE_OPTION_UNSPECIFIED"),
+                Self::IndexableEnabled => std::option::Option::Some("INDEXABLE_ENABLED"),
+                Self::IndexableDisabled => std::option::Option::Some("INDEXABLE_DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INDEXABLE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INDEXABLE_OPTION_UNSPECIFIED)
-                }
-                "INDEXABLE_ENABLED" => std::option::Option::Some(Self::INDEXABLE_ENABLED),
-                "INDEXABLE_DISABLED" => std::option::Option::Some(Self::INDEXABLE_DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IndexableOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IndexableOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IndexableOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IndexableOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::IndexableEnabled,
+                2 => Self::IndexableDisabled,
+                _ => Self::UnknownValue(indexable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IndexableOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INDEXABLE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "INDEXABLE_ENABLED" => Self::IndexableEnabled,
+                "INDEXABLE_DISABLED" => Self::IndexableDisabled,
+                _ => Self::UnknownValue(indexable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IndexableOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::IndexableEnabled => serializer.serialize_i32(1),
+                Self::IndexableDisabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IndexableOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndexableOption>::new(
+                ".google.cloud.retail.v2.CatalogAttribute.IndexableOption",
+            ))
         }
     }
 
     /// The status of the dynamic facetable option of a catalog attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DynamicFacetableOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DynamicFacetableOption {
+        /// Value used when unset.
+        Unspecified,
+        /// Dynamic facetable option enabled for an attribute.
+        DynamicFacetableEnabled,
+        /// Dynamic facetable option disabled for an attribute.
+        DynamicFacetableDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DynamicFacetableOption::value] or
+        /// [DynamicFacetableOption::name].
+        UnknownValue(dynamic_facetable_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod dynamic_facetable_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DynamicFacetableOption {
-        /// Value used when unset.
-        pub const DYNAMIC_FACETABLE_OPTION_UNSPECIFIED: DynamicFacetableOption =
-            DynamicFacetableOption::new(0);
-
-        /// Dynamic facetable option enabled for an attribute.
-        pub const DYNAMIC_FACETABLE_ENABLED: DynamicFacetableOption =
-            DynamicFacetableOption::new(1);
-
-        /// Dynamic facetable option disabled for an attribute.
-        pub const DYNAMIC_FACETABLE_DISABLED: DynamicFacetableOption =
-            DynamicFacetableOption::new(2);
-
-        /// Creates a new DynamicFacetableOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DynamicFacetableEnabled => std::option::Option::Some(1),
+                Self::DynamicFacetableDisabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DYNAMIC_FACETABLE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DYNAMIC_FACETABLE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DYNAMIC_FACETABLE_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DYNAMIC_FACETABLE_OPTION_UNSPECIFIED")
+                }
+                Self::DynamicFacetableEnabled => {
+                    std::option::Option::Some("DYNAMIC_FACETABLE_ENABLED")
+                }
+                Self::DynamicFacetableDisabled => {
+                    std::option::Option::Some("DYNAMIC_FACETABLE_DISABLED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DYNAMIC_FACETABLE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DYNAMIC_FACETABLE_OPTION_UNSPECIFIED)
-                }
-                "DYNAMIC_FACETABLE_ENABLED" => {
-                    std::option::Option::Some(Self::DYNAMIC_FACETABLE_ENABLED)
-                }
-                "DYNAMIC_FACETABLE_DISABLED" => {
-                    std::option::Option::Some(Self::DYNAMIC_FACETABLE_DISABLED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DynamicFacetableOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DynamicFacetableOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DynamicFacetableOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DynamicFacetableOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DynamicFacetableEnabled,
+                2 => Self::DynamicFacetableDisabled,
+                _ => Self::UnknownValue(dynamic_facetable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DynamicFacetableOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DYNAMIC_FACETABLE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "DYNAMIC_FACETABLE_ENABLED" => Self::DynamicFacetableEnabled,
+                "DYNAMIC_FACETABLE_DISABLED" => Self::DynamicFacetableDisabled,
+                _ => Self::UnknownValue(dynamic_facetable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DynamicFacetableOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DynamicFacetableEnabled => serializer.serialize_i32(1),
+                Self::DynamicFacetableDisabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DynamicFacetableOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DynamicFacetableOption>::new(
+                ".google.cloud.retail.v2.CatalogAttribute.DynamicFacetableOption",
+            ))
         }
     }
 
     /// The status of the searchable option of a catalog attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchableOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SearchableOption {
+        /// Value used when unset.
+        Unspecified,
+        /// Searchable option enabled for an attribute.
+        SearchableEnabled,
+        /// Searchable option disabled for an attribute.
+        SearchableDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SearchableOption::value] or
+        /// [SearchableOption::name].
+        UnknownValue(searchable_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod searchable_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SearchableOption {
-        /// Value used when unset.
-        pub const SEARCHABLE_OPTION_UNSPECIFIED: SearchableOption = SearchableOption::new(0);
-
-        /// Searchable option enabled for an attribute.
-        pub const SEARCHABLE_ENABLED: SearchableOption = SearchableOption::new(1);
-
-        /// Searchable option disabled for an attribute.
-        pub const SEARCHABLE_DISABLED: SearchableOption = SearchableOption::new(2);
-
-        /// Creates a new SearchableOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SearchableEnabled => std::option::Option::Some(1),
+                Self::SearchableDisabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEARCHABLE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SEARCHABLE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("SEARCHABLE_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEARCHABLE_OPTION_UNSPECIFIED"),
+                Self::SearchableEnabled => std::option::Option::Some("SEARCHABLE_ENABLED"),
+                Self::SearchableDisabled => std::option::Option::Some("SEARCHABLE_DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEARCHABLE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SEARCHABLE_OPTION_UNSPECIFIED)
-                }
-                "SEARCHABLE_ENABLED" => std::option::Option::Some(Self::SEARCHABLE_ENABLED),
-                "SEARCHABLE_DISABLED" => std::option::Option::Some(Self::SEARCHABLE_DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SearchableOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchableOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SearchableOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SearchableOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SearchableEnabled,
+                2 => Self::SearchableDisabled,
+                _ => Self::UnknownValue(searchable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SearchableOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEARCHABLE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "SEARCHABLE_ENABLED" => Self::SearchableEnabled,
+                "SEARCHABLE_DISABLED" => Self::SearchableDisabled,
+                _ => Self::UnknownValue(searchable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SearchableOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SearchableEnabled => serializer.serialize_i32(1),
+                Self::SearchableDisabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SearchableOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchableOption>::new(
+                ".google.cloud.retail.v2.CatalogAttribute.SearchableOption",
+            ))
         }
     }
 
     /// The status of the exact-searchable option of a catalog attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExactSearchableOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExactSearchableOption {
+        /// Value used when unset.
+        Unspecified,
+        /// Exact searchable option enabled for an attribute.
+        ExactSearchableEnabled,
+        /// Exact searchable option disabled for an attribute.
+        ExactSearchableDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExactSearchableOption::value] or
+        /// [ExactSearchableOption::name].
+        UnknownValue(exact_searchable_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod exact_searchable_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ExactSearchableOption {
-        /// Value used when unset.
-        pub const EXACT_SEARCHABLE_OPTION_UNSPECIFIED: ExactSearchableOption =
-            ExactSearchableOption::new(0);
-
-        /// Exact searchable option enabled for an attribute.
-        pub const EXACT_SEARCHABLE_ENABLED: ExactSearchableOption = ExactSearchableOption::new(1);
-
-        /// Exact searchable option disabled for an attribute.
-        pub const EXACT_SEARCHABLE_DISABLED: ExactSearchableOption = ExactSearchableOption::new(2);
-
-        /// Creates a new ExactSearchableOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ExactSearchableEnabled => std::option::Option::Some(1),
+                Self::ExactSearchableDisabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXACT_SEARCHABLE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXACT_SEARCHABLE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("EXACT_SEARCHABLE_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("EXACT_SEARCHABLE_OPTION_UNSPECIFIED")
+                }
+                Self::ExactSearchableEnabled => {
+                    std::option::Option::Some("EXACT_SEARCHABLE_ENABLED")
+                }
+                Self::ExactSearchableDisabled => {
+                    std::option::Option::Some("EXACT_SEARCHABLE_DISABLED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXACT_SEARCHABLE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXACT_SEARCHABLE_OPTION_UNSPECIFIED)
-                }
-                "EXACT_SEARCHABLE_ENABLED" => {
-                    std::option::Option::Some(Self::EXACT_SEARCHABLE_ENABLED)
-                }
-                "EXACT_SEARCHABLE_DISABLED" => {
-                    std::option::Option::Some(Self::EXACT_SEARCHABLE_DISABLED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExactSearchableOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExactSearchableOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExactSearchableOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExactSearchableOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ExactSearchableEnabled,
+                2 => Self::ExactSearchableDisabled,
+                _ => Self::UnknownValue(exact_searchable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExactSearchableOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXACT_SEARCHABLE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "EXACT_SEARCHABLE_ENABLED" => Self::ExactSearchableEnabled,
+                "EXACT_SEARCHABLE_DISABLED" => Self::ExactSearchableDisabled,
+                _ => Self::UnknownValue(exact_searchable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExactSearchableOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ExactSearchableEnabled => serializer.serialize_i32(1),
+                Self::ExactSearchableDisabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExactSearchableOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExactSearchableOption>::new(
+                ".google.cloud.retail.v2.CatalogAttribute.ExactSearchableOption",
+            ))
         }
     }
 
     /// The status of the retrievable option of a catalog attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetrievableOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RetrievableOption {
+        /// Value used when unset.
+        Unspecified,
+        /// Retrievable option enabled for an attribute.
+        RetrievableEnabled,
+        /// Retrievable option disabled for an attribute.
+        RetrievableDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RetrievableOption::value] or
+        /// [RetrievableOption::name].
+        UnknownValue(retrievable_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod retrievable_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RetrievableOption {
-        /// Value used when unset.
-        pub const RETRIEVABLE_OPTION_UNSPECIFIED: RetrievableOption = RetrievableOption::new(0);
-
-        /// Retrievable option enabled for an attribute.
-        pub const RETRIEVABLE_ENABLED: RetrievableOption = RetrievableOption::new(1);
-
-        /// Retrievable option disabled for an attribute.
-        pub const RETRIEVABLE_DISABLED: RetrievableOption = RetrievableOption::new(2);
-
-        /// Creates a new RetrievableOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RetrievableEnabled => std::option::Option::Some(1),
+                Self::RetrievableDisabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RETRIEVABLE_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RETRIEVABLE_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("RETRIEVABLE_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RETRIEVABLE_OPTION_UNSPECIFIED"),
+                Self::RetrievableEnabled => std::option::Option::Some("RETRIEVABLE_ENABLED"),
+                Self::RetrievableDisabled => std::option::Option::Some("RETRIEVABLE_DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RETRIEVABLE_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RETRIEVABLE_OPTION_UNSPECIFIED)
-                }
-                "RETRIEVABLE_ENABLED" => std::option::Option::Some(Self::RETRIEVABLE_ENABLED),
-                "RETRIEVABLE_DISABLED" => std::option::Option::Some(Self::RETRIEVABLE_DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RetrievableOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RetrievableOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RetrievableOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RetrievableOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RetrievableEnabled,
+                2 => Self::RetrievableDisabled,
+                _ => Self::UnknownValue(retrievable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RetrievableOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RETRIEVABLE_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "RETRIEVABLE_ENABLED" => Self::RetrievableEnabled,
+                "RETRIEVABLE_DISABLED" => Self::RetrievableDisabled,
+                _ => Self::UnknownValue(retrievable_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RetrievableOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RetrievableEnabled => serializer.serialize_i32(1),
+                Self::RetrievableDisabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RetrievableOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RetrievableOption>::new(
+                ".google.cloud.retail.v2.CatalogAttribute.RetrievableOption",
+            ))
         }
     }
 }
@@ -2454,7 +2810,7 @@ pub mod condition {
 ///   [SOLUTION_TYPE_SEARCH][google.cloud.retail.v2.SolutionType.SOLUTION_TYPE_SEARCH].
 ///
 /// [google.cloud.retail.v2.Control]: crate::model::Control
-/// [google.cloud.retail.v2.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+/// [google.cloud.retail.v2.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -4141,7 +4497,7 @@ pub struct PriceInfo {
     ///
     /// [google.cloud.retail.v2.PriceInfo.currency_code]: crate::model::PriceInfo::currency_code
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.Product.primary_product_id]: crate::model::Product::primary_product_id
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub currency_code: std::string::String,
@@ -4231,8 +4587,8 @@ pub struct PriceInfo {
     /// Do not set this field in API requests.
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.ProductService.GetProduct]: crate::client::ProductService::get_product
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub price_range: std::option::Option<crate::model::price_info::PriceRange>,
@@ -4317,7 +4673,7 @@ pub mod price_info {
     /// [Product.primary_product_id][google.cloud.retail.v2.Product.primary_product_id].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.Product.primary_product_id]: crate::model::Product::primary_product_id
     #[serde_with::serde_as]
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -4332,7 +4688,7 @@ pub mod price_info {
         ///
         /// [google.cloud.retail.v2.PriceInfo.price]: crate::model::PriceInfo::price
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         /// [google.cloud.retail.v2.Product.primary_product_id]: crate::model::Product::primary_product_id
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
         pub price: std::option::Option<crate::model::Interval>,
@@ -4345,7 +4701,7 @@ pub mod price_info {
         ///
         /// [google.cloud.retail.v2.PriceInfo.original_price]: crate::model::PriceInfo::original_price
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         /// [google.cloud.retail.v2.Product.primary_product_id]: crate::model::Product::primary_product_id
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
         pub original_price: std::option::Option<crate::model::Interval>,
@@ -5187,7 +5543,7 @@ pub struct Control {
     /// If no solution type is provided at creation time, will default to
     /// [SOLUTION_TYPE_SEARCH][google.cloud.retail.v2.SolutionType.SOLUTION_TYPE_SEARCH].
     ///
-    /// [google.cloud.retail.v2.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::solution_type::SOLUTION_TYPE_SEARCH
+    /// [google.cloud.retail.v2.SolutionType.SOLUTION_TYPE_SEARCH]: crate::model::SolutionType::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub solution_types: std::vec::Vec<crate::model::SolutionType>,
 
@@ -5199,7 +5555,7 @@ pub struct Control {
     /// if not specified. Currently only allow one search_solution_use_case per
     /// control.
     ///
-    /// [google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH]: crate::model::search_solution_use_case::SEARCH_SOLUTION_USE_CASE_SEARCH
+    /// [google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH]: crate::model::SearchSolutionUseCase::Search
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub search_solution_use_case: std::vec::Vec<crate::model::SearchSolutionUseCase>,
 
@@ -7189,7 +7545,7 @@ pub struct ImportProductsRequest {
     /// imported. Defaults to
     /// [ReconciliationMode.INCREMENTAL][google.cloud.retail.v2.ImportProductsRequest.ReconciliationMode.INCREMENTAL].
     ///
-    /// [google.cloud.retail.v2.ImportProductsRequest.ReconciliationMode.INCREMENTAL]: crate::model::import_products_request::reconciliation_mode::INCREMENTAL
+    /// [google.cloud.retail.v2.ImportProductsRequest.ReconciliationMode.INCREMENTAL]: crate::model::import_products_request::ReconciliationMode::Incremental
     pub reconciliation_mode: crate::model::import_products_request::ReconciliationMode,
 
     /// Full Pub/Sub topic name for receiving notification. If this field is set,
@@ -7301,62 +7657,121 @@ pub mod import_products_request {
 
     /// Indicates how imported products are reconciled with the existing products
     /// created or imported before.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReconciliationMode(i32);
-
-    impl ReconciliationMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReconciliationMode {
         /// Defaults to INCREMENTAL.
-        pub const RECONCILIATION_MODE_UNSPECIFIED: ReconciliationMode = ReconciliationMode::new(0);
-
+        Unspecified,
         /// Inserts new products or updates existing products.
-        pub const INCREMENTAL: ReconciliationMode = ReconciliationMode::new(1);
-
+        Incremental,
         /// Calculates diff and replaces the entire product dataset. Existing
         /// products may be deleted if they are not present in the source location.
-        pub const FULL: ReconciliationMode = ReconciliationMode::new(2);
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReconciliationMode::value] or
+        /// [ReconciliationMode::name].
+        UnknownValue(reconciliation_mode::UnknownValue),
+    }
 
-        /// Creates a new ReconciliationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reconciliation_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ReconciliationMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incremental => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RECONCILIATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCREMENTAL"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RECONCILIATION_MODE_UNSPECIFIED"),
+                Self::Incremental => std::option::Option::Some("INCREMENTAL"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RECONCILIATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RECONCILIATION_MODE_UNSPECIFIED)
-                }
-                "INCREMENTAL" => std::option::Option::Some(Self::INCREMENTAL),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReconciliationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReconciliationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReconciliationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReconciliationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Incremental,
+                2 => Self::Full,
+                _ => Self::UnknownValue(reconciliation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReconciliationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RECONCILIATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "INCREMENTAL" => Self::Incremental,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(reconciliation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReconciliationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incremental => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReconciliationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReconciliationMode>::new(
+                ".google.cloud.retail.v2.ImportProductsRequest.ReconciliationMode",
+            ))
         }
     }
 }
@@ -8569,7 +8984,7 @@ pub mod model {
         /// it isn't specified, it defaults to
         /// [MULTIPLE_CONTEXT_PRODUCTS][google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS].
         ///
-        /// [google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS]: crate::model::model::context_products_type::MULTIPLE_CONTEXT_PRODUCTS
+        /// [google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS]: crate::model::model::ContextProductsType::MultipleContextProducts
         pub context_products_type: crate::model::model::ContextProductsType,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8696,126 +9111,246 @@ pub mod model {
     }
 
     /// The serving state of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ServingState(i32);
-
-    impl ServingState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ServingState {
         /// Unspecified serving state.
-        pub const SERVING_STATE_UNSPECIFIED: ServingState = ServingState::new(0);
-
+        Unspecified,
         /// The model is not serving.
-        pub const INACTIVE: ServingState = ServingState::new(1);
-
+        Inactive,
         /// The model is serving and can be queried.
-        pub const ACTIVE: ServingState = ServingState::new(2);
-
+        Active,
         /// The model is trained on tuned hyperparameters and can be
         /// queried.
-        pub const TUNED: ServingState = ServingState::new(3);
+        Tuned,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ServingState::value] or
+        /// [ServingState::name].
+        UnknownValue(serving_state::UnknownValue),
+    }
 
-        /// Creates a new ServingState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod serving_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ServingState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Inactive => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Tuned => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SERVING_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INACTIVE"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("TUNED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SERVING_STATE_UNSPECIFIED"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Tuned => std::option::Option::Some("TUNED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SERVING_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SERVING_STATE_UNSPECIFIED)
-                }
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "TUNED" => std::option::Option::Some(Self::TUNED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ServingState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ServingState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ServingState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ServingState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Inactive,
+                2 => Self::Active,
+                3 => Self::Tuned,
+                _ => Self::UnknownValue(serving_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ServingState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SERVING_STATE_UNSPECIFIED" => Self::Unspecified,
+                "INACTIVE" => Self::Inactive,
+                "ACTIVE" => Self::Active,
+                "TUNED" => Self::Tuned,
+                _ => Self::UnknownValue(serving_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ServingState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Inactive => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Tuned => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ServingState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServingState>::new(
+                ".google.cloud.retail.v2.Model.ServingState",
+            ))
         }
     }
 
     /// The training state of the model.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TrainingState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TrainingState {
+        /// Unspecified training state.
+        Unspecified,
+        /// The model training is paused.
+        Paused,
+        /// The model is training.
+        Training,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TrainingState::value] or
+        /// [TrainingState::name].
+        UnknownValue(training_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod training_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TrainingState {
-        /// Unspecified training state.
-        pub const TRAINING_STATE_UNSPECIFIED: TrainingState = TrainingState::new(0);
-
-        /// The model training is paused.
-        pub const PAUSED: TrainingState = TrainingState::new(1);
-
-        /// The model is training.
-        pub const TRAINING: TrainingState = TrainingState::new(2);
-
-        /// Creates a new TrainingState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Paused => std::option::Option::Some(1),
+                Self::Training => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRAINING_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PAUSED"),
-                2 => std::borrow::Cow::Borrowed("TRAINING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRAINING_STATE_UNSPECIFIED"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Training => std::option::Option::Some("TRAINING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRAINING_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRAINING_STATE_UNSPECIFIED)
-                }
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "TRAINING" => std::option::Option::Some(Self::TRAINING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TrainingState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TrainingState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TrainingState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TrainingState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Paused,
+                2 => Self::Training,
+                _ => Self::UnknownValue(training_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TrainingState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRAINING_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PAUSED" => Self::Paused,
+                "TRAINING" => Self::Training,
+                _ => Self::UnknownValue(training_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TrainingState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Paused => serializer.serialize_i32(1),
+                Self::Training => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TrainingState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TrainingState>::new(
+                ".google.cloud.retail.v2.Model.TrainingState",
+            ))
         }
     }
 
@@ -8825,204 +9360,381 @@ pub mod model {
     /// method, which starts a tuning process immediately and resets the quarterly
     /// schedule. Enabling or disabling periodic tuning does not affect any
     /// current tuning processes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeriodicTuningState(i32);
-
-    impl PeriodicTuningState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PeriodicTuningState {
         /// Unspecified default value, should never be explicitly set.
-        pub const PERIODIC_TUNING_STATE_UNSPECIFIED: PeriodicTuningState =
-            PeriodicTuningState::new(0);
-
+        Unspecified,
         /// The model has periodic tuning disabled. Tuning
         /// can be reenabled by calling the `EnableModelPeriodicTuning`
         /// method or by calling the `TuneModel` method.
-        pub const PERIODIC_TUNING_DISABLED: PeriodicTuningState = PeriodicTuningState::new(1);
-
+        PeriodicTuningDisabled,
         /// The model cannot be tuned with periodic tuning OR the
         /// `TuneModel` method. Hide the options in customer UI and
         /// reject any requests through the backend self serve API.
-        pub const ALL_TUNING_DISABLED: PeriodicTuningState = PeriodicTuningState::new(3);
-
+        AllTuningDisabled,
         /// The model has periodic tuning enabled. Tuning
         /// can be disabled by calling the `DisableModelPeriodicTuning`
         /// method.
-        pub const PERIODIC_TUNING_ENABLED: PeriodicTuningState = PeriodicTuningState::new(2);
+        PeriodicTuningEnabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PeriodicTuningState::value] or
+        /// [PeriodicTuningState::name].
+        UnknownValue(periodic_tuning_state::UnknownValue),
+    }
 
-        /// Creates a new PeriodicTuningState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod periodic_tuning_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PeriodicTuningState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PeriodicTuningDisabled => std::option::Option::Some(1),
+                Self::AllTuningDisabled => std::option::Option::Some(3),
+                Self::PeriodicTuningEnabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERIODIC_TUNING_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PERIODIC_TUNING_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("PERIODIC_TUNING_ENABLED"),
-                3 => std::borrow::Cow::Borrowed("ALL_TUNING_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERIODIC_TUNING_STATE_UNSPECIFIED"),
+                Self::PeriodicTuningDisabled => {
+                    std::option::Option::Some("PERIODIC_TUNING_DISABLED")
+                }
+                Self::AllTuningDisabled => std::option::Option::Some("ALL_TUNING_DISABLED"),
+                Self::PeriodicTuningEnabled => std::option::Option::Some("PERIODIC_TUNING_ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERIODIC_TUNING_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PERIODIC_TUNING_STATE_UNSPECIFIED)
-                }
-                "PERIODIC_TUNING_DISABLED" => {
-                    std::option::Option::Some(Self::PERIODIC_TUNING_DISABLED)
-                }
-                "ALL_TUNING_DISABLED" => std::option::Option::Some(Self::ALL_TUNING_DISABLED),
-                "PERIODIC_TUNING_ENABLED" => {
-                    std::option::Option::Some(Self::PERIODIC_TUNING_ENABLED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PeriodicTuningState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PeriodicTuningState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PeriodicTuningState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PeriodicTuningState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PeriodicTuningDisabled,
+                2 => Self::PeriodicTuningEnabled,
+                3 => Self::AllTuningDisabled,
+                _ => Self::UnknownValue(periodic_tuning_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PeriodicTuningState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERIODIC_TUNING_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PERIODIC_TUNING_DISABLED" => Self::PeriodicTuningDisabled,
+                "ALL_TUNING_DISABLED" => Self::AllTuningDisabled,
+                "PERIODIC_TUNING_ENABLED" => Self::PeriodicTuningEnabled,
+                _ => Self::UnknownValue(periodic_tuning_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PeriodicTuningState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PeriodicTuningDisabled => serializer.serialize_i32(1),
+                Self::AllTuningDisabled => serializer.serialize_i32(3),
+                Self::PeriodicTuningEnabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PeriodicTuningState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PeriodicTuningState>::new(
+                ".google.cloud.retail.v2.Model.PeriodicTuningState",
+            ))
         }
     }
 
     /// Describes whether this model have sufficient training data
     /// to be continuously trained.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataState(i32);
-
-    impl DataState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataState {
         /// Unspecified default value, should never be explicitly set.
-        pub const DATA_STATE_UNSPECIFIED: DataState = DataState::new(0);
-
+        Unspecified,
         /// The model has sufficient training data.
-        pub const DATA_OK: DataState = DataState::new(1);
-
+        DataOk,
         /// The model does not have sufficient training data. Error
         /// messages can be queried via Stackdriver.
-        pub const DATA_ERROR: DataState = DataState::new(2);
+        DataError,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataState::value] or
+        /// [DataState::name].
+        UnknownValue(data_state::UnknownValue),
+    }
 
-        /// Creates a new DataState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DataOk => std::option::Option::Some(1),
+                Self::DataError => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATA_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATA_OK"),
-                2 => std::borrow::Cow::Borrowed("DATA_ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATA_STATE_UNSPECIFIED"),
+                Self::DataOk => std::option::Option::Some("DATA_OK"),
+                Self::DataError => std::option::Option::Some("DATA_ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATA_STATE_UNSPECIFIED" => std::option::Option::Some(Self::DATA_STATE_UNSPECIFIED),
-                "DATA_OK" => std::option::Option::Some(Self::DATA_OK),
-                "DATA_ERROR" => std::option::Option::Some(Self::DATA_ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DataOk,
+                2 => Self::DataError,
+                _ => Self::UnknownValue(data_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATA_STATE_UNSPECIFIED" => Self::Unspecified,
+                "DATA_OK" => Self::DataOk,
+                "DATA_ERROR" => Self::DataError,
+                _ => Self::UnknownValue(data_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DataOk => serializer.serialize_i32(1),
+                Self::DataError => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataState>::new(
+                ".google.cloud.retail.v2.Model.DataState",
+            ))
         }
     }
 
     /// Use single or multiple context products for recommendations.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContextProductsType(i32);
-
-    impl ContextProductsType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ContextProductsType {
         /// Unspecified default value, should never be explicitly set.
         /// Defaults to
         /// [MULTIPLE_CONTEXT_PRODUCTS][google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS].
         ///
-        /// [google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS]: crate::model::model::context_products_type::MULTIPLE_CONTEXT_PRODUCTS
-        pub const CONTEXT_PRODUCTS_TYPE_UNSPECIFIED: ContextProductsType =
-            ContextProductsType::new(0);
-
+        /// [google.cloud.retail.v2.Model.ContextProductsType.MULTIPLE_CONTEXT_PRODUCTS]: crate::model::model::ContextProductsType::MultipleContextProducts
+        Unspecified,
         /// Use only a single product as context for the recommendation. Typically
         /// used on pages like add-to-cart or product details.
-        pub const SINGLE_CONTEXT_PRODUCT: ContextProductsType = ContextProductsType::new(1);
-
+        SingleContextProduct,
         /// Use one or multiple products as context for the recommendation. Typically
         /// used on shopping cart pages.
-        pub const MULTIPLE_CONTEXT_PRODUCTS: ContextProductsType = ContextProductsType::new(2);
+        MultipleContextProducts,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ContextProductsType::value] or
+        /// [ContextProductsType::name].
+        UnknownValue(context_products_type::UnknownValue),
+    }
 
-        /// Creates a new ContextProductsType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod context_products_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ContextProductsType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SingleContextProduct => std::option::Option::Some(1),
+                Self::MultipleContextProducts => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONTEXT_PRODUCTS_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SINGLE_CONTEXT_PRODUCT"),
-                2 => std::borrow::Cow::Borrowed("MULTIPLE_CONTEXT_PRODUCTS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONTEXT_PRODUCTS_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONTEXT_PRODUCTS_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONTEXT_PRODUCTS_TYPE_UNSPECIFIED"),
+                Self::SingleContextProduct => std::option::Option::Some("SINGLE_CONTEXT_PRODUCT"),
+                Self::MultipleContextProducts => {
+                    std::option::Option::Some("MULTIPLE_CONTEXT_PRODUCTS")
                 }
-                "SINGLE_CONTEXT_PRODUCT" => std::option::Option::Some(Self::SINGLE_CONTEXT_PRODUCT),
-                "MULTIPLE_CONTEXT_PRODUCTS" => {
-                    std::option::Option::Some(Self::MULTIPLE_CONTEXT_PRODUCTS)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ContextProductsType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ContextProductsType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ContextProductsType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ContextProductsType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SingleContextProduct,
+                2 => Self::MultipleContextProducts,
+                _ => Self::UnknownValue(context_products_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ContextProductsType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONTEXT_PRODUCTS_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SINGLE_CONTEXT_PRODUCT" => Self::SingleContextProduct,
+                "MULTIPLE_CONTEXT_PRODUCTS" => Self::MultipleContextProducts,
+                _ => Self::UnknownValue(context_products_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ContextProductsType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SingleContextProduct => serializer.serialize_i32(1),
+                Self::MultipleContextProducts => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ContextProductsType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContextProductsType>::new(
+                ".google.cloud.retail.v2.Model.ContextProductsType",
+            ))
         }
     }
 }
@@ -9953,7 +10665,7 @@ pub struct Product {
     /// [Product.inProductGroupWithID](https://schema.org/inProductGroupWithID).
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
     /// [google.cloud.retail.v2.Product.id]: crate::model::Product::id
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub primary_product_id: std::string::String,
@@ -9970,9 +10682,9 @@ pub struct Product {
     /// maximum of 1000 values are allowed. Otherwise, an INVALID_ARGUMENT error is
     /// return.
     ///
-    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.Product.id]: crate::model::Product::id
     /// [google.cloud.retail.v2.Product.type]: crate::model::Product::type
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -10034,7 +10746,7 @@ pub struct Product {
     /// [Product.category] (<https://schema.org/category>).
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub categories: std::vec::Vec<std::string::String>,
 
@@ -10159,9 +10871,9 @@ pub struct Product {
     /// ignored for [Type.VARIANT][google.cloud.retail.v2.Product.Type.VARIANT].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.SearchService.Search]: crate::client::SearchService::search
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub available_time: std::option::Option<wkt::Timestamp>,
@@ -10184,8 +10896,8 @@ pub struct Product {
     /// Schema.org property [Offer.availability](https://schema.org/availability).
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Availability.IN_STOCK]: crate::model::product::availability::IN_STOCK
-    /// [google.cloud.retail.v2.Product.Availability.OUT_OF_STOCK]: crate::model::product::availability::OUT_OF_STOCK
+    /// [google.cloud.retail.v2.Product.Availability.IN_STOCK]: crate::model::product::Availability::InStock
+    /// [google.cloud.retail.v2.Product.Availability.OUT_OF_STOCK]: crate::model::product::Availability::OutOfStock
     pub availability: crate::model::product::Availability,
 
     /// The available quantity of the item.
@@ -10388,9 +11100,9 @@ pub struct Product {
     /// This field is deprecated. Use the retrievable site-wide control instead.
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.Product.attributes]: crate::model::Product::attributes
     /// [google.cloud.retail.v2.Product.audience]: crate::model::Product::audience
     /// [google.cloud.retail.v2.Product.availability]: crate::model::Product::availability
@@ -10426,7 +11138,7 @@ pub struct Product {
     /// Do not set this field in API requests.
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
     /// [google.cloud.retail.v2.Product.primary_product_id]: crate::model::Product::primary_product_id
     /// [google.cloud.retail.v2.ProductService.GetProduct]: crate::client::ProductService::get_product
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -10824,17 +11536,15 @@ pub mod product {
     use super::*;
 
     /// The type of this product.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Default value. Default to
         /// [Catalog.product_level_config.ingestion_product_type][google.cloud.retail.v2.ProductLevelConfig.ingestion_product_type]
         /// if unset.
         ///
         /// [google.cloud.retail.v2.ProductLevelConfig.ingestion_product_type]: crate::model::ProductLevelConfig::ingestion_product_type
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The primary type.
         ///
         /// As the primary unit for predicting, indexing and search serving, a
@@ -10844,10 +11554,9 @@ pub mod product {
         /// [Product][google.cloud.retail.v2.Product]s.
         ///
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
-        pub const PRIMARY: Type = Type::new(1);
-
+        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
+        Primary,
         /// The variant type.
         ///
         /// [Type.VARIANT][google.cloud.retail.v2.Product.Type.VARIANT]
@@ -10858,10 +11567,9 @@ pub mod product {
         /// attributes like different colors, sizes and prices, etc.
         ///
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
-        pub const VARIANT: Type = Type::new(2);
-
+        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
+        Variant,
         /// The collection type. Collection products are bundled
         /// [Type.PRIMARY][google.cloud.retail.v2.Product.Type.PRIMARY]
         /// [Product][google.cloud.retail.v2.Product]s or
@@ -10870,126 +11578,256 @@ pub mod product {
         /// as a jewelry set with necklaces, earrings and rings, etc.
         ///
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
-        pub const COLLECTION: Type = Type::new(3);
+        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
+        Collection,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Primary => std::option::Option::Some(1),
+                Self::Variant => std::option::Option::Some(2),
+                Self::Collection => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIMARY"),
-                2 => std::borrow::Cow::Borrowed("VARIANT"),
-                3 => std::borrow::Cow::Borrowed("COLLECTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Primary => std::option::Option::Some("PRIMARY"),
+                Self::Variant => std::option::Option::Some("VARIANT"),
+                Self::Collection => std::option::Option::Some("COLLECTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-                "VARIANT" => std::option::Option::Some(Self::VARIANT),
-                "COLLECTION" => std::option::Option::Some(Self::COLLECTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Primary,
+                2 => Self::Variant,
+                3 => Self::Collection,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PRIMARY" => Self::Primary,
+                "VARIANT" => Self::Variant,
+                "COLLECTION" => Self::Collection,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Primary => serializer.serialize_i32(1),
+                Self::Variant => serializer.serialize_i32(2),
+                Self::Collection => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.retail.v2.Product.Type",
+            ))
         }
     }
 
     /// Product availability. If this field is unspecified, the product is
     /// assumed to be in stock.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Availability(i32);
-
-    impl Availability {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Availability {
         /// Default product availability. Default to
         /// [Availability.IN_STOCK][google.cloud.retail.v2.Product.Availability.IN_STOCK]
         /// if unset.
         ///
-        /// [google.cloud.retail.v2.Product.Availability.IN_STOCK]: crate::model::product::availability::IN_STOCK
-        pub const AVAILABILITY_UNSPECIFIED: Availability = Availability::new(0);
-
+        /// [google.cloud.retail.v2.Product.Availability.IN_STOCK]: crate::model::product::Availability::InStock
+        Unspecified,
         /// Product in stock.
-        pub const IN_STOCK: Availability = Availability::new(1);
-
+        InStock,
         /// Product out of stock.
-        pub const OUT_OF_STOCK: Availability = Availability::new(2);
-
+        OutOfStock,
         /// Product that is in pre-order state.
-        pub const PREORDER: Availability = Availability::new(3);
-
+        Preorder,
         /// Product that is back-ordered (i.e. temporarily out of stock).
-        pub const BACKORDER: Availability = Availability::new(4);
+        Backorder,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Availability::value] or
+        /// [Availability::name].
+        UnknownValue(availability::UnknownValue),
+    }
 
-        /// Creates a new Availability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod availability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Availability {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InStock => std::option::Option::Some(1),
+                Self::OutOfStock => std::option::Option::Some(2),
+                Self::Preorder => std::option::Option::Some(3),
+                Self::Backorder => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AVAILABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_STOCK"),
-                2 => std::borrow::Cow::Borrowed("OUT_OF_STOCK"),
-                3 => std::borrow::Cow::Borrowed("PREORDER"),
-                4 => std::borrow::Cow::Borrowed("BACKORDER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AVAILABILITY_UNSPECIFIED"),
+                Self::InStock => std::option::Option::Some("IN_STOCK"),
+                Self::OutOfStock => std::option::Option::Some("OUT_OF_STOCK"),
+                Self::Preorder => std::option::Option::Some("PREORDER"),
+                Self::Backorder => std::option::Option::Some("BACKORDER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AVAILABILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AVAILABILITY_UNSPECIFIED)
-                }
-                "IN_STOCK" => std::option::Option::Some(Self::IN_STOCK),
-                "OUT_OF_STOCK" => std::option::Option::Some(Self::OUT_OF_STOCK),
-                "PREORDER" => std::option::Option::Some(Self::PREORDER),
-                "BACKORDER" => std::option::Option::Some(Self::BACKORDER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Availability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Availability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Availability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Availability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InStock,
+                2 => Self::OutOfStock,
+                3 => Self::Preorder,
+                4 => Self::Backorder,
+                _ => Self::UnknownValue(availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Availability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AVAILABILITY_UNSPECIFIED" => Self::Unspecified,
+                "IN_STOCK" => Self::InStock,
+                "OUT_OF_STOCK" => Self::OutOfStock,
+                "PREORDER" => Self::Preorder,
+                "BACKORDER" => Self::Backorder,
+                _ => Self::UnknownValue(availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Availability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InStock => serializer.serialize_i32(1),
+                Self::OutOfStock => serializer.serialize_i32(2),
+                Self::Preorder => serializer.serialize_i32(3),
+                Self::Backorder => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Availability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Availability>::new(
+                ".google.cloud.retail.v2.Product.Availability",
+            ))
         }
     }
 
@@ -11024,9 +11862,9 @@ pub mod product {
         /// [expiration_date](https://support.google.com/merchants/answer/6324499).
         ///
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         /// [google.cloud.retail.v2.Product.available_time]: crate::model::Product::available_time
         /// [google.cloud.retail.v2.Product.expire_time]: crate::model::Product::expiration
         /// [google.cloud.retail.v2.Product.publish_time]: crate::model::Product::publish_time
@@ -11055,9 +11893,9 @@ pub mod product {
         /// [ProductService.ListProducts][google.cloud.retail.v2.ProductService.ListProducts].
         ///
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+        /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         /// [google.cloud.retail.v2.Product.expire_time]: crate::model::Product::expiration
         /// [google.cloud.retail.v2.Product.ttl]: crate::model::Product::expiration
         /// [google.cloud.retail.v2.ProductService.GetProduct]: crate::client::ProductService::get_product
@@ -11318,9 +12156,9 @@ pub struct DeleteProductRequest {
     /// [Product][google.cloud.retail.v2.Product] will be deleted.
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub name: std::string::String,
 
@@ -11426,9 +12264,9 @@ pub struct ListProductsRequest {
     ///
     /// [google.cloud.retail.v2.ListProductsRequest.filter]: crate::model::ListProductsRequest::filter
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::r#type::COLLECTION
-    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::r#type::PRIMARY
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.COLLECTION]: crate::model::product::Type::Collection
+    /// [google.cloud.retail.v2.Product.Type.PRIMARY]: crate::model::product::Type::Primary
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub filter: std::string::String,
 
@@ -13377,7 +14215,7 @@ pub struct SearchRequest {
     /// [google.cloud.retail.v2.LocalInventory]: crate::model::LocalInventory
     /// [google.cloud.retail.v2.LocalInventory.attributes]: crate::model::LocalInventory::attributes
     /// [google.cloud.retail.v2.Product]: crate::model::Product
-    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+    /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
     /// [google.cloud.retail.v2.Product.attributes]: crate::model::Product::attributes
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub variant_rollup_keys: std::vec::Vec<std::string::String>,
@@ -14131,7 +14969,7 @@ pub mod search_request {
         /// [Mode.DISABLED][google.cloud.retail.v2.SearchRequest.DynamicFacetSpec.Mode.DISABLED]
         /// if it's unset.
         ///
-        /// [google.cloud.retail.v2.SearchRequest.DynamicFacetSpec.Mode.DISABLED]: crate::model::search_request::dynamic_facet_spec::mode::DISABLED
+        /// [google.cloud.retail.v2.SearchRequest.DynamicFacetSpec.Mode.DISABLED]: crate::model::search_request::dynamic_facet_spec::Mode::Disabled
         pub mode: crate::model::search_request::dynamic_facet_spec::Mode,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14167,59 +15005,123 @@ pub mod search_request {
         use super::*;
 
         /// Enum to control DynamicFacet mode
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Mode {
+            /// Default value.
+            Unspecified,
+            /// Disable Dynamic Facet.
+            Disabled,
+            /// Automatic mode built by Google Retail Search.
+            Enabled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Mode::value] or
+            /// [Mode::name].
+            UnknownValue(mode::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Mode {
-            /// Default value.
-            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-            /// Disable Dynamic Facet.
-            pub const DISABLED: Mode = Mode::new(1);
-
-            /// Automatic mode built by Google Retail Search.
-            pub const ENABLED: Mode = Mode::new(2);
-
-            /// Creates a new Mode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Disabled => std::option::Option::Some(1),
+                    Self::Enabled => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DISABLED"),
-                    2 => std::borrow::Cow::Borrowed("ENABLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::Enabled => std::option::Option::Some("ENABLED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Mode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Mode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Disabled,
+                    2 => Self::Enabled,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Mode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODE_UNSPECIFIED" => Self::Unspecified,
+                    "DISABLED" => Self::Disabled,
+                    "ENABLED" => Self::Enabled,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Mode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Disabled => serializer.serialize_i32(1),
+                    Self::Enabled => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Mode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                    ".google.cloud.retail.v2.SearchRequest.DynamicFacetSpec.Mode",
+                ))
             }
         }
     }
@@ -14375,7 +15277,7 @@ pub mod search_request {
         /// The condition under which query expansion should occur. Default to
         /// [Condition.DISABLED][google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED].
         ///
-        /// [google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::condition::DISABLED
+        /// [google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::Condition::Disabled
         pub condition: crate::model::search_request::query_expansion_spec::Condition,
 
         /// Whether to pin unexpanded results. If this field is set to true,
@@ -14423,69 +15325,131 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which condition query expansion should occur.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Condition(i32);
-
-        impl Condition {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Condition {
             /// Unspecified query expansion condition. In this case, server behavior
             /// defaults to
             /// [Condition.DISABLED][google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED].
             ///
-            /// [google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::condition::DISABLED
-            pub const CONDITION_UNSPECIFIED: Condition = Condition::new(0);
-
+            /// [google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition.DISABLED]: crate::model::search_request::query_expansion_spec::Condition::Disabled
+            Unspecified,
             /// Disabled query expansion. Only the exact search query is used, even if
             /// [SearchResponse.total_size][google.cloud.retail.v2.SearchResponse.total_size]
             /// is zero.
             ///
             /// [google.cloud.retail.v2.SearchResponse.total_size]: crate::model::SearchResponse::total_size
-            pub const DISABLED: Condition = Condition::new(1);
-
+            Disabled,
             /// Automatic query expansion built by Google Retail Search.
-            pub const AUTO: Condition = Condition::new(3);
+            Auto,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Condition::value] or
+            /// [Condition::name].
+            UnknownValue(condition::UnknownValue),
+        }
 
-            /// Creates a new Condition instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod condition {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Condition {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Disabled => std::option::Option::Some(1),
+                    Self::Auto => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONDITION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DISABLED"),
-                    3 => std::borrow::Cow::Borrowed("AUTO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CONDITION_UNSPECIFIED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONDITION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONDITION_UNSPECIFIED)
-                    }
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Condition {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Condition {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Condition {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Condition {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Disabled,
+                    3 => Self::Auto,
+                    _ => Self::UnknownValue(condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Condition {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONDITION_UNSPECIFIED" => Self::Unspecified,
+                    "DISABLED" => Self::Disabled,
+                    "AUTO" => Self::Auto,
+                    _ => Self::UnknownValue(condition::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Condition {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Disabled => serializer.serialize_i32(1),
+                    Self::Auto => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Condition {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Condition>::new(
+                    ".google.cloud.retail.v2.SearchRequest.QueryExpansionSpec.Condition",
+                ))
             }
         }
     }
@@ -14499,7 +15463,7 @@ pub mod search_request {
         /// Defaults to
         /// [Mode.AUTO][google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO].
         ///
-        /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::mode::AUTO
+        /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::Mode::Auto
         pub mode: crate::model::search_request::personalization_spec::Mode,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14535,63 +15499,127 @@ pub mod search_request {
         use super::*;
 
         /// The personalization mode of each search request.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(i32);
-
-        impl Mode {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Mode {
             /// Default value. In this case, server behavior defaults to
             /// [Mode.AUTO][google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO].
             ///
-            /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::mode::AUTO
-            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+            /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::Mode::Auto
+            Unspecified,
             /// Let CRS decide whether to use personalization based on quality of user
             /// event data.
-            pub const AUTO: Mode = Mode::new(1);
-
+            Auto,
             /// Disable personalization.
-            pub const DISABLED: Mode = Mode::new(2);
+            Disabled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Mode::value] or
+            /// [Mode::name].
+            UnknownValue(mode::UnknownValue),
+        }
 
-            /// Creates a new Mode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Mode {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Auto => std::option::Option::Some(1),
+                    Self::Disabled => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AUTO"),
-                    2 => std::borrow::Cow::Borrowed("DISABLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Mode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Mode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Auto,
+                    2 => Self::Disabled,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Mode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODE_UNSPECIFIED" => Self::Unspecified,
+                    "AUTO" => Self::Auto,
+                    "DISABLED" => Self::Disabled,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Mode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Auto => serializer.serialize_i32(1),
+                    Self::Disabled => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Mode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                    ".google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode",
+                ))
             }
         }
     }
@@ -14606,7 +15634,7 @@ pub mod search_request {
         /// replace the original search query. Default to
         /// [Mode.AUTO][google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO].
         ///
-        /// [google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::mode::AUTO
+        /// [google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::Mode::Auto
         pub mode: crate::model::search_request::spell_correction_spec::Mode,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14642,69 +15670,133 @@ pub mod search_request {
         use super::*;
 
         /// Enum describing under which mode spell correction should occur.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Mode(i32);
-
-        impl Mode {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Mode {
             /// Unspecified spell correction mode. In this case, server behavior
             /// defaults to
             /// [Mode.AUTO][google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO].
             ///
-            /// [google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::mode::AUTO
-            pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+            /// [google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode.AUTO]: crate::model::search_request::spell_correction_spec::Mode::Auto
+            Unspecified,
             /// Google Retail Search will try to find a spell suggestion if there
             /// is any and put in the
             /// [SearchResponse.corrected_query][google.cloud.retail.v2.SearchResponse.corrected_query].
             /// The spell suggestion will not be used as the search query.
             ///
             /// [google.cloud.retail.v2.SearchResponse.corrected_query]: crate::model::SearchResponse::corrected_query
-            pub const SUGGESTION_ONLY: Mode = Mode::new(1);
-
+            SuggestionOnly,
             /// Automatic spell correction built by Google Retail Search. Search will
             /// be based on the corrected query if found.
-            pub const AUTO: Mode = Mode::new(2);
+            Auto,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Mode::value] or
+            /// [Mode::name].
+            UnknownValue(mode::UnknownValue),
+        }
 
-            /// Creates a new Mode instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod mode {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Mode {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SuggestionOnly => std::option::Option::Some(1),
+                    Self::Auto => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SUGGESTION_ONLY"),
-                    2 => std::borrow::Cow::Borrowed("AUTO"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                    Self::SuggestionOnly => std::option::Option::Some("SUGGESTION_ONLY"),
+                    Self::Auto => std::option::Option::Some("AUTO"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                    "SUGGESTION_ONLY" => std::option::Option::Some(Self::SUGGESTION_ONLY),
-                    "AUTO" => std::option::Option::Some(Self::AUTO),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Mode {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Mode {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Mode {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Mode {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SuggestionOnly,
+                    2 => Self::Auto,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Mode {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "MODE_UNSPECIFIED" => Self::Unspecified,
+                    "SUGGESTION_ONLY" => Self::SuggestionOnly,
+                    "AUTO" => Self::Auto,
+                    _ => Self::UnknownValue(mode::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Mode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SuggestionOnly => serializer.serialize_i32(1),
+                    Self::Auto => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Mode {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                    ".google.cloud.retail.v2.SearchRequest.SpellCorrectionSpec.Mode",
+                ))
             }
         }
     }
@@ -15015,10 +16107,9 @@ pub mod search_request {
     }
 
     /// The search mode of each search request.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchMode(i32);
-
-    impl SearchMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SearchMode {
         /// Default value. In this case both product search and faceted search will
         /// be performed. Both
         /// [SearchResponse.SearchResult][google.cloud.retail.v2.SearchResponse.SearchResult]
@@ -15027,8 +16118,7 @@ pub mod search_request {
         ///
         /// [google.cloud.retail.v2.SearchResponse.Facet]: crate::model::search_response::Facet
         /// [google.cloud.retail.v2.SearchResponse.SearchResult]: crate::model::search_response::SearchResult
-        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new(0);
-
+        Unspecified,
         /// Only product search will be performed. The faceted search will be
         /// disabled.
         ///
@@ -15046,8 +16136,7 @@ pub mod search_request {
         /// [google.cloud.retail.v2.SearchRequest.facet_specs]: crate::model::SearchRequest::facet_specs
         /// [google.cloud.retail.v2.SearchResponse.Facet]: crate::model::search_response::Facet
         /// [google.cloud.retail.v2.SearchResponse.SearchResult]: crate::model::search_response::SearchResult
-        pub const PRODUCT_SEARCH_ONLY: SearchMode = SearchMode::new(1);
-
+        ProductSearchOnly,
         /// Only faceted search will be performed. The product search will be
         /// disabled.
         ///
@@ -15065,50 +16154,112 @@ pub mod search_request {
         /// [google.cloud.retail.v2.SearchRequest.facet_specs]: crate::model::SearchRequest::facet_specs
         /// [google.cloud.retail.v2.SearchResponse.Facet]: crate::model::search_response::Facet
         /// [google.cloud.retail.v2.SearchResponse.SearchResult]: crate::model::search_response::SearchResult
-        pub const FACETED_SEARCH_ONLY: SearchMode = SearchMode::new(2);
+        FacetedSearchOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SearchMode::value] or
+        /// [SearchMode::name].
+        UnknownValue(search_mode::UnknownValue),
+    }
 
-        /// Creates a new SearchMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod search_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SearchMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ProductSearchOnly => std::option::Option::Some(1),
+                Self::FacetedSearchOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEARCH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRODUCT_SEARCH_ONLY"),
-                2 => std::borrow::Cow::Borrowed("FACETED_SEARCH_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEARCH_MODE_UNSPECIFIED"),
+                Self::ProductSearchOnly => std::option::Option::Some("PRODUCT_SEARCH_ONLY"),
+                Self::FacetedSearchOnly => std::option::Option::Some("FACETED_SEARCH_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEARCH_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SEARCH_MODE_UNSPECIFIED)
-                }
-                "PRODUCT_SEARCH_ONLY" => std::option::Option::Some(Self::PRODUCT_SEARCH_ONLY),
-                "FACETED_SEARCH_ONLY" => std::option::Option::Some(Self::FACETED_SEARCH_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SearchMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SearchMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SearchMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ProductSearchOnly,
+                2 => Self::FacetedSearchOnly,
+                _ => Self::UnknownValue(search_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SearchMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEARCH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "PRODUCT_SEARCH_ONLY" => Self::ProductSearchOnly,
+                "FACETED_SEARCH_ONLY" => Self::FacetedSearchOnly,
+                _ => Self::UnknownValue(search_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SearchMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ProductSearchOnly => serializer.serialize_i32(1),
+                Self::FacetedSearchOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SearchMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchMode>::new(
+                ".google.cloud.retail.v2.SearchRequest.SearchMode",
+            ))
         }
     }
 }
@@ -15411,7 +16562,7 @@ pub mod search_response {
         /// [Product][google.cloud.retail.v2.Product]s.
         ///
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
         pub matching_variant_count: i32,
 
@@ -15429,7 +16580,7 @@ pub mod search_response {
         ///
         /// [google.cloud.retail.v2.ColorInfo]: crate::model::ColorInfo
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         /// [google.cloud.retail.v2.Product.name]: crate::model::Product::name
         #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
         pub matching_variant_fields: std::collections::HashMap<std::string::String, wkt::FieldMask>,
@@ -15470,7 +16621,7 @@ pub mod search_response {
         ///
         /// [google.cloud.retail.v2.FulfillmentInfo]: crate::model::FulfillmentInfo
         /// [google.cloud.retail.v2.Product]: crate::model::Product
-        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::r#type::VARIANT
+        /// [google.cloud.retail.v2.Product.Type.VARIANT]: crate::model::product::Type::Variant
         /// [google.cloud.retail.v2.SearchRequest.variant_rollup_keys]: crate::model::SearchRequest::variant_rollup_keys
         /// [google.protobuf.ListValue]: wkt::ListValue
         /// [google.protobuf.Value]: wkt::Value
@@ -15491,7 +16642,7 @@ pub mod search_response {
         ///
         /// * `purchased`: Indicates that this product has been purchased before.
         ///
-        /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::mode::AUTO
+        /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.Mode.AUTO]: crate::model::search_request::personalization_spec::Mode::Auto
         /// [google.cloud.retail.v2.SearchRequest.PersonalizationSpec.mode]: crate::model::search_request::PersonalizationSpec::mode
         /// [google.cloud.retail.v2.SearchRequest.visitor_id]: crate::model::SearchRequest::visitor_id
         /// [google.cloud.retail.v2.UserEvent]: crate::model::UserEvent
@@ -16498,7 +17649,7 @@ pub struct ServingConfig {
     /// server behavior defaults to
     /// [RULE_BASED_DIVERSITY][google.cloud.retail.v2.ServingConfig.DiversityType.RULE_BASED_DIVERSITY].
     ///
-    /// [google.cloud.retail.v2.ServingConfig.DiversityType.RULE_BASED_DIVERSITY]: crate::model::serving_config::diversity_type::RULE_BASED_DIVERSITY
+    /// [google.cloud.retail.v2.ServingConfig.DiversityType.RULE_BASED_DIVERSITY]: crate::model::serving_config::DiversityType::RuleBasedDiversity
     pub diversity_type: crate::model::serving_config::DiversityType,
 
     /// Whether to add additional category filters on the `similar-items` model.
@@ -16765,61 +17916,120 @@ pub mod serving_config {
     use super::*;
 
     /// What type of diversity - data or rule based.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiversityType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiversityType {
+        /// Default value.
+        Unspecified,
+        /// Rule based diversity.
+        RuleBasedDiversity,
+        /// Data driven diversity.
+        DataDrivenDiversity,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiversityType::value] or
+        /// [DiversityType::name].
+        UnknownValue(diversity_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod diversity_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DiversityType {
-        /// Default value.
-        pub const DIVERSITY_TYPE_UNSPECIFIED: DiversityType = DiversityType::new(0);
-
-        /// Rule based diversity.
-        pub const RULE_BASED_DIVERSITY: DiversityType = DiversityType::new(2);
-
-        /// Data driven diversity.
-        pub const DATA_DRIVEN_DIVERSITY: DiversityType = DiversityType::new(3);
-
-        /// Creates a new DiversityType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RuleBasedDiversity => std::option::Option::Some(2),
+                Self::DataDrivenDiversity => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIVERSITY_TYPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("RULE_BASED_DIVERSITY"),
-                3 => std::borrow::Cow::Borrowed("DATA_DRIVEN_DIVERSITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIVERSITY_TYPE_UNSPECIFIED"),
+                Self::RuleBasedDiversity => std::option::Option::Some("RULE_BASED_DIVERSITY"),
+                Self::DataDrivenDiversity => std::option::Option::Some("DATA_DRIVEN_DIVERSITY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIVERSITY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DIVERSITY_TYPE_UNSPECIFIED)
-                }
-                "RULE_BASED_DIVERSITY" => std::option::Option::Some(Self::RULE_BASED_DIVERSITY),
-                "DATA_DRIVEN_DIVERSITY" => std::option::Option::Some(Self::DATA_DRIVEN_DIVERSITY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiversityType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiversityType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiversityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiversityType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::RuleBasedDiversity,
+                3 => Self::DataDrivenDiversity,
+                _ => Self::UnknownValue(diversity_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiversityType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIVERSITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "RULE_BASED_DIVERSITY" => Self::RuleBasedDiversity,
+                "DATA_DRIVEN_DIVERSITY" => Self::DataDrivenDiversity,
+                _ => Self::UnknownValue(diversity_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiversityType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RuleBasedDiversity => serializer.serialize_i32(2),
+                Self::DataDrivenDiversity => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiversityType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiversityType>::new(
+                ".google.cloud.retail.v2.ServingConfig.DiversityType",
+            ))
         }
     }
 }
@@ -18188,63 +19398,123 @@ pub mod rejoin_user_events_request {
     /// events, set `UserEventRejoinScope` to `JOINED_EVENTS`.
     /// If all events needs to be rejoined, set `UserEventRejoinScope` to
     /// `USER_EVENT_REJOIN_SCOPE_UNSPECIFIED`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserEventRejoinScope(i32);
-
-    impl UserEventRejoinScope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserEventRejoinScope {
         /// Rejoin all events with the latest product catalog, including both joined
         /// events and unjoined events.
-        pub const USER_EVENT_REJOIN_SCOPE_UNSPECIFIED: UserEventRejoinScope =
-            UserEventRejoinScope::new(0);
-
+        Unspecified,
         /// Only rejoin joined events with the latest product catalog.
-        pub const JOINED_EVENTS: UserEventRejoinScope = UserEventRejoinScope::new(1);
-
+        JoinedEvents,
         /// Only rejoin unjoined events with the latest product catalog.
-        pub const UNJOINED_EVENTS: UserEventRejoinScope = UserEventRejoinScope::new(2);
+        UnjoinedEvents,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserEventRejoinScope::value] or
+        /// [UserEventRejoinScope::name].
+        UnknownValue(user_event_rejoin_scope::UnknownValue),
+    }
 
-        /// Creates a new UserEventRejoinScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod user_event_rejoin_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl UserEventRejoinScope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::JoinedEvents => std::option::Option::Some(1),
+                Self::UnjoinedEvents => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_EVENT_REJOIN_SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("JOINED_EVENTS"),
-                2 => std::borrow::Cow::Borrowed("UNJOINED_EVENTS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_EVENT_REJOIN_SCOPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::USER_EVENT_REJOIN_SCOPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("USER_EVENT_REJOIN_SCOPE_UNSPECIFIED")
                 }
-                "JOINED_EVENTS" => std::option::Option::Some(Self::JOINED_EVENTS),
-                "UNJOINED_EVENTS" => std::option::Option::Some(Self::UNJOINED_EVENTS),
-                _ => std::option::Option::None,
+                Self::JoinedEvents => std::option::Option::Some("JOINED_EVENTS"),
+                Self::UnjoinedEvents => std::option::Option::Some("UNJOINED_EVENTS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for UserEventRejoinScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserEventRejoinScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UserEventRejoinScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserEventRejoinScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::JoinedEvents,
+                2 => Self::UnjoinedEvents,
+                _ => Self::UnknownValue(user_event_rejoin_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserEventRejoinScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_EVENT_REJOIN_SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "JOINED_EVENTS" => Self::JoinedEvents,
+                "UNJOINED_EVENTS" => Self::UnjoinedEvents,
+                _ => Self::UnknownValue(user_event_rejoin_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserEventRejoinScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::JoinedEvents => serializer.serialize_i32(1),
+                Self::UnjoinedEvents => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserEventRejoinScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserEventRejoinScope>::new(
+                ".google.cloud.retail.v2.RejoinUserEventsRequest.UserEventRejoinScope",
+            ))
         }
     }
 }
@@ -18305,278 +19575,505 @@ impl wkt::message::Message for RejoinUserEventsMetadata {
 }
 
 /// At which level we offer configuration for attributes.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AttributeConfigLevel(i32);
-
-impl AttributeConfigLevel {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AttributeConfigLevel {
     /// Value used when unset. In this case, server behavior defaults to
     /// [CATALOG_LEVEL_ATTRIBUTE_CONFIG][google.cloud.retail.v2.AttributeConfigLevel.CATALOG_LEVEL_ATTRIBUTE_CONFIG].
     ///
-    /// [google.cloud.retail.v2.AttributeConfigLevel.CATALOG_LEVEL_ATTRIBUTE_CONFIG]: crate::model::attribute_config_level::CATALOG_LEVEL_ATTRIBUTE_CONFIG
-    pub const ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED: AttributeConfigLevel =
-        AttributeConfigLevel::new(0);
-
+    /// [google.cloud.retail.v2.AttributeConfigLevel.CATALOG_LEVEL_ATTRIBUTE_CONFIG]: crate::model::AttributeConfigLevel::CatalogLevelAttributeConfig
+    Unspecified,
     /// At this level, we honor the attribute configurations set in
     /// [Product.attributes][google.cloud.retail.v2.Product.attributes].
     ///
     /// [google.cloud.retail.v2.Product.attributes]: crate::model::Product::attributes
-    pub const PRODUCT_LEVEL_ATTRIBUTE_CONFIG: AttributeConfigLevel = AttributeConfigLevel::new(1);
-
+    ProductLevelAttributeConfig,
     /// At this level, we honor the attribute configurations set in
     /// [CatalogConfig.attribute_configs][].
-    pub const CATALOG_LEVEL_ATTRIBUTE_CONFIG: AttributeConfigLevel = AttributeConfigLevel::new(2);
+    CatalogLevelAttributeConfig,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AttributeConfigLevel::value] or
+    /// [AttributeConfigLevel::name].
+    UnknownValue(attribute_config_level::UnknownValue),
+}
 
-    /// Creates a new AttributeConfigLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod attribute_config_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AttributeConfigLevel {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ProductLevelAttributeConfig => std::option::Option::Some(1),
+            Self::CatalogLevelAttributeConfig => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PRODUCT_LEVEL_ATTRIBUTE_CONFIG"),
-            2 => std::borrow::Cow::Borrowed("CATALOG_LEVEL_ATTRIBUTE_CONFIG"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED"),
+            Self::ProductLevelAttributeConfig => {
+                std::option::Option::Some("PRODUCT_LEVEL_ATTRIBUTE_CONFIG")
+            }
+            Self::CatalogLevelAttributeConfig => {
+                std::option::Option::Some("CATALOG_LEVEL_ATTRIBUTE_CONFIG")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED)
-            }
-            "PRODUCT_LEVEL_ATTRIBUTE_CONFIG" => {
-                std::option::Option::Some(Self::PRODUCT_LEVEL_ATTRIBUTE_CONFIG)
-            }
-            "CATALOG_LEVEL_ATTRIBUTE_CONFIG" => {
-                std::option::Option::Some(Self::CATALOG_LEVEL_ATTRIBUTE_CONFIG)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AttributeConfigLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AttributeConfigLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AttributeConfigLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AttributeConfigLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ProductLevelAttributeConfig,
+            2 => Self::CatalogLevelAttributeConfig,
+            _ => Self::UnknownValue(attribute_config_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AttributeConfigLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ATTRIBUTE_CONFIG_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "PRODUCT_LEVEL_ATTRIBUTE_CONFIG" => Self::ProductLevelAttributeConfig,
+            "CATALOG_LEVEL_ATTRIBUTE_CONFIG" => Self::CatalogLevelAttributeConfig,
+            _ => Self::UnknownValue(attribute_config_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AttributeConfigLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ProductLevelAttributeConfig => serializer.serialize_i32(1),
+            Self::CatalogLevelAttributeConfig => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AttributeConfigLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttributeConfigLevel>::new(
+            ".google.cloud.retail.v2.AttributeConfigLevel",
+        ))
     }
 }
 
 /// The type of solution.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SolutionType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SolutionType {
+    /// Default value.
+    Unspecified,
+    /// Used for Recommendations AI.
+    Recommendation,
+    /// Used for Retail Search.
+    Search,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SolutionType::value] or
+    /// [SolutionType::name].
+    UnknownValue(solution_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod solution_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SolutionType {
-    /// Default value.
-    pub const SOLUTION_TYPE_UNSPECIFIED: SolutionType = SolutionType::new(0);
-
-    /// Used for Recommendations AI.
-    pub const SOLUTION_TYPE_RECOMMENDATION: SolutionType = SolutionType::new(1);
-
-    /// Used for Retail Search.
-    pub const SOLUTION_TYPE_SEARCH: SolutionType = SolutionType::new(2);
-
-    /// Creates a new SolutionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Recommendation => std::option::Option::Some(1),
+            Self::Search => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_RECOMMENDATION"),
-            2 => std::borrow::Cow::Borrowed("SOLUTION_TYPE_SEARCH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SOLUTION_TYPE_UNSPECIFIED"),
+            Self::Recommendation => std::option::Option::Some("SOLUTION_TYPE_RECOMMENDATION"),
+            Self::Search => std::option::Option::Some("SOLUTION_TYPE_SEARCH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SOLUTION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SOLUTION_TYPE_UNSPECIFIED)
-            }
-            "SOLUTION_TYPE_RECOMMENDATION" => {
-                std::option::Option::Some(Self::SOLUTION_TYPE_RECOMMENDATION)
-            }
-            "SOLUTION_TYPE_SEARCH" => std::option::Option::Some(Self::SOLUTION_TYPE_SEARCH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SolutionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SolutionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SolutionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SolutionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Recommendation,
+            2 => Self::Search,
+            _ => Self::UnknownValue(solution_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SolutionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SOLUTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SOLUTION_TYPE_RECOMMENDATION" => Self::Recommendation,
+            "SOLUTION_TYPE_SEARCH" => Self::Search,
+            _ => Self::UnknownValue(solution_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SolutionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Recommendation => serializer.serialize_i32(1),
+            Self::Search => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SolutionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SolutionType>::new(
+            ".google.cloud.retail.v2.SolutionType",
+        ))
     }
 }
 
 /// If filtering for recommendations is enabled.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RecommendationsFilteringOption(i32);
-
-impl RecommendationsFilteringOption {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RecommendationsFilteringOption {
     /// Value used when unset.
     /// In this case, server behavior defaults to
     /// [RECOMMENDATIONS_FILTERING_DISABLED][google.cloud.retail.v2.RecommendationsFilteringOption.RECOMMENDATIONS_FILTERING_DISABLED].
     ///
-    /// [google.cloud.retail.v2.RecommendationsFilteringOption.RECOMMENDATIONS_FILTERING_DISABLED]: crate::model::recommendations_filtering_option::RECOMMENDATIONS_FILTERING_DISABLED
-    pub const RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED: RecommendationsFilteringOption =
-        RecommendationsFilteringOption::new(0);
-
+    /// [google.cloud.retail.v2.RecommendationsFilteringOption.RECOMMENDATIONS_FILTERING_DISABLED]: crate::model::RecommendationsFilteringOption::RecommendationsFilteringDisabled
+    Unspecified,
     /// Recommendation filtering is disabled.
-    pub const RECOMMENDATIONS_FILTERING_DISABLED: RecommendationsFilteringOption =
-        RecommendationsFilteringOption::new(1);
-
+    RecommendationsFilteringDisabled,
     /// Recommendation filtering is enabled.
-    pub const RECOMMENDATIONS_FILTERING_ENABLED: RecommendationsFilteringOption =
-        RecommendationsFilteringOption::new(3);
+    RecommendationsFilteringEnabled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RecommendationsFilteringOption::value] or
+    /// [RecommendationsFilteringOption::name].
+    UnknownValue(recommendations_filtering_option::UnknownValue),
+}
 
-    /// Creates a new RecommendationsFilteringOption instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod recommendations_filtering_option {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl RecommendationsFilteringOption {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RecommendationsFilteringDisabled => std::option::Option::Some(1),
+            Self::RecommendationsFilteringEnabled => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RECOMMENDATIONS_FILTERING_DISABLED"),
-            3 => std::borrow::Cow::Borrowed("RECOMMENDATIONS_FILTERING_ENABLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED")
+            }
+            Self::RecommendationsFilteringDisabled => {
+                std::option::Option::Some("RECOMMENDATIONS_FILTERING_DISABLED")
+            }
+            Self::RecommendationsFilteringEnabled => {
+                std::option::Option::Some("RECOMMENDATIONS_FILTERING_ENABLED")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED)
-            }
-            "RECOMMENDATIONS_FILTERING_DISABLED" => {
-                std::option::Option::Some(Self::RECOMMENDATIONS_FILTERING_DISABLED)
-            }
-            "RECOMMENDATIONS_FILTERING_ENABLED" => {
-                std::option::Option::Some(Self::RECOMMENDATIONS_FILTERING_ENABLED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RecommendationsFilteringOption {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RecommendationsFilteringOption {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RecommendationsFilteringOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RecommendationsFilteringOption {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RecommendationsFilteringDisabled,
+            3 => Self::RecommendationsFilteringEnabled,
+            _ => Self::UnknownValue(recommendations_filtering_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RecommendationsFilteringOption {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RECOMMENDATIONS_FILTERING_OPTION_UNSPECIFIED" => Self::Unspecified,
+            "RECOMMENDATIONS_FILTERING_DISABLED" => Self::RecommendationsFilteringDisabled,
+            "RECOMMENDATIONS_FILTERING_ENABLED" => Self::RecommendationsFilteringEnabled,
+            _ => Self::UnknownValue(recommendations_filtering_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RecommendationsFilteringOption {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RecommendationsFilteringDisabled => serializer.serialize_i32(1),
+            Self::RecommendationsFilteringEnabled => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RecommendationsFilteringOption {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<RecommendationsFilteringOption>::new(
+                ".google.cloud.retail.v2.RecommendationsFilteringOption",
+            ),
+        )
     }
 }
 
 /// The use case of Cloud Retail Search.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SearchSolutionUseCase(i32);
-
-impl SearchSolutionUseCase {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SearchSolutionUseCase {
     /// The value when it's unspecified. In this case, server behavior defaults to
     /// [SEARCH_SOLUTION_USE_CASE_SEARCH][google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH].
     ///
-    /// [google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH]: crate::model::search_solution_use_case::SEARCH_SOLUTION_USE_CASE_SEARCH
-    pub const SEARCH_SOLUTION_USE_CASE_UNSPECIFIED: SearchSolutionUseCase =
-        SearchSolutionUseCase::new(0);
-
+    /// [google.cloud.retail.v2.SearchSolutionUseCase.SEARCH_SOLUTION_USE_CASE_SEARCH]: crate::model::SearchSolutionUseCase::Search
+    Unspecified,
     /// Search use case. Expects the traffic has a non-empty
     /// [query][google.cloud.retail.v2.SearchRequest.query].
     ///
     /// [google.cloud.retail.v2.SearchRequest.query]: crate::model::SearchRequest::query
-    pub const SEARCH_SOLUTION_USE_CASE_SEARCH: SearchSolutionUseCase =
-        SearchSolutionUseCase::new(1);
-
+    Search,
     /// Browse use case. Expects the traffic has an empty
     /// [query][google.cloud.retail.v2.SearchRequest.query].
     ///
     /// [google.cloud.retail.v2.SearchRequest.query]: crate::model::SearchRequest::query
-    pub const SEARCH_SOLUTION_USE_CASE_BROWSE: SearchSolutionUseCase =
-        SearchSolutionUseCase::new(2);
+    Browse,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SearchSolutionUseCase::value] or
+    /// [SearchSolutionUseCase::name].
+    UnknownValue(search_solution_use_case::UnknownValue),
+}
 
-    /// Creates a new SearchSolutionUseCase instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod search_solution_use_case {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SearchSolutionUseCase {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Search => std::option::Option::Some(1),
+            Self::Browse => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEARCH_SOLUTION_USE_CASE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SEARCH_SOLUTION_USE_CASE_SEARCH"),
-            2 => std::borrow::Cow::Borrowed("SEARCH_SOLUTION_USE_CASE_BROWSE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEARCH_SOLUTION_USE_CASE_UNSPECIFIED"),
+            Self::Search => std::option::Option::Some("SEARCH_SOLUTION_USE_CASE_SEARCH"),
+            Self::Browse => std::option::Option::Some("SEARCH_SOLUTION_USE_CASE_BROWSE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEARCH_SOLUTION_USE_CASE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SEARCH_SOLUTION_USE_CASE_UNSPECIFIED)
-            }
-            "SEARCH_SOLUTION_USE_CASE_SEARCH" => {
-                std::option::Option::Some(Self::SEARCH_SOLUTION_USE_CASE_SEARCH)
-            }
-            "SEARCH_SOLUTION_USE_CASE_BROWSE" => {
-                std::option::Option::Some(Self::SEARCH_SOLUTION_USE_CASE_BROWSE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SearchSolutionUseCase {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SearchSolutionUseCase {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SearchSolutionUseCase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SearchSolutionUseCase {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Search,
+            2 => Self::Browse,
+            _ => Self::UnknownValue(search_solution_use_case::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SearchSolutionUseCase {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEARCH_SOLUTION_USE_CASE_UNSPECIFIED" => Self::Unspecified,
+            "SEARCH_SOLUTION_USE_CASE_SEARCH" => Self::Search,
+            "SEARCH_SOLUTION_USE_CASE_BROWSE" => Self::Browse,
+            _ => Self::UnknownValue(search_solution_use_case::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SearchSolutionUseCase {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Search => serializer.serialize_i32(1),
+            Self::Browse => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SearchSolutionUseCase {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchSolutionUseCase>::new(
+            ".google.cloud.retail.v2.SearchSolutionUseCase",
+        ))
     }
 }

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -728,465 +728,822 @@ pub mod condition {
     use super::*;
 
     /// Represents the possible Condition states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// Transient state: Reconciliation has not started yet.
+        ConditionPending,
+        /// Transient state: reconciliation is still in progress.
+        ConditionReconciling,
+        /// Terminal state: Reconciliation did not succeed.
+        ConditionFailed,
+        /// Terminal state: Reconciliation completed successfully.
+        ConditionSucceeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Transient state: Reconciliation has not started yet.
-        pub const CONDITION_PENDING: State = State::new(1);
-
-        /// Transient state: reconciliation is still in progress.
-        pub const CONDITION_RECONCILING: State = State::new(2);
-
-        /// Terminal state: Reconciliation did not succeed.
-        pub const CONDITION_FAILED: State = State::new(3);
-
-        /// Terminal state: Reconciliation completed successfully.
-        pub const CONDITION_SUCCEEDED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConditionPending => std::option::Option::Some(1),
+                Self::ConditionReconciling => std::option::Option::Some(2),
+                Self::ConditionFailed => std::option::Option::Some(3),
+                Self::ConditionSucceeded => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONDITION_PENDING"),
-                2 => std::borrow::Cow::Borrowed("CONDITION_RECONCILING"),
-                3 => std::borrow::Cow::Borrowed("CONDITION_FAILED"),
-                4 => std::borrow::Cow::Borrowed("CONDITION_SUCCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::ConditionPending => std::option::Option::Some("CONDITION_PENDING"),
+                Self::ConditionReconciling => std::option::Option::Some("CONDITION_RECONCILING"),
+                Self::ConditionFailed => std::option::Option::Some("CONDITION_FAILED"),
+                Self::ConditionSucceeded => std::option::Option::Some("CONDITION_SUCCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CONDITION_PENDING" => std::option::Option::Some(Self::CONDITION_PENDING),
-                "CONDITION_RECONCILING" => std::option::Option::Some(Self::CONDITION_RECONCILING),
-                "CONDITION_FAILED" => std::option::Option::Some(Self::CONDITION_FAILED),
-                "CONDITION_SUCCEEDED" => std::option::Option::Some(Self::CONDITION_SUCCEEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConditionPending,
+                2 => Self::ConditionReconciling,
+                3 => Self::ConditionFailed,
+                4 => Self::ConditionSucceeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CONDITION_PENDING" => Self::ConditionPending,
+                "CONDITION_RECONCILING" => Self::ConditionReconciling,
+                "CONDITION_FAILED" => Self::ConditionFailed,
+                "CONDITION_SUCCEEDED" => Self::ConditionSucceeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConditionPending => serializer.serialize_i32(1),
+                Self::ConditionReconciling => serializer.serialize_i32(2),
+                Self::ConditionFailed => serializer.serialize_i32(3),
+                Self::ConditionSucceeded => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.run.v2.Condition.State",
+            ))
         }
     }
 
     /// Represents the severity of the condition failures.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Unspecified severity
+        Unspecified,
+        /// Error severity.
+        Error,
+        /// Warning severity.
+        Warning,
+        /// Info severity.
+        Info,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Unspecified severity
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// Error severity.
-        pub const ERROR: Severity = Severity::new(1);
-
-        /// Warning severity.
-        pub const WARNING: Severity = Severity::new(2);
-
-        /// Info severity.
-        pub const INFO: Severity = Severity::new(3);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Error => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Info => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ERROR"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("INFO"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Error,
+                2 => Self::Warning,
+                3 => Self::Info,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "ERROR" => Self::Error,
+                "WARNING" => Self::Warning,
+                "INFO" => Self::Info,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Error => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Info => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.run.v2.Condition.Severity",
+            ))
         }
     }
 
     /// Reasons common to all types of conditions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommonReason(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CommonReason {
+        /// Default value.
+        Undefined,
+        /// Reason unknown. Further details will be in message.
+        Unknown,
+        /// Revision creation process failed.
+        RevisionFailed,
+        /// Timed out waiting for completion.
+        ProgressDeadlineExceeded,
+        /// The container image path is incorrect.
+        ContainerMissing,
+        /// Insufficient permissions on the container image.
+        ContainerPermissionDenied,
+        /// Container image is not authorized by policy.
+        ContainerImageUnauthorized,
+        /// Container image policy authorization check failed.
+        ContainerImageAuthorizationCheckFailed,
+        /// Insufficient permissions on encryption key.
+        EncryptionKeyPermissionDenied,
+        /// Permission check on encryption key failed.
+        EncryptionKeyCheckFailed,
+        /// At least one Access check on secrets failed.
+        SecretsAccessCheckFailed,
+        /// Waiting for operation to complete.
+        WaitingForOperation,
+        /// System will retry immediately.
+        ImmediateRetry,
+        /// System will retry later; current attempt failed.
+        PostponedRetry,
+        /// An internal error occurred. Further information may be in the message.
+        Internal,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CommonReason::value] or
+        /// [CommonReason::name].
+        UnknownValue(common_reason::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod common_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CommonReason {
-        /// Default value.
-        pub const COMMON_REASON_UNDEFINED: CommonReason = CommonReason::new(0);
-
-        /// Reason unknown. Further details will be in message.
-        pub const UNKNOWN: CommonReason = CommonReason::new(1);
-
-        /// Revision creation process failed.
-        pub const REVISION_FAILED: CommonReason = CommonReason::new(3);
-
-        /// Timed out waiting for completion.
-        pub const PROGRESS_DEADLINE_EXCEEDED: CommonReason = CommonReason::new(4);
-
-        /// The container image path is incorrect.
-        pub const CONTAINER_MISSING: CommonReason = CommonReason::new(6);
-
-        /// Insufficient permissions on the container image.
-        pub const CONTAINER_PERMISSION_DENIED: CommonReason = CommonReason::new(7);
-
-        /// Container image is not authorized by policy.
-        pub const CONTAINER_IMAGE_UNAUTHORIZED: CommonReason = CommonReason::new(8);
-
-        /// Container image policy authorization check failed.
-        pub const CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED: CommonReason = CommonReason::new(9);
-
-        /// Insufficient permissions on encryption key.
-        pub const ENCRYPTION_KEY_PERMISSION_DENIED: CommonReason = CommonReason::new(10);
-
-        /// Permission check on encryption key failed.
-        pub const ENCRYPTION_KEY_CHECK_FAILED: CommonReason = CommonReason::new(11);
-
-        /// At least one Access check on secrets failed.
-        pub const SECRETS_ACCESS_CHECK_FAILED: CommonReason = CommonReason::new(12);
-
-        /// Waiting for operation to complete.
-        pub const WAITING_FOR_OPERATION: CommonReason = CommonReason::new(13);
-
-        /// System will retry immediately.
-        pub const IMMEDIATE_RETRY: CommonReason = CommonReason::new(14);
-
-        /// System will retry later; current attempt failed.
-        pub const POSTPONED_RETRY: CommonReason = CommonReason::new(15);
-
-        /// An internal error occurred. Further information may be in the message.
-        pub const INTERNAL: CommonReason = CommonReason::new(16);
-
-        /// Creates a new CommonReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Undefined => std::option::Option::Some(0),
+                Self::Unknown => std::option::Option::Some(1),
+                Self::RevisionFailed => std::option::Option::Some(3),
+                Self::ProgressDeadlineExceeded => std::option::Option::Some(4),
+                Self::ContainerMissing => std::option::Option::Some(6),
+                Self::ContainerPermissionDenied => std::option::Option::Some(7),
+                Self::ContainerImageUnauthorized => std::option::Option::Some(8),
+                Self::ContainerImageAuthorizationCheckFailed => std::option::Option::Some(9),
+                Self::EncryptionKeyPermissionDenied => std::option::Option::Some(10),
+                Self::EncryptionKeyCheckFailed => std::option::Option::Some(11),
+                Self::SecretsAccessCheckFailed => std::option::Option::Some(12),
+                Self::WaitingForOperation => std::option::Option::Some(13),
+                Self::ImmediateRetry => std::option::Option::Some(14),
+                Self::PostponedRetry => std::option::Option::Some(15),
+                Self::Internal => std::option::Option::Some(16),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMMON_REASON_UNDEFINED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                3 => std::borrow::Cow::Borrowed("REVISION_FAILED"),
-                4 => std::borrow::Cow::Borrowed("PROGRESS_DEADLINE_EXCEEDED"),
-                6 => std::borrow::Cow::Borrowed("CONTAINER_MISSING"),
-                7 => std::borrow::Cow::Borrowed("CONTAINER_PERMISSION_DENIED"),
-                8 => std::borrow::Cow::Borrowed("CONTAINER_IMAGE_UNAUTHORIZED"),
-                9 => std::borrow::Cow::Borrowed("CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED"),
-                10 => std::borrow::Cow::Borrowed("ENCRYPTION_KEY_PERMISSION_DENIED"),
-                11 => std::borrow::Cow::Borrowed("ENCRYPTION_KEY_CHECK_FAILED"),
-                12 => std::borrow::Cow::Borrowed("SECRETS_ACCESS_CHECK_FAILED"),
-                13 => std::borrow::Cow::Borrowed("WAITING_FOR_OPERATION"),
-                14 => std::borrow::Cow::Borrowed("IMMEDIATE_RETRY"),
-                15 => std::borrow::Cow::Borrowed("POSTPONED_RETRY"),
-                16 => std::borrow::Cow::Borrowed("INTERNAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Undefined => std::option::Option::Some("COMMON_REASON_UNDEFINED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::RevisionFailed => std::option::Option::Some("REVISION_FAILED"),
+                Self::ProgressDeadlineExceeded => {
+                    std::option::Option::Some("PROGRESS_DEADLINE_EXCEEDED")
+                }
+                Self::ContainerMissing => std::option::Option::Some("CONTAINER_MISSING"),
+                Self::ContainerPermissionDenied => {
+                    std::option::Option::Some("CONTAINER_PERMISSION_DENIED")
+                }
+                Self::ContainerImageUnauthorized => {
+                    std::option::Option::Some("CONTAINER_IMAGE_UNAUTHORIZED")
+                }
+                Self::ContainerImageAuthorizationCheckFailed => {
+                    std::option::Option::Some("CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED")
+                }
+                Self::EncryptionKeyPermissionDenied => {
+                    std::option::Option::Some("ENCRYPTION_KEY_PERMISSION_DENIED")
+                }
+                Self::EncryptionKeyCheckFailed => {
+                    std::option::Option::Some("ENCRYPTION_KEY_CHECK_FAILED")
+                }
+                Self::SecretsAccessCheckFailed => {
+                    std::option::Option::Some("SECRETS_ACCESS_CHECK_FAILED")
+                }
+                Self::WaitingForOperation => std::option::Option::Some("WAITING_FOR_OPERATION"),
+                Self::ImmediateRetry => std::option::Option::Some("IMMEDIATE_RETRY"),
+                Self::PostponedRetry => std::option::Option::Some("POSTPONED_RETRY"),
+                Self::Internal => std::option::Option::Some("INTERNAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMMON_REASON_UNDEFINED" => {
-                    std::option::Option::Some(Self::COMMON_REASON_UNDEFINED)
-                }
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "REVISION_FAILED" => std::option::Option::Some(Self::REVISION_FAILED),
-                "PROGRESS_DEADLINE_EXCEEDED" => {
-                    std::option::Option::Some(Self::PROGRESS_DEADLINE_EXCEEDED)
-                }
-                "CONTAINER_MISSING" => std::option::Option::Some(Self::CONTAINER_MISSING),
-                "CONTAINER_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::CONTAINER_PERMISSION_DENIED)
-                }
-                "CONTAINER_IMAGE_UNAUTHORIZED" => {
-                    std::option::Option::Some(Self::CONTAINER_IMAGE_UNAUTHORIZED)
-                }
-                "CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED" => {
-                    std::option::Option::Some(Self::CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED)
-                }
-                "ENCRYPTION_KEY_PERMISSION_DENIED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_KEY_PERMISSION_DENIED)
-                }
-                "ENCRYPTION_KEY_CHECK_FAILED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_KEY_CHECK_FAILED)
-                }
-                "SECRETS_ACCESS_CHECK_FAILED" => {
-                    std::option::Option::Some(Self::SECRETS_ACCESS_CHECK_FAILED)
-                }
-                "WAITING_FOR_OPERATION" => std::option::Option::Some(Self::WAITING_FOR_OPERATION),
-                "IMMEDIATE_RETRY" => std::option::Option::Some(Self::IMMEDIATE_RETRY),
-                "POSTPONED_RETRY" => std::option::Option::Some(Self::POSTPONED_RETRY),
-                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CommonReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CommonReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CommonReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CommonReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Undefined,
+                1 => Self::Unknown,
+                3 => Self::RevisionFailed,
+                4 => Self::ProgressDeadlineExceeded,
+                6 => Self::ContainerMissing,
+                7 => Self::ContainerPermissionDenied,
+                8 => Self::ContainerImageUnauthorized,
+                9 => Self::ContainerImageAuthorizationCheckFailed,
+                10 => Self::EncryptionKeyPermissionDenied,
+                11 => Self::EncryptionKeyCheckFailed,
+                12 => Self::SecretsAccessCheckFailed,
+                13 => Self::WaitingForOperation,
+                14 => Self::ImmediateRetry,
+                15 => Self::PostponedRetry,
+                16 => Self::Internal,
+                _ => Self::UnknownValue(common_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CommonReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMMON_REASON_UNDEFINED" => Self::Undefined,
+                "UNKNOWN" => Self::Unknown,
+                "REVISION_FAILED" => Self::RevisionFailed,
+                "PROGRESS_DEADLINE_EXCEEDED" => Self::ProgressDeadlineExceeded,
+                "CONTAINER_MISSING" => Self::ContainerMissing,
+                "CONTAINER_PERMISSION_DENIED" => Self::ContainerPermissionDenied,
+                "CONTAINER_IMAGE_UNAUTHORIZED" => Self::ContainerImageUnauthorized,
+                "CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED" => {
+                    Self::ContainerImageAuthorizationCheckFailed
+                }
+                "ENCRYPTION_KEY_PERMISSION_DENIED" => Self::EncryptionKeyPermissionDenied,
+                "ENCRYPTION_KEY_CHECK_FAILED" => Self::EncryptionKeyCheckFailed,
+                "SECRETS_ACCESS_CHECK_FAILED" => Self::SecretsAccessCheckFailed,
+                "WAITING_FOR_OPERATION" => Self::WaitingForOperation,
+                "IMMEDIATE_RETRY" => Self::ImmediateRetry,
+                "POSTPONED_RETRY" => Self::PostponedRetry,
+                "INTERNAL" => Self::Internal,
+                _ => Self::UnknownValue(common_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CommonReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Undefined => serializer.serialize_i32(0),
+                Self::Unknown => serializer.serialize_i32(1),
+                Self::RevisionFailed => serializer.serialize_i32(3),
+                Self::ProgressDeadlineExceeded => serializer.serialize_i32(4),
+                Self::ContainerMissing => serializer.serialize_i32(6),
+                Self::ContainerPermissionDenied => serializer.serialize_i32(7),
+                Self::ContainerImageUnauthorized => serializer.serialize_i32(8),
+                Self::ContainerImageAuthorizationCheckFailed => serializer.serialize_i32(9),
+                Self::EncryptionKeyPermissionDenied => serializer.serialize_i32(10),
+                Self::EncryptionKeyCheckFailed => serializer.serialize_i32(11),
+                Self::SecretsAccessCheckFailed => serializer.serialize_i32(12),
+                Self::WaitingForOperation => serializer.serialize_i32(13),
+                Self::ImmediateRetry => serializer.serialize_i32(14),
+                Self::PostponedRetry => serializer.serialize_i32(15),
+                Self::Internal => serializer.serialize_i32(16),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CommonReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommonReason>::new(
+                ".google.cloud.run.v2.Condition.CommonReason",
+            ))
         }
     }
 
     /// Reasons specific to Revision resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RevisionReason(i32);
-
-    impl RevisionReason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RevisionReason {
         /// Default value.
-        pub const REVISION_REASON_UNDEFINED: RevisionReason = RevisionReason::new(0);
-
+        Undefined,
         /// Revision in Pending state.
-        pub const PENDING: RevisionReason = RevisionReason::new(1);
-
+        Pending,
         /// Revision is in Reserve state.
-        pub const RESERVE: RevisionReason = RevisionReason::new(2);
-
+        Reserve,
         /// Revision is Retired.
-        pub const RETIRED: RevisionReason = RevisionReason::new(3);
-
+        Retired,
         /// Revision is being retired.
-        pub const RETIRING: RevisionReason = RevisionReason::new(4);
-
+        Retiring,
         /// Revision is being recreated.
-        pub const RECREATING: RevisionReason = RevisionReason::new(5);
-
+        Recreating,
         /// There was a health check error.
-        pub const HEALTH_CHECK_CONTAINER_ERROR: RevisionReason = RevisionReason::new(6);
-
+        HealthCheckContainerError,
         /// Health check failed due to user error from customized path of the
         /// container. System will retry.
-        pub const CUSTOMIZED_PATH_RESPONSE_PENDING: RevisionReason = RevisionReason::new(7);
-
+        CustomizedPathResponsePending,
         /// A revision with min_instance_count > 0 was created and is reserved, but
         /// it was not configured to serve traffic, so it's not live. This can also
         /// happen momentarily during traffic migration.
-        pub const MIN_INSTANCES_NOT_PROVISIONED: RevisionReason = RevisionReason::new(8);
-
+        MinInstancesNotProvisioned,
         /// The maximum allowed number of active revisions has been reached.
-        pub const ACTIVE_REVISION_LIMIT_REACHED: RevisionReason = RevisionReason::new(9);
-
+        ActiveRevisionLimitReached,
         /// There was no deployment defined.
         /// This value is no longer used, but Services created in older versions of
         /// the API might contain this value.
-        pub const NO_DEPLOYMENT: RevisionReason = RevisionReason::new(10);
-
+        NoDeployment,
         /// A revision's container has no port specified since the revision is of a
         /// manually scaled service with 0 instance count
-        pub const HEALTH_CHECK_SKIPPED: RevisionReason = RevisionReason::new(11);
-
+        HealthCheckSkipped,
         /// A revision with min_instance_count > 0 was created and is waiting for
         /// enough instances to begin a traffic migration.
-        pub const MIN_INSTANCES_WARMING: RevisionReason = RevisionReason::new(12);
+        MinInstancesWarming,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RevisionReason::value] or
+        /// [RevisionReason::name].
+        UnknownValue(revision_reason::UnknownValue),
+    }
 
-        /// Creates a new RevisionReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod revision_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RevisionReason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Undefined => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Reserve => std::option::Option::Some(2),
+                Self::Retired => std::option::Option::Some(3),
+                Self::Retiring => std::option::Option::Some(4),
+                Self::Recreating => std::option::Option::Some(5),
+                Self::HealthCheckContainerError => std::option::Option::Some(6),
+                Self::CustomizedPathResponsePending => std::option::Option::Some(7),
+                Self::MinInstancesNotProvisioned => std::option::Option::Some(8),
+                Self::ActiveRevisionLimitReached => std::option::Option::Some(9),
+                Self::NoDeployment => std::option::Option::Some(10),
+                Self::HealthCheckSkipped => std::option::Option::Some(11),
+                Self::MinInstancesWarming => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REVISION_REASON_UNDEFINED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RESERVE"),
-                3 => std::borrow::Cow::Borrowed("RETIRED"),
-                4 => std::borrow::Cow::Borrowed("RETIRING"),
-                5 => std::borrow::Cow::Borrowed("RECREATING"),
-                6 => std::borrow::Cow::Borrowed("HEALTH_CHECK_CONTAINER_ERROR"),
-                7 => std::borrow::Cow::Borrowed("CUSTOMIZED_PATH_RESPONSE_PENDING"),
-                8 => std::borrow::Cow::Borrowed("MIN_INSTANCES_NOT_PROVISIONED"),
-                9 => std::borrow::Cow::Borrowed("ACTIVE_REVISION_LIMIT_REACHED"),
-                10 => std::borrow::Cow::Borrowed("NO_DEPLOYMENT"),
-                11 => std::borrow::Cow::Borrowed("HEALTH_CHECK_SKIPPED"),
-                12 => std::borrow::Cow::Borrowed("MIN_INSTANCES_WARMING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Undefined => std::option::Option::Some("REVISION_REASON_UNDEFINED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Reserve => std::option::Option::Some("RESERVE"),
+                Self::Retired => std::option::Option::Some("RETIRED"),
+                Self::Retiring => std::option::Option::Some("RETIRING"),
+                Self::Recreating => std::option::Option::Some("RECREATING"),
+                Self::HealthCheckContainerError => {
+                    std::option::Option::Some("HEALTH_CHECK_CONTAINER_ERROR")
+                }
+                Self::CustomizedPathResponsePending => {
+                    std::option::Option::Some("CUSTOMIZED_PATH_RESPONSE_PENDING")
+                }
+                Self::MinInstancesNotProvisioned => {
+                    std::option::Option::Some("MIN_INSTANCES_NOT_PROVISIONED")
+                }
+                Self::ActiveRevisionLimitReached => {
+                    std::option::Option::Some("ACTIVE_REVISION_LIMIT_REACHED")
+                }
+                Self::NoDeployment => std::option::Option::Some("NO_DEPLOYMENT"),
+                Self::HealthCheckSkipped => std::option::Option::Some("HEALTH_CHECK_SKIPPED"),
+                Self::MinInstancesWarming => std::option::Option::Some("MIN_INSTANCES_WARMING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REVISION_REASON_UNDEFINED" => {
-                    std::option::Option::Some(Self::REVISION_REASON_UNDEFINED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RESERVE" => std::option::Option::Some(Self::RESERVE),
-                "RETIRED" => std::option::Option::Some(Self::RETIRED),
-                "RETIRING" => std::option::Option::Some(Self::RETIRING),
-                "RECREATING" => std::option::Option::Some(Self::RECREATING),
-                "HEALTH_CHECK_CONTAINER_ERROR" => {
-                    std::option::Option::Some(Self::HEALTH_CHECK_CONTAINER_ERROR)
-                }
-                "CUSTOMIZED_PATH_RESPONSE_PENDING" => {
-                    std::option::Option::Some(Self::CUSTOMIZED_PATH_RESPONSE_PENDING)
-                }
-                "MIN_INSTANCES_NOT_PROVISIONED" => {
-                    std::option::Option::Some(Self::MIN_INSTANCES_NOT_PROVISIONED)
-                }
-                "ACTIVE_REVISION_LIMIT_REACHED" => {
-                    std::option::Option::Some(Self::ACTIVE_REVISION_LIMIT_REACHED)
-                }
-                "NO_DEPLOYMENT" => std::option::Option::Some(Self::NO_DEPLOYMENT),
-                "HEALTH_CHECK_SKIPPED" => std::option::Option::Some(Self::HEALTH_CHECK_SKIPPED),
-                "MIN_INSTANCES_WARMING" => std::option::Option::Some(Self::MIN_INSTANCES_WARMING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RevisionReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RevisionReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RevisionReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RevisionReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Undefined,
+                1 => Self::Pending,
+                2 => Self::Reserve,
+                3 => Self::Retired,
+                4 => Self::Retiring,
+                5 => Self::Recreating,
+                6 => Self::HealthCheckContainerError,
+                7 => Self::CustomizedPathResponsePending,
+                8 => Self::MinInstancesNotProvisioned,
+                9 => Self::ActiveRevisionLimitReached,
+                10 => Self::NoDeployment,
+                11 => Self::HealthCheckSkipped,
+                12 => Self::MinInstancesWarming,
+                _ => Self::UnknownValue(revision_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RevisionReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REVISION_REASON_UNDEFINED" => Self::Undefined,
+                "PENDING" => Self::Pending,
+                "RESERVE" => Self::Reserve,
+                "RETIRED" => Self::Retired,
+                "RETIRING" => Self::Retiring,
+                "RECREATING" => Self::Recreating,
+                "HEALTH_CHECK_CONTAINER_ERROR" => Self::HealthCheckContainerError,
+                "CUSTOMIZED_PATH_RESPONSE_PENDING" => Self::CustomizedPathResponsePending,
+                "MIN_INSTANCES_NOT_PROVISIONED" => Self::MinInstancesNotProvisioned,
+                "ACTIVE_REVISION_LIMIT_REACHED" => Self::ActiveRevisionLimitReached,
+                "NO_DEPLOYMENT" => Self::NoDeployment,
+                "HEALTH_CHECK_SKIPPED" => Self::HealthCheckSkipped,
+                "MIN_INSTANCES_WARMING" => Self::MinInstancesWarming,
+                _ => Self::UnknownValue(revision_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RevisionReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Undefined => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Reserve => serializer.serialize_i32(2),
+                Self::Retired => serializer.serialize_i32(3),
+                Self::Retiring => serializer.serialize_i32(4),
+                Self::Recreating => serializer.serialize_i32(5),
+                Self::HealthCheckContainerError => serializer.serialize_i32(6),
+                Self::CustomizedPathResponsePending => serializer.serialize_i32(7),
+                Self::MinInstancesNotProvisioned => serializer.serialize_i32(8),
+                Self::ActiveRevisionLimitReached => serializer.serialize_i32(9),
+                Self::NoDeployment => serializer.serialize_i32(10),
+                Self::HealthCheckSkipped => serializer.serialize_i32(11),
+                Self::MinInstancesWarming => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RevisionReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RevisionReason>::new(
+                ".google.cloud.run.v2.Condition.RevisionReason",
+            ))
         }
     }
 
     /// Reasons specific to Execution resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionReason(i32);
-
-    impl ExecutionReason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExecutionReason {
         /// Default value.
-        pub const EXECUTION_REASON_UNDEFINED: ExecutionReason = ExecutionReason::new(0);
-
+        Undefined,
         /// Internal system error getting execution status. System will retry.
-        pub const JOB_STATUS_SERVICE_POLLING_ERROR: ExecutionReason = ExecutionReason::new(1);
-
+        JobStatusServicePollingError,
         /// A task reached its retry limit and the last attempt failed due to the
         /// user container exiting with a non-zero exit code.
-        pub const NON_ZERO_EXIT_CODE: ExecutionReason = ExecutionReason::new(2);
-
+        NonZeroExitCode,
         /// The execution was cancelled by users.
-        pub const CANCELLED: ExecutionReason = ExecutionReason::new(3);
-
+        Cancelled,
         /// The execution is in the process of being cancelled.
-        pub const CANCELLING: ExecutionReason = ExecutionReason::new(4);
-
+        Cancelling,
         /// The execution was deleted.
-        pub const DELETED: ExecutionReason = ExecutionReason::new(5);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExecutionReason::value] or
+        /// [ExecutionReason::name].
+        UnknownValue(execution_reason::UnknownValue),
+    }
 
-        /// Creates a new ExecutionReason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod execution_reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExecutionReason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Undefined => std::option::Option::Some(0),
+                Self::JobStatusServicePollingError => std::option::Option::Some(1),
+                Self::NonZeroExitCode => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Deleted => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXECUTION_REASON_UNDEFINED"),
-                1 => std::borrow::Cow::Borrowed("JOB_STATUS_SERVICE_POLLING_ERROR"),
-                2 => std::borrow::Cow::Borrowed("NON_ZERO_EXIT_CODE"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXECUTION_REASON_UNDEFINED" => {
-                    std::option::Option::Some(Self::EXECUTION_REASON_UNDEFINED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Undefined => std::option::Option::Some("EXECUTION_REASON_UNDEFINED"),
+                Self::JobStatusServicePollingError => {
+                    std::option::Option::Some("JOB_STATUS_SERVICE_POLLING_ERROR")
                 }
-                "JOB_STATUS_SERVICE_POLLING_ERROR" => {
-                    std::option::Option::Some(Self::JOB_STATUS_SERVICE_POLLING_ERROR)
-                }
-                "NON_ZERO_EXIT_CODE" => std::option::Option::Some(Self::NON_ZERO_EXIT_CODE),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
+                Self::NonZeroExitCode => std::option::Option::Some("NON_ZERO_EXIT_CODE"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ExecutionReason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionReason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExecutionReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExecutionReason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Undefined,
+                1 => Self::JobStatusServicePollingError,
+                2 => Self::NonZeroExitCode,
+                3 => Self::Cancelled,
+                4 => Self::Cancelling,
+                5 => Self::Deleted,
+                _ => Self::UnknownValue(execution_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExecutionReason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXECUTION_REASON_UNDEFINED" => Self::Undefined,
+                "JOB_STATUS_SERVICE_POLLING_ERROR" => Self::JobStatusServicePollingError,
+                "NON_ZERO_EXIT_CODE" => Self::NonZeroExitCode,
+                "CANCELLED" => Self::Cancelled,
+                "CANCELLING" => Self::Cancelling,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(execution_reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExecutionReason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Undefined => serializer.serialize_i32(0),
+                Self::JobStatusServicePollingError => serializer.serialize_i32(1),
+                Self::NonZeroExitCode => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Deleted => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExecutionReason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionReason>::new(
+                ".google.cloud.run.v2.Condition.ExecutionReason",
+            ))
         }
     }
 
@@ -3095,76 +3452,141 @@ pub mod execution_reference {
     use super::*;
 
     /// Possible execution completion status.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompletionStatus(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompletionStatus {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// Job execution has succeeded.
+        ExecutionSucceeded,
+        /// Job execution has failed.
+        ExecutionFailed,
+        /// Job execution is running normally.
+        ExecutionRunning,
+        /// Waiting for backing resources to be provisioned.
+        ExecutionPending,
+        /// Job execution has been cancelled by the user.
+        ExecutionCancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompletionStatus::value] or
+        /// [CompletionStatus::name].
+        UnknownValue(completion_status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod completion_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CompletionStatus {
-        /// The default value. This value is used if the state is omitted.
-        pub const COMPLETION_STATUS_UNSPECIFIED: CompletionStatus = CompletionStatus::new(0);
-
-        /// Job execution has succeeded.
-        pub const EXECUTION_SUCCEEDED: CompletionStatus = CompletionStatus::new(1);
-
-        /// Job execution has failed.
-        pub const EXECUTION_FAILED: CompletionStatus = CompletionStatus::new(2);
-
-        /// Job execution is running normally.
-        pub const EXECUTION_RUNNING: CompletionStatus = CompletionStatus::new(3);
-
-        /// Waiting for backing resources to be provisioned.
-        pub const EXECUTION_PENDING: CompletionStatus = CompletionStatus::new(4);
-
-        /// Job execution has been cancelled by the user.
-        pub const EXECUTION_CANCELLED: CompletionStatus = CompletionStatus::new(5);
-
-        /// Creates a new CompletionStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ExecutionSucceeded => std::option::Option::Some(1),
+                Self::ExecutionFailed => std::option::Option::Some(2),
+                Self::ExecutionRunning => std::option::Option::Some(3),
+                Self::ExecutionPending => std::option::Option::Some(4),
+                Self::ExecutionCancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPLETION_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXECUTION_SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("EXECUTION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("EXECUTION_RUNNING"),
-                4 => std::borrow::Cow::Borrowed("EXECUTION_PENDING"),
-                5 => std::borrow::Cow::Borrowed("EXECUTION_CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPLETION_STATUS_UNSPECIFIED"),
+                Self::ExecutionSucceeded => std::option::Option::Some("EXECUTION_SUCCEEDED"),
+                Self::ExecutionFailed => std::option::Option::Some("EXECUTION_FAILED"),
+                Self::ExecutionRunning => std::option::Option::Some("EXECUTION_RUNNING"),
+                Self::ExecutionPending => std::option::Option::Some("EXECUTION_PENDING"),
+                Self::ExecutionCancelled => std::option::Option::Some("EXECUTION_CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPLETION_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPLETION_STATUS_UNSPECIFIED)
-                }
-                "EXECUTION_SUCCEEDED" => std::option::Option::Some(Self::EXECUTION_SUCCEEDED),
-                "EXECUTION_FAILED" => std::option::Option::Some(Self::EXECUTION_FAILED),
-                "EXECUTION_RUNNING" => std::option::Option::Some(Self::EXECUTION_RUNNING),
-                "EXECUTION_PENDING" => std::option::Option::Some(Self::EXECUTION_PENDING),
-                "EXECUTION_CANCELLED" => std::option::Option::Some(Self::EXECUTION_CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompletionStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompletionStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompletionStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompletionStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ExecutionSucceeded,
+                2 => Self::ExecutionFailed,
+                3 => Self::ExecutionRunning,
+                4 => Self::ExecutionPending,
+                5 => Self::ExecutionCancelled,
+                _ => Self::UnknownValue(completion_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompletionStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPLETION_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "EXECUTION_SUCCEEDED" => Self::ExecutionSucceeded,
+                "EXECUTION_FAILED" => Self::ExecutionFailed,
+                "EXECUTION_RUNNING" => Self::ExecutionRunning,
+                "EXECUTION_PENDING" => Self::ExecutionPending,
+                "EXECUTION_CANCELLED" => Self::ExecutionCancelled,
+                _ => Self::UnknownValue(completion_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompletionStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ExecutionSucceeded => serializer.serialize_i32(1),
+                Self::ExecutionFailed => serializer.serialize_i32(2),
+                Self::ExecutionRunning => serializer.serialize_i32(3),
+                Self::ExecutionPending => serializer.serialize_i32(4),
+                Self::ExecutionCancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompletionStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompletionStatus>::new(
+                ".google.cloud.run.v2.ExecutionReference.CompletionStatus",
+            ))
         }
     }
 }
@@ -4209,55 +4631,114 @@ pub mod empty_dir_volume_source {
     use super::*;
 
     /// The different types of medium supported for EmptyDir.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Medium(i32);
-
-    impl Medium {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Medium {
         /// When not specified, falls back to the default implementation which
         /// is currently in memory (this may change over time).
-        pub const MEDIUM_UNSPECIFIED: Medium = Medium::new(0);
-
+        Unspecified,
         /// Explicitly set the EmptyDir to be in memory. Uses tmpfs.
-        pub const MEMORY: Medium = Medium::new(1);
+        Memory,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Medium::value] or
+        /// [Medium::name].
+        UnknownValue(medium::UnknownValue),
+    }
 
-        /// Creates a new Medium instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod medium {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Medium {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Memory => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MEDIUM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MEMORY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MEDIUM_UNSPECIFIED"),
+                Self::Memory => std::option::Option::Some("MEMORY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MEDIUM_UNSPECIFIED" => std::option::Option::Some(Self::MEDIUM_UNSPECIFIED),
-                "MEMORY" => std::option::Option::Some(Self::MEMORY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Medium {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Medium {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Medium {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Medium {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Memory,
+                _ => Self::UnknownValue(medium::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Medium {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MEDIUM_UNSPECIFIED" => Self::Unspecified,
+                "MEMORY" => Self::Memory,
+                _ => Self::UnknownValue(medium::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Medium {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Memory => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Medium {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Medium>::new(
+                ".google.cloud.run.v2.EmptyDirVolumeSource.Medium",
+            ))
         }
     }
 }
@@ -7776,59 +8257,120 @@ pub mod vpc_access {
     }
 
     /// Egress options for VPC access.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VpcEgress(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VpcEgress {
+        /// Unspecified
+        Unspecified,
+        /// All outbound traffic is routed through the VPC connector.
+        AllTraffic,
+        /// Only private IP ranges are routed through the VPC connector.
+        PrivateRangesOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VpcEgress::value] or
+        /// [VpcEgress::name].
+        UnknownValue(vpc_egress::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod vpc_egress {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VpcEgress {
-        /// Unspecified
-        pub const VPC_EGRESS_UNSPECIFIED: VpcEgress = VpcEgress::new(0);
-
-        /// All outbound traffic is routed through the VPC connector.
-        pub const ALL_TRAFFIC: VpcEgress = VpcEgress::new(1);
-
-        /// Only private IP ranges are routed through the VPC connector.
-        pub const PRIVATE_RANGES_ONLY: VpcEgress = VpcEgress::new(2);
-
-        /// Creates a new VpcEgress instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllTraffic => std::option::Option::Some(1),
+                Self::PrivateRangesOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VPC_EGRESS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_TRAFFIC"),
-                2 => std::borrow::Cow::Borrowed("PRIVATE_RANGES_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VPC_EGRESS_UNSPECIFIED"),
+                Self::AllTraffic => std::option::Option::Some("ALL_TRAFFIC"),
+                Self::PrivateRangesOnly => std::option::Option::Some("PRIVATE_RANGES_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VPC_EGRESS_UNSPECIFIED" => std::option::Option::Some(Self::VPC_EGRESS_UNSPECIFIED),
-                "ALL_TRAFFIC" => std::option::Option::Some(Self::ALL_TRAFFIC),
-                "PRIVATE_RANGES_ONLY" => std::option::Option::Some(Self::PRIVATE_RANGES_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VpcEgress {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VpcEgress {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VpcEgress {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VpcEgress {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllTraffic,
+                2 => Self::PrivateRangesOnly,
+                _ => Self::UnknownValue(vpc_egress::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VpcEgress {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VPC_EGRESS_UNSPECIFIED" => Self::Unspecified,
+                "ALL_TRAFFIC" => Self::AllTraffic,
+                "PRIVATE_RANGES_ONLY" => Self::PrivateRangesOnly,
+                _ => Self::UnknownValue(vpc_egress::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VpcEgress {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllTraffic => serializer.serialize_i32(1),
+                Self::PrivateRangesOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VpcEgress {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VpcEgress>::new(
+                ".google.cloud.run.v2.VpcAccess.VpcEgress",
+            ))
         }
     }
 }
@@ -8106,61 +8648,120 @@ pub mod service_scaling {
 
     /// The scaling mode for the service. If not provided, it defaults to
     /// AUTOMATIC.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ScalingMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ScalingMode {
+        /// Unspecified.
+        Unspecified,
+        /// Scale based on traffic between min and max instances.
+        Automatic,
+        /// Scale to exactly min instances and ignore max instances.
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ScalingMode::value] or
+        /// [ScalingMode::name].
+        UnknownValue(scaling_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scaling_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ScalingMode {
-        /// Unspecified.
-        pub const SCALING_MODE_UNSPECIFIED: ScalingMode = ScalingMode::new(0);
-
-        /// Scale based on traffic between min and max instances.
-        pub const AUTOMATIC: ScalingMode = ScalingMode::new(1);
-
-        /// Scale to exactly min instances and ignore max instances.
-        pub const MANUAL: ScalingMode = ScalingMode::new(2);
-
-        /// Creates a new ScalingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automatic => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCALING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC"),
-                2 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCALING_MODE_UNSPECIFIED"),
+                Self::Automatic => std::option::Option::Some("AUTOMATIC"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCALING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SCALING_MODE_UNSPECIFIED)
-                }
-                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ScalingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ScalingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ScalingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ScalingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automatic,
+                2 => Self::Manual,
+                _ => Self::UnknownValue(scaling_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ScalingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCALING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC" => Self::Automatic,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(scaling_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ScalingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automatic => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ScalingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ScalingMode>::new(
+                ".google.cloud.run.v2.ServiceScaling.ScalingMode",
+            ))
         }
     }
 }
@@ -8329,264 +8930,497 @@ impl wkt::message::Message for BuildConfig {
 }
 
 /// The type of instance allocation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TrafficTargetAllocationType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TrafficTargetAllocationType {
+    /// Unspecified instance allocation type.
+    Unspecified,
+    /// Allocates instances to the Service's latest ready Revision.
+    Latest,
+    /// Allocates instances to a Revision by name.
+    Revision,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TrafficTargetAllocationType::value] or
+    /// [TrafficTargetAllocationType::name].
+    UnknownValue(traffic_target_allocation_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod traffic_target_allocation_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TrafficTargetAllocationType {
-    /// Unspecified instance allocation type.
-    pub const TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED: TrafficTargetAllocationType =
-        TrafficTargetAllocationType::new(0);
-
-    /// Allocates instances to the Service's latest ready Revision.
-    pub const TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST: TrafficTargetAllocationType =
-        TrafficTargetAllocationType::new(1);
-
-    /// Allocates instances to a Revision by name.
-    pub const TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION: TrafficTargetAllocationType =
-        TrafficTargetAllocationType::new(2);
-
-    /// Creates a new TrafficTargetAllocationType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Latest => std::option::Option::Some(1),
+            Self::Revision => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"),
-            2 => std::borrow::Cow::Borrowed("TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED")
+            }
+            Self::Latest => std::option::Option::Some("TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"),
+            Self::Revision => std::option::Option::Some("TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED)
-            }
-            "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST" => {
-                std::option::Option::Some(Self::TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST)
-            }
-            "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION" => {
-                std::option::Option::Some(Self::TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for TrafficTargetAllocationType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TrafficTargetAllocationType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TrafficTargetAllocationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TrafficTargetAllocationType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Latest,
+            2 => Self::Revision,
+            _ => Self::UnknownValue(traffic_target_allocation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TrafficTargetAllocationType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRAFFIC_TARGET_ALLOCATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST" => Self::Latest,
+            "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION" => Self::Revision,
+            _ => Self::UnknownValue(traffic_target_allocation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TrafficTargetAllocationType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Latest => serializer.serialize_i32(1),
+            Self::Revision => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TrafficTargetAllocationType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<TrafficTargetAllocationType>::new(
+                ".google.cloud.run.v2.TrafficTargetAllocationType",
+            ),
+        )
     }
 }
 
 /// Allowed ingress traffic for the Container.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IngressTraffic(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IngressTraffic {
+    /// Unspecified
+    Unspecified,
+    /// All inbound traffic is allowed.
+    All,
+    /// Only internal traffic is allowed.
+    InternalOnly,
+    /// Both internal and Google Cloud Load Balancer traffic is allowed.
+    InternalLoadBalancer,
+    /// No ingress traffic is allowed.
+    None,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IngressTraffic::value] or
+    /// [IngressTraffic::name].
+    UnknownValue(ingress_traffic::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod ingress_traffic {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl IngressTraffic {
-    /// Unspecified
-    pub const INGRESS_TRAFFIC_UNSPECIFIED: IngressTraffic = IngressTraffic::new(0);
-
-    /// All inbound traffic is allowed.
-    pub const INGRESS_TRAFFIC_ALL: IngressTraffic = IngressTraffic::new(1);
-
-    /// Only internal traffic is allowed.
-    pub const INGRESS_TRAFFIC_INTERNAL_ONLY: IngressTraffic = IngressTraffic::new(2);
-
-    /// Both internal and Google Cloud Load Balancer traffic is allowed.
-    pub const INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER: IngressTraffic = IngressTraffic::new(3);
-
-    /// No ingress traffic is allowed.
-    pub const INGRESS_TRAFFIC_NONE: IngressTraffic = IngressTraffic::new(4);
-
-    /// Creates a new IngressTraffic instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::All => std::option::Option::Some(1),
+            Self::InternalOnly => std::option::Option::Some(2),
+            Self::InternalLoadBalancer => std::option::Option::Some(3),
+            Self::None => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_ALL"),
-            2 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_INTERNAL_ONLY"),
-            3 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"),
-            4 => std::borrow::Cow::Borrowed("INGRESS_TRAFFIC_NONE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INGRESS_TRAFFIC_UNSPECIFIED"),
+            Self::All => std::option::Option::Some("INGRESS_TRAFFIC_ALL"),
+            Self::InternalOnly => std::option::Option::Some("INGRESS_TRAFFIC_INTERNAL_ONLY"),
+            Self::InternalLoadBalancer => {
+                std::option::Option::Some("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER")
+            }
+            Self::None => std::option::Option::Some("INGRESS_TRAFFIC_NONE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INGRESS_TRAFFIC_UNSPECIFIED" => {
-                std::option::Option::Some(Self::INGRESS_TRAFFIC_UNSPECIFIED)
-            }
-            "INGRESS_TRAFFIC_ALL" => std::option::Option::Some(Self::INGRESS_TRAFFIC_ALL),
-            "INGRESS_TRAFFIC_INTERNAL_ONLY" => {
-                std::option::Option::Some(Self::INGRESS_TRAFFIC_INTERNAL_ONLY)
-            }
-            "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" => {
-                std::option::Option::Some(Self::INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER)
-            }
-            "INGRESS_TRAFFIC_NONE" => std::option::Option::Some(Self::INGRESS_TRAFFIC_NONE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IngressTraffic {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IngressTraffic {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IngressTraffic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IngressTraffic {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::All,
+            2 => Self::InternalOnly,
+            3 => Self::InternalLoadBalancer,
+            4 => Self::None,
+            _ => Self::UnknownValue(ingress_traffic::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IngressTraffic {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INGRESS_TRAFFIC_UNSPECIFIED" => Self::Unspecified,
+            "INGRESS_TRAFFIC_ALL" => Self::All,
+            "INGRESS_TRAFFIC_INTERNAL_ONLY" => Self::InternalOnly,
+            "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER" => Self::InternalLoadBalancer,
+            "INGRESS_TRAFFIC_NONE" => Self::None,
+            _ => Self::UnknownValue(ingress_traffic::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IngressTraffic {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::All => serializer.serialize_i32(1),
+            Self::InternalOnly => serializer.serialize_i32(2),
+            Self::InternalLoadBalancer => serializer.serialize_i32(3),
+            Self::None => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IngressTraffic {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IngressTraffic>::new(
+            ".google.cloud.run.v2.IngressTraffic",
+        ))
     }
 }
 
 /// Alternatives for execution environments.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExecutionEnvironment(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ExecutionEnvironment {
+    /// Unspecified
+    Unspecified,
+    /// Uses the First Generation environment.
+    Gen1,
+    /// Uses Second Generation environment.
+    Gen2,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ExecutionEnvironment::value] or
+    /// [ExecutionEnvironment::name].
+    UnknownValue(execution_environment::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod execution_environment {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ExecutionEnvironment {
-    /// Unspecified
-    pub const EXECUTION_ENVIRONMENT_UNSPECIFIED: ExecutionEnvironment =
-        ExecutionEnvironment::new(0);
-
-    /// Uses the First Generation environment.
-    pub const EXECUTION_ENVIRONMENT_GEN1: ExecutionEnvironment = ExecutionEnvironment::new(1);
-
-    /// Uses Second Generation environment.
-    pub const EXECUTION_ENVIRONMENT_GEN2: ExecutionEnvironment = ExecutionEnvironment::new(2);
-
-    /// Creates a new ExecutionEnvironment instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Gen1 => std::option::Option::Some(1),
+            Self::Gen2 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_GEN1"),
-            2 => std::borrow::Cow::Borrowed("EXECUTION_ENVIRONMENT_GEN2"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EXECUTION_ENVIRONMENT_UNSPECIFIED"),
+            Self::Gen1 => std::option::Option::Some("EXECUTION_ENVIRONMENT_GEN1"),
+            Self::Gen2 => std::option::Option::Some("EXECUTION_ENVIRONMENT_GEN2"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EXECUTION_ENVIRONMENT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_UNSPECIFIED)
-            }
-            "EXECUTION_ENVIRONMENT_GEN1" => {
-                std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_GEN1)
-            }
-            "EXECUTION_ENVIRONMENT_GEN2" => {
-                std::option::Option::Some(Self::EXECUTION_ENVIRONMENT_GEN2)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ExecutionEnvironment {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ExecutionEnvironment {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ExecutionEnvironment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ExecutionEnvironment {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Gen1,
+            2 => Self::Gen2,
+            _ => Self::UnknownValue(execution_environment::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ExecutionEnvironment {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EXECUTION_ENVIRONMENT_UNSPECIFIED" => Self::Unspecified,
+            "EXECUTION_ENVIRONMENT_GEN1" => Self::Gen1,
+            "EXECUTION_ENVIRONMENT_GEN2" => Self::Gen2,
+            _ => Self::UnknownValue(execution_environment::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ExecutionEnvironment {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Gen1 => serializer.serialize_i32(1),
+            Self::Gen2 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ExecutionEnvironment {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionEnvironment>::new(
+            ".google.cloud.run.v2.ExecutionEnvironment",
+        ))
     }
 }
 
 /// Specifies behavior if an encryption key used by a resource is revoked.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncryptionKeyRevocationAction(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EncryptionKeyRevocationAction {
+    /// Unspecified
+    Unspecified,
+    /// Prevents the creation of new instances.
+    PreventNew,
+    /// Shuts down existing instances, and prevents creation of new ones.
+    Shutdown,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EncryptionKeyRevocationAction::value] or
+    /// [EncryptionKeyRevocationAction::name].
+    UnknownValue(encryption_key_revocation_action::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod encryption_key_revocation_action {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl EncryptionKeyRevocationAction {
-    /// Unspecified
-    pub const ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED: EncryptionKeyRevocationAction =
-        EncryptionKeyRevocationAction::new(0);
-
-    /// Prevents the creation of new instances.
-    pub const PREVENT_NEW: EncryptionKeyRevocationAction = EncryptionKeyRevocationAction::new(1);
-
-    /// Shuts down existing instances, and prevents creation of new ones.
-    pub const SHUTDOWN: EncryptionKeyRevocationAction = EncryptionKeyRevocationAction::new(2);
-
-    /// Creates a new EncryptionKeyRevocationAction instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PreventNew => std::option::Option::Some(1),
+            Self::Shutdown => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PREVENT_NEW"),
-            2 => std::borrow::Cow::Borrowed("SHUTDOWN"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED")
             }
-            "PREVENT_NEW" => std::option::Option::Some(Self::PREVENT_NEW),
-            "SHUTDOWN" => std::option::Option::Some(Self::SHUTDOWN),
-            _ => std::option::Option::None,
+            Self::PreventNew => std::option::Option::Some("PREVENT_NEW"),
+            Self::Shutdown => std::option::Option::Some("SHUTDOWN"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for EncryptionKeyRevocationAction {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EncryptionKeyRevocationAction {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EncryptionKeyRevocationAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EncryptionKeyRevocationAction {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PreventNew,
+            2 => Self::Shutdown,
+            _ => Self::UnknownValue(encryption_key_revocation_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EncryptionKeyRevocationAction {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENCRYPTION_KEY_REVOCATION_ACTION_UNSPECIFIED" => Self::Unspecified,
+            "PREVENT_NEW" => Self::PreventNew,
+            "SHUTDOWN" => Self::Shutdown,
+            _ => Self::UnknownValue(encryption_key_revocation_action::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EncryptionKeyRevocationAction {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PreventNew => serializer.serialize_i32(1),
+            Self::Shutdown => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EncryptionKeyRevocationAction {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<EncryptionKeyRevocationAction>::new(
+                ".google.cloud.run.v2.EncryptionKeyRevocationAction",
+            ),
+        )
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/client.rs
+++ b/src/generated/cloud/scheduler/v1/src/client.rs
@@ -157,7 +157,7 @@ impl CloudScheduler {
     /// UpdateJob request until a successful response is received.
     ///
     /// [google.cloud.scheduler.v1.Job]: crate::model::Job
-    /// [google.cloud.scheduler.v1.Job.State.UPDATE_FAILED]: crate::model::job::state::UPDATE_FAILED
+    /// [google.cloud.scheduler.v1.Job.State.UPDATE_FAILED]: crate::model::job::State::UpdateFailed
     pub fn update_job(
         &self,
         job: impl Into<crate::model::Job>,
@@ -185,8 +185,8 @@ impl CloudScheduler {
     /// be paused.
     ///
     /// [google.cloud.scheduler.v1.CloudScheduler.ResumeJob]: crate::client::CloudScheduler::resume_job
-    /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::state::ENABLED
-    /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::state::PAUSED
+    /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::State::Enabled
+    /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::State::Paused
     /// [google.cloud.scheduler.v1.Job.state]: crate::model::Job::state
     pub fn pause_job(
         &self,
@@ -205,8 +205,8 @@ impl CloudScheduler {
     /// must be in [Job.State.PAUSED][google.cloud.scheduler.v1.Job.State.PAUSED]
     /// to be resumed.
     ///
-    /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::state::ENABLED
-    /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::state::PAUSED
+    /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::State::Enabled
+    /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::State::Paused
     /// [google.cloud.scheduler.v1.Job.state]: crate::model::Job::state
     pub fn resume_job(
         &self,

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -820,27 +820,22 @@ pub mod job {
     use super::*;
 
     /// State of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The job is executing normally.
-        pub const ENABLED: State = State::new(1);
-
+        Enabled,
         /// The job is paused by the user. It will not execute. A user can
         /// intentionally pause the job using
         /// [PauseJobRequest][google.cloud.scheduler.v1.PauseJobRequest].
         ///
         /// [google.cloud.scheduler.v1.PauseJobRequest]: crate::model::PauseJobRequest
-        pub const PAUSED: State = State::new(2);
-
+        Paused,
         /// The job is disabled by the system due to error. The user
         /// cannot directly set a job to be disabled.
-        pub const DISABLED: State = State::new(3);
-
+        Disabled,
         /// The job state resulting from a failed
         /// [CloudScheduler.UpdateJob][google.cloud.scheduler.v1.CloudScheduler.UpdateJob]
         /// operation. To recover a job from this state, retry
@@ -848,52 +843,122 @@ pub mod job {
         /// until a successful response is received.
         ///
         /// [google.cloud.scheduler.v1.CloudScheduler.UpdateJob]: crate::client::CloudScheduler::update_job
-        pub const UPDATE_FAILED: State = State::new(4);
+        UpdateFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Disabled => std::option::Option::Some(3),
+                Self::UpdateFailed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("DISABLED"),
-                4 => std::borrow::Cow::Borrowed("UPDATE_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UpdateFailed => std::option::Option::Some("UPDATE_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "UPDATE_FAILED" => std::option::Option::Some(Self::UPDATE_FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Paused,
+                3 => Self::Disabled,
+                4 => Self::UpdateFailed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "PAUSED" => Self::Paused,
+                "DISABLED" => Self::Disabled,
+                "UPDATE_FAILED" => Self::UpdateFailed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Disabled => serializer.serialize_i32(3),
+                Self::UpdateFailed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.scheduler.v1.Job.State",
+            ))
         }
     }
 
@@ -1784,83 +1849,154 @@ impl wkt::message::Message for OidcToken {
 }
 
 /// The HTTP method used to execute the job.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HttpMethod(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HttpMethod {
+    /// HTTP method unspecified. Defaults to POST.
+    Unspecified,
+    /// HTTP POST
+    Post,
+    /// HTTP GET
+    Get,
+    /// HTTP HEAD
+    Head,
+    /// HTTP PUT
+    Put,
+    /// HTTP DELETE
+    Delete,
+    /// HTTP PATCH
+    Patch,
+    /// HTTP OPTIONS
+    Options,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HttpMethod::value] or
+    /// [HttpMethod::name].
+    UnknownValue(http_method::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod http_method {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl HttpMethod {
-    /// HTTP method unspecified. Defaults to POST.
-    pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new(0);
-
-    /// HTTP POST
-    pub const POST: HttpMethod = HttpMethod::new(1);
-
-    /// HTTP GET
-    pub const GET: HttpMethod = HttpMethod::new(2);
-
-    /// HTTP HEAD
-    pub const HEAD: HttpMethod = HttpMethod::new(3);
-
-    /// HTTP PUT
-    pub const PUT: HttpMethod = HttpMethod::new(4);
-
-    /// HTTP DELETE
-    pub const DELETE: HttpMethod = HttpMethod::new(5);
-
-    /// HTTP PATCH
-    pub const PATCH: HttpMethod = HttpMethod::new(6);
-
-    /// HTTP OPTIONS
-    pub const OPTIONS: HttpMethod = HttpMethod::new(7);
-
-    /// Creates a new HttpMethod instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Post => std::option::Option::Some(1),
+            Self::Get => std::option::Option::Some(2),
+            Self::Head => std::option::Option::Some(3),
+            Self::Put => std::option::Option::Some(4),
+            Self::Delete => std::option::Option::Some(5),
+            Self::Patch => std::option::Option::Some(6),
+            Self::Options => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HTTP_METHOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("POST"),
-            2 => std::borrow::Cow::Borrowed("GET"),
-            3 => std::borrow::Cow::Borrowed("HEAD"),
-            4 => std::borrow::Cow::Borrowed("PUT"),
-            5 => std::borrow::Cow::Borrowed("DELETE"),
-            6 => std::borrow::Cow::Borrowed("PATCH"),
-            7 => std::borrow::Cow::Borrowed("OPTIONS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HTTP_METHOD_UNSPECIFIED"),
+            Self::Post => std::option::Option::Some("POST"),
+            Self::Get => std::option::Option::Some("GET"),
+            Self::Head => std::option::Option::Some("HEAD"),
+            Self::Put => std::option::Option::Some("PUT"),
+            Self::Delete => std::option::Option::Some("DELETE"),
+            Self::Patch => std::option::Option::Some("PATCH"),
+            Self::Options => std::option::Option::Some("OPTIONS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HTTP_METHOD_UNSPECIFIED" => std::option::Option::Some(Self::HTTP_METHOD_UNSPECIFIED),
-            "POST" => std::option::Option::Some(Self::POST),
-            "GET" => std::option::Option::Some(Self::GET),
-            "HEAD" => std::option::Option::Some(Self::HEAD),
-            "PUT" => std::option::Option::Some(Self::PUT),
-            "DELETE" => std::option::Option::Some(Self::DELETE),
-            "PATCH" => std::option::Option::Some(Self::PATCH),
-            "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HttpMethod {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HttpMethod {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HttpMethod {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Post,
+            2 => Self::Get,
+            3 => Self::Head,
+            4 => Self::Put,
+            5 => Self::Delete,
+            6 => Self::Patch,
+            7 => Self::Options,
+            _ => Self::UnknownValue(http_method::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HttpMethod {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HTTP_METHOD_UNSPECIFIED" => Self::Unspecified,
+            "POST" => Self::Post,
+            "GET" => Self::Get,
+            "HEAD" => Self::Head,
+            "PUT" => Self::Put,
+            "DELETE" => Self::Delete,
+            "PATCH" => Self::Patch,
+            "OPTIONS" => Self::Options,
+            _ => Self::UnknownValue(http_method::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HttpMethod {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Post => serializer.serialize_i32(1),
+            Self::Get => serializer.serialize_i32(2),
+            Self::Head => serializer.serialize_i32(3),
+            Self::Put => serializer.serialize_i32(4),
+            Self::Delete => serializer.serialize_i32(5),
+            Self::Patch => serializer.serialize_i32(6),
+            Self::Options => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HttpMethod {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HttpMethod>::new(
+            ".google.cloud.scheduler.v1.HttpMethod",
+        ))
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -251,7 +251,7 @@ impl SecretManagerService {
     /// [DISABLED][google.cloud.secretmanager.v1.SecretVersion.State.DISABLED].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::state::DISABLED
+    /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::State::Disabled
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     pub fn disable_secret_version(
         &self,
@@ -268,7 +268,7 @@ impl SecretManagerService {
     /// [ENABLED][google.cloud.secretmanager.v1.SecretVersion.State.ENABLED].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
+    /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::State::Enabled
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     pub fn enable_secret_version(
         &self,
@@ -286,7 +286,7 @@ impl SecretManagerService {
     /// and irrevocably destroys the secret data.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::state::DESTROYED
+    /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::State::Destroyed
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     pub fn destroy_secret_version(
         &self,

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -430,7 +430,7 @@ pub struct SecretVersion {
     /// [DESTROYED][google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::state::DESTROYED
+    /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::State::Destroyed
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub destroy_time: std::option::Option<wkt::Timestamp>,
@@ -594,19 +594,16 @@ pub mod secret_version {
     /// it can be accessed.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified. This value is unused and invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may be
         /// accessed.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        pub const ENABLED: State = State::new(1);
-
+        Enabled,
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] may not
         /// be accessed, but the secret data is still available and can be placed
         /// back into the
@@ -614,58 +611,124 @@ pub mod secret_version {
         /// state.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::state::ENABLED
-        pub const DISABLED: State = State::new(2);
-
+        /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::State::Enabled
+        Disabled,
         /// The [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] is
         /// destroyed and the secret data is no longer stored. A version may not
         /// leave this state once entered.
         ///
         /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
-        pub const DESTROYED: State = State::new(3);
+        Destroyed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Destroyed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("DESTROYED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Destroyed => std::option::Option::Some("DESTROYED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "DESTROYED" => std::option::Option::Some(Self::DESTROYED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Destroyed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "DESTROYED" => Self::Destroyed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Destroyed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.secretmanager.v1.SecretVersion.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -339,134 +339,260 @@ pub mod instance {
     }
 
     /// Secure Source Manager instance state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Not set. This should only be the case for incoming requests.
+        Unspecified,
+        /// Instance is being created.
+        Creating,
+        /// Instance is ready.
+        Active,
+        /// Instance is being deleted.
+        Deleting,
+        /// Instance is paused.
+        Paused,
+        /// Instance is unknown, we are not sure if it's functioning.
+        Unknown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Not set. This should only be the case for incoming requests.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Instance is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Instance is ready.
-        pub const ACTIVE: State = State::new(2);
-
-        /// Instance is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// Instance is paused.
-        pub const PAUSED: State = State::new(4);
-
-        /// Instance is unknown, we are not sure if it's functioning.
-        pub const UNKNOWN: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Paused => std::option::Option::Some(4),
+                Self::Unknown => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("PAUSED"),
-                6 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Paused,
+                6 => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "PAUSED" => Self::Paused,
+                "UNKNOWN" => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Paused => serializer.serialize_i32(4),
+                Self::Unknown => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.securesourcemanager.v1.Instance.State",
+            ))
         }
     }
 
     /// Provides information about the current instance state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StateNote(i32);
-
-    impl StateNote {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StateNote {
         /// STATE_NOTE_UNSPECIFIED as the first value of State.
-        pub const STATE_NOTE_UNSPECIFIED: StateNote = StateNote::new(0);
-
+        Unspecified,
         /// CMEK access is unavailable.
-        pub const PAUSED_CMEK_UNAVAILABLE: StateNote = StateNote::new(1);
-
+        PausedCmekUnavailable,
         /// INSTANCE_RESUMING indicates that the instance was previously paused
         /// and is under the process of being brought back.
-        pub const INSTANCE_RESUMING: StateNote = StateNote::new(2);
+        InstanceResuming,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StateNote::value] or
+        /// [StateNote::name].
+        UnknownValue(state_note::UnknownValue),
+    }
 
-        /// Creates a new StateNote instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state_note {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl StateNote {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PausedCmekUnavailable => std::option::Option::Some(1),
+                Self::InstanceResuming => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_NOTE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PAUSED_CMEK_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("INSTANCE_RESUMING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_NOTE_UNSPECIFIED"),
+                Self::PausedCmekUnavailable => std::option::Option::Some("PAUSED_CMEK_UNAVAILABLE"),
+                Self::InstanceResuming => std::option::Option::Some("INSTANCE_RESUMING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_NOTE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_NOTE_UNSPECIFIED),
-                "PAUSED_CMEK_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::PAUSED_CMEK_UNAVAILABLE)
-                }
-                "INSTANCE_RESUMING" => std::option::Option::Some(Self::INSTANCE_RESUMING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StateNote {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StateNote {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StateNote {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StateNote {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PausedCmekUnavailable,
+                2 => Self::InstanceResuming,
+                _ => Self::UnknownValue(state_note::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StateNote {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_NOTE_UNSPECIFIED" => Self::Unspecified,
+                "PAUSED_CMEK_UNAVAILABLE" => Self::PausedCmekUnavailable,
+                "INSTANCE_RESUMING" => Self::InstanceResuming,
+                _ => Self::UnknownValue(state_note::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StateNote {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PausedCmekUnavailable => serializer.serialize_i32(1),
+                Self::InstanceResuming => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StateNote {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StateNote>::new(
+                ".google.cloud.securesourcemanager.v1.Instance.StateNote",
+            ))
         }
     }
 }

--- a/src/generated/cloud/security/privateca/v1/src/client.rs
+++ b/src/generated/cloud/security/privateca/v1/src/client.rs
@@ -198,8 +198,8 @@ impl CertificateAuthorityService {
     /// this method can complete the activation process.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: crate::model::certificate_authority::state::AWAITING_USER_ACTIVATION
-    /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: crate::model::certificate_authority::r#type::SUBORDINATE
+    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: crate::model::certificate_authority::State::AwaitingUserActivation
+    /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: crate::model::certificate_authority::Type::Subordinate
     /// [google.cloud.security.privateca.v1.CertificateAuthorityService.FetchCertificateAuthorityCsr]: crate::client::CertificateAuthorityService::fetch_certificate_authority_csr
     ///
     /// # Long running operations
@@ -307,8 +307,8 @@ impl CertificateAuthorityService {
     /// [ActivateCertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthorityService.ActivateCertificateAuthority].
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: crate::model::certificate_authority::state::AWAITING_USER_ACTIVATION
-    /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: crate::model::certificate_authority::r#type::SUBORDINATE
+    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: crate::model::certificate_authority::State::AwaitingUserActivation
+    /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: crate::model::certificate_authority::Type::Subordinate
     /// [google.cloud.security.privateca.v1.CertificateAuthorityService.ActivateCertificateAuthority]: crate::client::CertificateAuthorityService::activate_certificate_authority
     pub fn fetch_certificate_authority_csr(
         &self,

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -181,7 +181,7 @@ pub struct CertificateAuthority {
     /// state.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.DELETED]: crate::model::certificate_authority::state::DELETED
+    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.DELETED]: crate::model::certificate_authority::State::Deleted
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub delete_time: std::option::Option<wkt::Timestamp>,
 
@@ -192,7 +192,7 @@ pub struct CertificateAuthority {
     /// state.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.DELETED]: crate::model::certificate_authority::state::DELETED
+    /// [google.cloud.security.privateca.v1.CertificateAuthority.State.DELETED]: crate::model::certificate_authority::State::Deleted
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub expire_time: std::option::Option<wkt::Timestamp>,
 
@@ -583,63 +583,124 @@ pub mod certificate_authority {
     /// indicating its issuing chain.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Self-signed CA.
-        pub const SELF_SIGNED: Type = Type::new(1);
-
+        SelfSigned,
         /// Subordinate CA. Could be issued by a Private CA
         /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
         /// or an unmanaged CA.
         ///
         /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-        pub const SUBORDINATE: Type = Type::new(2);
+        Subordinate,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SelfSigned => std::option::Option::Some(1),
+                Self::Subordinate => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SELF_SIGNED"),
-                2 => std::borrow::Cow::Borrowed("SUBORDINATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::SelfSigned => std::option::Option::Some("SELF_SIGNED"),
+                Self::Subordinate => std::option::Option::Some("SUBORDINATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "SELF_SIGNED" => std::option::Option::Some(Self::SELF_SIGNED),
-                "SUBORDINATE" => std::option::Option::Some(Self::SUBORDINATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SelfSigned,
+                2 => Self::Subordinate,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SELF_SIGNED" => Self::SelfSigned,
+                "SUBORDINATE" => Self::Subordinate,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SelfSigned => serializer.serialize_i32(1),
+                Self::Subordinate => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.security.privateca.v1.CertificateAuthority.Type",
+            ))
         }
     }
 
@@ -648,13 +709,11 @@ pub mod certificate_authority {
     /// indicating if it can be used.
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Certificates can be issued from this CA. CRLs will be generated for this
         /// CA. The CA will be part of the
         /// [CaPool][google.cloud.security.privateca.v1.CaPool]'s trust anchor, and
@@ -662,8 +721,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const ENABLED: State = State::new(1);
-
+        Enabled,
         /// Certificates cannot be issued from this CA. CRLs will still be generated.
         /// The CA will be part of the
         /// [CaPool][google.cloud.security.privateca.v1.CaPool]'s trust anchor, but
@@ -671,8 +729,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const DISABLED: State = State::new(2);
-
+        Disabled,
         /// Certificates can be issued from this CA. CRLs will be generated for this
         /// CA. The CA will be part of the
         /// [CaPool][google.cloud.security.privateca.v1.CaPool]'s trust anchor, but
@@ -680,8 +737,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const STAGED: State = State::new(3);
-
+        Staged,
         /// Certificates cannot be issued from this CA. CRLs will not be generated.
         /// The CA will not be part of the
         /// [CaPool][google.cloud.security.privateca.v1.CaPool]'s trust anchor, and
@@ -689,8 +745,7 @@ pub mod certificate_authority {
         /// [CaPool][google.cloud.security.privateca.v1.CaPool].
         ///
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-        pub const AWAITING_USER_ACTIVATION: State = State::new(4);
-
+        AwaitingUserActivation,
         /// Certificates cannot be issued from this CA. CRLs will not be generated.
         /// The CA may still be recovered by calling
         /// [CertificateAuthorityService.UndeleteCertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthorityService.UndeleteCertificateAuthority]
@@ -704,56 +759,129 @@ pub mod certificate_authority {
         /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
         /// [google.cloud.security.privateca.v1.CertificateAuthority.expire_time]: crate::model::CertificateAuthority::expire_time
         /// [google.cloud.security.privateca.v1.CertificateAuthorityService.UndeleteCertificateAuthority]: crate::client::CertificateAuthorityService::undelete_certificate_authority
-        pub const DELETED: State = State::new(5);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Staged => std::option::Option::Some(3),
+                Self::AwaitingUserActivation => std::option::Option::Some(4),
+                Self::Deleted => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("STAGED"),
-                4 => std::borrow::Cow::Borrowed("AWAITING_USER_ACTIVATION"),
-                5 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "STAGED" => std::option::Option::Some(Self::STAGED),
-                "AWAITING_USER_ACTIVATION" => {
-                    std::option::Option::Some(Self::AWAITING_USER_ACTIVATION)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Staged => std::option::Option::Some("STAGED"),
+                Self::AwaitingUserActivation => {
+                    std::option::Option::Some("AWAITING_USER_ACTIVATION")
                 }
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Staged,
+                4 => Self::AwaitingUserActivation,
+                5 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "STAGED" => Self::Staged,
+                "AWAITING_USER_ACTIVATION" => Self::AwaitingUserActivation,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Staged => serializer.serialize_i32(3),
+                Self::AwaitingUserActivation => serializer.serialize_i32(4),
+                Self::Deleted => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.security.privateca.v1.CertificateAuthority.State",
+            ))
         }
     }
 
@@ -766,91 +894,162 @@ pub mod certificate_authority {
     /// use PKCS1 algorithms if required for compatibility. For further
     /// recommendations, see
     /// <https://cloud.google.com/kms/docs/algorithms#algorithm_recommendations>.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SignHashAlgorithm(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SignHashAlgorithm {
+        /// Not specified.
+        Unspecified,
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256
+        RsaPss2048Sha256,
+        /// maps to CryptoKeyVersionAlgorithm. RSA_SIGN_PSS_3072_SHA256
+        RsaPss3072Sha256,
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_4096_SHA256
+        RsaPss4096Sha256,
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_2048_SHA256
+        RsaPkcs12048Sha256,
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_3072_SHA256
+        RsaPkcs13072Sha256,
+        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_4096_SHA256
+        RsaPkcs14096Sha256,
+        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P256_SHA256
+        EcP256Sha256,
+        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P384_SHA384
+        EcP384Sha384,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SignHashAlgorithm::value] or
+        /// [SignHashAlgorithm::name].
+        UnknownValue(sign_hash_algorithm::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod sign_hash_algorithm {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SignHashAlgorithm {
-        /// Not specified.
-        pub const SIGN_HASH_ALGORITHM_UNSPECIFIED: SignHashAlgorithm = SignHashAlgorithm::new(0);
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256
-        pub const RSA_PSS_2048_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(1);
-
-        /// maps to CryptoKeyVersionAlgorithm. RSA_SIGN_PSS_3072_SHA256
-        pub const RSA_PSS_3072_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(2);
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_4096_SHA256
-        pub const RSA_PSS_4096_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(3);
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_2048_SHA256
-        pub const RSA_PKCS1_2048_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(6);
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_3072_SHA256
-        pub const RSA_PKCS1_3072_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(7);
-
-        /// maps to CryptoKeyVersionAlgorithm.RSA_SIGN_PKCS1_4096_SHA256
-        pub const RSA_PKCS1_4096_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(8);
-
-        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P256_SHA256
-        pub const EC_P256_SHA256: SignHashAlgorithm = SignHashAlgorithm::new(4);
-
-        /// maps to CryptoKeyVersionAlgorithm.EC_SIGN_P384_SHA384
-        pub const EC_P384_SHA384: SignHashAlgorithm = SignHashAlgorithm::new(5);
-
-        /// Creates a new SignHashAlgorithm instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RsaPss2048Sha256 => std::option::Option::Some(1),
+                Self::RsaPss3072Sha256 => std::option::Option::Some(2),
+                Self::RsaPss4096Sha256 => std::option::Option::Some(3),
+                Self::RsaPkcs12048Sha256 => std::option::Option::Some(6),
+                Self::RsaPkcs13072Sha256 => std::option::Option::Some(7),
+                Self::RsaPkcs14096Sha256 => std::option::Option::Some(8),
+                Self::EcP256Sha256 => std::option::Option::Some(4),
+                Self::EcP384Sha384 => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SIGN_HASH_ALGORITHM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RSA_PSS_2048_SHA256"),
-                2 => std::borrow::Cow::Borrowed("RSA_PSS_3072_SHA256"),
-                3 => std::borrow::Cow::Borrowed("RSA_PSS_4096_SHA256"),
-                4 => std::borrow::Cow::Borrowed("EC_P256_SHA256"),
-                5 => std::borrow::Cow::Borrowed("EC_P384_SHA384"),
-                6 => std::borrow::Cow::Borrowed("RSA_PKCS1_2048_SHA256"),
-                7 => std::borrow::Cow::Borrowed("RSA_PKCS1_3072_SHA256"),
-                8 => std::borrow::Cow::Borrowed("RSA_PKCS1_4096_SHA256"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SIGN_HASH_ALGORITHM_UNSPECIFIED"),
+                Self::RsaPss2048Sha256 => std::option::Option::Some("RSA_PSS_2048_SHA256"),
+                Self::RsaPss3072Sha256 => std::option::Option::Some("RSA_PSS_3072_SHA256"),
+                Self::RsaPss4096Sha256 => std::option::Option::Some("RSA_PSS_4096_SHA256"),
+                Self::RsaPkcs12048Sha256 => std::option::Option::Some("RSA_PKCS1_2048_SHA256"),
+                Self::RsaPkcs13072Sha256 => std::option::Option::Some("RSA_PKCS1_3072_SHA256"),
+                Self::RsaPkcs14096Sha256 => std::option::Option::Some("RSA_PKCS1_4096_SHA256"),
+                Self::EcP256Sha256 => std::option::Option::Some("EC_P256_SHA256"),
+                Self::EcP384Sha384 => std::option::Option::Some("EC_P384_SHA384"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SIGN_HASH_ALGORITHM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SIGN_HASH_ALGORITHM_UNSPECIFIED)
-                }
-                "RSA_PSS_2048_SHA256" => std::option::Option::Some(Self::RSA_PSS_2048_SHA256),
-                "RSA_PSS_3072_SHA256" => std::option::Option::Some(Self::RSA_PSS_3072_SHA256),
-                "RSA_PSS_4096_SHA256" => std::option::Option::Some(Self::RSA_PSS_4096_SHA256),
-                "RSA_PKCS1_2048_SHA256" => std::option::Option::Some(Self::RSA_PKCS1_2048_SHA256),
-                "RSA_PKCS1_3072_SHA256" => std::option::Option::Some(Self::RSA_PKCS1_3072_SHA256),
-                "RSA_PKCS1_4096_SHA256" => std::option::Option::Some(Self::RSA_PKCS1_4096_SHA256),
-                "EC_P256_SHA256" => std::option::Option::Some(Self::EC_P256_SHA256),
-                "EC_P384_SHA384" => std::option::Option::Some(Self::EC_P384_SHA384),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SignHashAlgorithm {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SignHashAlgorithm {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SignHashAlgorithm {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SignHashAlgorithm {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RsaPss2048Sha256,
+                2 => Self::RsaPss3072Sha256,
+                3 => Self::RsaPss4096Sha256,
+                4 => Self::EcP256Sha256,
+                5 => Self::EcP384Sha384,
+                6 => Self::RsaPkcs12048Sha256,
+                7 => Self::RsaPkcs13072Sha256,
+                8 => Self::RsaPkcs14096Sha256,
+                _ => Self::UnknownValue(sign_hash_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SignHashAlgorithm {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SIGN_HASH_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                "RSA_PSS_2048_SHA256" => Self::RsaPss2048Sha256,
+                "RSA_PSS_3072_SHA256" => Self::RsaPss3072Sha256,
+                "RSA_PSS_4096_SHA256" => Self::RsaPss4096Sha256,
+                "RSA_PKCS1_2048_SHA256" => Self::RsaPkcs12048Sha256,
+                "RSA_PKCS1_3072_SHA256" => Self::RsaPkcs13072Sha256,
+                "RSA_PKCS1_4096_SHA256" => Self::RsaPkcs14096Sha256,
+                "EC_P256_SHA256" => Self::EcP256Sha256,
+                "EC_P384_SHA384" => Self::EcP384Sha384,
+                _ => Self::UnknownValue(sign_hash_algorithm::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SignHashAlgorithm {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RsaPss2048Sha256 => serializer.serialize_i32(1),
+                Self::RsaPss3072Sha256 => serializer.serialize_i32(2),
+                Self::RsaPss4096Sha256 => serializer.serialize_i32(3),
+                Self::RsaPkcs12048Sha256 => serializer.serialize_i32(6),
+                Self::RsaPkcs13072Sha256 => serializer.serialize_i32(7),
+                Self::RsaPkcs14096Sha256 => serializer.serialize_i32(8),
+                Self::EcP256Sha256 => serializer.serialize_i32(4),
+                Self::EcP384Sha384 => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SignHashAlgorithm {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SignHashAlgorithm>::new(
+                ".google.cloud.security.privateca.v1.CertificateAuthority.SignHashAlgorithm",
+            ))
         }
     }
 }
@@ -1080,69 +1279,131 @@ pub mod ca_pool {
         use super::*;
 
         /// Supported encoding formats for publishing.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EncodingFormat(i32);
-
-        impl EncodingFormat {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EncodingFormat {
             /// Not specified. By default, PEM format will be used.
-            pub const ENCODING_FORMAT_UNSPECIFIED: EncodingFormat = EncodingFormat::new(0);
-
+            Unspecified,
             /// The
             /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]'s
             /// CA certificate and CRLs will be published in PEM format.
             ///
             /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-            pub const PEM: EncodingFormat = EncodingFormat::new(1);
-
+            Pem,
             /// The
             /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]'s
             /// CA certificate and CRLs will be published in DER format.
             ///
             /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
-            pub const DER: EncodingFormat = EncodingFormat::new(2);
+            Der,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EncodingFormat::value] or
+            /// [EncodingFormat::name].
+            UnknownValue(encoding_format::UnknownValue),
+        }
 
-            /// Creates a new EncodingFormat instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod encoding_format {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl EncodingFormat {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Pem => std::option::Option::Some(1),
+                    Self::Der => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENCODING_FORMAT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PEM"),
-                    2 => std::borrow::Cow::Borrowed("DER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENCODING_FORMAT_UNSPECIFIED"),
+                    Self::Pem => std::option::Option::Some("PEM"),
+                    Self::Der => std::option::Option::Some("DER"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENCODING_FORMAT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ENCODING_FORMAT_UNSPECIFIED)
-                    }
-                    "PEM" => std::option::Option::Some(Self::PEM),
-                    "DER" => std::option::Option::Some(Self::DER),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EncodingFormat {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EncodingFormat {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EncodingFormat {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EncodingFormat {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Pem,
+                    2 => Self::Der,
+                    _ => Self::UnknownValue(encoding_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EncodingFormat {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENCODING_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                    "PEM" => Self::Pem,
+                    "DER" => Self::Der,
+                    _ => Self::UnknownValue(encoding_format::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EncodingFormat {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Pem => serializer.serialize_i32(1),
+                    Self::Der => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EncodingFormat {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncodingFormat>::new(
+                    ".google.cloud.security.privateca.v1.CaPool.PublishingOptions.EncodingFormat",
+                ))
             }
         }
     }
@@ -1576,70 +1837,134 @@ pub mod ca_pool {
                 ///
                 /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
                 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-                #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-                pub struct EcSignatureAlgorithm(i32);
-
-                impl EcSignatureAlgorithm {
+                #[derive(Clone, Debug, PartialEq)]
+                #[non_exhaustive]
+                pub enum EcSignatureAlgorithm {
                     /// Not specified. Signifies that any signature algorithm may be used.
-                    pub const EC_SIGNATURE_ALGORITHM_UNSPECIFIED: EcSignatureAlgorithm =
-                        EcSignatureAlgorithm::new(0);
-
+                    Unspecified,
                     /// Refers to the Elliptic Curve Digital Signature Algorithm over the
                     /// NIST P-256 curve.
-                    pub const ECDSA_P256: EcSignatureAlgorithm = EcSignatureAlgorithm::new(1);
-
+                    EcdsaP256,
                     /// Refers to the Elliptic Curve Digital Signature Algorithm over the
                     /// NIST P-384 curve.
-                    pub const ECDSA_P384: EcSignatureAlgorithm = EcSignatureAlgorithm::new(2);
-
+                    EcdsaP384,
                     /// Refers to the Edwards-curve Digital Signature Algorithm over curve
                     /// 25519, as described in RFC 8410.
-                    pub const EDDSA_25519: EcSignatureAlgorithm = EcSignatureAlgorithm::new(3);
+                    Eddsa25519,
+                    /// If set, the enum was initialized with an unknown value.
+                    ///
+                    /// Applications can examine the value using [EcSignatureAlgorithm::value] or
+                    /// [EcSignatureAlgorithm::name].
+                    UnknownValue(ec_signature_algorithm::UnknownValue),
+                }
 
-                    /// Creates a new EcSignatureAlgorithm instance.
-                    pub(crate) const fn new(value: i32) -> Self {
-                        Self(value)
-                    }
+                #[doc(hidden)]
+                pub mod ec_signature_algorithm {
+                    #[allow(unused_imports)]
+                    use super::*;
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+                }
 
+                impl EcSignatureAlgorithm {
                     /// Gets the enum value.
-                    pub fn value(&self) -> i32 {
-                        self.0
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the string representation of enums.
+                    pub fn value(&self) -> std::option::Option<i32> {
+                        match self {
+                            Self::Unspecified => std::option::Option::Some(0),
+                            Self::EcdsaP256 => std::option::Option::Some(1),
+                            Self::EcdsaP384 => std::option::Option::Some(2),
+                            Self::Eddsa25519 => std::option::Option::Some(3),
+                            Self::UnknownValue(u) => u.0.value(),
+                        }
                     }
 
                     /// Gets the enum value as a string.
-                    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                        match self.0 {
-                            0 => std::borrow::Cow::Borrowed("EC_SIGNATURE_ALGORITHM_UNSPECIFIED"),
-                            1 => std::borrow::Cow::Borrowed("ECDSA_P256"),
-                            2 => std::borrow::Cow::Borrowed("ECDSA_P384"),
-                            3 => std::borrow::Cow::Borrowed("EDDSA_25519"),
-                            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                        }
-                    }
-
-                    /// Creates an enum value from the value name.
-                    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                        match name {
-                            "EC_SIGNATURE_ALGORITHM_UNSPECIFIED" => {
-                                std::option::Option::Some(Self::EC_SIGNATURE_ALGORITHM_UNSPECIFIED)
+                    ///
+                    /// Returns `None` if the enum contains an unknown value deserialized from
+                    /// the integer representation of enums.
+                    pub fn name(&self) -> std::option::Option<&str> {
+                        match self {
+                            Self::Unspecified => {
+                                std::option::Option::Some("EC_SIGNATURE_ALGORITHM_UNSPECIFIED")
                             }
-                            "ECDSA_P256" => std::option::Option::Some(Self::ECDSA_P256),
-                            "ECDSA_P384" => std::option::Option::Some(Self::ECDSA_P384),
-                            "EDDSA_25519" => std::option::Option::Some(Self::EDDSA_25519),
-                            _ => std::option::Option::None,
+                            Self::EcdsaP256 => std::option::Option::Some("ECDSA_P256"),
+                            Self::EcdsaP384 => std::option::Option::Some("ECDSA_P384"),
+                            Self::Eddsa25519 => std::option::Option::Some("EDDSA_25519"),
+                            Self::UnknownValue(u) => u.0.name(),
                         }
-                    }
-                }
-
-                impl std::convert::From<i32> for EcSignatureAlgorithm {
-                    fn from(value: i32) -> Self {
-                        Self::new(value)
                     }
                 }
 
                 impl std::default::Default for EcSignatureAlgorithm {
                     fn default() -> Self {
-                        Self::new(0)
+                        use std::convert::From;
+                        Self::from(0)
+                    }
+                }
+
+                impl std::fmt::Display for EcSignatureAlgorithm {
+                    fn fmt(
+                        &self,
+                        f: &mut std::fmt::Formatter<'_>,
+                    ) -> std::result::Result<(), std::fmt::Error> {
+                        wkt::internal::display_enum(f, self.name(), self.value())
+                    }
+                }
+
+                impl std::convert::From<i32> for EcSignatureAlgorithm {
+                    fn from(value: i32) -> Self {
+                        match value {
+                            0 => Self::Unspecified,
+                            1 => Self::EcdsaP256,
+                            2 => Self::EcdsaP384,
+                            3 => Self::Eddsa25519,
+                            _ => Self::UnknownValue(ec_signature_algorithm::UnknownValue(
+                                wkt::internal::UnknownEnumValue::Integer(value),
+                            )),
+                        }
+                    }
+                }
+
+                impl std::convert::From<&str> for EcSignatureAlgorithm {
+                    fn from(value: &str) -> Self {
+                        use std::string::ToString;
+                        match value {
+                            "EC_SIGNATURE_ALGORITHM_UNSPECIFIED" => Self::Unspecified,
+                            "ECDSA_P256" => Self::EcdsaP256,
+                            "ECDSA_P384" => Self::EcdsaP384,
+                            "EDDSA_25519" => Self::Eddsa25519,
+                            _ => Self::UnknownValue(ec_signature_algorithm::UnknownValue(
+                                wkt::internal::UnknownEnumValue::String(value.to_string()),
+                            )),
+                        }
+                    }
+                }
+
+                impl serde::ser::Serialize for EcSignatureAlgorithm {
+                    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                    where
+                        S: serde::Serializer,
+                    {
+                        match self {
+                            Self::Unspecified => serializer.serialize_i32(0),
+                            Self::EcdsaP256 => serializer.serialize_i32(1),
+                            Self::EcdsaP384 => serializer.serialize_i32(2),
+                            Self::Eddsa25519 => serializer.serialize_i32(3),
+                            Self::UnknownValue(u) => u.0.serialize(serializer),
+                        }
+                    }
+                }
+
+                impl<'de> serde::de::Deserialize<'de> for EcSignatureAlgorithm {
+                    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EcSignatureAlgorithm>::new(
+                            ".google.cloud.security.privateca.v1.CaPool.IssuancePolicy.AllowedKeyType.EcKeyType.EcSignatureAlgorithm"))
                     }
                 }
             }
@@ -1733,59 +2058,120 @@ pub mod ca_pool {
     /// indicating its supported functionality and/or billing SKU.
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
+        /// Not specified.
+        Unspecified,
+        /// Enterprise tier.
+        Enterprise,
+        /// DevOps tier.
+        Devops,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Tier {
-        /// Not specified.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
-        /// Enterprise tier.
-        pub const ENTERPRISE: Tier = Tier::new(1);
-
-        /// DevOps tier.
-        pub const DEVOPS: Tier = Tier::new(2);
-
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enterprise => std::option::Option::Some(1),
+                Self::Devops => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                2 => std::borrow::Cow::Borrowed("DEVOPS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::Devops => std::option::Option::Some("DEVOPS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                "DEVOPS" => std::option::Option::Some(Self::DEVOPS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enterprise,
+                2 => Self::Devops,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "ENTERPRISE" => Self::Enterprise,
+                "DEVOPS" => Self::Devops,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enterprise => serializer.serialize_i32(1),
+                Self::Devops => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.security.privateca.v1.CaPool.Tier",
+            ))
         }
     }
 }
@@ -2043,67 +2429,128 @@ pub mod certificate_revocation_list {
     /// indicating if it is current.
     ///
     /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The
         /// [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList]
         /// is up to date.
         ///
         /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The
         /// [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList]
         /// is no longer current.
         ///
         /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
-        pub const SUPERSEDED: State = State::new(2);
+        Superseded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Superseded => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("SUPERSEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Superseded => std::option::Option::Some("SUPERSEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SUPERSEDED" => std::option::Option::Some(Self::SUPERSEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Superseded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "SUPERSEDED" => Self::Superseded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Superseded => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.security.privateca.v1.CertificateRevocationList.State",
+            ))
         }
     }
 }
@@ -3285,13 +3732,11 @@ pub mod public_key {
 
     /// Types of public keys formats that are supported. Currently, only `PEM`
     /// format is supported.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyFormat(i32);
-
-    impl KeyFormat {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KeyFormat {
         /// Default unspecified value.
-        pub const KEY_FORMAT_UNSPECIFIED: KeyFormat = KeyFormat::new(0);
-
+        Unspecified,
         /// The key is PEM-encoded as defined in [RFC
         /// 7468](https://tools.ietf.org/html/rfc7468). It can be any of the
         /// following: a PEM-encoded PKCS#1/RFC 3447 RSAPublicKey
@@ -3305,46 +3750,107 @@ pub mod public_key {
         /// generated by the service, it will always be an RFC 5280
         /// [SubjectPublicKeyInfo](https://tools.ietf.org/html/rfc5280#section-4.1)
         /// structure containing an algorithm identifier and a key.
-        pub const PEM: KeyFormat = KeyFormat::new(1);
+        Pem,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KeyFormat::value] or
+        /// [KeyFormat::name].
+        UnknownValue(key_format::UnknownValue),
+    }
 
-        /// Creates a new KeyFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod key_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KeyFormat {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pem => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KEY_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PEM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KEY_FORMAT_UNSPECIFIED"),
+                Self::Pem => std::option::Option::Some("PEM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KEY_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::KEY_FORMAT_UNSPECIFIED),
-                "PEM" => std::option::Option::Some(Self::PEM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for KeyFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KeyFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KeyFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pem,
+                _ => Self::UnknownValue(key_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KeyFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KEY_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "PEM" => Self::Pem,
+                _ => Self::UnknownValue(key_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KeyFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pem => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KeyFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KeyFormat>::new(
+                ".google.cloud.security.privateca.v1.PublicKey.KeyFormat",
+            ))
         }
     }
 }
@@ -4646,14 +5152,11 @@ pub mod certificate_extension_constraints {
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KnownCertificateExtension(i32);
-
-    impl KnownCertificateExtension {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KnownCertificateExtension {
         /// Not specified.
-        pub const KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED: KnownCertificateExtension =
-            KnownCertificateExtension::new(0);
-
+        Unspecified,
         /// Refers to a certificate's Key Usage extension, as described in [RFC 5280
         /// section 4.2.1.3](https://tools.ietf.org/html/rfc5280#section-4.2.1.3).
         /// This corresponds to the
@@ -4661,8 +5164,7 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.KeyUsage.base_key_usage]: crate::model::KeyUsage::base_key_usage
-        pub const BASE_KEY_USAGE: KnownCertificateExtension = KnownCertificateExtension::new(1);
-
+        BaseKeyUsage,
         /// Refers to a certificate's Extended Key Usage extension, as described in
         /// [RFC 5280
         /// section 4.2.1.12](https://tools.ietf.org/html/rfc5280#section-4.2.1.12).
@@ -4671,8 +5173,7 @@ pub mod certificate_extension_constraints {
         /// message.
         ///
         /// [google.cloud.security.privateca.v1.KeyUsage.extended_key_usage]: crate::model::KeyUsage::extended_key_usage
-        pub const EXTENDED_KEY_USAGE: KnownCertificateExtension = KnownCertificateExtension::new(2);
-
+        ExtendedKeyUsage,
         /// Refers to a certificate's Basic Constraints extension, as described in
         /// [RFC 5280
         /// section 4.2.1.9](https://tools.ietf.org/html/rfc5280#section-4.2.1.9).
@@ -4681,8 +5182,7 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.X509Parameters.ca_options]: crate::model::X509Parameters::ca_options
-        pub const CA_OPTIONS: KnownCertificateExtension = KnownCertificateExtension::new(3);
-
+        CaOptions,
         /// Refers to a certificate's Policy object identifiers, as described in
         /// [RFC 5280
         /// section 4.2.1.4](https://tools.ietf.org/html/rfc5280#section-4.2.1.4).
@@ -4691,8 +5191,7 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.X509Parameters.policy_ids]: crate::model::X509Parameters::policy_ids
-        pub const POLICY_IDS: KnownCertificateExtension = KnownCertificateExtension::new(4);
-
+        PolicyIds,
         /// Refers to OCSP servers in a certificate's Authority Information Access
         /// extension, as described in
         /// [RFC 5280
@@ -4702,63 +5201,137 @@ pub mod certificate_extension_constraints {
         /// field.
         ///
         /// [google.cloud.security.privateca.v1.X509Parameters.aia_ocsp_servers]: crate::model::X509Parameters::aia_ocsp_servers
-        pub const AIA_OCSP_SERVERS: KnownCertificateExtension = KnownCertificateExtension::new(5);
-
+        AiaOcspServers,
         /// Refers to Name Constraints extension as described in
         /// [RFC 5280
         /// section 4.2.1.10](https://tools.ietf.org/html/rfc5280#section-4.2.1.10)
-        pub const NAME_CONSTRAINTS: KnownCertificateExtension = KnownCertificateExtension::new(6);
+        NameConstraints,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KnownCertificateExtension::value] or
+        /// [KnownCertificateExtension::name].
+        UnknownValue(known_certificate_extension::UnknownValue),
+    }
 
-        /// Creates a new KnownCertificateExtension instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod known_certificate_extension {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KnownCertificateExtension {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BaseKeyUsage => std::option::Option::Some(1),
+                Self::ExtendedKeyUsage => std::option::Option::Some(2),
+                Self::CaOptions => std::option::Option::Some(3),
+                Self::PolicyIds => std::option::Option::Some(4),
+                Self::AiaOcspServers => std::option::Option::Some(5),
+                Self::NameConstraints => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASE_KEY_USAGE"),
-                2 => std::borrow::Cow::Borrowed("EXTENDED_KEY_USAGE"),
-                3 => std::borrow::Cow::Borrowed("CA_OPTIONS"),
-                4 => std::borrow::Cow::Borrowed("POLICY_IDS"),
-                5 => std::borrow::Cow::Borrowed("AIA_OCSP_SERVERS"),
-                6 => std::borrow::Cow::Borrowed("NAME_CONSTRAINTS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED")
                 }
-                "BASE_KEY_USAGE" => std::option::Option::Some(Self::BASE_KEY_USAGE),
-                "EXTENDED_KEY_USAGE" => std::option::Option::Some(Self::EXTENDED_KEY_USAGE),
-                "CA_OPTIONS" => std::option::Option::Some(Self::CA_OPTIONS),
-                "POLICY_IDS" => std::option::Option::Some(Self::POLICY_IDS),
-                "AIA_OCSP_SERVERS" => std::option::Option::Some(Self::AIA_OCSP_SERVERS),
-                "NAME_CONSTRAINTS" => std::option::Option::Some(Self::NAME_CONSTRAINTS),
-                _ => std::option::Option::None,
+                Self::BaseKeyUsage => std::option::Option::Some("BASE_KEY_USAGE"),
+                Self::ExtendedKeyUsage => std::option::Option::Some("EXTENDED_KEY_USAGE"),
+                Self::CaOptions => std::option::Option::Some("CA_OPTIONS"),
+                Self::PolicyIds => std::option::Option::Some("POLICY_IDS"),
+                Self::AiaOcspServers => std::option::Option::Some("AIA_OCSP_SERVERS"),
+                Self::NameConstraints => std::option::Option::Some("NAME_CONSTRAINTS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for KnownCertificateExtension {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KnownCertificateExtension {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KnownCertificateExtension {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KnownCertificateExtension {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BaseKeyUsage,
+                2 => Self::ExtendedKeyUsage,
+                3 => Self::CaOptions,
+                4 => Self::PolicyIds,
+                5 => Self::AiaOcspServers,
+                6 => Self::NameConstraints,
+                _ => Self::UnknownValue(known_certificate_extension::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KnownCertificateExtension {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KNOWN_CERTIFICATE_EXTENSION_UNSPECIFIED" => Self::Unspecified,
+                "BASE_KEY_USAGE" => Self::BaseKeyUsage,
+                "EXTENDED_KEY_USAGE" => Self::ExtendedKeyUsage,
+                "CA_OPTIONS" => Self::CaOptions,
+                "POLICY_IDS" => Self::PolicyIds,
+                "AIA_OCSP_SERVERS" => Self::AiaOcspServers,
+                "NAME_CONSTRAINTS" => Self::NameConstraints,
+                _ => Self::UnknownValue(known_certificate_extension::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KnownCertificateExtension {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BaseKeyUsage => serializer.serialize_i32(1),
+                Self::ExtendedKeyUsage => serializer.serialize_i32(2),
+                Self::CaOptions => serializer.serialize_i32(3),
+                Self::PolicyIds => serializer.serialize_i32(4),
+                Self::AiaOcspServers => serializer.serialize_i32(5),
+                Self::NameConstraints => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KnownCertificateExtension {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KnownCertificateExtension>::new(
+                ".google.cloud.security.privateca.v1.CertificateExtensionConstraints.KnownCertificateExtension"))
         }
     }
 }
@@ -7607,124 +8180,195 @@ impl wkt::message::Message for OperationMetadata {
 ///
 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
 /// [google.cloud.security.privateca.v1.RevocationReason]: crate::model::RevocationReason
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RevocationReason(i32);
-
-impl RevocationReason {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RevocationReason {
     /// Default unspecified value. This value does indicate that a
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] has been
     /// revoked, but that a reason has not been recorded.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const REVOCATION_REASON_UNSPECIFIED: RevocationReason = RevocationReason::new(0);
-
+    Unspecified,
     /// Key material for this
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] may have
     /// leaked.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const KEY_COMPROMISE: RevocationReason = RevocationReason::new(1);
-
+    KeyCompromise,
     /// The key material for a certificate authority in the issuing path may have
     /// leaked.
-    pub const CERTIFICATE_AUTHORITY_COMPROMISE: RevocationReason = RevocationReason::new(2);
-
+    CertificateAuthorityCompromise,
     /// The subject or other attributes in this
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] have changed.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const AFFILIATION_CHANGED: RevocationReason = RevocationReason::new(3);
-
+    AffiliationChanged,
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] has been
     /// superseded.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const SUPERSEDED: RevocationReason = RevocationReason::new(4);
-
+    Superseded,
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] or
     /// entities in the issuing path have ceased to operate.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const CESSATION_OF_OPERATION: RevocationReason = RevocationReason::new(5);
-
+    CessationOfOperation,
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] should
     /// not be considered valid, it is expected that it may become valid in the
     /// future.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const CERTIFICATE_HOLD: RevocationReason = RevocationReason::new(6);
-
+    CertificateHold,
     /// This [Certificate][google.cloud.security.privateca.v1.Certificate] no
     /// longer has permission to assert the listed attributes.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const PRIVILEGE_WITHDRAWN: RevocationReason = RevocationReason::new(7);
-
+    PrivilegeWithdrawn,
     /// The authority which determines appropriate attributes for a
     /// [Certificate][google.cloud.security.privateca.v1.Certificate] may have been
     /// compromised.
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
-    pub const ATTRIBUTE_AUTHORITY_COMPROMISE: RevocationReason = RevocationReason::new(8);
+    AttributeAuthorityCompromise,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RevocationReason::value] or
+    /// [RevocationReason::name].
+    UnknownValue(revocation_reason::UnknownValue),
+}
 
-    /// Creates a new RevocationReason instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod revocation_reason {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl RevocationReason {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::KeyCompromise => std::option::Option::Some(1),
+            Self::CertificateAuthorityCompromise => std::option::Option::Some(2),
+            Self::AffiliationChanged => std::option::Option::Some(3),
+            Self::Superseded => std::option::Option::Some(4),
+            Self::CessationOfOperation => std::option::Option::Some(5),
+            Self::CertificateHold => std::option::Option::Some(6),
+            Self::PrivilegeWithdrawn => std::option::Option::Some(7),
+            Self::AttributeAuthorityCompromise => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REVOCATION_REASON_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("KEY_COMPROMISE"),
-            2 => std::borrow::Cow::Borrowed("CERTIFICATE_AUTHORITY_COMPROMISE"),
-            3 => std::borrow::Cow::Borrowed("AFFILIATION_CHANGED"),
-            4 => std::borrow::Cow::Borrowed("SUPERSEDED"),
-            5 => std::borrow::Cow::Borrowed("CESSATION_OF_OPERATION"),
-            6 => std::borrow::Cow::Borrowed("CERTIFICATE_HOLD"),
-            7 => std::borrow::Cow::Borrowed("PRIVILEGE_WITHDRAWN"),
-            8 => std::borrow::Cow::Borrowed("ATTRIBUTE_AUTHORITY_COMPROMISE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("REVOCATION_REASON_UNSPECIFIED"),
+            Self::KeyCompromise => std::option::Option::Some("KEY_COMPROMISE"),
+            Self::CertificateAuthorityCompromise => {
+                std::option::Option::Some("CERTIFICATE_AUTHORITY_COMPROMISE")
+            }
+            Self::AffiliationChanged => std::option::Option::Some("AFFILIATION_CHANGED"),
+            Self::Superseded => std::option::Option::Some("SUPERSEDED"),
+            Self::CessationOfOperation => std::option::Option::Some("CESSATION_OF_OPERATION"),
+            Self::CertificateHold => std::option::Option::Some("CERTIFICATE_HOLD"),
+            Self::PrivilegeWithdrawn => std::option::Option::Some("PRIVILEGE_WITHDRAWN"),
+            Self::AttributeAuthorityCompromise => {
+                std::option::Option::Some("ATTRIBUTE_AUTHORITY_COMPROMISE")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REVOCATION_REASON_UNSPECIFIED" => {
-                std::option::Option::Some(Self::REVOCATION_REASON_UNSPECIFIED)
-            }
-            "KEY_COMPROMISE" => std::option::Option::Some(Self::KEY_COMPROMISE),
-            "CERTIFICATE_AUTHORITY_COMPROMISE" => {
-                std::option::Option::Some(Self::CERTIFICATE_AUTHORITY_COMPROMISE)
-            }
-            "AFFILIATION_CHANGED" => std::option::Option::Some(Self::AFFILIATION_CHANGED),
-            "SUPERSEDED" => std::option::Option::Some(Self::SUPERSEDED),
-            "CESSATION_OF_OPERATION" => std::option::Option::Some(Self::CESSATION_OF_OPERATION),
-            "CERTIFICATE_HOLD" => std::option::Option::Some(Self::CERTIFICATE_HOLD),
-            "PRIVILEGE_WITHDRAWN" => std::option::Option::Some(Self::PRIVILEGE_WITHDRAWN),
-            "ATTRIBUTE_AUTHORITY_COMPROMISE" => {
-                std::option::Option::Some(Self::ATTRIBUTE_AUTHORITY_COMPROMISE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RevocationReason {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RevocationReason {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RevocationReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RevocationReason {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::KeyCompromise,
+            2 => Self::CertificateAuthorityCompromise,
+            3 => Self::AffiliationChanged,
+            4 => Self::Superseded,
+            5 => Self::CessationOfOperation,
+            6 => Self::CertificateHold,
+            7 => Self::PrivilegeWithdrawn,
+            8 => Self::AttributeAuthorityCompromise,
+            _ => Self::UnknownValue(revocation_reason::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RevocationReason {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REVOCATION_REASON_UNSPECIFIED" => Self::Unspecified,
+            "KEY_COMPROMISE" => Self::KeyCompromise,
+            "CERTIFICATE_AUTHORITY_COMPROMISE" => Self::CertificateAuthorityCompromise,
+            "AFFILIATION_CHANGED" => Self::AffiliationChanged,
+            "SUPERSEDED" => Self::Superseded,
+            "CESSATION_OF_OPERATION" => Self::CessationOfOperation,
+            "CERTIFICATE_HOLD" => Self::CertificateHold,
+            "PRIVILEGE_WITHDRAWN" => Self::PrivilegeWithdrawn,
+            "ATTRIBUTE_AUTHORITY_COMPROMISE" => Self::AttributeAuthorityCompromise,
+            _ => Self::UnknownValue(revocation_reason::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RevocationReason {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::KeyCompromise => serializer.serialize_i32(1),
+            Self::CertificateAuthorityCompromise => serializer.serialize_i32(2),
+            Self::AffiliationChanged => serializer.serialize_i32(3),
+            Self::Superseded => serializer.serialize_i32(4),
+            Self::CessationOfOperation => serializer.serialize_i32(5),
+            Self::CertificateHold => serializer.serialize_i32(6),
+            Self::PrivilegeWithdrawn => serializer.serialize_i32(7),
+            Self::AttributeAuthorityCompromise => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RevocationReason {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RevocationReason>::new(
+            ".google.cloud.security.privateca.v1.RevocationReason",
+        ))
     }
 }
 
@@ -7737,13 +8381,11 @@ impl std::default::Default for RevocationReason {
 /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
 /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
 /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SubjectRequestMode(i32);
-
-impl SubjectRequestMode {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SubjectRequestMode {
     /// Not specified.
-    pub const SUBJECT_REQUEST_MODE_UNSPECIFIED: SubjectRequestMode = SubjectRequestMode::new(0);
-
+    Unspecified,
     /// The default mode used in most cases. Indicates that the certificate's
     /// [Subject][google.cloud.security.privateca.v1.Subject] and/or
     /// [SubjectAltNames][google.cloud.security.privateca.v1.SubjectAltNames] are
@@ -7752,8 +8394,7 @@ impl SubjectRequestMode {
     ///
     /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-    pub const DEFAULT: SubjectRequestMode = SubjectRequestMode::new(1);
-
+    Default,
     /// A mode reserved for special cases. Indicates that the certificate should
     /// have one SPIFFE
     /// [SubjectAltNames][google.cloud.security.privateca.v1.SubjectAltNames] set
@@ -7766,49 +8407,111 @@ impl SubjectRequestMode {
     ///
     /// [google.cloud.security.privateca.v1.Subject]: crate::model::Subject
     /// [google.cloud.security.privateca.v1.SubjectAltNames]: crate::model::SubjectAltNames
-    pub const REFLECTED_SPIFFE: SubjectRequestMode = SubjectRequestMode::new(2);
+    ReflectedSpiffe,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SubjectRequestMode::value] or
+    /// [SubjectRequestMode::name].
+    UnknownValue(subject_request_mode::UnknownValue),
+}
 
-    /// Creates a new SubjectRequestMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod subject_request_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SubjectRequestMode {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Default => std::option::Option::Some(1),
+            Self::ReflectedSpiffe => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SUBJECT_REQUEST_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DEFAULT"),
-            2 => std::borrow::Cow::Borrowed("REFLECTED_SPIFFE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SUBJECT_REQUEST_MODE_UNSPECIFIED"),
+            Self::Default => std::option::Option::Some("DEFAULT"),
+            Self::ReflectedSpiffe => std::option::Option::Some("REFLECTED_SPIFFE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SUBJECT_REQUEST_MODE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SUBJECT_REQUEST_MODE_UNSPECIFIED)
-            }
-            "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-            "REFLECTED_SPIFFE" => std::option::Option::Some(Self::REFLECTED_SPIFFE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SubjectRequestMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SubjectRequestMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SubjectRequestMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SubjectRequestMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Default,
+            2 => Self::ReflectedSpiffe,
+            _ => Self::UnknownValue(subject_request_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SubjectRequestMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SUBJECT_REQUEST_MODE_UNSPECIFIED" => Self::Unspecified,
+            "DEFAULT" => Self::Default,
+            "REFLECTED_SPIFFE" => Self::ReflectedSpiffe,
+            _ => Self::UnknownValue(subject_request_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SubjectRequestMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Default => serializer.serialize_i32(1),
+            Self::ReflectedSpiffe => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SubjectRequestMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SubjectRequestMode>::new(
+            ".google.cloud.security.privateca.v1.SubjectRequestMode",
+        ))
     }
 }

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -464,59 +464,120 @@ pub mod attack_exposure {
     use super::*;
 
     /// This enum defines the various states an AttackExposure can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state is not specified.
+        Unspecified,
+        /// The attack exposure has been calculated.
+        Calculated,
+        /// The attack exposure has not been calculated.
+        NotCalculated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The attack exposure has been calculated.
-        pub const CALCULATED: State = State::new(1);
-
-        /// The attack exposure has not been calculated.
-        pub const NOT_CALCULATED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Calculated => std::option::Option::Some(1),
+                Self::NotCalculated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CALCULATED"),
-                2 => std::borrow::Cow::Borrowed("NOT_CALCULATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Calculated => std::option::Option::Some("CALCULATED"),
+                Self::NotCalculated => std::option::Option::Some("NOT_CALCULATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CALCULATED" => std::option::Option::Some(Self::CALCULATED),
-                "NOT_CALCULATED" => std::option::Option::Some(Self::NOT_CALCULATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Calculated,
+                2 => Self::NotCalculated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CALCULATED" => Self::Calculated,
+                "NOT_CALCULATED" => Self::NotCalculated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Calculated => serializer.serialize_i32(1),
+                Self::NotCalculated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.securitycenter.v2.AttackExposure.State",
+            ))
         }
     }
 }
@@ -849,71 +910,137 @@ pub mod attack_path {
         }
 
         /// The type of the incoming attack step node.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct NodeType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum NodeType {
+            /// Type not specified
+            Unspecified,
+            /// Incoming edge joined with AND
+            And,
+            /// Incoming edge joined with OR
+            Or,
+            /// Incoming edge is defense
+            Defense,
+            /// Incoming edge is attacker
+            Attacker,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [NodeType::value] or
+            /// [NodeType::name].
+            UnknownValue(node_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod node_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl NodeType {
-            /// Type not specified
-            pub const NODE_TYPE_UNSPECIFIED: NodeType = NodeType::new(0);
-
-            /// Incoming edge joined with AND
-            pub const NODE_TYPE_AND: NodeType = NodeType::new(1);
-
-            /// Incoming edge joined with OR
-            pub const NODE_TYPE_OR: NodeType = NodeType::new(2);
-
-            /// Incoming edge is defense
-            pub const NODE_TYPE_DEFENSE: NodeType = NodeType::new(3);
-
-            /// Incoming edge is attacker
-            pub const NODE_TYPE_ATTACKER: NodeType = NodeType::new(4);
-
-            /// Creates a new NodeType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::And => std::option::Option::Some(1),
+                    Self::Or => std::option::Option::Some(2),
+                    Self::Defense => std::option::Option::Some(3),
+                    Self::Attacker => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("NODE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NODE_TYPE_AND"),
-                    2 => std::borrow::Cow::Borrowed("NODE_TYPE_OR"),
-                    3 => std::borrow::Cow::Borrowed("NODE_TYPE_DEFENSE"),
-                    4 => std::borrow::Cow::Borrowed("NODE_TYPE_ATTACKER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("NODE_TYPE_UNSPECIFIED"),
+                    Self::And => std::option::Option::Some("NODE_TYPE_AND"),
+                    Self::Or => std::option::Option::Some("NODE_TYPE_OR"),
+                    Self::Defense => std::option::Option::Some("NODE_TYPE_DEFENSE"),
+                    Self::Attacker => std::option::Option::Some("NODE_TYPE_ATTACKER"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "NODE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::NODE_TYPE_UNSPECIFIED)
-                    }
-                    "NODE_TYPE_AND" => std::option::Option::Some(Self::NODE_TYPE_AND),
-                    "NODE_TYPE_OR" => std::option::Option::Some(Self::NODE_TYPE_OR),
-                    "NODE_TYPE_DEFENSE" => std::option::Option::Some(Self::NODE_TYPE_DEFENSE),
-                    "NODE_TYPE_ATTACKER" => std::option::Option::Some(Self::NODE_TYPE_ATTACKER),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for NodeType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for NodeType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for NodeType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for NodeType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::And,
+                    2 => Self::Or,
+                    3 => Self::Defense,
+                    4 => Self::Attacker,
+                    _ => Self::UnknownValue(node_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for NodeType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "NODE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "NODE_TYPE_AND" => Self::And,
+                    "NODE_TYPE_OR" => Self::Or,
+                    "NODE_TYPE_DEFENSE" => Self::Defense,
+                    "NODE_TYPE_ATTACKER" => Self::Attacker,
+                    _ => Self::UnknownValue(node_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for NodeType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::And => serializer.serialize_i32(1),
+                    Self::Or => serializer.serialize_i32(2),
+                    Self::Defense => serializer.serialize_i32(3),
+                    Self::Attacker => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for NodeType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodeType>::new(
+                    ".google.cloud.securitycenter.v2.AttackPath.AttackPathNode.NodeType",
+                ))
             }
         }
     }
@@ -1681,61 +1808,120 @@ pub mod cloud_dlp_data_profile {
     use super::*;
 
     /// Parents for configurations that produce data profile findings.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ParentType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ParentType {
+        /// Unspecified parent type.
+        Unspecified,
+        /// Organization-level configurations.
+        Organization,
+        /// Project-level configurations.
+        Project,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ParentType::value] or
+        /// [ParentType::name].
+        UnknownValue(parent_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod parent_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ParentType {
-        /// Unspecified parent type.
-        pub const PARENT_TYPE_UNSPECIFIED: ParentType = ParentType::new(0);
-
-        /// Organization-level configurations.
-        pub const ORGANIZATION: ParentType = ParentType::new(1);
-
-        /// Project-level configurations.
-        pub const PROJECT: ParentType = ParentType::new(2);
-
-        /// Creates a new ParentType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Organization => std::option::Option::Some(1),
+                Self::Project => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PARENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ORGANIZATION"),
-                2 => std::borrow::Cow::Borrowed("PROJECT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PARENT_TYPE_UNSPECIFIED"),
+                Self::Organization => std::option::Option::Some("ORGANIZATION"),
+                Self::Project => std::option::Option::Some("PROJECT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PARENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PARENT_TYPE_UNSPECIFIED)
-                }
-                "ORGANIZATION" => std::option::Option::Some(Self::ORGANIZATION),
-                "PROJECT" => std::option::Option::Some(Self::PROJECT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ParentType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ParentType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ParentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ParentType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Organization,
+                2 => Self::Project,
+                _ => Self::UnknownValue(parent_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ParentType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PARENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ORGANIZATION" => Self::Organization,
+                "PROJECT" => Self::Project,
+                _ => Self::UnknownValue(parent_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ParentType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Organization => serializer.serialize_i32(1),
+                Self::Project => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ParentType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ParentType>::new(
+                ".google.cloud.securitycenter.v2.CloudDlpDataProfile.ParentType",
+            ))
         }
     }
 }
@@ -1950,74 +2136,141 @@ pub mod connection {
     use super::*;
 
     /// IANA Internet Protocol Number such as TCP(6) and UDP(17).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Protocol {
+        /// Unspecified protocol (not HOPOPT).
+        Unspecified,
+        /// Internet Control Message Protocol.
+        Icmp,
+        /// Transmission Control Protocol.
+        Tcp,
+        /// User Datagram Protocol.
+        Udp,
+        /// Generic Routing Encapsulation.
+        Gre,
+        /// Encap Security Payload.
+        Esp,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Protocol::value] or
+        /// [Protocol::name].
+        UnknownValue(protocol::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Protocol {
-        /// Unspecified protocol (not HOPOPT).
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
-
-        /// Internet Control Message Protocol.
-        pub const ICMP: Protocol = Protocol::new(1);
-
-        /// Transmission Control Protocol.
-        pub const TCP: Protocol = Protocol::new(6);
-
-        /// User Datagram Protocol.
-        pub const UDP: Protocol = Protocol::new(17);
-
-        /// Generic Routing Encapsulation.
-        pub const GRE: Protocol = Protocol::new(47);
-
-        /// Encap Security Payload.
-        pub const ESP: Protocol = Protocol::new(50);
-
-        /// Creates a new Protocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Icmp => std::option::Option::Some(1),
+                Self::Tcp => std::option::Option::Some(6),
+                Self::Udp => std::option::Option::Some(17),
+                Self::Gre => std::option::Option::Some(47),
+                Self::Esp => std::option::Option::Some(50),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ICMP"),
-                6 => std::borrow::Cow::Borrowed("TCP"),
-                17 => std::borrow::Cow::Borrowed("UDP"),
-                47 => std::borrow::Cow::Borrowed("GRE"),
-                50 => std::borrow::Cow::Borrowed("ESP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROTOCOL_UNSPECIFIED"),
+                Self::Icmp => std::option::Option::Some("ICMP"),
+                Self::Tcp => std::option::Option::Some("TCP"),
+                Self::Udp => std::option::Option::Some("UDP"),
+                Self::Gre => std::option::Option::Some("GRE"),
+                Self::Esp => std::option::Option::Some("ESP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
-                "ICMP" => std::option::Option::Some(Self::ICMP),
-                "TCP" => std::option::Option::Some(Self::TCP),
-                "UDP" => std::option::Option::Some(Self::UDP),
-                "GRE" => std::option::Option::Some(Self::GRE),
-                "ESP" => std::option::Option::Some(Self::ESP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Protocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Protocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Icmp,
+                6 => Self::Tcp,
+                17 => Self::Udp,
+                47 => Self::Gre,
+                50 => Self::Esp,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Protocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "ICMP" => Self::Icmp,
+                "TCP" => Self::Tcp,
+                "UDP" => Self::Udp,
+                "GRE" => Self::Gre,
+                "ESP" => Self::Esp,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Protocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Icmp => serializer.serialize_i32(1),
+                Self::Tcp => serializer.serialize_i32(6),
+                Self::Udp => serializer.serialize_i32(17),
+                Self::Gre => serializer.serialize_i32(47),
+                Self::Esp => serializer.serialize_i32(50),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Protocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Protocol>::new(
+                ".google.cloud.securitycenter.v2.Connection.Protocol",
+            ))
         }
     }
 }
@@ -2248,64 +2501,127 @@ pub mod data_access_event {
     use super::*;
 
     /// The operation of a data access event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operation(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Operation {
+        /// The operation is unspecified.
+        Unspecified,
+        /// Represents a read operation.
+        Read,
+        /// Represents a move operation.
+        Move,
+        /// Represents a copy operation.
+        Copy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Operation::value] or
+        /// [Operation::name].
+        UnknownValue(operation::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod operation {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Operation {
-        /// The operation is unspecified.
-        pub const OPERATION_UNSPECIFIED: Operation = Operation::new(0);
-
-        /// Represents a read operation.
-        pub const READ: Operation = Operation::new(1);
-
-        /// Represents a move operation.
-        pub const MOVE: Operation = Operation::new(2);
-
-        /// Represents a copy operation.
-        pub const COPY: Operation = Operation::new(3);
-
-        /// Creates a new Operation instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Read => std::option::Option::Some(1),
+                Self::Move => std::option::Option::Some(2),
+                Self::Copy => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPERATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ"),
-                2 => std::borrow::Cow::Borrowed("MOVE"),
-                3 => std::borrow::Cow::Borrowed("COPY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPERATION_UNSPECIFIED"),
+                Self::Read => std::option::Option::Some("READ"),
+                Self::Move => std::option::Option::Some("MOVE"),
+                Self::Copy => std::option::Option::Some("COPY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPERATION_UNSPECIFIED" => std::option::Option::Some(Self::OPERATION_UNSPECIFIED),
-                "READ" => std::option::Option::Some(Self::READ),
-                "MOVE" => std::option::Option::Some(Self::MOVE),
-                "COPY" => std::option::Option::Some(Self::COPY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Operation {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Operation {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Operation {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Read,
+                2 => Self::Move,
+                3 => Self::Copy,
+                _ => Self::UnknownValue(operation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Operation {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPERATION_UNSPECIFIED" => Self::Unspecified,
+                "READ" => Self::Read,
+                "MOVE" => Self::Move,
+                "COPY" => Self::Copy,
+                _ => Self::UnknownValue(operation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Operation {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Read => serializer.serialize_i32(1),
+                Self::Move => serializer.serialize_i32(2),
+                Self::Copy => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Operation {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operation>::new(
+                ".google.cloud.securitycenter.v2.DataAccessEvent.Operation",
+            ))
         }
     }
 }
@@ -2399,64 +2715,127 @@ pub mod data_flow_event {
     use super::*;
 
     /// The operation of a data flow event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operation(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Operation {
+        /// The operation is unspecified.
+        Unspecified,
+        /// Represents a read operation.
+        Read,
+        /// Represents a move operation.
+        Move,
+        /// Represents a copy operation.
+        Copy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Operation::value] or
+        /// [Operation::name].
+        UnknownValue(operation::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod operation {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Operation {
-        /// The operation is unspecified.
-        pub const OPERATION_UNSPECIFIED: Operation = Operation::new(0);
-
-        /// Represents a read operation.
-        pub const READ: Operation = Operation::new(1);
-
-        /// Represents a move operation.
-        pub const MOVE: Operation = Operation::new(2);
-
-        /// Represents a copy operation.
-        pub const COPY: Operation = Operation::new(3);
-
-        /// Creates a new Operation instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Read => std::option::Option::Some(1),
+                Self::Move => std::option::Option::Some(2),
+                Self::Copy => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPERATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ"),
-                2 => std::borrow::Cow::Borrowed("MOVE"),
-                3 => std::borrow::Cow::Borrowed("COPY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPERATION_UNSPECIFIED"),
+                Self::Read => std::option::Option::Some("READ"),
+                Self::Move => std::option::Option::Some("MOVE"),
+                Self::Copy => std::option::Option::Some("COPY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPERATION_UNSPECIFIED" => std::option::Option::Some(Self::OPERATION_UNSPECIFIED),
-                "READ" => std::option::Option::Some(Self::READ),
-                "MOVE" => std::option::Option::Some(Self::MOVE),
-                "COPY" => std::option::Option::Some(Self::COPY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Operation {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Operation {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Operation {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Read,
+                2 => Self::Move,
+                3 => Self::Copy,
+                _ => Self::UnknownValue(operation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Operation {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPERATION_UNSPECIFIED" => Self::Unspecified,
+                "READ" => Self::Read,
+                "MOVE" => Self::Move,
+                "COPY" => Self::Copy,
+                _ => Self::UnknownValue(operation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Operation {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Read => serializer.serialize_i32(1),
+                Self::Move => serializer.serialize_i32(2),
+                Self::Copy => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Operation {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operation>::new(
+                ".google.cloud.securitycenter.v2.DataFlowEvent.Operation",
+            ))
         }
     }
 }
@@ -2556,56 +2935,113 @@ pub mod data_retention_deletion_event {
     use super::*;
 
     /// Type of the DRD event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// Unspecified event type.
+        Unspecified,
+        /// The maximum retention time has been exceeded.
+        MaxTtlExceeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// Unspecified event type.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// The maximum retention time has been exceeded.
-        pub const EVENT_TYPE_MAX_TTL_EXCEEDED: EventType = EventType::new(1);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MaxTtlExceeded => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EVENT_TYPE_MAX_TTL_EXCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::MaxTtlExceeded => std::option::Option::Some("EVENT_TYPE_MAX_TTL_EXCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "EVENT_TYPE_MAX_TTL_EXCEEDED" => {
-                    std::option::Option::Some(Self::EVENT_TYPE_MAX_TTL_EXCEEDED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MaxTtlExceeded,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "EVENT_TYPE_MAX_TTL_EXCEEDED" => Self::MaxTtlExceeded,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MaxTtlExceeded => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.securitycenter.v2.DataRetentionDeletionEvent.EventType",
+            ))
         }
     }
 }
@@ -4323,72 +4759,131 @@ pub mod finding {
     }
 
     /// The state of the finding.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The finding requires attention and has not been addressed yet.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The finding has been fixed, triaged as a non-issue or otherwise addressed
         /// and is no longer active.
-        pub const INACTIVE: State = State::new(2);
+        Inactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Inactive => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "INACTIVE" => Self::Inactive,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Inactive => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.securitycenter.v2.Finding.State",
+            ))
         }
     }
 
     /// The severity of the finding.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
-
-    impl Severity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
         /// This value is used for findings when a source doesn't write a severity
         /// value.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
+        Unspecified,
         /// Vulnerability:
         /// A critical vulnerability is easily discoverable by an external actor,
         /// exploitable, and results in the direct ability to execute arbitrary code,
@@ -4400,8 +4895,7 @@ pub mod finding {
         /// Threat:
         /// Indicates a threat that is able to access, modify, or delete data or
         /// execute unauthorized code within existing resources.
-        pub const CRITICAL: Severity = Severity::new(1);
-
+        Critical,
         /// Vulnerability:
         /// A high risk vulnerability can be easily discovered and exploited in
         /// combination with other vulnerabilities in order to gain direct access and
@@ -4415,8 +4909,7 @@ pub mod finding {
         /// Indicates a threat that is able to create new computational resources in
         /// an environment but not able to access data or execute code in existing
         /// resources.
-        pub const HIGH: Severity = Severity::new(2);
-
+        High,
         /// Vulnerability:
         /// A medium risk vulnerability could be used by an actor to gain access to
         /// resources or privileges that enable them to eventually (through multiple
@@ -4429,8 +4922,7 @@ pub mod finding {
         /// Threat:
         /// Indicates a threat that is able to cause operational impact but may not
         /// access data or execute unauthorized code.
-        pub const MEDIUM: Severity = Severity::new(3);
-
+        Medium,
         /// Vulnerability:
         /// A low risk vulnerability hampers a security organization's ability to
         /// detect vulnerabilities or active threats in their deployment, or prevents
@@ -4440,208 +4932,412 @@ pub mod finding {
         /// Threat:
         /// Indicates a threat that has obtained minimal access to an environment but
         /// is not able to access data, execute code, or create resources.
-        pub const LOW: Severity = Severity::new(4);
+        Low,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
 
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Severity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Critical => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::Low => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CRITICAL"),
-                2 => std::borrow::Cow::Borrowed("HIGH"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("LOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Critical,
+                2 => Self::High,
+                3 => Self::Medium,
+                4 => Self::Low,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "CRITICAL" => Self::Critical,
+                "HIGH" => Self::High,
+                "MEDIUM" => Self::Medium,
+                "LOW" => Self::Low,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Critical => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::Low => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.securitycenter.v2.Finding.Severity",
+            ))
         }
     }
 
     /// Mute state a finding can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mute(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mute {
+        /// Unspecified.
+        Unspecified,
+        /// Finding has been muted.
+        Muted,
+        /// Finding has been unmuted.
+        Unmuted,
+        /// Finding has never been muted/unmuted.
+        Undefined,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mute::value] or
+        /// [Mute::name].
+        UnknownValue(mute::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mute {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mute {
-        /// Unspecified.
-        pub const MUTE_UNSPECIFIED: Mute = Mute::new(0);
-
-        /// Finding has been muted.
-        pub const MUTED: Mute = Mute::new(1);
-
-        /// Finding has been unmuted.
-        pub const UNMUTED: Mute = Mute::new(2);
-
-        /// Finding has never been muted/unmuted.
-        pub const UNDEFINED: Mute = Mute::new(3);
-
-        /// Creates a new Mute instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Muted => std::option::Option::Some(1),
+                Self::Unmuted => std::option::Option::Some(2),
+                Self::Undefined => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MUTE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MUTED"),
-                2 => std::borrow::Cow::Borrowed("UNMUTED"),
-                3 => std::borrow::Cow::Borrowed("UNDEFINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MUTE_UNSPECIFIED"),
+                Self::Muted => std::option::Option::Some("MUTED"),
+                Self::Unmuted => std::option::Option::Some("UNMUTED"),
+                Self::Undefined => std::option::Option::Some("UNDEFINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MUTE_UNSPECIFIED" => std::option::Option::Some(Self::MUTE_UNSPECIFIED),
-                "MUTED" => std::option::Option::Some(Self::MUTED),
-                "UNMUTED" => std::option::Option::Some(Self::UNMUTED),
-                "UNDEFINED" => std::option::Option::Some(Self::UNDEFINED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mute {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mute {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mute {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mute {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Muted,
+                2 => Self::Unmuted,
+                3 => Self::Undefined,
+                _ => Self::UnknownValue(mute::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mute {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MUTE_UNSPECIFIED" => Self::Unspecified,
+                "MUTED" => Self::Muted,
+                "UNMUTED" => Self::Unmuted,
+                "UNDEFINED" => Self::Undefined,
+                _ => Self::UnknownValue(mute::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mute {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Muted => serializer.serialize_i32(1),
+                Self::Unmuted => serializer.serialize_i32(2),
+                Self::Undefined => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mute {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mute>::new(
+                ".google.cloud.securitycenter.v2.Finding.Mute",
+            ))
         }
     }
 
     /// Represents what kind of Finding it is.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FindingClass(i32);
-
-    impl FindingClass {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FindingClass {
         /// Unspecified finding class.
-        pub const FINDING_CLASS_UNSPECIFIED: FindingClass = FindingClass::new(0);
-
+        Unspecified,
         /// Describes unwanted or malicious activity.
-        pub const THREAT: FindingClass = FindingClass::new(1);
-
+        Threat,
         /// Describes a potential weakness in software that increases risk to
         /// Confidentiality & Integrity & Availability.
-        pub const VULNERABILITY: FindingClass = FindingClass::new(2);
-
+        Vulnerability,
         /// Describes a potential weakness in cloud resource/asset configuration that
         /// increases risk.
-        pub const MISCONFIGURATION: FindingClass = FindingClass::new(3);
-
+        Misconfiguration,
         /// Describes a security observation that is for informational purposes.
-        pub const OBSERVATION: FindingClass = FindingClass::new(4);
-
+        Observation,
         /// Describes an error that prevents some SCC functionality.
-        pub const SCC_ERROR: FindingClass = FindingClass::new(5);
-
+        SccError,
         /// Describes a potential security risk due to a change in the security
         /// posture.
-        pub const POSTURE_VIOLATION: FindingClass = FindingClass::new(6);
-
+        PostureViolation,
         /// Describes a combination of security issues that represent a more severe
         /// security problem when taken together.
-        pub const TOXIC_COMBINATION: FindingClass = FindingClass::new(7);
-
+        ToxicCombination,
         /// Describes a potential security risk to data assets that contain sensitive
         /// data.
-        pub const SENSITIVE_DATA_RISK: FindingClass = FindingClass::new(8);
+        SensitiveDataRisk,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FindingClass::value] or
+        /// [FindingClass::name].
+        UnknownValue(finding_class::UnknownValue),
+    }
 
-        /// Creates a new FindingClass instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod finding_class {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FindingClass {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Threat => std::option::Option::Some(1),
+                Self::Vulnerability => std::option::Option::Some(2),
+                Self::Misconfiguration => std::option::Option::Some(3),
+                Self::Observation => std::option::Option::Some(4),
+                Self::SccError => std::option::Option::Some(5),
+                Self::PostureViolation => std::option::Option::Some(6),
+                Self::ToxicCombination => std::option::Option::Some(7),
+                Self::SensitiveDataRisk => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FINDING_CLASS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("THREAT"),
-                2 => std::borrow::Cow::Borrowed("VULNERABILITY"),
-                3 => std::borrow::Cow::Borrowed("MISCONFIGURATION"),
-                4 => std::borrow::Cow::Borrowed("OBSERVATION"),
-                5 => std::borrow::Cow::Borrowed("SCC_ERROR"),
-                6 => std::borrow::Cow::Borrowed("POSTURE_VIOLATION"),
-                7 => std::borrow::Cow::Borrowed("TOXIC_COMBINATION"),
-                8 => std::borrow::Cow::Borrowed("SENSITIVE_DATA_RISK"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FINDING_CLASS_UNSPECIFIED"),
+                Self::Threat => std::option::Option::Some("THREAT"),
+                Self::Vulnerability => std::option::Option::Some("VULNERABILITY"),
+                Self::Misconfiguration => std::option::Option::Some("MISCONFIGURATION"),
+                Self::Observation => std::option::Option::Some("OBSERVATION"),
+                Self::SccError => std::option::Option::Some("SCC_ERROR"),
+                Self::PostureViolation => std::option::Option::Some("POSTURE_VIOLATION"),
+                Self::ToxicCombination => std::option::Option::Some("TOXIC_COMBINATION"),
+                Self::SensitiveDataRisk => std::option::Option::Some("SENSITIVE_DATA_RISK"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FINDING_CLASS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FINDING_CLASS_UNSPECIFIED)
-                }
-                "THREAT" => std::option::Option::Some(Self::THREAT),
-                "VULNERABILITY" => std::option::Option::Some(Self::VULNERABILITY),
-                "MISCONFIGURATION" => std::option::Option::Some(Self::MISCONFIGURATION),
-                "OBSERVATION" => std::option::Option::Some(Self::OBSERVATION),
-                "SCC_ERROR" => std::option::Option::Some(Self::SCC_ERROR),
-                "POSTURE_VIOLATION" => std::option::Option::Some(Self::POSTURE_VIOLATION),
-                "TOXIC_COMBINATION" => std::option::Option::Some(Self::TOXIC_COMBINATION),
-                "SENSITIVE_DATA_RISK" => std::option::Option::Some(Self::SENSITIVE_DATA_RISK),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FindingClass {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FindingClass {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FindingClass {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FindingClass {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Threat,
+                2 => Self::Vulnerability,
+                3 => Self::Misconfiguration,
+                4 => Self::Observation,
+                5 => Self::SccError,
+                6 => Self::PostureViolation,
+                7 => Self::ToxicCombination,
+                8 => Self::SensitiveDataRisk,
+                _ => Self::UnknownValue(finding_class::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FindingClass {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FINDING_CLASS_UNSPECIFIED" => Self::Unspecified,
+                "THREAT" => Self::Threat,
+                "VULNERABILITY" => Self::Vulnerability,
+                "MISCONFIGURATION" => Self::Misconfiguration,
+                "OBSERVATION" => Self::Observation,
+                "SCC_ERROR" => Self::SccError,
+                "POSTURE_VIOLATION" => Self::PostureViolation,
+                "TOXIC_COMBINATION" => Self::ToxicCombination,
+                "SENSITIVE_DATA_RISK" => Self::SensitiveDataRisk,
+                _ => Self::UnknownValue(finding_class::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FindingClass {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Threat => serializer.serialize_i32(1),
+                Self::Vulnerability => serializer.serialize_i32(2),
+                Self::Misconfiguration => serializer.serialize_i32(3),
+                Self::Observation => serializer.serialize_i32(4),
+                Self::SccError => serializer.serialize_i32(5),
+                Self::PostureViolation => serializer.serialize_i32(6),
+                Self::ToxicCombination => serializer.serialize_i32(7),
+                Self::SensitiveDataRisk => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FindingClass {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FindingClass>::new(
+                ".google.cloud.securitycenter.v2.Finding.FindingClass",
+            ))
         }
     }
 }
@@ -4744,56 +5440,113 @@ pub mod group_membership {
     use super::*;
 
     /// Possible types of groups.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GroupType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum GroupType {
+        /// Default value.
+        Unspecified,
+        /// Group represents a toxic combination.
+        ToxicCombination,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [GroupType::value] or
+        /// [GroupType::name].
+        UnknownValue(group_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod group_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl GroupType {
-        /// Default value.
-        pub const GROUP_TYPE_UNSPECIFIED: GroupType = GroupType::new(0);
-
-        /// Group represents a toxic combination.
-        pub const GROUP_TYPE_TOXIC_COMBINATION: GroupType = GroupType::new(1);
-
-        /// Creates a new GroupType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ToxicCombination => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GROUP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GROUP_TYPE_TOXIC_COMBINATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("GROUP_TYPE_UNSPECIFIED"),
+                Self::ToxicCombination => std::option::Option::Some("GROUP_TYPE_TOXIC_COMBINATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GROUP_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::GROUP_TYPE_UNSPECIFIED),
-                "GROUP_TYPE_TOXIC_COMBINATION" => {
-                    std::option::Option::Some(Self::GROUP_TYPE_TOXIC_COMBINATION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for GroupType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for GroupType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for GroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for GroupType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ToxicCombination,
+                _ => Self::UnknownValue(group_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for GroupType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GROUP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GROUP_TYPE_TOXIC_COMBINATION" => Self::ToxicCombination,
+                _ => Self::UnknownValue(group_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for GroupType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ToxicCombination => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for GroupType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<GroupType>::new(
+                ".google.cloud.securitycenter.v2.GroupMembership.GroupType",
+            ))
         }
     }
 }
@@ -4861,59 +5614,120 @@ pub mod iam_binding {
     use super::*;
 
     /// The type of action performed on a Binding in a policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Unspecified.
+        Unspecified,
+        /// Addition of a Binding.
+        Add,
+        /// Removal of a Binding.
+        Remove,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Addition of a Binding.
-        pub const ADD: Action = Action::new(1);
-
-        /// Removal of a Binding.
-        pub const REMOVE: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Add => std::option::Option::Some(1),
+                Self::Remove => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADD"),
-                2 => std::borrow::Cow::Borrowed("REMOVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Add => std::option::Option::Some("ADD"),
+                Self::Remove => std::option::Option::Some("REMOVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "ADD" => std::option::Option::Some(Self::ADD),
-                "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Add,
+                2 => Self::Remove,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ADD" => Self::Add,
+                "REMOVE" => Self::Remove,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Add => serializer.serialize_i32(1),
+                Self::Remove => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.cloud.securitycenter.v2.IamBinding.Action",
+            ))
         }
     }
 }
@@ -5291,63 +6105,123 @@ pub mod indicator {
         }
 
         /// Possible resource types to be associated with a signature.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SignatureType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SignatureType {
+            /// The default signature type.
+            Unspecified,
+            /// Used for signatures concerning processes.
+            Process,
+            /// Used for signatures concerning disks.
+            File,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SignatureType::value] or
+            /// [SignatureType::name].
+            UnknownValue(signature_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod signature_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SignatureType {
-            /// The default signature type.
-            pub const SIGNATURE_TYPE_UNSPECIFIED: SignatureType = SignatureType::new(0);
-
-            /// Used for signatures concerning processes.
-            pub const SIGNATURE_TYPE_PROCESS: SignatureType = SignatureType::new(1);
-
-            /// Used for signatures concerning disks.
-            pub const SIGNATURE_TYPE_FILE: SignatureType = SignatureType::new(2);
-
-            /// Creates a new SignatureType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Process => std::option::Option::Some(1),
+                    Self::File => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SIGNATURE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SIGNATURE_TYPE_PROCESS"),
-                    2 => std::borrow::Cow::Borrowed("SIGNATURE_TYPE_FILE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SIGNATURE_TYPE_UNSPECIFIED"),
+                    Self::Process => std::option::Option::Some("SIGNATURE_TYPE_PROCESS"),
+                    Self::File => std::option::Option::Some("SIGNATURE_TYPE_FILE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SIGNATURE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SIGNATURE_TYPE_UNSPECIFIED)
-                    }
-                    "SIGNATURE_TYPE_PROCESS" => {
-                        std::option::Option::Some(Self::SIGNATURE_TYPE_PROCESS)
-                    }
-                    "SIGNATURE_TYPE_FILE" => std::option::Option::Some(Self::SIGNATURE_TYPE_FILE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SignatureType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SignatureType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SignatureType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SignatureType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Process,
+                    2 => Self::File,
+                    _ => Self::UnknownValue(signature_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SignatureType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SIGNATURE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "SIGNATURE_TYPE_PROCESS" => Self::Process,
+                    "SIGNATURE_TYPE_FILE" => Self::File,
+                    _ => Self::UnknownValue(signature_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SignatureType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Process => serializer.serialize_i32(1),
+                    Self::File => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SignatureType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SignatureType>::new(
+                    ".google.cloud.securitycenter.v2.Indicator.ProcessSignature.SignatureType",
+                ))
             }
         }
 
@@ -5849,59 +6723,123 @@ pub mod kubernetes {
         use super::*;
 
         /// Types of Kubernetes roles.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Kind(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Kind {
+            /// Role type is not specified.
+            Unspecified,
+            /// Kubernetes Role.
+            Role,
+            /// Kubernetes ClusterRole.
+            ClusterRole,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Kind::value] or
+            /// [Kind::name].
+            UnknownValue(kind::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod kind {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Kind {
-            /// Role type is not specified.
-            pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
-
-            /// Kubernetes Role.
-            pub const ROLE: Kind = Kind::new(1);
-
-            /// Kubernetes ClusterRole.
-            pub const CLUSTER_ROLE: Kind = Kind::new(2);
-
-            /// Creates a new Kind instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Role => std::option::Option::Some(1),
+                    Self::ClusterRole => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ROLE"),
-                    2 => std::borrow::Cow::Borrowed("CLUSTER_ROLE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("KIND_UNSPECIFIED"),
+                    Self::Role => std::option::Option::Some("ROLE"),
+                    Self::ClusterRole => std::option::Option::Some("CLUSTER_ROLE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
-                    "ROLE" => std::option::Option::Some(Self::ROLE),
-                    "CLUSTER_ROLE" => std::option::Option::Some(Self::CLUSTER_ROLE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Kind {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Kind {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Kind {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Kind {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Role,
+                    2 => Self::ClusterRole,
+                    _ => Self::UnknownValue(kind::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Kind {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "KIND_UNSPECIFIED" => Self::Unspecified,
+                    "ROLE" => Self::Role,
+                    "CLUSTER_ROLE" => Self::ClusterRole,
+                    _ => Self::UnknownValue(kind::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Kind {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Role => serializer.serialize_i32(1),
+                    Self::ClusterRole => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Kind {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                    ".google.cloud.securitycenter.v2.Kubernetes.Role.Kind",
+                ))
             }
         }
     }
@@ -6039,66 +6977,130 @@ pub mod kubernetes {
         use super::*;
 
         /// Auth types that can be used for the subject's kind field.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct AuthType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum AuthType {
+            /// Authentication is not specified.
+            Unspecified,
+            /// User with valid certificate.
+            User,
+            /// Users managed by Kubernetes API with credentials stored as secrets.
+            Serviceaccount,
+            /// Collection of users.
+            Group,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [AuthType::value] or
+            /// [AuthType::name].
+            UnknownValue(auth_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod auth_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl AuthType {
-            /// Authentication is not specified.
-            pub const AUTH_TYPE_UNSPECIFIED: AuthType = AuthType::new(0);
-
-            /// User with valid certificate.
-            pub const USER: AuthType = AuthType::new(1);
-
-            /// Users managed by Kubernetes API with credentials stored as secrets.
-            pub const SERVICEACCOUNT: AuthType = AuthType::new(2);
-
-            /// Collection of users.
-            pub const GROUP: AuthType = AuthType::new(3);
-
-            /// Creates a new AuthType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::User => std::option::Option::Some(1),
+                    Self::Serviceaccount => std::option::Option::Some(2),
+                    Self::Group => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("AUTH_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("USER"),
-                    2 => std::borrow::Cow::Borrowed("SERVICEACCOUNT"),
-                    3 => std::borrow::Cow::Borrowed("GROUP"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("AUTH_TYPE_UNSPECIFIED"),
+                    Self::User => std::option::Option::Some("USER"),
+                    Self::Serviceaccount => std::option::Option::Some("SERVICEACCOUNT"),
+                    Self::Group => std::option::Option::Some("GROUP"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "AUTH_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::AUTH_TYPE_UNSPECIFIED)
-                    }
-                    "USER" => std::option::Option::Some(Self::USER),
-                    "SERVICEACCOUNT" => std::option::Option::Some(Self::SERVICEACCOUNT),
-                    "GROUP" => std::option::Option::Some(Self::GROUP),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for AuthType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for AuthType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for AuthType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for AuthType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::User,
+                    2 => Self::Serviceaccount,
+                    3 => Self::Group,
+                    _ => Self::UnknownValue(auth_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for AuthType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "AUTH_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "USER" => Self::User,
+                    "SERVICEACCOUNT" => Self::Serviceaccount,
+                    "GROUP" => Self::Group,
+                    _ => Self::UnknownValue(auth_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for AuthType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::User => serializer.serialize_i32(1),
+                    Self::Serviceaccount => serializer.serialize_i32(2),
+                    Self::Group => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for AuthType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthType>::new(
+                    ".google.cloud.securitycenter.v2.Kubernetes.Subject.AuthType",
+                ))
             }
         }
     }
@@ -6621,561 +7623,831 @@ pub mod mitre_attack {
 
     /// MITRE ATT&CK tactics that can be referenced by SCC findings.
     /// See: <https://attack.mitre.org/tactics/enterprise/>
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tactic(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tactic {
+        /// Unspecified value.
+        Unspecified,
+        /// TA0043
+        Reconnaissance,
+        /// TA0042
+        ResourceDevelopment,
+        /// TA0001
+        InitialAccess,
+        /// TA0002
+        Execution,
+        /// TA0003
+        Persistence,
+        /// TA0004
+        PrivilegeEscalation,
+        /// TA0005
+        DefenseEvasion,
+        /// TA0006
+        CredentialAccess,
+        /// TA0007
+        Discovery,
+        /// TA0008
+        LateralMovement,
+        /// TA0009
+        Collection,
+        /// TA0011
+        CommandAndControl,
+        /// TA0010
+        Exfiltration,
+        /// TA0040
+        Impact,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tactic::value] or
+        /// [Tactic::name].
+        UnknownValue(tactic::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tactic {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Tactic {
-        /// Unspecified value.
-        pub const TACTIC_UNSPECIFIED: Tactic = Tactic::new(0);
-
-        /// TA0043
-        pub const RECONNAISSANCE: Tactic = Tactic::new(1);
-
-        /// TA0042
-        pub const RESOURCE_DEVELOPMENT: Tactic = Tactic::new(2);
-
-        /// TA0001
-        pub const INITIAL_ACCESS: Tactic = Tactic::new(5);
-
-        /// TA0002
-        pub const EXECUTION: Tactic = Tactic::new(3);
-
-        /// TA0003
-        pub const PERSISTENCE: Tactic = Tactic::new(6);
-
-        /// TA0004
-        pub const PRIVILEGE_ESCALATION: Tactic = Tactic::new(8);
-
-        /// TA0005
-        pub const DEFENSE_EVASION: Tactic = Tactic::new(7);
-
-        /// TA0006
-        pub const CREDENTIAL_ACCESS: Tactic = Tactic::new(9);
-
-        /// TA0007
-        pub const DISCOVERY: Tactic = Tactic::new(10);
-
-        /// TA0008
-        pub const LATERAL_MOVEMENT: Tactic = Tactic::new(11);
-
-        /// TA0009
-        pub const COLLECTION: Tactic = Tactic::new(12);
-
-        /// TA0011
-        pub const COMMAND_AND_CONTROL: Tactic = Tactic::new(4);
-
-        /// TA0010
-        pub const EXFILTRATION: Tactic = Tactic::new(13);
-
-        /// TA0040
-        pub const IMPACT: Tactic = Tactic::new(14);
-
-        /// Creates a new Tactic instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Reconnaissance => std::option::Option::Some(1),
+                Self::ResourceDevelopment => std::option::Option::Some(2),
+                Self::InitialAccess => std::option::Option::Some(5),
+                Self::Execution => std::option::Option::Some(3),
+                Self::Persistence => std::option::Option::Some(6),
+                Self::PrivilegeEscalation => std::option::Option::Some(8),
+                Self::DefenseEvasion => std::option::Option::Some(7),
+                Self::CredentialAccess => std::option::Option::Some(9),
+                Self::Discovery => std::option::Option::Some(10),
+                Self::LateralMovement => std::option::Option::Some(11),
+                Self::Collection => std::option::Option::Some(12),
+                Self::CommandAndControl => std::option::Option::Some(4),
+                Self::Exfiltration => std::option::Option::Some(13),
+                Self::Impact => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TACTIC_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RECONNAISSANCE"),
-                2 => std::borrow::Cow::Borrowed("RESOURCE_DEVELOPMENT"),
-                3 => std::borrow::Cow::Borrowed("EXECUTION"),
-                4 => std::borrow::Cow::Borrowed("COMMAND_AND_CONTROL"),
-                5 => std::borrow::Cow::Borrowed("INITIAL_ACCESS"),
-                6 => std::borrow::Cow::Borrowed("PERSISTENCE"),
-                7 => std::borrow::Cow::Borrowed("DEFENSE_EVASION"),
-                8 => std::borrow::Cow::Borrowed("PRIVILEGE_ESCALATION"),
-                9 => std::borrow::Cow::Borrowed("CREDENTIAL_ACCESS"),
-                10 => std::borrow::Cow::Borrowed("DISCOVERY"),
-                11 => std::borrow::Cow::Borrowed("LATERAL_MOVEMENT"),
-                12 => std::borrow::Cow::Borrowed("COLLECTION"),
-                13 => std::borrow::Cow::Borrowed("EXFILTRATION"),
-                14 => std::borrow::Cow::Borrowed("IMPACT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TACTIC_UNSPECIFIED"),
+                Self::Reconnaissance => std::option::Option::Some("RECONNAISSANCE"),
+                Self::ResourceDevelopment => std::option::Option::Some("RESOURCE_DEVELOPMENT"),
+                Self::InitialAccess => std::option::Option::Some("INITIAL_ACCESS"),
+                Self::Execution => std::option::Option::Some("EXECUTION"),
+                Self::Persistence => std::option::Option::Some("PERSISTENCE"),
+                Self::PrivilegeEscalation => std::option::Option::Some("PRIVILEGE_ESCALATION"),
+                Self::DefenseEvasion => std::option::Option::Some("DEFENSE_EVASION"),
+                Self::CredentialAccess => std::option::Option::Some("CREDENTIAL_ACCESS"),
+                Self::Discovery => std::option::Option::Some("DISCOVERY"),
+                Self::LateralMovement => std::option::Option::Some("LATERAL_MOVEMENT"),
+                Self::Collection => std::option::Option::Some("COLLECTION"),
+                Self::CommandAndControl => std::option::Option::Some("COMMAND_AND_CONTROL"),
+                Self::Exfiltration => std::option::Option::Some("EXFILTRATION"),
+                Self::Impact => std::option::Option::Some("IMPACT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TACTIC_UNSPECIFIED" => std::option::Option::Some(Self::TACTIC_UNSPECIFIED),
-                "RECONNAISSANCE" => std::option::Option::Some(Self::RECONNAISSANCE),
-                "RESOURCE_DEVELOPMENT" => std::option::Option::Some(Self::RESOURCE_DEVELOPMENT),
-                "INITIAL_ACCESS" => std::option::Option::Some(Self::INITIAL_ACCESS),
-                "EXECUTION" => std::option::Option::Some(Self::EXECUTION),
-                "PERSISTENCE" => std::option::Option::Some(Self::PERSISTENCE),
-                "PRIVILEGE_ESCALATION" => std::option::Option::Some(Self::PRIVILEGE_ESCALATION),
-                "DEFENSE_EVASION" => std::option::Option::Some(Self::DEFENSE_EVASION),
-                "CREDENTIAL_ACCESS" => std::option::Option::Some(Self::CREDENTIAL_ACCESS),
-                "DISCOVERY" => std::option::Option::Some(Self::DISCOVERY),
-                "LATERAL_MOVEMENT" => std::option::Option::Some(Self::LATERAL_MOVEMENT),
-                "COLLECTION" => std::option::Option::Some(Self::COLLECTION),
-                "COMMAND_AND_CONTROL" => std::option::Option::Some(Self::COMMAND_AND_CONTROL),
-                "EXFILTRATION" => std::option::Option::Some(Self::EXFILTRATION),
-                "IMPACT" => std::option::Option::Some(Self::IMPACT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tactic {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tactic {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tactic {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tactic {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Reconnaissance,
+                2 => Self::ResourceDevelopment,
+                3 => Self::Execution,
+                4 => Self::CommandAndControl,
+                5 => Self::InitialAccess,
+                6 => Self::Persistence,
+                7 => Self::DefenseEvasion,
+                8 => Self::PrivilegeEscalation,
+                9 => Self::CredentialAccess,
+                10 => Self::Discovery,
+                11 => Self::LateralMovement,
+                12 => Self::Collection,
+                13 => Self::Exfiltration,
+                14 => Self::Impact,
+                _ => Self::UnknownValue(tactic::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tactic {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TACTIC_UNSPECIFIED" => Self::Unspecified,
+                "RECONNAISSANCE" => Self::Reconnaissance,
+                "RESOURCE_DEVELOPMENT" => Self::ResourceDevelopment,
+                "INITIAL_ACCESS" => Self::InitialAccess,
+                "EXECUTION" => Self::Execution,
+                "PERSISTENCE" => Self::Persistence,
+                "PRIVILEGE_ESCALATION" => Self::PrivilegeEscalation,
+                "DEFENSE_EVASION" => Self::DefenseEvasion,
+                "CREDENTIAL_ACCESS" => Self::CredentialAccess,
+                "DISCOVERY" => Self::Discovery,
+                "LATERAL_MOVEMENT" => Self::LateralMovement,
+                "COLLECTION" => Self::Collection,
+                "COMMAND_AND_CONTROL" => Self::CommandAndControl,
+                "EXFILTRATION" => Self::Exfiltration,
+                "IMPACT" => Self::Impact,
+                _ => Self::UnknownValue(tactic::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tactic {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Reconnaissance => serializer.serialize_i32(1),
+                Self::ResourceDevelopment => serializer.serialize_i32(2),
+                Self::InitialAccess => serializer.serialize_i32(5),
+                Self::Execution => serializer.serialize_i32(3),
+                Self::Persistence => serializer.serialize_i32(6),
+                Self::PrivilegeEscalation => serializer.serialize_i32(8),
+                Self::DefenseEvasion => serializer.serialize_i32(7),
+                Self::CredentialAccess => serializer.serialize_i32(9),
+                Self::Discovery => serializer.serialize_i32(10),
+                Self::LateralMovement => serializer.serialize_i32(11),
+                Self::Collection => serializer.serialize_i32(12),
+                Self::CommandAndControl => serializer.serialize_i32(4),
+                Self::Exfiltration => serializer.serialize_i32(13),
+                Self::Impact => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tactic {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tactic>::new(
+                ".google.cloud.securitycenter.v2.MitreAttack.Tactic",
+            ))
         }
     }
 
     /// MITRE ATT&CK techniques that can be referenced by SCC findings.
     /// See: <https://attack.mitre.org/techniques/enterprise/>
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Technique(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Technique {
+        /// Unspecified value.
+        Unspecified,
+        /// T1036
+        Masquerading,
+        /// T1036.005
+        MatchLegitimateNameOrLocation,
+        /// T1037
+        BootOrLogonInitializationScripts,
+        /// T1037.005
+        StartupItems,
+        /// T1046
+        NetworkServiceDiscovery,
+        /// T1057
+        ProcessDiscovery,
+        /// T1059
+        CommandAndScriptingInterpreter,
+        /// T1059.004
+        UnixShell,
+        /// T1059.006
+        Python,
+        /// T1068
+        ExploitationForPrivilegeEscalation,
+        /// T1069
+        PermissionGroupsDiscovery,
+        /// T1069.003
+        CloudGroups,
+        /// T1070.004
+        IndicatorRemovalFileDeletion,
+        /// T1071
+        ApplicationLayerProtocol,
+        /// T1071.004
+        Dns,
+        /// T1072
+        SoftwareDeploymentTools,
+        /// T1078
+        ValidAccounts,
+        /// T1078.001
+        DefaultAccounts,
+        /// T1078.003
+        LocalAccounts,
+        /// T1078.004
+        CloudAccounts,
+        /// T1090
+        Proxy,
+        /// T1090.002
+        ExternalProxy,
+        /// T1090.003
+        MultiHopProxy,
+        /// T1098
+        AccountManipulation,
+        /// T1098.001
+        AdditionalCloudCredentials,
+        /// T1098.004
+        SshAuthorizedKeys,
+        /// T1098.006
+        AdditionalContainerClusterRoles,
+        /// T1105
+        IngressToolTransfer,
+        /// T1106
+        NativeApi,
+        /// T1110
+        BruteForce,
+        /// T1129
+        SharedModules,
+        /// T1134
+        AccessTokenManipulation,
+        /// T1134.001
+        TokenImpersonationOrTheft,
+        /// T1190
+        ExploitPublicFacingApplication,
+        /// T1484
+        DomainPolicyModification,
+        /// T1485
+        DataDestruction,
+        /// T1489
+        ServiceStop,
+        /// T1490
+        InhibitSystemRecovery,
+        /// T1496
+        ResourceHijacking,
+        /// T1498
+        NetworkDenialOfService,
+        /// T1526
+        CloudServiceDiscovery,
+        /// T1528
+        StealApplicationAccessToken,
+        /// T1531
+        AccountAccessRemoval,
+        /// T1539
+        StealWebSessionCookie,
+        /// T1543
+        CreateOrModifySystemProcess,
+        /// T1546
+        EventTriggeredExecution,
+        /// T1548
+        AbuseElevationControlMechanism,
+        /// T1552
+        UnsecuredCredentials,
+        /// T1556
+        ModifyAuthenticationProcess,
+        /// T1562
+        ImpairDefenses,
+        /// T1562.001
+        DisableOrModifyTools,
+        /// T1567
+        ExfiltrationOverWebService,
+        /// T1567.002
+        ExfiltrationToCloudStorage,
+        /// T1568
+        DynamicResolution,
+        /// T1570
+        LateralToolTransfer,
+        /// T1578
+        ModifyCloudComputeInfrastructure,
+        /// T1578.001
+        CreateSnapshot,
+        /// T1580
+        CloudInfrastructureDiscovery,
+        /// T1588
+        ObtainCapabilities,
+        /// T1595
+        ActiveScanning,
+        /// T1595.001
+        ScanningIpBlocks,
+        /// T1609
+        ContainerAdministrationCommand,
+        /// T1610
+        DeployContainer,
+        /// T1611
+        EscapeToHost,
+        /// T1613
+        ContainerAndResourceDiscovery,
+        /// T1649
+        StealOrForgeAuthenticationCertificates,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Technique::value] or
+        /// [Technique::name].
+        UnknownValue(technique::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod technique {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Technique {
-        /// Unspecified value.
-        pub const TECHNIQUE_UNSPECIFIED: Technique = Technique::new(0);
-
-        /// T1036
-        pub const MASQUERADING: Technique = Technique::new(49);
-
-        /// T1036.005
-        pub const MATCH_LEGITIMATE_NAME_OR_LOCATION: Technique = Technique::new(50);
-
-        /// T1037
-        pub const BOOT_OR_LOGON_INITIALIZATION_SCRIPTS: Technique = Technique::new(37);
-
-        /// T1037.005
-        pub const STARTUP_ITEMS: Technique = Technique::new(38);
-
-        /// T1046
-        pub const NETWORK_SERVICE_DISCOVERY: Technique = Technique::new(32);
-
-        /// T1057
-        pub const PROCESS_DISCOVERY: Technique = Technique::new(56);
-
-        /// T1059
-        pub const COMMAND_AND_SCRIPTING_INTERPRETER: Technique = Technique::new(6);
-
-        /// T1059.004
-        pub const UNIX_SHELL: Technique = Technique::new(7);
-
-        /// T1059.006
-        pub const PYTHON: Technique = Technique::new(59);
-
-        /// T1068
-        pub const EXPLOITATION_FOR_PRIVILEGE_ESCALATION: Technique = Technique::new(63);
-
-        /// T1069
-        pub const PERMISSION_GROUPS_DISCOVERY: Technique = Technique::new(18);
-
-        /// T1069.003
-        pub const CLOUD_GROUPS: Technique = Technique::new(19);
-
-        /// T1070.004
-        pub const INDICATOR_REMOVAL_FILE_DELETION: Technique = Technique::new(64);
-
-        /// T1071
-        pub const APPLICATION_LAYER_PROTOCOL: Technique = Technique::new(45);
-
-        /// T1071.004
-        pub const DNS: Technique = Technique::new(46);
-
-        /// T1072
-        pub const SOFTWARE_DEPLOYMENT_TOOLS: Technique = Technique::new(47);
-
-        /// T1078
-        pub const VALID_ACCOUNTS: Technique = Technique::new(14);
-
-        /// T1078.001
-        pub const DEFAULT_ACCOUNTS: Technique = Technique::new(35);
-
-        /// T1078.003
-        pub const LOCAL_ACCOUNTS: Technique = Technique::new(15);
-
-        /// T1078.004
-        pub const CLOUD_ACCOUNTS: Technique = Technique::new(16);
-
-        /// T1090
-        pub const PROXY: Technique = Technique::new(9);
-
-        /// T1090.002
-        pub const EXTERNAL_PROXY: Technique = Technique::new(10);
-
-        /// T1090.003
-        pub const MULTI_HOP_PROXY: Technique = Technique::new(11);
-
-        /// T1098
-        pub const ACCOUNT_MANIPULATION: Technique = Technique::new(22);
-
-        /// T1098.001
-        pub const ADDITIONAL_CLOUD_CREDENTIALS: Technique = Technique::new(40);
-
-        /// T1098.004
-        pub const SSH_AUTHORIZED_KEYS: Technique = Technique::new(23);
-
-        /// T1098.006
-        pub const ADDITIONAL_CONTAINER_CLUSTER_ROLES: Technique = Technique::new(58);
-
-        /// T1105
-        pub const INGRESS_TOOL_TRANSFER: Technique = Technique::new(3);
-
-        /// T1106
-        pub const NATIVE_API: Technique = Technique::new(4);
-
-        /// T1110
-        pub const BRUTE_FORCE: Technique = Technique::new(44);
-
-        /// T1129
-        pub const SHARED_MODULES: Technique = Technique::new(5);
-
-        /// T1134
-        pub const ACCESS_TOKEN_MANIPULATION: Technique = Technique::new(33);
-
-        /// T1134.001
-        pub const TOKEN_IMPERSONATION_OR_THEFT: Technique = Technique::new(39);
-
-        /// T1190
-        pub const EXPLOIT_PUBLIC_FACING_APPLICATION: Technique = Technique::new(27);
-
-        /// T1484
-        pub const DOMAIN_POLICY_MODIFICATION: Technique = Technique::new(30);
-
-        /// T1485
-        pub const DATA_DESTRUCTION: Technique = Technique::new(29);
-
-        /// T1489
-        pub const SERVICE_STOP: Technique = Technique::new(52);
-
-        /// T1490
-        pub const INHIBIT_SYSTEM_RECOVERY: Technique = Technique::new(36);
-
-        /// T1496
-        pub const RESOURCE_HIJACKING: Technique = Technique::new(8);
-
-        /// T1498
-        pub const NETWORK_DENIAL_OF_SERVICE: Technique = Technique::new(17);
-
-        /// T1526
-        pub const CLOUD_SERVICE_DISCOVERY: Technique = Technique::new(48);
-
-        /// T1528
-        pub const STEAL_APPLICATION_ACCESS_TOKEN: Technique = Technique::new(42);
-
-        /// T1531
-        pub const ACCOUNT_ACCESS_REMOVAL: Technique = Technique::new(51);
-
-        /// T1539
-        pub const STEAL_WEB_SESSION_COOKIE: Technique = Technique::new(25);
-
-        /// T1543
-        pub const CREATE_OR_MODIFY_SYSTEM_PROCESS: Technique = Technique::new(24);
-
-        /// T1546
-        pub const EVENT_TRIGGERED_EXECUTION: Technique = Technique::new(65);
-
-        /// T1548
-        pub const ABUSE_ELEVATION_CONTROL_MECHANISM: Technique = Technique::new(34);
-
-        /// T1552
-        pub const UNSECURED_CREDENTIALS: Technique = Technique::new(13);
-
-        /// T1556
-        pub const MODIFY_AUTHENTICATION_PROCESS: Technique = Technique::new(28);
-
-        /// T1562
-        pub const IMPAIR_DEFENSES: Technique = Technique::new(31);
-
-        /// T1562.001
-        pub const DISABLE_OR_MODIFY_TOOLS: Technique = Technique::new(55);
-
-        /// T1567
-        pub const EXFILTRATION_OVER_WEB_SERVICE: Technique = Technique::new(20);
-
-        /// T1567.002
-        pub const EXFILTRATION_TO_CLOUD_STORAGE: Technique = Technique::new(21);
-
-        /// T1568
-        pub const DYNAMIC_RESOLUTION: Technique = Technique::new(12);
-
-        /// T1570
-        pub const LATERAL_TOOL_TRANSFER: Technique = Technique::new(41);
-
-        /// T1578
-        pub const MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE: Technique = Technique::new(26);
-
-        /// T1578.001
-        pub const CREATE_SNAPSHOT: Technique = Technique::new(54);
-
-        /// T1580
-        pub const CLOUD_INFRASTRUCTURE_DISCOVERY: Technique = Technique::new(53);
-
-        /// T1588
-        pub const OBTAIN_CAPABILITIES: Technique = Technique::new(43);
-
-        /// T1595
-        pub const ACTIVE_SCANNING: Technique = Technique::new(1);
-
-        /// T1595.001
-        pub const SCANNING_IP_BLOCKS: Technique = Technique::new(2);
-
-        /// T1609
-        pub const CONTAINER_ADMINISTRATION_COMMAND: Technique = Technique::new(60);
-
-        /// T1610
-        pub const DEPLOY_CONTAINER: Technique = Technique::new(66);
-
-        /// T1611
-        pub const ESCAPE_TO_HOST: Technique = Technique::new(61);
-
-        /// T1613
-        pub const CONTAINER_AND_RESOURCE_DISCOVERY: Technique = Technique::new(57);
-
-        /// T1649
-        pub const STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES: Technique = Technique::new(62);
-
-        /// Creates a new Technique instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Masquerading => std::option::Option::Some(49),
+                Self::MatchLegitimateNameOrLocation => std::option::Option::Some(50),
+                Self::BootOrLogonInitializationScripts => std::option::Option::Some(37),
+                Self::StartupItems => std::option::Option::Some(38),
+                Self::NetworkServiceDiscovery => std::option::Option::Some(32),
+                Self::ProcessDiscovery => std::option::Option::Some(56),
+                Self::CommandAndScriptingInterpreter => std::option::Option::Some(6),
+                Self::UnixShell => std::option::Option::Some(7),
+                Self::Python => std::option::Option::Some(59),
+                Self::ExploitationForPrivilegeEscalation => std::option::Option::Some(63),
+                Self::PermissionGroupsDiscovery => std::option::Option::Some(18),
+                Self::CloudGroups => std::option::Option::Some(19),
+                Self::IndicatorRemovalFileDeletion => std::option::Option::Some(64),
+                Self::ApplicationLayerProtocol => std::option::Option::Some(45),
+                Self::Dns => std::option::Option::Some(46),
+                Self::SoftwareDeploymentTools => std::option::Option::Some(47),
+                Self::ValidAccounts => std::option::Option::Some(14),
+                Self::DefaultAccounts => std::option::Option::Some(35),
+                Self::LocalAccounts => std::option::Option::Some(15),
+                Self::CloudAccounts => std::option::Option::Some(16),
+                Self::Proxy => std::option::Option::Some(9),
+                Self::ExternalProxy => std::option::Option::Some(10),
+                Self::MultiHopProxy => std::option::Option::Some(11),
+                Self::AccountManipulation => std::option::Option::Some(22),
+                Self::AdditionalCloudCredentials => std::option::Option::Some(40),
+                Self::SshAuthorizedKeys => std::option::Option::Some(23),
+                Self::AdditionalContainerClusterRoles => std::option::Option::Some(58),
+                Self::IngressToolTransfer => std::option::Option::Some(3),
+                Self::NativeApi => std::option::Option::Some(4),
+                Self::BruteForce => std::option::Option::Some(44),
+                Self::SharedModules => std::option::Option::Some(5),
+                Self::AccessTokenManipulation => std::option::Option::Some(33),
+                Self::TokenImpersonationOrTheft => std::option::Option::Some(39),
+                Self::ExploitPublicFacingApplication => std::option::Option::Some(27),
+                Self::DomainPolicyModification => std::option::Option::Some(30),
+                Self::DataDestruction => std::option::Option::Some(29),
+                Self::ServiceStop => std::option::Option::Some(52),
+                Self::InhibitSystemRecovery => std::option::Option::Some(36),
+                Self::ResourceHijacking => std::option::Option::Some(8),
+                Self::NetworkDenialOfService => std::option::Option::Some(17),
+                Self::CloudServiceDiscovery => std::option::Option::Some(48),
+                Self::StealApplicationAccessToken => std::option::Option::Some(42),
+                Self::AccountAccessRemoval => std::option::Option::Some(51),
+                Self::StealWebSessionCookie => std::option::Option::Some(25),
+                Self::CreateOrModifySystemProcess => std::option::Option::Some(24),
+                Self::EventTriggeredExecution => std::option::Option::Some(65),
+                Self::AbuseElevationControlMechanism => std::option::Option::Some(34),
+                Self::UnsecuredCredentials => std::option::Option::Some(13),
+                Self::ModifyAuthenticationProcess => std::option::Option::Some(28),
+                Self::ImpairDefenses => std::option::Option::Some(31),
+                Self::DisableOrModifyTools => std::option::Option::Some(55),
+                Self::ExfiltrationOverWebService => std::option::Option::Some(20),
+                Self::ExfiltrationToCloudStorage => std::option::Option::Some(21),
+                Self::DynamicResolution => std::option::Option::Some(12),
+                Self::LateralToolTransfer => std::option::Option::Some(41),
+                Self::ModifyCloudComputeInfrastructure => std::option::Option::Some(26),
+                Self::CreateSnapshot => std::option::Option::Some(54),
+                Self::CloudInfrastructureDiscovery => std::option::Option::Some(53),
+                Self::ObtainCapabilities => std::option::Option::Some(43),
+                Self::ActiveScanning => std::option::Option::Some(1),
+                Self::ScanningIpBlocks => std::option::Option::Some(2),
+                Self::ContainerAdministrationCommand => std::option::Option::Some(60),
+                Self::DeployContainer => std::option::Option::Some(66),
+                Self::EscapeToHost => std::option::Option::Some(61),
+                Self::ContainerAndResourceDiscovery => std::option::Option::Some(57),
+                Self::StealOrForgeAuthenticationCertificates => std::option::Option::Some(62),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TECHNIQUE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE_SCANNING"),
-                2 => std::borrow::Cow::Borrowed("SCANNING_IP_BLOCKS"),
-                3 => std::borrow::Cow::Borrowed("INGRESS_TOOL_TRANSFER"),
-                4 => std::borrow::Cow::Borrowed("NATIVE_API"),
-                5 => std::borrow::Cow::Borrowed("SHARED_MODULES"),
-                6 => std::borrow::Cow::Borrowed("COMMAND_AND_SCRIPTING_INTERPRETER"),
-                7 => std::borrow::Cow::Borrowed("UNIX_SHELL"),
-                8 => std::borrow::Cow::Borrowed("RESOURCE_HIJACKING"),
-                9 => std::borrow::Cow::Borrowed("PROXY"),
-                10 => std::borrow::Cow::Borrowed("EXTERNAL_PROXY"),
-                11 => std::borrow::Cow::Borrowed("MULTI_HOP_PROXY"),
-                12 => std::borrow::Cow::Borrowed("DYNAMIC_RESOLUTION"),
-                13 => std::borrow::Cow::Borrowed("UNSECURED_CREDENTIALS"),
-                14 => std::borrow::Cow::Borrowed("VALID_ACCOUNTS"),
-                15 => std::borrow::Cow::Borrowed("LOCAL_ACCOUNTS"),
-                16 => std::borrow::Cow::Borrowed("CLOUD_ACCOUNTS"),
-                17 => std::borrow::Cow::Borrowed("NETWORK_DENIAL_OF_SERVICE"),
-                18 => std::borrow::Cow::Borrowed("PERMISSION_GROUPS_DISCOVERY"),
-                19 => std::borrow::Cow::Borrowed("CLOUD_GROUPS"),
-                20 => std::borrow::Cow::Borrowed("EXFILTRATION_OVER_WEB_SERVICE"),
-                21 => std::borrow::Cow::Borrowed("EXFILTRATION_TO_CLOUD_STORAGE"),
-                22 => std::borrow::Cow::Borrowed("ACCOUNT_MANIPULATION"),
-                23 => std::borrow::Cow::Borrowed("SSH_AUTHORIZED_KEYS"),
-                24 => std::borrow::Cow::Borrowed("CREATE_OR_MODIFY_SYSTEM_PROCESS"),
-                25 => std::borrow::Cow::Borrowed("STEAL_WEB_SESSION_COOKIE"),
-                26 => std::borrow::Cow::Borrowed("MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE"),
-                27 => std::borrow::Cow::Borrowed("EXPLOIT_PUBLIC_FACING_APPLICATION"),
-                28 => std::borrow::Cow::Borrowed("MODIFY_AUTHENTICATION_PROCESS"),
-                29 => std::borrow::Cow::Borrowed("DATA_DESTRUCTION"),
-                30 => std::borrow::Cow::Borrowed("DOMAIN_POLICY_MODIFICATION"),
-                31 => std::borrow::Cow::Borrowed("IMPAIR_DEFENSES"),
-                32 => std::borrow::Cow::Borrowed("NETWORK_SERVICE_DISCOVERY"),
-                33 => std::borrow::Cow::Borrowed("ACCESS_TOKEN_MANIPULATION"),
-                34 => std::borrow::Cow::Borrowed("ABUSE_ELEVATION_CONTROL_MECHANISM"),
-                35 => std::borrow::Cow::Borrowed("DEFAULT_ACCOUNTS"),
-                36 => std::borrow::Cow::Borrowed("INHIBIT_SYSTEM_RECOVERY"),
-                37 => std::borrow::Cow::Borrowed("BOOT_OR_LOGON_INITIALIZATION_SCRIPTS"),
-                38 => std::borrow::Cow::Borrowed("STARTUP_ITEMS"),
-                39 => std::borrow::Cow::Borrowed("TOKEN_IMPERSONATION_OR_THEFT"),
-                40 => std::borrow::Cow::Borrowed("ADDITIONAL_CLOUD_CREDENTIALS"),
-                41 => std::borrow::Cow::Borrowed("LATERAL_TOOL_TRANSFER"),
-                42 => std::borrow::Cow::Borrowed("STEAL_APPLICATION_ACCESS_TOKEN"),
-                43 => std::borrow::Cow::Borrowed("OBTAIN_CAPABILITIES"),
-                44 => std::borrow::Cow::Borrowed("BRUTE_FORCE"),
-                45 => std::borrow::Cow::Borrowed("APPLICATION_LAYER_PROTOCOL"),
-                46 => std::borrow::Cow::Borrowed("DNS"),
-                47 => std::borrow::Cow::Borrowed("SOFTWARE_DEPLOYMENT_TOOLS"),
-                48 => std::borrow::Cow::Borrowed("CLOUD_SERVICE_DISCOVERY"),
-                49 => std::borrow::Cow::Borrowed("MASQUERADING"),
-                50 => std::borrow::Cow::Borrowed("MATCH_LEGITIMATE_NAME_OR_LOCATION"),
-                51 => std::borrow::Cow::Borrowed("ACCOUNT_ACCESS_REMOVAL"),
-                52 => std::borrow::Cow::Borrowed("SERVICE_STOP"),
-                53 => std::borrow::Cow::Borrowed("CLOUD_INFRASTRUCTURE_DISCOVERY"),
-                54 => std::borrow::Cow::Borrowed("CREATE_SNAPSHOT"),
-                55 => std::borrow::Cow::Borrowed("DISABLE_OR_MODIFY_TOOLS"),
-                56 => std::borrow::Cow::Borrowed("PROCESS_DISCOVERY"),
-                57 => std::borrow::Cow::Borrowed("CONTAINER_AND_RESOURCE_DISCOVERY"),
-                58 => std::borrow::Cow::Borrowed("ADDITIONAL_CONTAINER_CLUSTER_ROLES"),
-                59 => std::borrow::Cow::Borrowed("PYTHON"),
-                60 => std::borrow::Cow::Borrowed("CONTAINER_ADMINISTRATION_COMMAND"),
-                61 => std::borrow::Cow::Borrowed("ESCAPE_TO_HOST"),
-                62 => std::borrow::Cow::Borrowed("STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES"),
-                63 => std::borrow::Cow::Borrowed("EXPLOITATION_FOR_PRIVILEGE_ESCALATION"),
-                64 => std::borrow::Cow::Borrowed("INDICATOR_REMOVAL_FILE_DELETION"),
-                65 => std::borrow::Cow::Borrowed("EVENT_TRIGGERED_EXECUTION"),
-                66 => std::borrow::Cow::Borrowed("DEPLOY_CONTAINER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TECHNIQUE_UNSPECIFIED"),
+                Self::Masquerading => std::option::Option::Some("MASQUERADING"),
+                Self::MatchLegitimateNameOrLocation => {
+                    std::option::Option::Some("MATCH_LEGITIMATE_NAME_OR_LOCATION")
+                }
+                Self::BootOrLogonInitializationScripts => {
+                    std::option::Option::Some("BOOT_OR_LOGON_INITIALIZATION_SCRIPTS")
+                }
+                Self::StartupItems => std::option::Option::Some("STARTUP_ITEMS"),
+                Self::NetworkServiceDiscovery => {
+                    std::option::Option::Some("NETWORK_SERVICE_DISCOVERY")
+                }
+                Self::ProcessDiscovery => std::option::Option::Some("PROCESS_DISCOVERY"),
+                Self::CommandAndScriptingInterpreter => {
+                    std::option::Option::Some("COMMAND_AND_SCRIPTING_INTERPRETER")
+                }
+                Self::UnixShell => std::option::Option::Some("UNIX_SHELL"),
+                Self::Python => std::option::Option::Some("PYTHON"),
+                Self::ExploitationForPrivilegeEscalation => {
+                    std::option::Option::Some("EXPLOITATION_FOR_PRIVILEGE_ESCALATION")
+                }
+                Self::PermissionGroupsDiscovery => {
+                    std::option::Option::Some("PERMISSION_GROUPS_DISCOVERY")
+                }
+                Self::CloudGroups => std::option::Option::Some("CLOUD_GROUPS"),
+                Self::IndicatorRemovalFileDeletion => {
+                    std::option::Option::Some("INDICATOR_REMOVAL_FILE_DELETION")
+                }
+                Self::ApplicationLayerProtocol => {
+                    std::option::Option::Some("APPLICATION_LAYER_PROTOCOL")
+                }
+                Self::Dns => std::option::Option::Some("DNS"),
+                Self::SoftwareDeploymentTools => {
+                    std::option::Option::Some("SOFTWARE_DEPLOYMENT_TOOLS")
+                }
+                Self::ValidAccounts => std::option::Option::Some("VALID_ACCOUNTS"),
+                Self::DefaultAccounts => std::option::Option::Some("DEFAULT_ACCOUNTS"),
+                Self::LocalAccounts => std::option::Option::Some("LOCAL_ACCOUNTS"),
+                Self::CloudAccounts => std::option::Option::Some("CLOUD_ACCOUNTS"),
+                Self::Proxy => std::option::Option::Some("PROXY"),
+                Self::ExternalProxy => std::option::Option::Some("EXTERNAL_PROXY"),
+                Self::MultiHopProxy => std::option::Option::Some("MULTI_HOP_PROXY"),
+                Self::AccountManipulation => std::option::Option::Some("ACCOUNT_MANIPULATION"),
+                Self::AdditionalCloudCredentials => {
+                    std::option::Option::Some("ADDITIONAL_CLOUD_CREDENTIALS")
+                }
+                Self::SshAuthorizedKeys => std::option::Option::Some("SSH_AUTHORIZED_KEYS"),
+                Self::AdditionalContainerClusterRoles => {
+                    std::option::Option::Some("ADDITIONAL_CONTAINER_CLUSTER_ROLES")
+                }
+                Self::IngressToolTransfer => std::option::Option::Some("INGRESS_TOOL_TRANSFER"),
+                Self::NativeApi => std::option::Option::Some("NATIVE_API"),
+                Self::BruteForce => std::option::Option::Some("BRUTE_FORCE"),
+                Self::SharedModules => std::option::Option::Some("SHARED_MODULES"),
+                Self::AccessTokenManipulation => {
+                    std::option::Option::Some("ACCESS_TOKEN_MANIPULATION")
+                }
+                Self::TokenImpersonationOrTheft => {
+                    std::option::Option::Some("TOKEN_IMPERSONATION_OR_THEFT")
+                }
+                Self::ExploitPublicFacingApplication => {
+                    std::option::Option::Some("EXPLOIT_PUBLIC_FACING_APPLICATION")
+                }
+                Self::DomainPolicyModification => {
+                    std::option::Option::Some("DOMAIN_POLICY_MODIFICATION")
+                }
+                Self::DataDestruction => std::option::Option::Some("DATA_DESTRUCTION"),
+                Self::ServiceStop => std::option::Option::Some("SERVICE_STOP"),
+                Self::InhibitSystemRecovery => std::option::Option::Some("INHIBIT_SYSTEM_RECOVERY"),
+                Self::ResourceHijacking => std::option::Option::Some("RESOURCE_HIJACKING"),
+                Self::NetworkDenialOfService => {
+                    std::option::Option::Some("NETWORK_DENIAL_OF_SERVICE")
+                }
+                Self::CloudServiceDiscovery => std::option::Option::Some("CLOUD_SERVICE_DISCOVERY"),
+                Self::StealApplicationAccessToken => {
+                    std::option::Option::Some("STEAL_APPLICATION_ACCESS_TOKEN")
+                }
+                Self::AccountAccessRemoval => std::option::Option::Some("ACCOUNT_ACCESS_REMOVAL"),
+                Self::StealWebSessionCookie => {
+                    std::option::Option::Some("STEAL_WEB_SESSION_COOKIE")
+                }
+                Self::CreateOrModifySystemProcess => {
+                    std::option::Option::Some("CREATE_OR_MODIFY_SYSTEM_PROCESS")
+                }
+                Self::EventTriggeredExecution => {
+                    std::option::Option::Some("EVENT_TRIGGERED_EXECUTION")
+                }
+                Self::AbuseElevationControlMechanism => {
+                    std::option::Option::Some("ABUSE_ELEVATION_CONTROL_MECHANISM")
+                }
+                Self::UnsecuredCredentials => std::option::Option::Some("UNSECURED_CREDENTIALS"),
+                Self::ModifyAuthenticationProcess => {
+                    std::option::Option::Some("MODIFY_AUTHENTICATION_PROCESS")
+                }
+                Self::ImpairDefenses => std::option::Option::Some("IMPAIR_DEFENSES"),
+                Self::DisableOrModifyTools => std::option::Option::Some("DISABLE_OR_MODIFY_TOOLS"),
+                Self::ExfiltrationOverWebService => {
+                    std::option::Option::Some("EXFILTRATION_OVER_WEB_SERVICE")
+                }
+                Self::ExfiltrationToCloudStorage => {
+                    std::option::Option::Some("EXFILTRATION_TO_CLOUD_STORAGE")
+                }
+                Self::DynamicResolution => std::option::Option::Some("DYNAMIC_RESOLUTION"),
+                Self::LateralToolTransfer => std::option::Option::Some("LATERAL_TOOL_TRANSFER"),
+                Self::ModifyCloudComputeInfrastructure => {
+                    std::option::Option::Some("MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE")
+                }
+                Self::CreateSnapshot => std::option::Option::Some("CREATE_SNAPSHOT"),
+                Self::CloudInfrastructureDiscovery => {
+                    std::option::Option::Some("CLOUD_INFRASTRUCTURE_DISCOVERY")
+                }
+                Self::ObtainCapabilities => std::option::Option::Some("OBTAIN_CAPABILITIES"),
+                Self::ActiveScanning => std::option::Option::Some("ACTIVE_SCANNING"),
+                Self::ScanningIpBlocks => std::option::Option::Some("SCANNING_IP_BLOCKS"),
+                Self::ContainerAdministrationCommand => {
+                    std::option::Option::Some("CONTAINER_ADMINISTRATION_COMMAND")
+                }
+                Self::DeployContainer => std::option::Option::Some("DEPLOY_CONTAINER"),
+                Self::EscapeToHost => std::option::Option::Some("ESCAPE_TO_HOST"),
+                Self::ContainerAndResourceDiscovery => {
+                    std::option::Option::Some("CONTAINER_AND_RESOURCE_DISCOVERY")
+                }
+                Self::StealOrForgeAuthenticationCertificates => {
+                    std::option::Option::Some("STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TECHNIQUE_UNSPECIFIED" => std::option::Option::Some(Self::TECHNIQUE_UNSPECIFIED),
-                "MASQUERADING" => std::option::Option::Some(Self::MASQUERADING),
-                "MATCH_LEGITIMATE_NAME_OR_LOCATION" => {
-                    std::option::Option::Some(Self::MATCH_LEGITIMATE_NAME_OR_LOCATION)
-                }
-                "BOOT_OR_LOGON_INITIALIZATION_SCRIPTS" => {
-                    std::option::Option::Some(Self::BOOT_OR_LOGON_INITIALIZATION_SCRIPTS)
-                }
-                "STARTUP_ITEMS" => std::option::Option::Some(Self::STARTUP_ITEMS),
-                "NETWORK_SERVICE_DISCOVERY" => {
-                    std::option::Option::Some(Self::NETWORK_SERVICE_DISCOVERY)
-                }
-                "PROCESS_DISCOVERY" => std::option::Option::Some(Self::PROCESS_DISCOVERY),
-                "COMMAND_AND_SCRIPTING_INTERPRETER" => {
-                    std::option::Option::Some(Self::COMMAND_AND_SCRIPTING_INTERPRETER)
-                }
-                "UNIX_SHELL" => std::option::Option::Some(Self::UNIX_SHELL),
-                "PYTHON" => std::option::Option::Some(Self::PYTHON),
-                "EXPLOITATION_FOR_PRIVILEGE_ESCALATION" => {
-                    std::option::Option::Some(Self::EXPLOITATION_FOR_PRIVILEGE_ESCALATION)
-                }
-                "PERMISSION_GROUPS_DISCOVERY" => {
-                    std::option::Option::Some(Self::PERMISSION_GROUPS_DISCOVERY)
-                }
-                "CLOUD_GROUPS" => std::option::Option::Some(Self::CLOUD_GROUPS),
-                "INDICATOR_REMOVAL_FILE_DELETION" => {
-                    std::option::Option::Some(Self::INDICATOR_REMOVAL_FILE_DELETION)
-                }
-                "APPLICATION_LAYER_PROTOCOL" => {
-                    std::option::Option::Some(Self::APPLICATION_LAYER_PROTOCOL)
-                }
-                "DNS" => std::option::Option::Some(Self::DNS),
-                "SOFTWARE_DEPLOYMENT_TOOLS" => {
-                    std::option::Option::Some(Self::SOFTWARE_DEPLOYMENT_TOOLS)
-                }
-                "VALID_ACCOUNTS" => std::option::Option::Some(Self::VALID_ACCOUNTS),
-                "DEFAULT_ACCOUNTS" => std::option::Option::Some(Self::DEFAULT_ACCOUNTS),
-                "LOCAL_ACCOUNTS" => std::option::Option::Some(Self::LOCAL_ACCOUNTS),
-                "CLOUD_ACCOUNTS" => std::option::Option::Some(Self::CLOUD_ACCOUNTS),
-                "PROXY" => std::option::Option::Some(Self::PROXY),
-                "EXTERNAL_PROXY" => std::option::Option::Some(Self::EXTERNAL_PROXY),
-                "MULTI_HOP_PROXY" => std::option::Option::Some(Self::MULTI_HOP_PROXY),
-                "ACCOUNT_MANIPULATION" => std::option::Option::Some(Self::ACCOUNT_MANIPULATION),
-                "ADDITIONAL_CLOUD_CREDENTIALS" => {
-                    std::option::Option::Some(Self::ADDITIONAL_CLOUD_CREDENTIALS)
-                }
-                "SSH_AUTHORIZED_KEYS" => std::option::Option::Some(Self::SSH_AUTHORIZED_KEYS),
-                "ADDITIONAL_CONTAINER_CLUSTER_ROLES" => {
-                    std::option::Option::Some(Self::ADDITIONAL_CONTAINER_CLUSTER_ROLES)
-                }
-                "INGRESS_TOOL_TRANSFER" => std::option::Option::Some(Self::INGRESS_TOOL_TRANSFER),
-                "NATIVE_API" => std::option::Option::Some(Self::NATIVE_API),
-                "BRUTE_FORCE" => std::option::Option::Some(Self::BRUTE_FORCE),
-                "SHARED_MODULES" => std::option::Option::Some(Self::SHARED_MODULES),
-                "ACCESS_TOKEN_MANIPULATION" => {
-                    std::option::Option::Some(Self::ACCESS_TOKEN_MANIPULATION)
-                }
-                "TOKEN_IMPERSONATION_OR_THEFT" => {
-                    std::option::Option::Some(Self::TOKEN_IMPERSONATION_OR_THEFT)
-                }
-                "EXPLOIT_PUBLIC_FACING_APPLICATION" => {
-                    std::option::Option::Some(Self::EXPLOIT_PUBLIC_FACING_APPLICATION)
-                }
-                "DOMAIN_POLICY_MODIFICATION" => {
-                    std::option::Option::Some(Self::DOMAIN_POLICY_MODIFICATION)
-                }
-                "DATA_DESTRUCTION" => std::option::Option::Some(Self::DATA_DESTRUCTION),
-                "SERVICE_STOP" => std::option::Option::Some(Self::SERVICE_STOP),
-                "INHIBIT_SYSTEM_RECOVERY" => {
-                    std::option::Option::Some(Self::INHIBIT_SYSTEM_RECOVERY)
-                }
-                "RESOURCE_HIJACKING" => std::option::Option::Some(Self::RESOURCE_HIJACKING),
-                "NETWORK_DENIAL_OF_SERVICE" => {
-                    std::option::Option::Some(Self::NETWORK_DENIAL_OF_SERVICE)
-                }
-                "CLOUD_SERVICE_DISCOVERY" => {
-                    std::option::Option::Some(Self::CLOUD_SERVICE_DISCOVERY)
-                }
-                "STEAL_APPLICATION_ACCESS_TOKEN" => {
-                    std::option::Option::Some(Self::STEAL_APPLICATION_ACCESS_TOKEN)
-                }
-                "ACCOUNT_ACCESS_REMOVAL" => std::option::Option::Some(Self::ACCOUNT_ACCESS_REMOVAL),
-                "STEAL_WEB_SESSION_COOKIE" => {
-                    std::option::Option::Some(Self::STEAL_WEB_SESSION_COOKIE)
-                }
-                "CREATE_OR_MODIFY_SYSTEM_PROCESS" => {
-                    std::option::Option::Some(Self::CREATE_OR_MODIFY_SYSTEM_PROCESS)
-                }
-                "EVENT_TRIGGERED_EXECUTION" => {
-                    std::option::Option::Some(Self::EVENT_TRIGGERED_EXECUTION)
-                }
-                "ABUSE_ELEVATION_CONTROL_MECHANISM" => {
-                    std::option::Option::Some(Self::ABUSE_ELEVATION_CONTROL_MECHANISM)
-                }
-                "UNSECURED_CREDENTIALS" => std::option::Option::Some(Self::UNSECURED_CREDENTIALS),
-                "MODIFY_AUTHENTICATION_PROCESS" => {
-                    std::option::Option::Some(Self::MODIFY_AUTHENTICATION_PROCESS)
-                }
-                "IMPAIR_DEFENSES" => std::option::Option::Some(Self::IMPAIR_DEFENSES),
-                "DISABLE_OR_MODIFY_TOOLS" => {
-                    std::option::Option::Some(Self::DISABLE_OR_MODIFY_TOOLS)
-                }
-                "EXFILTRATION_OVER_WEB_SERVICE" => {
-                    std::option::Option::Some(Self::EXFILTRATION_OVER_WEB_SERVICE)
-                }
-                "EXFILTRATION_TO_CLOUD_STORAGE" => {
-                    std::option::Option::Some(Self::EXFILTRATION_TO_CLOUD_STORAGE)
-                }
-                "DYNAMIC_RESOLUTION" => std::option::Option::Some(Self::DYNAMIC_RESOLUTION),
-                "LATERAL_TOOL_TRANSFER" => std::option::Option::Some(Self::LATERAL_TOOL_TRANSFER),
-                "MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE" => {
-                    std::option::Option::Some(Self::MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE)
-                }
-                "CREATE_SNAPSHOT" => std::option::Option::Some(Self::CREATE_SNAPSHOT),
-                "CLOUD_INFRASTRUCTURE_DISCOVERY" => {
-                    std::option::Option::Some(Self::CLOUD_INFRASTRUCTURE_DISCOVERY)
-                }
-                "OBTAIN_CAPABILITIES" => std::option::Option::Some(Self::OBTAIN_CAPABILITIES),
-                "ACTIVE_SCANNING" => std::option::Option::Some(Self::ACTIVE_SCANNING),
-                "SCANNING_IP_BLOCKS" => std::option::Option::Some(Self::SCANNING_IP_BLOCKS),
-                "CONTAINER_ADMINISTRATION_COMMAND" => {
-                    std::option::Option::Some(Self::CONTAINER_ADMINISTRATION_COMMAND)
-                }
-                "DEPLOY_CONTAINER" => std::option::Option::Some(Self::DEPLOY_CONTAINER),
-                "ESCAPE_TO_HOST" => std::option::Option::Some(Self::ESCAPE_TO_HOST),
-                "CONTAINER_AND_RESOURCE_DISCOVERY" => {
-                    std::option::Option::Some(Self::CONTAINER_AND_RESOURCE_DISCOVERY)
-                }
-                "STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES" => {
-                    std::option::Option::Some(Self::STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Technique {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Technique {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Technique {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Technique {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ActiveScanning,
+                2 => Self::ScanningIpBlocks,
+                3 => Self::IngressToolTransfer,
+                4 => Self::NativeApi,
+                5 => Self::SharedModules,
+                6 => Self::CommandAndScriptingInterpreter,
+                7 => Self::UnixShell,
+                8 => Self::ResourceHijacking,
+                9 => Self::Proxy,
+                10 => Self::ExternalProxy,
+                11 => Self::MultiHopProxy,
+                12 => Self::DynamicResolution,
+                13 => Self::UnsecuredCredentials,
+                14 => Self::ValidAccounts,
+                15 => Self::LocalAccounts,
+                16 => Self::CloudAccounts,
+                17 => Self::NetworkDenialOfService,
+                18 => Self::PermissionGroupsDiscovery,
+                19 => Self::CloudGroups,
+                20 => Self::ExfiltrationOverWebService,
+                21 => Self::ExfiltrationToCloudStorage,
+                22 => Self::AccountManipulation,
+                23 => Self::SshAuthorizedKeys,
+                24 => Self::CreateOrModifySystemProcess,
+                25 => Self::StealWebSessionCookie,
+                26 => Self::ModifyCloudComputeInfrastructure,
+                27 => Self::ExploitPublicFacingApplication,
+                28 => Self::ModifyAuthenticationProcess,
+                29 => Self::DataDestruction,
+                30 => Self::DomainPolicyModification,
+                31 => Self::ImpairDefenses,
+                32 => Self::NetworkServiceDiscovery,
+                33 => Self::AccessTokenManipulation,
+                34 => Self::AbuseElevationControlMechanism,
+                35 => Self::DefaultAccounts,
+                36 => Self::InhibitSystemRecovery,
+                37 => Self::BootOrLogonInitializationScripts,
+                38 => Self::StartupItems,
+                39 => Self::TokenImpersonationOrTheft,
+                40 => Self::AdditionalCloudCredentials,
+                41 => Self::LateralToolTransfer,
+                42 => Self::StealApplicationAccessToken,
+                43 => Self::ObtainCapabilities,
+                44 => Self::BruteForce,
+                45 => Self::ApplicationLayerProtocol,
+                46 => Self::Dns,
+                47 => Self::SoftwareDeploymentTools,
+                48 => Self::CloudServiceDiscovery,
+                49 => Self::Masquerading,
+                50 => Self::MatchLegitimateNameOrLocation,
+                51 => Self::AccountAccessRemoval,
+                52 => Self::ServiceStop,
+                53 => Self::CloudInfrastructureDiscovery,
+                54 => Self::CreateSnapshot,
+                55 => Self::DisableOrModifyTools,
+                56 => Self::ProcessDiscovery,
+                57 => Self::ContainerAndResourceDiscovery,
+                58 => Self::AdditionalContainerClusterRoles,
+                59 => Self::Python,
+                60 => Self::ContainerAdministrationCommand,
+                61 => Self::EscapeToHost,
+                62 => Self::StealOrForgeAuthenticationCertificates,
+                63 => Self::ExploitationForPrivilegeEscalation,
+                64 => Self::IndicatorRemovalFileDeletion,
+                65 => Self::EventTriggeredExecution,
+                66 => Self::DeployContainer,
+                _ => Self::UnknownValue(technique::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Technique {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TECHNIQUE_UNSPECIFIED" => Self::Unspecified,
+                "MASQUERADING" => Self::Masquerading,
+                "MATCH_LEGITIMATE_NAME_OR_LOCATION" => Self::MatchLegitimateNameOrLocation,
+                "BOOT_OR_LOGON_INITIALIZATION_SCRIPTS" => Self::BootOrLogonInitializationScripts,
+                "STARTUP_ITEMS" => Self::StartupItems,
+                "NETWORK_SERVICE_DISCOVERY" => Self::NetworkServiceDiscovery,
+                "PROCESS_DISCOVERY" => Self::ProcessDiscovery,
+                "COMMAND_AND_SCRIPTING_INTERPRETER" => Self::CommandAndScriptingInterpreter,
+                "UNIX_SHELL" => Self::UnixShell,
+                "PYTHON" => Self::Python,
+                "EXPLOITATION_FOR_PRIVILEGE_ESCALATION" => Self::ExploitationForPrivilegeEscalation,
+                "PERMISSION_GROUPS_DISCOVERY" => Self::PermissionGroupsDiscovery,
+                "CLOUD_GROUPS" => Self::CloudGroups,
+                "INDICATOR_REMOVAL_FILE_DELETION" => Self::IndicatorRemovalFileDeletion,
+                "APPLICATION_LAYER_PROTOCOL" => Self::ApplicationLayerProtocol,
+                "DNS" => Self::Dns,
+                "SOFTWARE_DEPLOYMENT_TOOLS" => Self::SoftwareDeploymentTools,
+                "VALID_ACCOUNTS" => Self::ValidAccounts,
+                "DEFAULT_ACCOUNTS" => Self::DefaultAccounts,
+                "LOCAL_ACCOUNTS" => Self::LocalAccounts,
+                "CLOUD_ACCOUNTS" => Self::CloudAccounts,
+                "PROXY" => Self::Proxy,
+                "EXTERNAL_PROXY" => Self::ExternalProxy,
+                "MULTI_HOP_PROXY" => Self::MultiHopProxy,
+                "ACCOUNT_MANIPULATION" => Self::AccountManipulation,
+                "ADDITIONAL_CLOUD_CREDENTIALS" => Self::AdditionalCloudCredentials,
+                "SSH_AUTHORIZED_KEYS" => Self::SshAuthorizedKeys,
+                "ADDITIONAL_CONTAINER_CLUSTER_ROLES" => Self::AdditionalContainerClusterRoles,
+                "INGRESS_TOOL_TRANSFER" => Self::IngressToolTransfer,
+                "NATIVE_API" => Self::NativeApi,
+                "BRUTE_FORCE" => Self::BruteForce,
+                "SHARED_MODULES" => Self::SharedModules,
+                "ACCESS_TOKEN_MANIPULATION" => Self::AccessTokenManipulation,
+                "TOKEN_IMPERSONATION_OR_THEFT" => Self::TokenImpersonationOrTheft,
+                "EXPLOIT_PUBLIC_FACING_APPLICATION" => Self::ExploitPublicFacingApplication,
+                "DOMAIN_POLICY_MODIFICATION" => Self::DomainPolicyModification,
+                "DATA_DESTRUCTION" => Self::DataDestruction,
+                "SERVICE_STOP" => Self::ServiceStop,
+                "INHIBIT_SYSTEM_RECOVERY" => Self::InhibitSystemRecovery,
+                "RESOURCE_HIJACKING" => Self::ResourceHijacking,
+                "NETWORK_DENIAL_OF_SERVICE" => Self::NetworkDenialOfService,
+                "CLOUD_SERVICE_DISCOVERY" => Self::CloudServiceDiscovery,
+                "STEAL_APPLICATION_ACCESS_TOKEN" => Self::StealApplicationAccessToken,
+                "ACCOUNT_ACCESS_REMOVAL" => Self::AccountAccessRemoval,
+                "STEAL_WEB_SESSION_COOKIE" => Self::StealWebSessionCookie,
+                "CREATE_OR_MODIFY_SYSTEM_PROCESS" => Self::CreateOrModifySystemProcess,
+                "EVENT_TRIGGERED_EXECUTION" => Self::EventTriggeredExecution,
+                "ABUSE_ELEVATION_CONTROL_MECHANISM" => Self::AbuseElevationControlMechanism,
+                "UNSECURED_CREDENTIALS" => Self::UnsecuredCredentials,
+                "MODIFY_AUTHENTICATION_PROCESS" => Self::ModifyAuthenticationProcess,
+                "IMPAIR_DEFENSES" => Self::ImpairDefenses,
+                "DISABLE_OR_MODIFY_TOOLS" => Self::DisableOrModifyTools,
+                "EXFILTRATION_OVER_WEB_SERVICE" => Self::ExfiltrationOverWebService,
+                "EXFILTRATION_TO_CLOUD_STORAGE" => Self::ExfiltrationToCloudStorage,
+                "DYNAMIC_RESOLUTION" => Self::DynamicResolution,
+                "LATERAL_TOOL_TRANSFER" => Self::LateralToolTransfer,
+                "MODIFY_CLOUD_COMPUTE_INFRASTRUCTURE" => Self::ModifyCloudComputeInfrastructure,
+                "CREATE_SNAPSHOT" => Self::CreateSnapshot,
+                "CLOUD_INFRASTRUCTURE_DISCOVERY" => Self::CloudInfrastructureDiscovery,
+                "OBTAIN_CAPABILITIES" => Self::ObtainCapabilities,
+                "ACTIVE_SCANNING" => Self::ActiveScanning,
+                "SCANNING_IP_BLOCKS" => Self::ScanningIpBlocks,
+                "CONTAINER_ADMINISTRATION_COMMAND" => Self::ContainerAdministrationCommand,
+                "DEPLOY_CONTAINER" => Self::DeployContainer,
+                "ESCAPE_TO_HOST" => Self::EscapeToHost,
+                "CONTAINER_AND_RESOURCE_DISCOVERY" => Self::ContainerAndResourceDiscovery,
+                "STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES" => {
+                    Self::StealOrForgeAuthenticationCertificates
+                }
+                _ => Self::UnknownValue(technique::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Technique {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Masquerading => serializer.serialize_i32(49),
+                Self::MatchLegitimateNameOrLocation => serializer.serialize_i32(50),
+                Self::BootOrLogonInitializationScripts => serializer.serialize_i32(37),
+                Self::StartupItems => serializer.serialize_i32(38),
+                Self::NetworkServiceDiscovery => serializer.serialize_i32(32),
+                Self::ProcessDiscovery => serializer.serialize_i32(56),
+                Self::CommandAndScriptingInterpreter => serializer.serialize_i32(6),
+                Self::UnixShell => serializer.serialize_i32(7),
+                Self::Python => serializer.serialize_i32(59),
+                Self::ExploitationForPrivilegeEscalation => serializer.serialize_i32(63),
+                Self::PermissionGroupsDiscovery => serializer.serialize_i32(18),
+                Self::CloudGroups => serializer.serialize_i32(19),
+                Self::IndicatorRemovalFileDeletion => serializer.serialize_i32(64),
+                Self::ApplicationLayerProtocol => serializer.serialize_i32(45),
+                Self::Dns => serializer.serialize_i32(46),
+                Self::SoftwareDeploymentTools => serializer.serialize_i32(47),
+                Self::ValidAccounts => serializer.serialize_i32(14),
+                Self::DefaultAccounts => serializer.serialize_i32(35),
+                Self::LocalAccounts => serializer.serialize_i32(15),
+                Self::CloudAccounts => serializer.serialize_i32(16),
+                Self::Proxy => serializer.serialize_i32(9),
+                Self::ExternalProxy => serializer.serialize_i32(10),
+                Self::MultiHopProxy => serializer.serialize_i32(11),
+                Self::AccountManipulation => serializer.serialize_i32(22),
+                Self::AdditionalCloudCredentials => serializer.serialize_i32(40),
+                Self::SshAuthorizedKeys => serializer.serialize_i32(23),
+                Self::AdditionalContainerClusterRoles => serializer.serialize_i32(58),
+                Self::IngressToolTransfer => serializer.serialize_i32(3),
+                Self::NativeApi => serializer.serialize_i32(4),
+                Self::BruteForce => serializer.serialize_i32(44),
+                Self::SharedModules => serializer.serialize_i32(5),
+                Self::AccessTokenManipulation => serializer.serialize_i32(33),
+                Self::TokenImpersonationOrTheft => serializer.serialize_i32(39),
+                Self::ExploitPublicFacingApplication => serializer.serialize_i32(27),
+                Self::DomainPolicyModification => serializer.serialize_i32(30),
+                Self::DataDestruction => serializer.serialize_i32(29),
+                Self::ServiceStop => serializer.serialize_i32(52),
+                Self::InhibitSystemRecovery => serializer.serialize_i32(36),
+                Self::ResourceHijacking => serializer.serialize_i32(8),
+                Self::NetworkDenialOfService => serializer.serialize_i32(17),
+                Self::CloudServiceDiscovery => serializer.serialize_i32(48),
+                Self::StealApplicationAccessToken => serializer.serialize_i32(42),
+                Self::AccountAccessRemoval => serializer.serialize_i32(51),
+                Self::StealWebSessionCookie => serializer.serialize_i32(25),
+                Self::CreateOrModifySystemProcess => serializer.serialize_i32(24),
+                Self::EventTriggeredExecution => serializer.serialize_i32(65),
+                Self::AbuseElevationControlMechanism => serializer.serialize_i32(34),
+                Self::UnsecuredCredentials => serializer.serialize_i32(13),
+                Self::ModifyAuthenticationProcess => serializer.serialize_i32(28),
+                Self::ImpairDefenses => serializer.serialize_i32(31),
+                Self::DisableOrModifyTools => serializer.serialize_i32(55),
+                Self::ExfiltrationOverWebService => serializer.serialize_i32(20),
+                Self::ExfiltrationToCloudStorage => serializer.serialize_i32(21),
+                Self::DynamicResolution => serializer.serialize_i32(12),
+                Self::LateralToolTransfer => serializer.serialize_i32(41),
+                Self::ModifyCloudComputeInfrastructure => serializer.serialize_i32(26),
+                Self::CreateSnapshot => serializer.serialize_i32(54),
+                Self::CloudInfrastructureDiscovery => serializer.serialize_i32(53),
+                Self::ObtainCapabilities => serializer.serialize_i32(43),
+                Self::ActiveScanning => serializer.serialize_i32(1),
+                Self::ScanningIpBlocks => serializer.serialize_i32(2),
+                Self::ContainerAdministrationCommand => serializer.serialize_i32(60),
+                Self::DeployContainer => serializer.serialize_i32(66),
+                Self::EscapeToHost => serializer.serialize_i32(61),
+                Self::ContainerAndResourceDiscovery => serializer.serialize_i32(57),
+                Self::StealOrForgeAuthenticationCertificates => serializer.serialize_i32(62),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Technique {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Technique>::new(
+                ".google.cloud.securitycenter.v2.MitreAttack.Technique",
+            ))
         }
     }
 }
@@ -7342,68 +8614,127 @@ pub mod mute_config {
     use super::*;
 
     /// The type of MuteConfig.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MuteConfigType(i32);
-
-    impl MuteConfigType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MuteConfigType {
         /// Unused.
-        pub const MUTE_CONFIG_TYPE_UNSPECIFIED: MuteConfigType = MuteConfigType::new(0);
-
+        Unspecified,
         /// A static mute config, which sets the static mute state of future matching
         /// findings to muted. Once the static mute state has been set, finding or
         /// config modifications will not affect the state.
-        pub const STATIC: MuteConfigType = MuteConfigType::new(1);
-
+        Static,
         /// A dynamic mute config, which is applied to existing and future matching
         /// findings, setting their dynamic mute state to "muted". If the config is
         /// updated or deleted, or a matching finding is updated, such that the
         /// finding doesn't match the config, the config will be removed from the
         /// finding, and the finding's dynamic mute state may become "unmuted"
         /// (unless other configs still match).
-        pub const DYNAMIC: MuteConfigType = MuteConfigType::new(2);
+        Dynamic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MuteConfigType::value] or
+        /// [MuteConfigType::name].
+        UnknownValue(mute_config_type::UnknownValue),
+    }
 
-        /// Creates a new MuteConfigType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod mute_config_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MuteConfigType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Static => std::option::Option::Some(1),
+                Self::Dynamic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MUTE_CONFIG_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATIC"),
-                2 => std::borrow::Cow::Borrowed("DYNAMIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MUTE_CONFIG_TYPE_UNSPECIFIED"),
+                Self::Static => std::option::Option::Some("STATIC"),
+                Self::Dynamic => std::option::Option::Some("DYNAMIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MUTE_CONFIG_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MUTE_CONFIG_TYPE_UNSPECIFIED)
-                }
-                "STATIC" => std::option::Option::Some(Self::STATIC),
-                "DYNAMIC" => std::option::Option::Some(Self::DYNAMIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MuteConfigType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MuteConfigType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MuteConfigType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MuteConfigType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Static,
+                2 => Self::Dynamic,
+                _ => Self::UnknownValue(mute_config_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MuteConfigType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MUTE_CONFIG_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STATIC" => Self::Static,
+                "DYNAMIC" => Self::Dynamic,
+                _ => Self::UnknownValue(mute_config_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MuteConfigType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Static => serializer.serialize_i32(1),
+                Self::Dynamic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MuteConfigType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MuteConfigType>::new(
+                ".google.cloud.securitycenter.v2.MuteConfig.MuteConfigType",
+            ))
         }
     }
 }
@@ -8920,99 +10251,171 @@ pub mod resource_path {
     }
 
     /// The type of resource the node represents.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResourcePathNodeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResourcePathNodeType {
+        /// Node type is unspecified.
+        Unspecified,
+        /// The node represents a Google Cloud organization.
+        GcpOrganization,
+        /// The node represents a Google Cloud folder.
+        GcpFolder,
+        /// The node represents a Google Cloud project.
+        GcpProject,
+        /// The node represents an AWS organization.
+        AwsOrganization,
+        /// The node represents an AWS organizational unit.
+        AwsOrganizationalUnit,
+        /// The node represents an AWS account.
+        AwsAccount,
+        /// The node represents an Azure management group.
+        AzureManagementGroup,
+        /// The node represents an Azure subscription.
+        AzureSubscription,
+        /// The node represents an Azure resource group.
+        AzureResourceGroup,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResourcePathNodeType::value] or
+        /// [ResourcePathNodeType::name].
+        UnknownValue(resource_path_node_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod resource_path_node_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ResourcePathNodeType {
-        /// Node type is unspecified.
-        pub const RESOURCE_PATH_NODE_TYPE_UNSPECIFIED: ResourcePathNodeType =
-            ResourcePathNodeType::new(0);
-
-        /// The node represents a Google Cloud organization.
-        pub const GCP_ORGANIZATION: ResourcePathNodeType = ResourcePathNodeType::new(1);
-
-        /// The node represents a Google Cloud folder.
-        pub const GCP_FOLDER: ResourcePathNodeType = ResourcePathNodeType::new(2);
-
-        /// The node represents a Google Cloud project.
-        pub const GCP_PROJECT: ResourcePathNodeType = ResourcePathNodeType::new(3);
-
-        /// The node represents an AWS organization.
-        pub const AWS_ORGANIZATION: ResourcePathNodeType = ResourcePathNodeType::new(4);
-
-        /// The node represents an AWS organizational unit.
-        pub const AWS_ORGANIZATIONAL_UNIT: ResourcePathNodeType = ResourcePathNodeType::new(5);
-
-        /// The node represents an AWS account.
-        pub const AWS_ACCOUNT: ResourcePathNodeType = ResourcePathNodeType::new(6);
-
-        /// The node represents an Azure management group.
-        pub const AZURE_MANAGEMENT_GROUP: ResourcePathNodeType = ResourcePathNodeType::new(7);
-
-        /// The node represents an Azure subscription.
-        pub const AZURE_SUBSCRIPTION: ResourcePathNodeType = ResourcePathNodeType::new(8);
-
-        /// The node represents an Azure resource group.
-        pub const AZURE_RESOURCE_GROUP: ResourcePathNodeType = ResourcePathNodeType::new(9);
-
-        /// Creates a new ResourcePathNodeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GcpOrganization => std::option::Option::Some(1),
+                Self::GcpFolder => std::option::Option::Some(2),
+                Self::GcpProject => std::option::Option::Some(3),
+                Self::AwsOrganization => std::option::Option::Some(4),
+                Self::AwsOrganizationalUnit => std::option::Option::Some(5),
+                Self::AwsAccount => std::option::Option::Some(6),
+                Self::AzureManagementGroup => std::option::Option::Some(7),
+                Self::AzureSubscription => std::option::Option::Some(8),
+                Self::AzureResourceGroup => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESOURCE_PATH_NODE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCP_ORGANIZATION"),
-                2 => std::borrow::Cow::Borrowed("GCP_FOLDER"),
-                3 => std::borrow::Cow::Borrowed("GCP_PROJECT"),
-                4 => std::borrow::Cow::Borrowed("AWS_ORGANIZATION"),
-                5 => std::borrow::Cow::Borrowed("AWS_ORGANIZATIONAL_UNIT"),
-                6 => std::borrow::Cow::Borrowed("AWS_ACCOUNT"),
-                7 => std::borrow::Cow::Borrowed("AZURE_MANAGEMENT_GROUP"),
-                8 => std::borrow::Cow::Borrowed("AZURE_SUBSCRIPTION"),
-                9 => std::borrow::Cow::Borrowed("AZURE_RESOURCE_GROUP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESOURCE_PATH_NODE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESOURCE_PATH_NODE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("RESOURCE_PATH_NODE_TYPE_UNSPECIFIED")
                 }
-                "GCP_ORGANIZATION" => std::option::Option::Some(Self::GCP_ORGANIZATION),
-                "GCP_FOLDER" => std::option::Option::Some(Self::GCP_FOLDER),
-                "GCP_PROJECT" => std::option::Option::Some(Self::GCP_PROJECT),
-                "AWS_ORGANIZATION" => std::option::Option::Some(Self::AWS_ORGANIZATION),
-                "AWS_ORGANIZATIONAL_UNIT" => {
-                    std::option::Option::Some(Self::AWS_ORGANIZATIONAL_UNIT)
-                }
-                "AWS_ACCOUNT" => std::option::Option::Some(Self::AWS_ACCOUNT),
-                "AZURE_MANAGEMENT_GROUP" => std::option::Option::Some(Self::AZURE_MANAGEMENT_GROUP),
-                "AZURE_SUBSCRIPTION" => std::option::Option::Some(Self::AZURE_SUBSCRIPTION),
-                "AZURE_RESOURCE_GROUP" => std::option::Option::Some(Self::AZURE_RESOURCE_GROUP),
-                _ => std::option::Option::None,
+                Self::GcpOrganization => std::option::Option::Some("GCP_ORGANIZATION"),
+                Self::GcpFolder => std::option::Option::Some("GCP_FOLDER"),
+                Self::GcpProject => std::option::Option::Some("GCP_PROJECT"),
+                Self::AwsOrganization => std::option::Option::Some("AWS_ORGANIZATION"),
+                Self::AwsOrganizationalUnit => std::option::Option::Some("AWS_ORGANIZATIONAL_UNIT"),
+                Self::AwsAccount => std::option::Option::Some("AWS_ACCOUNT"),
+                Self::AzureManagementGroup => std::option::Option::Some("AZURE_MANAGEMENT_GROUP"),
+                Self::AzureSubscription => std::option::Option::Some("AZURE_SUBSCRIPTION"),
+                Self::AzureResourceGroup => std::option::Option::Some("AZURE_RESOURCE_GROUP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ResourcePathNodeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResourcePathNodeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResourcePathNodeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResourcePathNodeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GcpOrganization,
+                2 => Self::GcpFolder,
+                3 => Self::GcpProject,
+                4 => Self::AwsOrganization,
+                5 => Self::AwsOrganizationalUnit,
+                6 => Self::AwsAccount,
+                7 => Self::AzureManagementGroup,
+                8 => Self::AzureSubscription,
+                9 => Self::AzureResourceGroup,
+                _ => Self::UnknownValue(resource_path_node_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResourcePathNodeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESOURCE_PATH_NODE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GCP_ORGANIZATION" => Self::GcpOrganization,
+                "GCP_FOLDER" => Self::GcpFolder,
+                "GCP_PROJECT" => Self::GcpProject,
+                "AWS_ORGANIZATION" => Self::AwsOrganization,
+                "AWS_ORGANIZATIONAL_UNIT" => Self::AwsOrganizationalUnit,
+                "AWS_ACCOUNT" => Self::AwsAccount,
+                "AZURE_MANAGEMENT_GROUP" => Self::AzureManagementGroup,
+                "AZURE_SUBSCRIPTION" => Self::AzureSubscription,
+                "AZURE_RESOURCE_GROUP" => Self::AzureResourceGroup,
+                _ => Self::UnknownValue(resource_path_node_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResourcePathNodeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GcpOrganization => serializer.serialize_i32(1),
+                Self::GcpFolder => serializer.serialize_i32(2),
+                Self::GcpProject => serializer.serialize_i32(3),
+                Self::AwsOrganization => serializer.serialize_i32(4),
+                Self::AwsOrganizationalUnit => serializer.serialize_i32(5),
+                Self::AwsAccount => serializer.serialize_i32(6),
+                Self::AzureManagementGroup => serializer.serialize_i32(7),
+                Self::AzureSubscription => serializer.serialize_i32(8),
+                Self::AzureResourceGroup => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResourcePathNodeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourcePathNodeType>::new(
+                ".google.cloud.securitycenter.v2.ResourcePath.ResourcePathNodeType",
+            ))
         }
     }
 }
@@ -9725,59 +11128,120 @@ pub mod bulk_mute_findings_request {
     use super::*;
 
     /// The mute state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MuteState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MuteState {
+        /// Unused.
+        Unspecified,
+        /// Matching findings will be muted (default).
+        Muted,
+        /// Matching findings will have their mute state cleared.
+        Undefined,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MuteState::value] or
+        /// [MuteState::name].
+        UnknownValue(mute_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mute_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MuteState {
-        /// Unused.
-        pub const MUTE_STATE_UNSPECIFIED: MuteState = MuteState::new(0);
-
-        /// Matching findings will be muted (default).
-        pub const MUTED: MuteState = MuteState::new(1);
-
-        /// Matching findings will have their mute state cleared.
-        pub const UNDEFINED: MuteState = MuteState::new(2);
-
-        /// Creates a new MuteState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Muted => std::option::Option::Some(1),
+                Self::Undefined => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MUTE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MUTED"),
-                2 => std::borrow::Cow::Borrowed("UNDEFINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MUTE_STATE_UNSPECIFIED"),
+                Self::Muted => std::option::Option::Some("MUTED"),
+                Self::Undefined => std::option::Option::Some("UNDEFINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MUTE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::MUTE_STATE_UNSPECIFIED),
-                "MUTED" => std::option::Option::Some(Self::MUTED),
-                "UNDEFINED" => std::option::Option::Some(Self::UNDEFINED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MuteState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MuteState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MuteState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MuteState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Muted,
+                2 => Self::Undefined,
+                _ => Self::UnknownValue(mute_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MuteState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MUTE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "MUTED" => Self::Muted,
+                "UNDEFINED" => Self::Undefined,
+                _ => Self::UnknownValue(mute_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MuteState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Muted => serializer.serialize_i32(1),
+                Self::Undefined => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MuteState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MuteState>::new(
+                ".google.cloud.securitycenter.v2.BulkMuteFindingsRequest.MuteState",
+            ))
         }
     }
 }
@@ -13217,66 +14681,127 @@ pub mod valued_resource {
     use super::*;
 
     /// How valuable the resource is.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResourceValue(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResourceValue {
+        /// The resource value isn't specified.
+        Unspecified,
+        /// This is a low-value resource.
+        Low,
+        /// This is a medium-value resource.
+        Medium,
+        /// This is a high-value resource.
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResourceValue::value] or
+        /// [ResourceValue::name].
+        UnknownValue(resource_value::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod resource_value {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ResourceValue {
-        /// The resource value isn't specified.
-        pub const RESOURCE_VALUE_UNSPECIFIED: ResourceValue = ResourceValue::new(0);
-
-        /// This is a low-value resource.
-        pub const RESOURCE_VALUE_LOW: ResourceValue = ResourceValue::new(1);
-
-        /// This is a medium-value resource.
-        pub const RESOURCE_VALUE_MEDIUM: ResourceValue = ResourceValue::new(2);
-
-        /// This is a high-value resource.
-        pub const RESOURCE_VALUE_HIGH: ResourceValue = ResourceValue::new(3);
-
-        /// Creates a new ResourceValue instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::Medium => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_LOW"),
-                2 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESOURCE_VALUE_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("RESOURCE_VALUE_LOW"),
+                Self::Medium => std::option::Option::Some("RESOURCE_VALUE_MEDIUM"),
+                Self::High => std::option::Option::Some("RESOURCE_VALUE_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESOURCE_VALUE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESOURCE_VALUE_UNSPECIFIED)
-                }
-                "RESOURCE_VALUE_LOW" => std::option::Option::Some(Self::RESOURCE_VALUE_LOW),
-                "RESOURCE_VALUE_MEDIUM" => std::option::Option::Some(Self::RESOURCE_VALUE_MEDIUM),
-                "RESOURCE_VALUE_HIGH" => std::option::Option::Some(Self::RESOURCE_VALUE_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResourceValue {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResourceValue {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResourceValue {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResourceValue {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::Medium,
+                3 => Self::High,
+                _ => Self::UnknownValue(resource_value::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResourceValue {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESOURCE_VALUE_UNSPECIFIED" => Self::Unspecified,
+                "RESOURCE_VALUE_LOW" => Self::Low,
+                "RESOURCE_VALUE_MEDIUM" => Self::Medium,
+                "RESOURCE_VALUE_HIGH" => Self::High,
+                _ => Self::UnknownValue(resource_value::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResourceValue {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::Medium => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResourceValue {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceValue>::new(
+                ".google.cloud.securitycenter.v2.ValuedResource.ResourceValue",
+            ))
         }
     }
 }
@@ -13549,152 +15074,279 @@ pub mod cve {
 
     /// The possible values of impact of the vulnerability if it was to be
     /// exploited.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RiskRating(i32);
-
-    impl RiskRating {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RiskRating {
         /// Invalid or empty value.
-        pub const RISK_RATING_UNSPECIFIED: RiskRating = RiskRating::new(0);
-
+        Unspecified,
         /// Exploitation would have little to no security impact.
-        pub const LOW: RiskRating = RiskRating::new(1);
-
+        Low,
         /// Exploitation would enable attackers to perform activities, or could allow
         /// attackers to have a direct impact, but would require additional steps.
-        pub const MEDIUM: RiskRating = RiskRating::new(2);
-
+        Medium,
         /// Exploitation would enable attackers to have a notable direct impact
         /// without needing to overcome any major mitigating factors.
-        pub const HIGH: RiskRating = RiskRating::new(3);
-
+        High,
         /// Exploitation would fundamentally undermine the security of affected
         /// systems, enable actors to perform significant attacks with minimal
         /// effort, with little to no mitigating factors to overcome.
-        pub const CRITICAL: RiskRating = RiskRating::new(4);
+        Critical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RiskRating::value] or
+        /// [RiskRating::name].
+        UnknownValue(risk_rating::UnknownValue),
+    }
 
-        /// Creates a new RiskRating instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod risk_rating {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RiskRating {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::Medium => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::Critical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RISK_RATING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOW"),
-                2 => std::borrow::Cow::Borrowed("MEDIUM"),
-                3 => std::borrow::Cow::Borrowed("HIGH"),
-                4 => std::borrow::Cow::Borrowed("CRITICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RISK_RATING_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RISK_RATING_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RISK_RATING_UNSPECIFIED)
-                }
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RiskRating {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RiskRating {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RiskRating {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RiskRating {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::Medium,
+                3 => Self::High,
+                4 => Self::Critical,
+                _ => Self::UnknownValue(risk_rating::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RiskRating {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RISK_RATING_UNSPECIFIED" => Self::Unspecified,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                "CRITICAL" => Self::Critical,
+                _ => Self::UnknownValue(risk_rating::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RiskRating {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::Medium => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::Critical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RiskRating {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RiskRating>::new(
+                ".google.cloud.securitycenter.v2.Cve.RiskRating",
+            ))
         }
     }
 
     /// The possible values of exploitation activity of the vulnerability in the
     /// wild.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExploitationActivity(i32);
-
-    impl ExploitationActivity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExploitationActivity {
         /// Invalid or empty value.
-        pub const EXPLOITATION_ACTIVITY_UNSPECIFIED: ExploitationActivity =
-            ExploitationActivity::new(0);
-
+        Unspecified,
         /// Exploitation has been reported or confirmed to widely occur.
-        pub const WIDE: ExploitationActivity = ExploitationActivity::new(1);
-
+        Wide,
         /// Limited reported or confirmed exploitation activities.
-        pub const CONFIRMED: ExploitationActivity = ExploitationActivity::new(2);
-
+        Confirmed,
         /// Exploit is publicly available.
-        pub const AVAILABLE: ExploitationActivity = ExploitationActivity::new(3);
-
+        Available,
         /// No known exploitation activity, but has a high potential for
         /// exploitation.
-        pub const ANTICIPATED: ExploitationActivity = ExploitationActivity::new(4);
-
+        Anticipated,
         /// No known exploitation activity.
-        pub const NO_KNOWN: ExploitationActivity = ExploitationActivity::new(5);
+        NoKnown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExploitationActivity::value] or
+        /// [ExploitationActivity::name].
+        UnknownValue(exploitation_activity::UnknownValue),
+    }
 
-        /// Creates a new ExploitationActivity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod exploitation_activity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExploitationActivity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Wide => std::option::Option::Some(1),
+                Self::Confirmed => std::option::Option::Some(2),
+                Self::Available => std::option::Option::Some(3),
+                Self::Anticipated => std::option::Option::Some(4),
+                Self::NoKnown => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXPLOITATION_ACTIVITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WIDE"),
-                2 => std::borrow::Cow::Borrowed("CONFIRMED"),
-                3 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                4 => std::borrow::Cow::Borrowed("ANTICIPATED"),
-                5 => std::borrow::Cow::Borrowed("NO_KNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXPLOITATION_ACTIVITY_UNSPECIFIED"),
+                Self::Wide => std::option::Option::Some("WIDE"),
+                Self::Confirmed => std::option::Option::Some("CONFIRMED"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Anticipated => std::option::Option::Some("ANTICIPATED"),
+                Self::NoKnown => std::option::Option::Some("NO_KNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXPLOITATION_ACTIVITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXPLOITATION_ACTIVITY_UNSPECIFIED)
-                }
-                "WIDE" => std::option::Option::Some(Self::WIDE),
-                "CONFIRMED" => std::option::Option::Some(Self::CONFIRMED),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "ANTICIPATED" => std::option::Option::Some(Self::ANTICIPATED),
-                "NO_KNOWN" => std::option::Option::Some(Self::NO_KNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExploitationActivity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExploitationActivity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExploitationActivity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExploitationActivity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Wide,
+                2 => Self::Confirmed,
+                3 => Self::Available,
+                4 => Self::Anticipated,
+                5 => Self::NoKnown,
+                _ => Self::UnknownValue(exploitation_activity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExploitationActivity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXPLOITATION_ACTIVITY_UNSPECIFIED" => Self::Unspecified,
+                "WIDE" => Self::Wide,
+                "CONFIRMED" => Self::Confirmed,
+                "AVAILABLE" => Self::Available,
+                "ANTICIPATED" => Self::Anticipated,
+                "NO_KNOWN" => Self::NoKnown,
+                _ => Self::UnknownValue(exploitation_activity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExploitationActivity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Wide => serializer.serialize_i32(1),
+                Self::Confirmed => serializer.serialize_i32(2),
+                Self::Available => serializer.serialize_i32(3),
+                Self::Anticipated => serializer.serialize_i32(4),
+                Self::NoKnown => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExploitationActivity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExploitationActivity>::new(
+                ".google.cloud.securitycenter.v2.Cve.ExploitationActivity",
+            ))
         }
     }
 }
@@ -13889,408 +15541,766 @@ pub mod cvssv_3 {
 
     /// This metric reflects the context by which vulnerability exploitation is
     /// possible.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(i32);
-
-    impl AttackVector {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackVector {
         /// Invalid value.
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
-
+        Unspecified,
         /// The vulnerable component is bound to the network stack and the set of
         /// possible attackers extends beyond the other options listed below, up to
         /// and including the entire Internet.
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
-
+        Network,
         /// The vulnerable component is bound to the network stack, but the attack is
         /// limited at the protocol level to a logically adjacent topology.
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
-
+        Adjacent,
         /// The vulnerable component is not bound to the network stack and the
         /// attacker's path is via read/write/execute capabilities.
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
-
+        Local,
         /// The attack requires the attacker to physically touch or manipulate the
         /// vulnerable component.
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
+        Physical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackVector::value] or
+        /// [AttackVector::name].
+        UnknownValue(attack_vector::UnknownValue),
+    }
 
-        /// Creates a new AttackVector instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attack_vector {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttackVector {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Network => std::option::Option::Some(1),
+                Self::Adjacent => std::option::Option::Some(2),
+                Self::Local => std::option::Option::Some(3),
+                Self::Physical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
-                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
-                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_VECTOR_UNSPECIFIED"),
+                Self::Network => std::option::Option::Some("ATTACK_VECTOR_NETWORK"),
+                Self::Adjacent => std::option::Option::Some("ATTACK_VECTOR_ADJACENT"),
+                Self::Local => std::option::Option::Some("ATTACK_VECTOR_LOCAL"),
+                Self::Physical => std::option::Option::Some("ATTACK_VECTOR_PHYSICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_VECTOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
-                }
-                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
-                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
-                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
-                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackVector {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttackVector {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Network,
+                2 => Self::Adjacent,
+                3 => Self::Local,
+                4 => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackVector {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_VECTOR_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_VECTOR_NETWORK" => Self::Network,
+                "ATTACK_VECTOR_ADJACENT" => Self::Adjacent,
+                "ATTACK_VECTOR_LOCAL" => Self::Local,
+                "ATTACK_VECTOR_PHYSICAL" => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackVector {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Network => serializer.serialize_i32(1),
+                Self::Adjacent => serializer.serialize_i32(2),
+                Self::Local => serializer.serialize_i32(3),
+                Self::Physical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackVector {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackVector>::new(
+                ".google.cloud.securitycenter.v2.Cvssv3.AttackVector",
+            ))
         }
     }
 
     /// This metric describes the conditions beyond the attacker's control that
     /// must exist in order to exploit the vulnerability.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(i32);
-
-    impl AttackComplexity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackComplexity {
         /// Invalid value.
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
-
+        Unspecified,
         /// Specialized access conditions or extenuating circumstances do not exist.
         /// An attacker can expect repeatable success when attacking the vulnerable
         /// component.
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
-
+        Low,
         /// A successful attack depends on conditions beyond the attacker's control.
         /// That is, a successful attack cannot be accomplished at will, but requires
         /// the attacker to invest in some measurable amount of effort in preparation
         /// or execution against the vulnerable component before a successful attack
         /// can be expected.
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackComplexity::value] or
+        /// [AttackComplexity::name].
+        UnknownValue(attack_complexity::UnknownValue),
+    }
 
-        /// Creates a new AttackComplexity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attack_complexity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttackComplexity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("ATTACK_COMPLEXITY_LOW"),
+                Self::High => std::option::Option::Some("ATTACK_COMPLEXITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
-                }
-                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
-                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackComplexity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttackComplexity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::High,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackComplexity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_COMPLEXITY_LOW" => Self::Low,
+                "ATTACK_COMPLEXITY_HIGH" => Self::High,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackComplexity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackComplexity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackComplexity>::new(
+                ".google.cloud.securitycenter.v2.Cvssv3.AttackComplexity",
+            ))
         }
     }
 
     /// This metric describes the level of privileges an attacker must possess
     /// before successfully exploiting the vulnerability.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(i32);
-
-    impl PrivilegesRequired {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PrivilegesRequired {
         /// Invalid value.
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
-
+        Unspecified,
         /// The attacker is unauthorized prior to attack, and therefore does not
         /// require any access to settings or files of the vulnerable system to
         /// carry out an attack.
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
-
+        None,
         /// The attacker requires privileges that provide basic user capabilities
         /// that could normally affect only settings and files owned by a user.
         /// Alternatively, an attacker with Low privileges has the ability to access
         /// only non-sensitive resources.
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
-
+        Low,
         /// The attacker requires privileges that provide significant (e.g.,
         /// administrative) control over the vulnerable component allowing access to
         /// component-wide settings and files.
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PrivilegesRequired::value] or
+        /// [PrivilegesRequired::name].
+        UnknownValue(privileges_required::UnknownValue),
+    }
 
-        /// Creates a new PrivilegesRequired instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod privileges_required {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PrivilegesRequired {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
-                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
-                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("PRIVILEGES_REQUIRED_NONE"),
+                Self::Low => std::option::Option::Some("PRIVILEGES_REQUIRED_LOW"),
+                Self::High => std::option::Option::Some("PRIVILEGES_REQUIRED_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
-                }
-                "PRIVILEGES_REQUIRED_NONE" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
-                }
-                "PRIVILEGES_REQUIRED_LOW" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
-                }
-                "PRIVILEGES_REQUIRED_HIGH" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PrivilegesRequired {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PrivilegesRequired {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Low,
+                3 => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PrivilegesRequired {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => Self::Unspecified,
+                "PRIVILEGES_REQUIRED_NONE" => Self::None,
+                "PRIVILEGES_REQUIRED_LOW" => Self::Low,
+                "PRIVILEGES_REQUIRED_HIGH" => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PrivilegesRequired {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PrivilegesRequired {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PrivilegesRequired>::new(
+                ".google.cloud.securitycenter.v2.Cvssv3.PrivilegesRequired",
+            ))
         }
     }
 
     /// This metric captures the requirement for a human user, other than the
     /// attacker, to participate in the successful compromise of the vulnerable
     /// component.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(i32);
-
-    impl UserInteraction {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserInteraction {
         /// Invalid value.
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
-
+        Unspecified,
         /// The vulnerable system can be exploited without interaction from any user.
-        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
-
+        None,
         /// Successful exploitation of this vulnerability requires a user to take
         /// some action before the vulnerability can be exploited.
-        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
+        Required,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserInteraction::value] or
+        /// [UserInteraction::name].
+        UnknownValue(user_interaction::UnknownValue),
+    }
 
-        /// Creates a new UserInteraction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod user_interaction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl UserInteraction {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Required => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
-                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("USER_INTERACTION_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("USER_INTERACTION_NONE"),
+                Self::Required => std::option::Option::Some("USER_INTERACTION_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_INTERACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
-                }
-                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
-                "USER_INTERACTION_REQUIRED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UserInteraction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UserInteraction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserInteraction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_INTERACTION_UNSPECIFIED" => Self::Unspecified,
+                "USER_INTERACTION_NONE" => Self::None,
+                "USER_INTERACTION_REQUIRED" => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserInteraction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Required => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserInteraction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserInteraction>::new(
+                ".google.cloud.securitycenter.v2.Cvssv3.UserInteraction",
+            ))
         }
     }
 
     /// The Scope metric captures whether a vulnerability in one vulnerable
     /// component impacts resources in components beyond its security scope.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
-
-    impl Scope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
         /// Invalid value.
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
-
+        Unspecified,
         /// An exploited vulnerability can only affect resources managed by the same
         /// security authority.
-        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
-
+        Unchanged,
         /// An exploited vulnerability can affect resources beyond the security scope
         /// managed by the security authority of the vulnerable component.
-        pub const SCOPE_CHANGED: Scope = Scope::new(2);
+        Changed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
 
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Scope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unchanged => std::option::Option::Some(1),
+                Self::Changed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
-                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCOPE_UNSPECIFIED"),
+                Self::Unchanged => std::option::Option::Some("SCOPE_UNCHANGED"),
+                Self::Changed => std::option::Option::Some("SCOPE_CHANGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
-                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
-                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unchanged,
+                2 => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "SCOPE_UNCHANGED" => Self::Unchanged,
+                "SCOPE_CHANGED" => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unchanged => serializer.serialize_i32(1),
+                Self::Changed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".google.cloud.securitycenter.v2.Cvssv3.Scope",
+            ))
         }
     }
 
     /// The Impact metrics capture the effects of a successfully exploited
     /// vulnerability on the component that suffers the worst outcome that is most
     /// directly and predictably associated with the attack.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Impact {
+        /// Invalid value.
+        Unspecified,
+        /// High impact.
+        High,
+        /// Low impact.
+        Low,
+        /// No impact.
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Impact::value] or
+        /// [Impact::name].
+        UnknownValue(impact::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod impact {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Impact {
-        /// Invalid value.
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
-
-        /// High impact.
-        pub const IMPACT_HIGH: Impact = Impact::new(1);
-
-        /// Low impact.
-        pub const IMPACT_LOW: Impact = Impact::new(2);
-
-        /// No impact.
-        pub const IMPACT_NONE: Impact = Impact::new(3);
-
-        /// Creates a new Impact instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
-                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
-                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPACT_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("IMPACT_HIGH"),
+                Self::Low => std::option::Option::Some("IMPACT_LOW"),
+                Self::None => std::option::Option::Some("IMPACT_NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
-                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
-                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
-                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Impact {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Impact {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::Low,
+                3 => Self::None,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Impact {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPACT_UNSPECIFIED" => Self::Unspecified,
+                "IMPACT_HIGH" => Self::High,
+                "IMPACT_LOW" => Self::Low,
+                "IMPACT_NONE" => Self::None,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Impact {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Impact {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Impact>::new(
+                ".google.cloud.securitycenter.v2.Cvssv3.Impact",
+            ))
         }
     }
 }
@@ -14417,134 +16427,258 @@ impl wkt::message::Message for SecurityBulletin {
 }
 
 /// The cloud provider the finding pertains to.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CloudProvider(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CloudProvider {
+    /// The cloud provider is unspecified.
+    Unspecified,
+    /// The cloud provider is Google Cloud Platform.
+    GoogleCloudPlatform,
+    /// The cloud provider is Amazon Web Services.
+    AmazonWebServices,
+    /// The cloud provider is Microsoft Azure.
+    MicrosoftAzure,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CloudProvider::value] or
+    /// [CloudProvider::name].
+    UnknownValue(cloud_provider::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod cloud_provider {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CloudProvider {
-    /// The cloud provider is unspecified.
-    pub const CLOUD_PROVIDER_UNSPECIFIED: CloudProvider = CloudProvider::new(0);
-
-    /// The cloud provider is Google Cloud Platform.
-    pub const GOOGLE_CLOUD_PLATFORM: CloudProvider = CloudProvider::new(1);
-
-    /// The cloud provider is Amazon Web Services.
-    pub const AMAZON_WEB_SERVICES: CloudProvider = CloudProvider::new(2);
-
-    /// The cloud provider is Microsoft Azure.
-    pub const MICROSOFT_AZURE: CloudProvider = CloudProvider::new(3);
-
-    /// Creates a new CloudProvider instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::GoogleCloudPlatform => std::option::Option::Some(1),
+            Self::AmazonWebServices => std::option::Option::Some(2),
+            Self::MicrosoftAzure => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CLOUD_PROVIDER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD_PLATFORM"),
-            2 => std::borrow::Cow::Borrowed("AMAZON_WEB_SERVICES"),
-            3 => std::borrow::Cow::Borrowed("MICROSOFT_AZURE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CLOUD_PROVIDER_UNSPECIFIED"),
+            Self::GoogleCloudPlatform => std::option::Option::Some("GOOGLE_CLOUD_PLATFORM"),
+            Self::AmazonWebServices => std::option::Option::Some("AMAZON_WEB_SERVICES"),
+            Self::MicrosoftAzure => std::option::Option::Some("MICROSOFT_AZURE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CLOUD_PROVIDER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CLOUD_PROVIDER_UNSPECIFIED)
-            }
-            "GOOGLE_CLOUD_PLATFORM" => std::option::Option::Some(Self::GOOGLE_CLOUD_PLATFORM),
-            "AMAZON_WEB_SERVICES" => std::option::Option::Some(Self::AMAZON_WEB_SERVICES),
-            "MICROSOFT_AZURE" => std::option::Option::Some(Self::MICROSOFT_AZURE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CloudProvider {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CloudProvider {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CloudProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CloudProvider {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::GoogleCloudPlatform,
+            2 => Self::AmazonWebServices,
+            3 => Self::MicrosoftAzure,
+            _ => Self::UnknownValue(cloud_provider::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CloudProvider {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CLOUD_PROVIDER_UNSPECIFIED" => Self::Unspecified,
+            "GOOGLE_CLOUD_PLATFORM" => Self::GoogleCloudPlatform,
+            "AMAZON_WEB_SERVICES" => Self::AmazonWebServices,
+            "MICROSOFT_AZURE" => Self::MicrosoftAzure,
+            _ => Self::UnknownValue(cloud_provider::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CloudProvider {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::GoogleCloudPlatform => serializer.serialize_i32(1),
+            Self::AmazonWebServices => serializer.serialize_i32(2),
+            Self::MicrosoftAzure => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CloudProvider {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CloudProvider>::new(
+            ".google.cloud.securitycenter.v2.CloudProvider",
+        ))
     }
 }
 
 /// Value enum to map to a resource
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceValue(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ResourceValue {
+    /// Unspecific value
+    Unspecified,
+    /// High resource value
+    High,
+    /// Medium resource value
+    Medium,
+    /// Low resource value
+    Low,
+    /// No resource value, e.g. ignore these resources
+    None,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ResourceValue::value] or
+    /// [ResourceValue::name].
+    UnknownValue(resource_value::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod resource_value {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ResourceValue {
-    /// Unspecific value
-    pub const RESOURCE_VALUE_UNSPECIFIED: ResourceValue = ResourceValue::new(0);
-
-    /// High resource value
-    pub const HIGH: ResourceValue = ResourceValue::new(1);
-
-    /// Medium resource value
-    pub const MEDIUM: ResourceValue = ResourceValue::new(2);
-
-    /// Low resource value
-    pub const LOW: ResourceValue = ResourceValue::new(3);
-
-    /// No resource value, e.g. ignore these resources
-    pub const NONE: ResourceValue = ResourceValue::new(4);
-
-    /// Creates a new ResourceValue instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::High => std::option::Option::Some(1),
+            Self::Medium => std::option::Option::Some(2),
+            Self::Low => std::option::Option::Some(3),
+            Self::None => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESOURCE_VALUE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HIGH"),
-            2 => std::borrow::Cow::Borrowed("MEDIUM"),
-            3 => std::borrow::Cow::Borrowed("LOW"),
-            4 => std::borrow::Cow::Borrowed("NONE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RESOURCE_VALUE_UNSPECIFIED"),
+            Self::High => std::option::Option::Some("HIGH"),
+            Self::Medium => std::option::Option::Some("MEDIUM"),
+            Self::Low => std::option::Option::Some("LOW"),
+            Self::None => std::option::Option::Some("NONE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESOURCE_VALUE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESOURCE_VALUE_UNSPECIFIED)
-            }
-            "HIGH" => std::option::Option::Some(Self::HIGH),
-            "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-            "LOW" => std::option::Option::Some(Self::LOW),
-            "NONE" => std::option::Option::Some(Self::NONE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ResourceValue {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceValue {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ResourceValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ResourceValue {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::High,
+            2 => Self::Medium,
+            3 => Self::Low,
+            4 => Self::None,
+            _ => Self::UnknownValue(resource_value::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ResourceValue {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESOURCE_VALUE_UNSPECIFIED" => Self::Unspecified,
+            "HIGH" => Self::High,
+            "MEDIUM" => Self::Medium,
+            "LOW" => Self::Low,
+            "NONE" => Self::None,
+            _ => Self::UnknownValue(resource_value::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ResourceValue {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::High => serializer.serialize_i32(1),
+            Self::Medium => serializer.serialize_i32(2),
+            Self::Low => serializer.serialize_i32(3),
+            Self::None => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ResourceValue {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceValue>::new(
+            ".google.cloud.securitycenter.v2.ResourceValue",
+        ))
     }
 }

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -433,126 +433,246 @@ pub mod custom_constraint {
     ///
     /// `UPDATE` only custom constraints are not supported. Use `CREATE` or
     /// `CREATE, UPDATE`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MethodType(i32);
-
-    impl MethodType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MethodType {
         /// Unspecified. Results in an error.
-        pub const METHOD_TYPE_UNSPECIFIED: MethodType = MethodType::new(0);
-
+        Unspecified,
         /// Constraint applied when creating the resource.
-        pub const CREATE: MethodType = MethodType::new(1);
-
+        Create,
         /// Constraint applied when updating the resource.
-        pub const UPDATE: MethodType = MethodType::new(2);
-
+        Update,
         /// Constraint applied when deleting the resource.
         /// Not supported yet.
-        pub const DELETE: MethodType = MethodType::new(3);
+        Delete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MethodType::value] or
+        /// [MethodType::name].
+        UnknownValue(method_type::UnknownValue),
+    }
 
-        /// Creates a new MethodType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod method_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MethodType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("METHOD_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("METHOD_TYPE_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "METHOD_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::METHOD_TYPE_UNSPECIFIED)
-                }
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MethodType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MethodType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MethodType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MethodType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                _ => Self::UnknownValue(method_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MethodType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "METHOD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                _ => Self::UnknownValue(method_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MethodType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MethodType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MethodType>::new(
+                ".google.cloud.securityposture.v1.CustomConstraint.MethodType",
+            ))
         }
     }
 
     /// Allow or deny type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ActionType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ActionType {
+        /// Unspecified. Results in an error.
+        Unspecified,
+        /// Allowed action type.
+        Allow,
+        /// Deny action type.
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ActionType::value] or
+        /// [ActionType::name].
+        UnknownValue(action_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ActionType {
-        /// Unspecified. Results in an error.
-        pub const ACTION_TYPE_UNSPECIFIED: ActionType = ActionType::new(0);
-
-        /// Allowed action type.
-        pub const ALLOW: ActionType = ActionType::new(1);
-
-        /// Deny action type.
-        pub const DENY: ActionType = ActionType::new(2);
-
-        /// Creates a new ActionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_TYPE_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ACTION_TYPE_UNSPECIFIED)
-                }
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ActionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ActionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ActionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ActionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(action_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ActionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(action_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ActionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ActionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ActionType>::new(
+                ".google.cloud.securityposture.v1.CustomConstraint.ActionType",
+            ))
         }
     }
 }
@@ -935,64 +1055,127 @@ pub mod posture {
     use super::*;
 
     /// State of a Posture.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified operation state.
+        Unspecified,
+        /// The Posture is marked deprecated when it is not in use by the user.
+        Deprecated,
+        /// The Posture is created successfully but is not yet ready for usage.
+        Draft,
+        /// The Posture state is active. Ready for use/deployments.
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified operation state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Posture is marked deprecated when it is not in use by the user.
-        pub const DEPRECATED: State = State::new(1);
-
-        /// The Posture is created successfully but is not yet ready for usage.
-        pub const DRAFT: State = State::new(2);
-
-        /// The Posture state is active. Ready for use/deployments.
-        pub const ACTIVE: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Deprecated => std::option::Option::Some(1),
+                Self::Draft => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                2 => std::borrow::Cow::Borrowed("DRAFT"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Deprecated,
+                2 => Self::Draft,
+                3 => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DEPRECATED" => Self::Deprecated,
+                "DRAFT" => Self::Draft,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Deprecated => serializer.serialize_i32(1),
+                Self::Draft => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.securityposture.v1.Posture.State",
+            ))
         }
     }
 }
@@ -2085,84 +2268,155 @@ pub mod posture_deployment {
     use super::*;
 
     /// State of a PostureDeployment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified operation state.
+        Unspecified,
+        /// The PostureDeployment is being created.
+        Creating,
+        /// The PostureDeployment is being deleted.
+        Deleting,
+        /// The PostureDeployment state is being updated.
+        Updating,
+        /// The PostureDeployment state is active and in use.
+        Active,
+        /// The PostureDeployment creation failed.
+        CreateFailed,
+        /// The PostureDeployment update failed.
+        UpdateFailed,
+        /// The PostureDeployment deletion failed.
+        DeleteFailed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified operation state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The PostureDeployment is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The PostureDeployment is being deleted.
-        pub const DELETING: State = State::new(2);
-
-        /// The PostureDeployment state is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The PostureDeployment state is active and in use.
-        pub const ACTIVE: State = State::new(4);
-
-        /// The PostureDeployment creation failed.
-        pub const CREATE_FAILED: State = State::new(5);
-
-        /// The PostureDeployment update failed.
-        pub const UPDATE_FAILED: State = State::new(6);
-
-        /// The PostureDeployment deletion failed.
-        pub const DELETE_FAILED: State = State::new(7);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Deleting => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Active => std::option::Option::Some(4),
+                Self::CreateFailed => std::option::Option::Some(5),
+                Self::UpdateFailed => std::option::Option::Some(6),
+                Self::DeleteFailed => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("DELETING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("ACTIVE"),
-                5 => std::borrow::Cow::Borrowed("CREATE_FAILED"),
-                6 => std::borrow::Cow::Borrowed("UPDATE_FAILED"),
-                7 => std::borrow::Cow::Borrowed("DELETE_FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::CreateFailed => std::option::Option::Some("CREATE_FAILED"),
+                Self::UpdateFailed => std::option::Option::Some("UPDATE_FAILED"),
+                Self::DeleteFailed => std::option::Option::Some("DELETE_FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATE_FAILED" => std::option::Option::Some(Self::CREATE_FAILED),
-                "UPDATE_FAILED" => std::option::Option::Some(Self::UPDATE_FAILED),
-                "DELETE_FAILED" => std::option::Option::Some(Self::DELETE_FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Deleting,
+                3 => Self::Updating,
+                4 => Self::Active,
+                5 => Self::CreateFailed,
+                6 => Self::UpdateFailed,
+                7 => Self::DeleteFailed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "UPDATING" => Self::Updating,
+                "ACTIVE" => Self::Active,
+                "CREATE_FAILED" => Self::CreateFailed,
+                "UPDATE_FAILED" => Self::UpdateFailed,
+                "DELETE_FAILED" => Self::DeleteFailed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Deleting => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Active => serializer.serialize_i32(4),
+                Self::CreateFailed => serializer.serialize_i32(5),
+                Self::UpdateFailed => serializer.serialize_i32(6),
+                Self::DeleteFailed => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.securityposture.v1.PostureDeployment.State",
+            ))
         }
     }
 }
@@ -2585,60 +2839,121 @@ pub mod posture_template {
     use super::*;
 
     /// State of a PostureTemplate
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// If the Posture template is adhering to the latest controls and standards.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// If the Posture template controls and standards are outdated and not
         /// recommended for use.
-        pub const DEPRECATED: State = State::new(2);
+        Deprecated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Deprecated => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Deprecated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DEPRECATED" => Self::Deprecated,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Deprecated => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.securityposture.v1.PostureTemplate.State",
+            ))
         }
     }
 }
@@ -3175,128 +3490,252 @@ pub mod custom_config {
     }
 
     /// Defines the valid value options for the severity of a finding.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// Unspecified severity.
+        Unspecified,
+        /// Critical severity.
+        Critical,
+        /// High severity.
+        High,
+        /// Medium severity.
+        Medium,
+        /// Low severity.
+        Low,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// Unspecified severity.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// Critical severity.
-        pub const CRITICAL: Severity = Severity::new(1);
-
-        /// High severity.
-        pub const HIGH: Severity = Severity::new(2);
-
-        /// Medium severity.
-        pub const MEDIUM: Severity = Severity::new(3);
-
-        /// Low severity.
-        pub const LOW: Severity = Severity::new(4);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Critical => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::Low => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CRITICAL"),
-                2 => std::borrow::Cow::Borrowed("HIGH"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("LOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Critical,
+                2 => Self::High,
+                3 => Self::Medium,
+                4 => Self::Low,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "CRITICAL" => Self::Critical,
+                "HIGH" => Self::High,
+                "MEDIUM" => Self::Medium,
+                "LOW" => Self::Low,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Critical => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::Low => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.securityposture.v1.CustomConfig.Severity",
+            ))
         }
     }
 }
 
 /// Possible enablement states of a service or module.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EnablementState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EnablementState {
+    /// Default value. This value is unused.
+    Unspecified,
+    /// State is enabled.
+    Enabled,
+    /// State is disabled.
+    Disabled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EnablementState::value] or
+    /// [EnablementState::name].
+    UnknownValue(enablement_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod enablement_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl EnablementState {
-    /// Default value. This value is unused.
-    pub const ENABLEMENT_STATE_UNSPECIFIED: EnablementState = EnablementState::new(0);
-
-    /// State is enabled.
-    pub const ENABLED: EnablementState = EnablementState::new(1);
-
-    /// State is disabled.
-    pub const DISABLED: EnablementState = EnablementState::new(2);
-
-    /// Creates a new EnablementState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enabled => std::option::Option::Some(1),
+            Self::Disabled => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENABLEMENT_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENABLED"),
-            2 => std::borrow::Cow::Borrowed("DISABLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENABLEMENT_STATE_UNSPECIFIED"),
+            Self::Enabled => std::option::Option::Some("ENABLED"),
+            Self::Disabled => std::option::Option::Some("DISABLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENABLEMENT_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ENABLEMENT_STATE_UNSPECIFIED)
-            }
-            "ENABLED" => std::option::Option::Some(Self::ENABLED),
-            "DISABLED" => std::option::Option::Some(Self::DISABLED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EnablementState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EnablementState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EnablementState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EnablementState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enabled,
+            2 => Self::Disabled,
+            _ => Self::UnknownValue(enablement_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EnablementState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENABLEMENT_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ENABLED" => Self::Enabled,
+            "DISABLED" => Self::Disabled,
+            _ => Self::UnknownValue(enablement_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EnablementState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enabled => serializer.serialize_i32(1),
+            Self::Disabled => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EnablementState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnablementState>::new(
+            ".google.cloud.securityposture.v1.EnablementState",
+        ))
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -246,206 +246,377 @@ pub mod event {
 
     /// The category of the event. This enum lists all possible categories of
     /// event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventCategory(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventCategory {
+        /// Unspecified category.
+        Unspecified,
+        /// Event category for service outage or degradation.
+        Incident,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventCategory::value] or
+        /// [EventCategory::name].
+        UnknownValue(event_category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventCategory {
-        /// Unspecified category.
-        pub const EVENT_CATEGORY_UNSPECIFIED: EventCategory = EventCategory::new(0);
-
-        /// Event category for service outage or degradation.
-        pub const INCIDENT: EventCategory = EventCategory::new(2);
-
-        /// Creates a new EventCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incident => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_CATEGORY_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("INCIDENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_CATEGORY_UNSPECIFIED"),
+                Self::Incident => std::option::Option::Some("INCIDENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_CATEGORY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVENT_CATEGORY_UNSPECIFIED)
-                }
-                "INCIDENT" => std::option::Option::Some(Self::INCIDENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Incident,
+                _ => Self::UnknownValue(event_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "INCIDENT" => Self::Incident,
+                _ => Self::UnknownValue(event_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incident => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventCategory>::new(
+                ".google.cloud.servicehealth.v1.Event.EventCategory",
+            ))
         }
     }
 
     /// The detailed category of an event. Contains all possible states for all
     /// event categories.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedCategory(i32);
-
-    impl DetailedCategory {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DetailedCategory {
         /// Unspecified detailed category.
-        pub const DETAILED_CATEGORY_UNSPECIFIED: DetailedCategory = DetailedCategory::new(0);
-
+        Unspecified,
         /// Indicates an event with category INCIDENT has a confirmed impact to at
         /// least one Google Cloud product.
-        pub const CONFIRMED_INCIDENT: DetailedCategory = DetailedCategory::new(1);
-
+        ConfirmedIncident,
         /// Indicates an event with category INCIDENT is under investigation to
         /// determine if it has a confirmed impact on any Google Cloud products.
-        pub const EMERGING_INCIDENT: DetailedCategory = DetailedCategory::new(2);
+        EmergingIncident,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DetailedCategory::value] or
+        /// [DetailedCategory::name].
+        UnknownValue(detailed_category::UnknownValue),
+    }
 
-        /// Creates a new DetailedCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod detailed_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DetailedCategory {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConfirmedIncident => std::option::Option::Some(1),
+                Self::EmergingIncident => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DETAILED_CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFIRMED_INCIDENT"),
-                2 => std::borrow::Cow::Borrowed("EMERGING_INCIDENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DETAILED_CATEGORY_UNSPECIFIED"),
+                Self::ConfirmedIncident => std::option::Option::Some("CONFIRMED_INCIDENT"),
+                Self::EmergingIncident => std::option::Option::Some("EMERGING_INCIDENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DETAILED_CATEGORY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DETAILED_CATEGORY_UNSPECIFIED)
-                }
-                "CONFIRMED_INCIDENT" => std::option::Option::Some(Self::CONFIRMED_INCIDENT),
-                "EMERGING_INCIDENT" => std::option::Option::Some(Self::EMERGING_INCIDENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DetailedCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DetailedCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DetailedCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConfirmedIncident,
+                2 => Self::EmergingIncident,
+                _ => Self::UnknownValue(detailed_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DetailedCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DETAILED_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "CONFIRMED_INCIDENT" => Self::ConfirmedIncident,
+                "EMERGING_INCIDENT" => Self::EmergingIncident,
+                _ => Self::UnknownValue(detailed_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DetailedCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConfirmedIncident => serializer.serialize_i32(1),
+                Self::EmergingIncident => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DetailedCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DetailedCategory>::new(
+                ".google.cloud.servicehealth.v1.Event.DetailedCategory",
+            ))
         }
     }
 
     /// The state of the event. This enum lists all possible states of event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Event is actively affecting a Google Cloud product and will continue to
         /// receive updates.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Event is no longer affecting the Google Cloud product or has been merged
         /// with another event.
-        pub const CLOSED: State = State::new(2);
+        Closed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Closed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CLOSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Closed => std::option::Option::Some("CLOSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CLOSED" => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Closed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.servicehealth.v1.Event.State",
+            ))
         }
     }
 
     /// The detailed state of the incident. This enum lists all possible detailed
     /// states of an incident.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedState(i32);
-
-    impl DetailedState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DetailedState {
         /// Unspecified detail state.
-        pub const DETAILED_STATE_UNSPECIFIED: DetailedState = DetailedState::new(0);
-
+        Unspecified,
         /// Google engineers are actively investigating the event to determine the
         /// impact.
-        pub const EMERGING: DetailedState = DetailedState::new(1);
-
+        Emerging,
         /// The incident is confirmed and impacting at least one Google Cloud
         /// product. Ongoing status updates will be provided until it is resolved.
-        pub const CONFIRMED: DetailedState = DetailedState::new(2);
-
+        Confirmed,
         /// The incident is no longer affecting any Google Cloud product, and there
         /// will be no further updates.
-        pub const RESOLVED: DetailedState = DetailedState::new(3);
-
+        Resolved,
         /// The incident was merged into a parent incident. All further updates will
         /// be published to the parent only. The `parent_event` field contains the
         /// name of the parent.
-        pub const MERGED: DetailedState = DetailedState::new(4);
-
+        Merged,
         /// The incident was automatically closed because of the following reasons:
         ///
         /// * The impact of the incident could not be confirmed.
@@ -453,140 +624,280 @@ pub mod event {
         ///
         /// The incident does not have a resolution because no action or
         /// investigation happened. If it is intermittent, the incident may reopen.
-        pub const AUTO_CLOSED: DetailedState = DetailedState::new(9);
-
+        AutoClosed,
         /// Upon investigation, Google engineers concluded that the incident is not
         /// affecting a Google Cloud product. This state can change if the incident
         /// is reviewed again.
-        pub const FALSE_POSITIVE: DetailedState = DetailedState::new(10);
+        FalsePositive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DetailedState::value] or
+        /// [DetailedState::name].
+        UnknownValue(detailed_state::UnknownValue),
+    }
 
-        /// Creates a new DetailedState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod detailed_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DetailedState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Emerging => std::option::Option::Some(1),
+                Self::Confirmed => std::option::Option::Some(2),
+                Self::Resolved => std::option::Option::Some(3),
+                Self::Merged => std::option::Option::Some(4),
+                Self::AutoClosed => std::option::Option::Some(9),
+                Self::FalsePositive => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DETAILED_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EMERGING"),
-                2 => std::borrow::Cow::Borrowed("CONFIRMED"),
-                3 => std::borrow::Cow::Borrowed("RESOLVED"),
-                4 => std::borrow::Cow::Borrowed("MERGED"),
-                9 => std::borrow::Cow::Borrowed("AUTO_CLOSED"),
-                10 => std::borrow::Cow::Borrowed("FALSE_POSITIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DETAILED_STATE_UNSPECIFIED"),
+                Self::Emerging => std::option::Option::Some("EMERGING"),
+                Self::Confirmed => std::option::Option::Some("CONFIRMED"),
+                Self::Resolved => std::option::Option::Some("RESOLVED"),
+                Self::Merged => std::option::Option::Some("MERGED"),
+                Self::AutoClosed => std::option::Option::Some("AUTO_CLOSED"),
+                Self::FalsePositive => std::option::Option::Some("FALSE_POSITIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DETAILED_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DETAILED_STATE_UNSPECIFIED)
-                }
-                "EMERGING" => std::option::Option::Some(Self::EMERGING),
-                "CONFIRMED" => std::option::Option::Some(Self::CONFIRMED),
-                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
-                "MERGED" => std::option::Option::Some(Self::MERGED),
-                "AUTO_CLOSED" => std::option::Option::Some(Self::AUTO_CLOSED),
-                "FALSE_POSITIVE" => std::option::Option::Some(Self::FALSE_POSITIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DetailedState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DetailedState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DetailedState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Emerging,
+                2 => Self::Confirmed,
+                3 => Self::Resolved,
+                4 => Self::Merged,
+                9 => Self::AutoClosed,
+                10 => Self::FalsePositive,
+                _ => Self::UnknownValue(detailed_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DetailedState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DETAILED_STATE_UNSPECIFIED" => Self::Unspecified,
+                "EMERGING" => Self::Emerging,
+                "CONFIRMED" => Self::Confirmed,
+                "RESOLVED" => Self::Resolved,
+                "MERGED" => Self::Merged,
+                "AUTO_CLOSED" => Self::AutoClosed,
+                "FALSE_POSITIVE" => Self::FalsePositive,
+                _ => Self::UnknownValue(detailed_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DetailedState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Emerging => serializer.serialize_i32(1),
+                Self::Confirmed => serializer.serialize_i32(2),
+                Self::Resolved => serializer.serialize_i32(3),
+                Self::Merged => serializer.serialize_i32(4),
+                Self::AutoClosed => serializer.serialize_i32(9),
+                Self::FalsePositive => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DetailedState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DetailedState>::new(
+                ".google.cloud.servicehealth.v1.Event.DetailedState",
+            ))
         }
     }
 
     /// Communicates why a given incident is deemed relevant in the context of a
     /// given project. This enum lists all possible detailed states of relevance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Relevance(i32);
-
-    impl Relevance {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Relevance {
         /// Unspecified relevance.
-        pub const RELEVANCE_UNSPECIFIED: Relevance = Relevance::new(0);
-
+        Unspecified,
         /// The relevance of the incident to the project is unknown.
-        pub const UNKNOWN: Relevance = Relevance::new(2);
-
+        Unknown,
         /// The incident does not impact the project.
-        pub const NOT_IMPACTED: Relevance = Relevance::new(6);
-
+        NotImpacted,
         /// The incident is associated with a Google Cloud product your project uses,
         /// but the incident may not be impacting your project. For example, the
         /// incident may be impacting a Google Cloud product that your project uses,
         /// but in a location that your project does not use.
-        pub const PARTIALLY_RELATED: Relevance = Relevance::new(7);
-
+        PartiallyRelated,
         /// The incident has a direct connection with your project and impacts a
         /// Google Cloud product in a location your project uses.
-        pub const RELATED: Relevance = Relevance::new(8);
-
+        Related,
         /// The incident is verified to be impacting your project.
-        pub const IMPACTED: Relevance = Relevance::new(9);
+        Impacted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Relevance::value] or
+        /// [Relevance::name].
+        UnknownValue(relevance::UnknownValue),
+    }
 
-        /// Creates a new Relevance instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod relevance {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Relevance {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unknown => std::option::Option::Some(2),
+                Self::NotImpacted => std::option::Option::Some(6),
+                Self::PartiallyRelated => std::option::Option::Some(7),
+                Self::Related => std::option::Option::Some(8),
+                Self::Impacted => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RELEVANCE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                6 => std::borrow::Cow::Borrowed("NOT_IMPACTED"),
-                7 => std::borrow::Cow::Borrowed("PARTIALLY_RELATED"),
-                8 => std::borrow::Cow::Borrowed("RELATED"),
-                9 => std::borrow::Cow::Borrowed("IMPACTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RELEVANCE_UNSPECIFIED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::NotImpacted => std::option::Option::Some("NOT_IMPACTED"),
+                Self::PartiallyRelated => std::option::Option::Some("PARTIALLY_RELATED"),
+                Self::Related => std::option::Option::Some("RELATED"),
+                Self::Impacted => std::option::Option::Some("IMPACTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RELEVANCE_UNSPECIFIED" => std::option::Option::Some(Self::RELEVANCE_UNSPECIFIED),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "NOT_IMPACTED" => std::option::Option::Some(Self::NOT_IMPACTED),
-                "PARTIALLY_RELATED" => std::option::Option::Some(Self::PARTIALLY_RELATED),
-                "RELATED" => std::option::Option::Some(Self::RELATED),
-                "IMPACTED" => std::option::Option::Some(Self::IMPACTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Relevance {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Relevance {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Relevance {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Relevance {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Unknown,
+                6 => Self::NotImpacted,
+                7 => Self::PartiallyRelated,
+                8 => Self::Related,
+                9 => Self::Impacted,
+                _ => Self::UnknownValue(relevance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Relevance {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RELEVANCE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN" => Self::Unknown,
+                "NOT_IMPACTED" => Self::NotImpacted,
+                "PARTIALLY_RELATED" => Self::PartiallyRelated,
+                "RELATED" => Self::Related,
+                "IMPACTED" => Self::Impacted,
+                _ => Self::UnknownValue(relevance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Relevance {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unknown => serializer.serialize_i32(2),
+                Self::NotImpacted => serializer.serialize_i32(6),
+                Self::PartiallyRelated => serializer.serialize_i32(7),
+                Self::Related => serializer.serialize_i32(8),
+                Self::Impacted => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Relevance {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Relevance>::new(
+                ".google.cloud.servicehealth.v1.Event.Relevance",
+            ))
         }
     }
 }
@@ -808,207 +1119,378 @@ pub mod organization_event {
 
     /// The category of the event. This enum lists all possible categories of
     /// event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventCategory(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventCategory {
+        /// Unspecified category.
+        Unspecified,
+        /// Event category for service outage or degradation.
+        Incident,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventCategory::value] or
+        /// [EventCategory::name].
+        UnknownValue(event_category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventCategory {
-        /// Unspecified category.
-        pub const EVENT_CATEGORY_UNSPECIFIED: EventCategory = EventCategory::new(0);
-
-        /// Event category for service outage or degradation.
-        pub const INCIDENT: EventCategory = EventCategory::new(2);
-
-        /// Creates a new EventCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incident => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_CATEGORY_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("INCIDENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_CATEGORY_UNSPECIFIED"),
+                Self::Incident => std::option::Option::Some("INCIDENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_CATEGORY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVENT_CATEGORY_UNSPECIFIED)
-                }
-                "INCIDENT" => std::option::Option::Some(Self::INCIDENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Incident,
+                _ => Self::UnknownValue(event_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "INCIDENT" => Self::Incident,
+                _ => Self::UnknownValue(event_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incident => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventCategory>::new(
+                ".google.cloud.servicehealth.v1.OrganizationEvent.EventCategory",
+            ))
         }
     }
 
     /// The detailed category of an event. Contains all possible states for all
     /// event categories.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedCategory(i32);
-
-    impl DetailedCategory {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DetailedCategory {
         /// Unspecified detailed category.
-        pub const DETAILED_CATEGORY_UNSPECIFIED: DetailedCategory = DetailedCategory::new(0);
-
+        Unspecified,
         /// Indicates an event with category INCIDENT has a confirmed impact to at
         /// least one Google Cloud product.
-        pub const CONFIRMED_INCIDENT: DetailedCategory = DetailedCategory::new(1);
-
+        ConfirmedIncident,
         /// Indicates an event with category INCIDENT is under investigation to
         /// determine if it has a confirmed impact on any Google Cloud products.
-        pub const EMERGING_INCIDENT: DetailedCategory = DetailedCategory::new(2);
+        EmergingIncident,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DetailedCategory::value] or
+        /// [DetailedCategory::name].
+        UnknownValue(detailed_category::UnknownValue),
+    }
 
-        /// Creates a new DetailedCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod detailed_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DetailedCategory {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConfirmedIncident => std::option::Option::Some(1),
+                Self::EmergingIncident => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DETAILED_CATEGORY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONFIRMED_INCIDENT"),
-                2 => std::borrow::Cow::Borrowed("EMERGING_INCIDENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DETAILED_CATEGORY_UNSPECIFIED"),
+                Self::ConfirmedIncident => std::option::Option::Some("CONFIRMED_INCIDENT"),
+                Self::EmergingIncident => std::option::Option::Some("EMERGING_INCIDENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DETAILED_CATEGORY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DETAILED_CATEGORY_UNSPECIFIED)
-                }
-                "CONFIRMED_INCIDENT" => std::option::Option::Some(Self::CONFIRMED_INCIDENT),
-                "EMERGING_INCIDENT" => std::option::Option::Some(Self::EMERGING_INCIDENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DetailedCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DetailedCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DetailedCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConfirmedIncident,
+                2 => Self::EmergingIncident,
+                _ => Self::UnknownValue(detailed_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DetailedCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DETAILED_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+                "CONFIRMED_INCIDENT" => Self::ConfirmedIncident,
+                "EMERGING_INCIDENT" => Self::EmergingIncident,
+                _ => Self::UnknownValue(detailed_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DetailedCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConfirmedIncident => serializer.serialize_i32(1),
+                Self::EmergingIncident => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DetailedCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DetailedCategory>::new(
+                ".google.cloud.servicehealth.v1.OrganizationEvent.DetailedCategory",
+            ))
         }
     }
 
     /// The state of the organization event. This enum lists all possible states of
     /// event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Event is actively affecting a Google Cloud product and will continue to
         /// receive updates.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// Event is no longer affecting the Google Cloud product or has been merged
         /// with another event.
-        pub const CLOSED: State = State::new(2);
+        Closed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Closed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CLOSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Closed => std::option::Option::Some("CLOSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CLOSED" => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Closed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.servicehealth.v1.OrganizationEvent.State",
+            ))
         }
     }
 
     /// The detailed state of the incident. This enum lists all possible detailed
     /// states of an incident.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DetailedState(i32);
-
-    impl DetailedState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DetailedState {
         /// Unspecified detail state.
-        pub const DETAILED_STATE_UNSPECIFIED: DetailedState = DetailedState::new(0);
-
+        Unspecified,
         /// Google engineers are actively investigating the incident to determine the
         /// impact.
-        pub const EMERGING: DetailedState = DetailedState::new(1);
-
+        Emerging,
         /// The incident is confirmed and impacting at least one Google Cloud
         /// product. Ongoing status updates will be provided until it is resolved.
-        pub const CONFIRMED: DetailedState = DetailedState::new(2);
-
+        Confirmed,
         /// The incident is no longer affecting any Google Cloud product, and there
         /// will be no further updates.
-        pub const RESOLVED: DetailedState = DetailedState::new(3);
-
+        Resolved,
         /// The incident was merged into a parent event. All further updates will be
         /// published to the parent only. The `parent_event` contains the name of the
         /// parent.
-        pub const MERGED: DetailedState = DetailedState::new(4);
-
+        Merged,
         /// The incident was automatically closed because of the following reasons:
         ///
         /// * The impact of the incident could not be confirmed.
@@ -1016,63 +1498,136 @@ pub mod organization_event {
         ///
         /// The incident does not have a resolution because no action or
         /// investigation happened. If it is intermittent, the incident may reopen.
-        pub const AUTO_CLOSED: DetailedState = DetailedState::new(9);
-
+        AutoClosed,
         /// Upon investigation, Google engineers concluded that the incident is not
         /// affecting a Google Cloud product. This state can change if the incident
         /// is reviewed again.
-        pub const FALSE_POSITIVE: DetailedState = DetailedState::new(10);
+        FalsePositive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DetailedState::value] or
+        /// [DetailedState::name].
+        UnknownValue(detailed_state::UnknownValue),
+    }
 
-        /// Creates a new DetailedState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod detailed_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DetailedState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Emerging => std::option::Option::Some(1),
+                Self::Confirmed => std::option::Option::Some(2),
+                Self::Resolved => std::option::Option::Some(3),
+                Self::Merged => std::option::Option::Some(4),
+                Self::AutoClosed => std::option::Option::Some(9),
+                Self::FalsePositive => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DETAILED_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EMERGING"),
-                2 => std::borrow::Cow::Borrowed("CONFIRMED"),
-                3 => std::borrow::Cow::Borrowed("RESOLVED"),
-                4 => std::borrow::Cow::Borrowed("MERGED"),
-                9 => std::borrow::Cow::Borrowed("AUTO_CLOSED"),
-                10 => std::borrow::Cow::Borrowed("FALSE_POSITIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DETAILED_STATE_UNSPECIFIED"),
+                Self::Emerging => std::option::Option::Some("EMERGING"),
+                Self::Confirmed => std::option::Option::Some("CONFIRMED"),
+                Self::Resolved => std::option::Option::Some("RESOLVED"),
+                Self::Merged => std::option::Option::Some("MERGED"),
+                Self::AutoClosed => std::option::Option::Some("AUTO_CLOSED"),
+                Self::FalsePositive => std::option::Option::Some("FALSE_POSITIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DETAILED_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DETAILED_STATE_UNSPECIFIED)
-                }
-                "EMERGING" => std::option::Option::Some(Self::EMERGING),
-                "CONFIRMED" => std::option::Option::Some(Self::CONFIRMED),
-                "RESOLVED" => std::option::Option::Some(Self::RESOLVED),
-                "MERGED" => std::option::Option::Some(Self::MERGED),
-                "AUTO_CLOSED" => std::option::Option::Some(Self::AUTO_CLOSED),
-                "FALSE_POSITIVE" => std::option::Option::Some(Self::FALSE_POSITIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DetailedState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DetailedState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DetailedState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DetailedState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Emerging,
+                2 => Self::Confirmed,
+                3 => Self::Resolved,
+                4 => Self::Merged,
+                9 => Self::AutoClosed,
+                10 => Self::FalsePositive,
+                _ => Self::UnknownValue(detailed_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DetailedState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DETAILED_STATE_UNSPECIFIED" => Self::Unspecified,
+                "EMERGING" => Self::Emerging,
+                "CONFIRMED" => Self::Confirmed,
+                "RESOLVED" => Self::Resolved,
+                "MERGED" => Self::Merged,
+                "AUTO_CLOSED" => Self::AutoClosed,
+                "FALSE_POSITIVE" => Self::FalsePositive,
+                _ => Self::UnknownValue(detailed_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DetailedState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Emerging => serializer.serialize_i32(1),
+                Self::Confirmed => serializer.serialize_i32(2),
+                Self::Resolved => serializer.serialize_i32(3),
+                Self::Merged => serializer.serialize_i32(4),
+                Self::AutoClosed => serializer.serialize_i32(9),
+                Self::FalsePositive => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DetailedState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DetailedState>::new(
+                ".google.cloud.servicehealth.v1.OrganizationEvent.DetailedState",
+            ))
         }
     }
 }
@@ -2070,125 +2625,240 @@ impl wkt::message::Message for GetOrganizationImpactRequest {
 
 /// The event fields to include in ListEvents API response. This enum lists all
 /// possible event views.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EventView(i32);
-
-impl EventView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EventView {
     /// Unspecified event view. Default to `EVENT_VIEW_BASIC`.
-    pub const EVENT_VIEW_UNSPECIFIED: EventView = EventView::new(0);
-
+    Unspecified,
     /// Includes all fields except `updates`. This view is the default for
     /// ListEvents API.
-    pub const EVENT_VIEW_BASIC: EventView = EventView::new(1);
-
+    Basic,
     /// Includes all event fields.
-    pub const EVENT_VIEW_FULL: EventView = EventView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EventView::value] or
+    /// [EventView::name].
+    UnknownValue(event_view::UnknownValue),
+}
 
-    /// Creates a new EventView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod event_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl EventView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EVENT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EVENT_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("EVENT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EVENT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("EVENT_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("EVENT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EVENT_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_VIEW_UNSPECIFIED),
-            "EVENT_VIEW_BASIC" => std::option::Option::Some(Self::EVENT_VIEW_BASIC),
-            "EVENT_VIEW_FULL" => std::option::Option::Some(Self::EVENT_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EventView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EventView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EventView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EventView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(event_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EventView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EVENT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "EVENT_VIEW_BASIC" => Self::Basic,
+            "EVENT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(event_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EventView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EventView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventView>::new(
+            ".google.cloud.servicehealth.v1.EventView",
+        ))
     }
 }
 
 /// The organization event fields to include in ListOrganizationEvents API
 /// response. This enum lists all possible organization event views.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OrganizationEventView(i32);
-
-impl OrganizationEventView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OrganizationEventView {
     /// Unspecified event view. Default to `ORGANIZATION_EVENT_VIEW_BASIC`.
-    pub const ORGANIZATION_EVENT_VIEW_UNSPECIFIED: OrganizationEventView =
-        OrganizationEventView::new(0);
-
+    Unspecified,
     /// Includes all organization event fields except `updates`. This view is the
     /// default for ListOrganizationEvents API.
-    pub const ORGANIZATION_EVENT_VIEW_BASIC: OrganizationEventView = OrganizationEventView::new(1);
-
+    Basic,
     /// Includes all organization event fields.
-    pub const ORGANIZATION_EVENT_VIEW_FULL: OrganizationEventView = OrganizationEventView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OrganizationEventView::value] or
+    /// [OrganizationEventView::name].
+    UnknownValue(organization_event_view::UnknownValue),
+}
 
-    /// Creates a new OrganizationEventView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod organization_event_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl OrganizationEventView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ORGANIZATION_EVENT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ORGANIZATION_EVENT_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("ORGANIZATION_EVENT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ORGANIZATION_EVENT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("ORGANIZATION_EVENT_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("ORGANIZATION_EVENT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ORGANIZATION_EVENT_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ORGANIZATION_EVENT_VIEW_UNSPECIFIED)
-            }
-            "ORGANIZATION_EVENT_VIEW_BASIC" => {
-                std::option::Option::Some(Self::ORGANIZATION_EVENT_VIEW_BASIC)
-            }
-            "ORGANIZATION_EVENT_VIEW_FULL" => {
-                std::option::Option::Some(Self::ORGANIZATION_EVENT_VIEW_FULL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OrganizationEventView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OrganizationEventView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OrganizationEventView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OrganizationEventView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(organization_event_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OrganizationEventView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ORGANIZATION_EVENT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "ORGANIZATION_EVENT_VIEW_BASIC" => Self::Basic,
+            "ORGANIZATION_EVENT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(organization_event_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OrganizationEventView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OrganizationEventView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OrganizationEventView>::new(
+            ".google.cloud.servicehealth.v1.OrganizationEventView",
+        ))
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/transport.rs
+++ b/src/generated/cloud/servicehealth/v1/src/transport.rs
@@ -57,7 +57,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -102,7 +102,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/shell/v1/src/model.rs
+++ b/src/generated/cloud/shell/v1/src/model.rs
@@ -174,73 +174,138 @@ pub mod environment {
     use super::*;
 
     /// Possible execution states for an environment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The environment's states is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The environment is not running and can't be connected to. Starting the
         /// environment will transition it to the PENDING state.
-        pub const SUSPENDED: State = State::new(1);
-
+        Suspended,
         /// The environment is being started but is not yet ready to accept
         /// connections.
-        pub const PENDING: State = State::new(2);
-
+        Pending,
         /// The environment is running and ready to accept connections. It will
         /// automatically transition back to DISABLED after a period of inactivity or
         /// if another environment is started.
-        pub const RUNNING: State = State::new(3);
-
+        Running,
         /// The environment is being deleted and can't be connected to.
-        pub const DELETING: State = State::new(4);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Suspended => std::option::Option::Some(1),
+                Self::Pending => std::option::Option::Some(2),
+                Self::Running => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                2 => std::borrow::Cow::Borrowed("PENDING"),
-                3 => std::borrow::Cow::Borrowed("RUNNING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Suspended,
+                2 => Self::Pending,
+                3 => Self::Running,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUSPENDED" => Self::Suspended,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Suspended => serializer.serialize_i32(1),
+                Self::Pending => serializer.serialize_i32(2),
+                Self::Running => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.shell.v1.Environment.State",
+            ))
         }
     }
 }
@@ -560,79 +625,144 @@ pub mod start_environment_metadata {
     /// show a progress message to the user. An environment won't necessarily go
     /// through all of these states when starting. More states are likely to be
     /// added in the future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The environment's start state is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The environment is in the process of being started, but no additional
         /// details are available.
-        pub const STARTING: State = State::new(1);
-
+        Starting,
         /// Startup is waiting for the user's disk to be unarchived. This can happen
         /// when the user returns to Cloud Shell after not having used it for a
         /// while, and suggests that startup will take longer than normal.
-        pub const UNARCHIVING_DISK: State = State::new(2);
-
+        UnarchivingDisk,
         /// Startup is waiting for compute resources to be assigned to the
         /// environment. This should normally happen very quickly, but an environment
         /// might stay in this state for an extended period of time if the system is
         /// experiencing heavy load.
-        pub const AWAITING_COMPUTE_RESOURCES: State = State::new(4);
-
+        AwaitingComputeResources,
         /// Startup has completed. If the start operation was successful, the user
         /// should be able to establish an SSH connection to their environment.
         /// Otherwise, the operation will contain details of the failure.
-        pub const FINISHED: State = State::new(3);
+        Finished,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Starting => std::option::Option::Some(1),
+                Self::UnarchivingDisk => std::option::Option::Some(2),
+                Self::AwaitingComputeResources => std::option::Option::Some(4),
+                Self::Finished => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STARTING"),
-                2 => std::borrow::Cow::Borrowed("UNARCHIVING_DISK"),
-                3 => std::borrow::Cow::Borrowed("FINISHED"),
-                4 => std::borrow::Cow::Borrowed("AWAITING_COMPUTE_RESOURCES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "UNARCHIVING_DISK" => std::option::Option::Some(Self::UNARCHIVING_DISK),
-                "AWAITING_COMPUTE_RESOURCES" => {
-                    std::option::Option::Some(Self::AWAITING_COMPUTE_RESOURCES)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::UnarchivingDisk => std::option::Option::Some("UNARCHIVING_DISK"),
+                Self::AwaitingComputeResources => {
+                    std::option::Option::Some("AWAITING_COMPUTE_RESOURCES")
                 }
-                "FINISHED" => std::option::Option::Some(Self::FINISHED),
-                _ => std::option::Option::None,
+                Self::Finished => std::option::Option::Some("FINISHED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Starting,
+                2 => Self::UnarchivingDisk,
+                3 => Self::Finished,
+                4 => Self::AwaitingComputeResources,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STARTING" => Self::Starting,
+                "UNARCHIVING_DISK" => Self::UnarchivingDisk,
+                "AWAITING_COMPUTE_RESOURCES" => Self::AwaitingComputeResources,
+                "FINISHED" => Self::Finished,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Starting => serializer.serialize_i32(1),
+                Self::UnarchivingDisk => serializer.serialize_i32(2),
+                Self::AwaitingComputeResources => serializer.serialize_i32(4),
+                Self::Finished => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.shell.v1.StartEnvironmentMetadata.State",
+            ))
         }
     }
 }
@@ -928,84 +1058,150 @@ pub mod cloud_shell_error_details {
     use super::*;
 
     /// Set of possible errors returned from API calls.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CloudShellErrorCode(i32);
-
-    impl CloudShellErrorCode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CloudShellErrorCode {
         /// An unknown error occurred.
-        pub const CLOUD_SHELL_ERROR_CODE_UNSPECIFIED: CloudShellErrorCode =
-            CloudShellErrorCode::new(0);
-
+        Unspecified,
         /// The image used by the Cloud Shell environment either does not exist or
         /// the user does not have access to it.
-        pub const IMAGE_UNAVAILABLE: CloudShellErrorCode = CloudShellErrorCode::new(1);
-
+        ImageUnavailable,
         /// Cloud Shell has been disabled by an administrator for the user making the
         /// request.
-        pub const CLOUD_SHELL_DISABLED: CloudShellErrorCode = CloudShellErrorCode::new(2);
-
+        CloudShellDisabled,
         /// Cloud Shell has been permanently disabled due to a Terms of Service
         /// violation by the user.
-        pub const TOS_VIOLATION: CloudShellErrorCode = CloudShellErrorCode::new(4);
-
+        TosViolation,
         /// The user has exhausted their weekly Cloud Shell quota, and Cloud Shell
         /// will be disabled until the quota resets.
-        pub const QUOTA_EXCEEDED: CloudShellErrorCode = CloudShellErrorCode::new(5);
-
+        QuotaExceeded,
         /// The Cloud Shell environment is unavailable and cannot be connected to at
         /// the moment.
-        pub const ENVIRONMENT_UNAVAILABLE: CloudShellErrorCode = CloudShellErrorCode::new(6);
+        EnvironmentUnavailable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CloudShellErrorCode::value] or
+        /// [CloudShellErrorCode::name].
+        UnknownValue(cloud_shell_error_code::UnknownValue),
+    }
 
-        /// Creates a new CloudShellErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cloud_shell_error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CloudShellErrorCode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ImageUnavailable => std::option::Option::Some(1),
+                Self::CloudShellDisabled => std::option::Option::Some(2),
+                Self::TosViolation => std::option::Option::Some(4),
+                Self::QuotaExceeded => std::option::Option::Some(5),
+                Self::EnvironmentUnavailable => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLOUD_SHELL_ERROR_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMAGE_UNAVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_SHELL_DISABLED"),
-                4 => std::borrow::Cow::Borrowed("TOS_VIOLATION"),
-                5 => std::borrow::Cow::Borrowed("QUOTA_EXCEEDED"),
-                6 => std::borrow::Cow::Borrowed("ENVIRONMENT_UNAVAILABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLOUD_SHELL_ERROR_CODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLOUD_SHELL_ERROR_CODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CLOUD_SHELL_ERROR_CODE_UNSPECIFIED")
                 }
-                "IMAGE_UNAVAILABLE" => std::option::Option::Some(Self::IMAGE_UNAVAILABLE),
-                "CLOUD_SHELL_DISABLED" => std::option::Option::Some(Self::CLOUD_SHELL_DISABLED),
-                "TOS_VIOLATION" => std::option::Option::Some(Self::TOS_VIOLATION),
-                "QUOTA_EXCEEDED" => std::option::Option::Some(Self::QUOTA_EXCEEDED),
-                "ENVIRONMENT_UNAVAILABLE" => {
-                    std::option::Option::Some(Self::ENVIRONMENT_UNAVAILABLE)
+                Self::ImageUnavailable => std::option::Option::Some("IMAGE_UNAVAILABLE"),
+                Self::CloudShellDisabled => std::option::Option::Some("CLOUD_SHELL_DISABLED"),
+                Self::TosViolation => std::option::Option::Some("TOS_VIOLATION"),
+                Self::QuotaExceeded => std::option::Option::Some("QUOTA_EXCEEDED"),
+                Self::EnvironmentUnavailable => {
+                    std::option::Option::Some("ENVIRONMENT_UNAVAILABLE")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CloudShellErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CloudShellErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CloudShellErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CloudShellErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ImageUnavailable,
+                2 => Self::CloudShellDisabled,
+                4 => Self::TosViolation,
+                5 => Self::QuotaExceeded,
+                6 => Self::EnvironmentUnavailable,
+                _ => Self::UnknownValue(cloud_shell_error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CloudShellErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLOUD_SHELL_ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "IMAGE_UNAVAILABLE" => Self::ImageUnavailable,
+                "CLOUD_SHELL_DISABLED" => Self::CloudShellDisabled,
+                "TOS_VIOLATION" => Self::TosViolation,
+                "QUOTA_EXCEEDED" => Self::QuotaExceeded,
+                "ENVIRONMENT_UNAVAILABLE" => Self::EnvironmentUnavailable,
+                _ => Self::UnknownValue(cloud_shell_error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CloudShellErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ImageUnavailable => serializer.serialize_i32(1),
+                Self::CloudShellDisabled => serializer.serialize_i32(2),
+                Self::TosViolation => serializer.serialize_i32(4),
+                Self::QuotaExceeded => serializer.serialize_i32(5),
+                Self::EnvironmentUnavailable => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CloudShellErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CloudShellErrorCode>::new(
+                ".google.cloud.shell.v1.CloudShellErrorDetails.CloudShellErrorCode",
+            ))
         }
     }
 }

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -1432,59 +1432,120 @@ pub mod recognizer {
     use super::*;
 
     /// Set of states that define the lifecycle of a Recognizer.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The Recognizer is active and ready for use.
+        Active,
+        /// This Recognizer has been deleted.
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Recognizer is active and ready for use.
-        pub const ACTIVE: State = State::new(2);
-
-        /// This Recognizer has been deleted.
-        pub const DELETED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Active,
+                4 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.speech.v2.Recognizer.State",
+            ))
         }
     }
 }
@@ -1608,111 +1669,190 @@ pub mod explicit_decoding_config {
     use super::*;
 
     /// Supported audio data encodings.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AudioEncoding(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AudioEncoding {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// Headerless 16-bit signed little-endian PCM samples.
+        Linear16,
+        /// Headerless 8-bit companded mulaw samples.
+        Mulaw,
+        /// Headerless 8-bit companded alaw samples.
+        Alaw,
+        /// AMR frames with an rfc4867.5 header.
+        Amr,
+        /// AMR-WB frames with an rfc4867.5 header.
+        AmrWb,
+        /// FLAC frames in the "native FLAC" container format.
+        Flac,
+        /// MPEG audio frames with optional (ignored) ID3 metadata.
+        Mp3,
+        /// Opus audio frames in an Ogg container.
+        OggOpus,
+        /// Opus audio frames in a WebM container.
+        WebmOpus,
+        /// AAC audio frames in an MP4 container.
+        Mp4Aac,
+        /// AAC audio frames in an M4A container.
+        M4AAac,
+        /// AAC audio frames in an MOV container.
+        MovAac,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AudioEncoding::value] or
+        /// [AudioEncoding::name].
+        UnknownValue(audio_encoding::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod audio_encoding {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AudioEncoding {
-        /// Default value. This value is unused.
-        pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
-
-        /// Headerless 16-bit signed little-endian PCM samples.
-        pub const LINEAR16: AudioEncoding = AudioEncoding::new(1);
-
-        /// Headerless 8-bit companded mulaw samples.
-        pub const MULAW: AudioEncoding = AudioEncoding::new(2);
-
-        /// Headerless 8-bit companded alaw samples.
-        pub const ALAW: AudioEncoding = AudioEncoding::new(3);
-
-        /// AMR frames with an rfc4867.5 header.
-        pub const AMR: AudioEncoding = AudioEncoding::new(4);
-
-        /// AMR-WB frames with an rfc4867.5 header.
-        pub const AMR_WB: AudioEncoding = AudioEncoding::new(5);
-
-        /// FLAC frames in the "native FLAC" container format.
-        pub const FLAC: AudioEncoding = AudioEncoding::new(6);
-
-        /// MPEG audio frames with optional (ignored) ID3 metadata.
-        pub const MP3: AudioEncoding = AudioEncoding::new(7);
-
-        /// Opus audio frames in an Ogg container.
-        pub const OGG_OPUS: AudioEncoding = AudioEncoding::new(8);
-
-        /// Opus audio frames in a WebM container.
-        pub const WEBM_OPUS: AudioEncoding = AudioEncoding::new(9);
-
-        /// AAC audio frames in an MP4 container.
-        pub const MP4_AAC: AudioEncoding = AudioEncoding::new(10);
-
-        /// AAC audio frames in an M4A container.
-        pub const M4A_AAC: AudioEncoding = AudioEncoding::new(11);
-
-        /// AAC audio frames in an MOV container.
-        pub const MOV_AAC: AudioEncoding = AudioEncoding::new(12);
-
-        /// Creates a new AudioEncoding instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Linear16 => std::option::Option::Some(1),
+                Self::Mulaw => std::option::Option::Some(2),
+                Self::Alaw => std::option::Option::Some(3),
+                Self::Amr => std::option::Option::Some(4),
+                Self::AmrWb => std::option::Option::Some(5),
+                Self::Flac => std::option::Option::Some(6),
+                Self::Mp3 => std::option::Option::Some(7),
+                Self::OggOpus => std::option::Option::Some(8),
+                Self::WebmOpus => std::option::Option::Some(9),
+                Self::Mp4Aac => std::option::Option::Some(10),
+                Self::M4AAac => std::option::Option::Some(11),
+                Self::MovAac => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LINEAR16"),
-                2 => std::borrow::Cow::Borrowed("MULAW"),
-                3 => std::borrow::Cow::Borrowed("ALAW"),
-                4 => std::borrow::Cow::Borrowed("AMR"),
-                5 => std::borrow::Cow::Borrowed("AMR_WB"),
-                6 => std::borrow::Cow::Borrowed("FLAC"),
-                7 => std::borrow::Cow::Borrowed("MP3"),
-                8 => std::borrow::Cow::Borrowed("OGG_OPUS"),
-                9 => std::borrow::Cow::Borrowed("WEBM_OPUS"),
-                10 => std::borrow::Cow::Borrowed("MP4_AAC"),
-                11 => std::borrow::Cow::Borrowed("M4A_AAC"),
-                12 => std::borrow::Cow::Borrowed("MOV_AAC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUDIO_ENCODING_UNSPECIFIED"),
+                Self::Linear16 => std::option::Option::Some("LINEAR16"),
+                Self::Mulaw => std::option::Option::Some("MULAW"),
+                Self::Alaw => std::option::Option::Some("ALAW"),
+                Self::Amr => std::option::Option::Some("AMR"),
+                Self::AmrWb => std::option::Option::Some("AMR_WB"),
+                Self::Flac => std::option::Option::Some("FLAC"),
+                Self::Mp3 => std::option::Option::Some("MP3"),
+                Self::OggOpus => std::option::Option::Some("OGG_OPUS"),
+                Self::WebmOpus => std::option::Option::Some("WEBM_OPUS"),
+                Self::Mp4Aac => std::option::Option::Some("MP4_AAC"),
+                Self::M4AAac => std::option::Option::Some("M4A_AAC"),
+                Self::MovAac => std::option::Option::Some("MOV_AAC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUDIO_ENCODING_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
-                }
-                "LINEAR16" => std::option::Option::Some(Self::LINEAR16),
-                "MULAW" => std::option::Option::Some(Self::MULAW),
-                "ALAW" => std::option::Option::Some(Self::ALAW),
-                "AMR" => std::option::Option::Some(Self::AMR),
-                "AMR_WB" => std::option::Option::Some(Self::AMR_WB),
-                "FLAC" => std::option::Option::Some(Self::FLAC),
-                "MP3" => std::option::Option::Some(Self::MP3),
-                "OGG_OPUS" => std::option::Option::Some(Self::OGG_OPUS),
-                "WEBM_OPUS" => std::option::Option::Some(Self::WEBM_OPUS),
-                "MP4_AAC" => std::option::Option::Some(Self::MP4_AAC),
-                "M4A_AAC" => std::option::Option::Some(Self::M4A_AAC),
-                "MOV_AAC" => std::option::Option::Some(Self::MOV_AAC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AudioEncoding {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AudioEncoding {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AudioEncoding {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AudioEncoding {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Linear16,
+                2 => Self::Mulaw,
+                3 => Self::Alaw,
+                4 => Self::Amr,
+                5 => Self::AmrWb,
+                6 => Self::Flac,
+                7 => Self::Mp3,
+                8 => Self::OggOpus,
+                9 => Self::WebmOpus,
+                10 => Self::Mp4Aac,
+                11 => Self::M4AAac,
+                12 => Self::MovAac,
+                _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AudioEncoding {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUDIO_ENCODING_UNSPECIFIED" => Self::Unspecified,
+                "LINEAR16" => Self::Linear16,
+                "MULAW" => Self::Mulaw,
+                "ALAW" => Self::Alaw,
+                "AMR" => Self::Amr,
+                "AMR_WB" => Self::AmrWb,
+                "FLAC" => Self::Flac,
+                "MP3" => Self::Mp3,
+                "OGG_OPUS" => Self::OggOpus,
+                "WEBM_OPUS" => Self::WebmOpus,
+                "MP4_AAC" => Self::Mp4Aac,
+                "M4A_AAC" => Self::M4AAac,
+                "MOV_AAC" => Self::MovAac,
+                _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AudioEncoding {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Linear16 => serializer.serialize_i32(1),
+                Self::Mulaw => serializer.serialize_i32(2),
+                Self::Alaw => serializer.serialize_i32(3),
+                Self::Amr => serializer.serialize_i32(4),
+                Self::AmrWb => serializer.serialize_i32(5),
+                Self::Flac => serializer.serialize_i32(6),
+                Self::Mp3 => serializer.serialize_i32(7),
+                Self::OggOpus => serializer.serialize_i32(8),
+                Self::WebmOpus => serializer.serialize_i32(9),
+                Self::Mp4Aac => serializer.serialize_i32(10),
+                Self::M4AAac => serializer.serialize_i32(11),
+                Self::MovAac => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AudioEncoding {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AudioEncoding>::new(
+                ".google.cloud.speech.v2.ExplicitDecodingConfig.AudioEncoding",
+            ))
         }
     }
 }
@@ -1920,64 +2060,121 @@ pub mod recognition_features {
     use super::*;
 
     /// Options for how to recognize multi-channel audio.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MultiChannelMode(i32);
-
-    impl MultiChannelMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MultiChannelMode {
         /// Default value for the multi-channel mode. If the audio contains
         /// multiple channels, only the first channel will be transcribed; other
         /// channels will be ignored.
-        pub const MULTI_CHANNEL_MODE_UNSPECIFIED: MultiChannelMode = MultiChannelMode::new(0);
-
+        Unspecified,
         /// If selected, each channel in the provided audio is transcribed
         /// independently. This cannot be selected if the selected
         /// [model][google.cloud.speech.v2.Recognizer.model] is `latest_short`.
         ///
         /// [google.cloud.speech.v2.Recognizer.model]: crate::model::Recognizer::model
-        pub const SEPARATE_RECOGNITION_PER_CHANNEL: MultiChannelMode = MultiChannelMode::new(1);
+        SeparateRecognitionPerChannel,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MultiChannelMode::value] or
+        /// [MultiChannelMode::name].
+        UnknownValue(multi_channel_mode::UnknownValue),
+    }
 
-        /// Creates a new MultiChannelMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod multi_channel_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl MultiChannelMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SeparateRecognitionPerChannel => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MULTI_CHANNEL_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SEPARATE_RECOGNITION_PER_CHANNEL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MULTI_CHANNEL_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MULTI_CHANNEL_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MULTI_CHANNEL_MODE_UNSPECIFIED"),
+                Self::SeparateRecognitionPerChannel => {
+                    std::option::Option::Some("SEPARATE_RECOGNITION_PER_CHANNEL")
                 }
-                "SEPARATE_RECOGNITION_PER_CHANNEL" => {
-                    std::option::Option::Some(Self::SEPARATE_RECOGNITION_PER_CHANNEL)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for MultiChannelMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MultiChannelMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MultiChannelMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MultiChannelMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SeparateRecognitionPerChannel,
+                _ => Self::UnknownValue(multi_channel_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MultiChannelMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MULTI_CHANNEL_MODE_UNSPECIFIED" => Self::Unspecified,
+                "SEPARATE_RECOGNITION_PER_CHANNEL" => Self::SeparateRecognitionPerChannel,
+                _ => Self::UnknownValue(multi_channel_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MultiChannelMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SeparateRecognitionPerChannel => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MultiChannelMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MultiChannelMode>::new(
+                ".google.cloud.speech.v2.RecognitionFeatures.MultiChannelMode",
+            ))
         }
     }
 }
@@ -3590,58 +3787,115 @@ pub mod batch_recognize_request {
     use super::*;
 
     /// Possible processing strategies for batch requests.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProcessingStrategy(i32);
-
-    impl ProcessingStrategy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProcessingStrategy {
         /// Default value for the processing strategy. The request is processed as
         /// soon as its received.
-        pub const PROCESSING_STRATEGY_UNSPECIFIED: ProcessingStrategy = ProcessingStrategy::new(0);
-
+        Unspecified,
         /// If selected, processes the request during lower utilization periods for a
         /// price discount. The request is fulfilled within 24 hours.
-        pub const DYNAMIC_BATCHING: ProcessingStrategy = ProcessingStrategy::new(1);
+        DynamicBatching,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProcessingStrategy::value] or
+        /// [ProcessingStrategy::name].
+        UnknownValue(processing_strategy::UnknownValue),
+    }
 
-        /// Creates a new ProcessingStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod processing_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ProcessingStrategy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DynamicBatching => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROCESSING_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DYNAMIC_BATCHING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROCESSING_STRATEGY_UNSPECIFIED"),
+                Self::DynamicBatching => std::option::Option::Some("DYNAMIC_BATCHING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROCESSING_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROCESSING_STRATEGY_UNSPECIFIED)
-                }
-                "DYNAMIC_BATCHING" => std::option::Option::Some(Self::DYNAMIC_BATCHING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ProcessingStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProcessingStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProcessingStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProcessingStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DynamicBatching,
+                _ => Self::UnknownValue(processing_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProcessingStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROCESSING_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "DYNAMIC_BATCHING" => Self::DynamicBatching,
+                _ => Self::UnknownValue(processing_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProcessingStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DynamicBatching => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProcessingStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProcessingStrategy>::new(
+                ".google.cloud.speech.v2.BatchRecognizeRequest.ProcessingStrategy",
+            ))
         }
     }
 }
@@ -4880,13 +5134,11 @@ pub mod streaming_recognize_response {
     use super::*;
 
     /// Indicates the type of speech event.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SpeechEventType(i32);
-
-    impl SpeechEventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SpeechEventType {
         /// No speech event specified.
-        pub const SPEECH_EVENT_TYPE_UNSPECIFIED: SpeechEventType = SpeechEventType::new(0);
-
+        Unspecified,
         /// This event indicates that the server has detected the end of the user's
         /// speech utterance and expects no additional speech. Therefore, the server
         /// will not process additional audio and will close the gRPC bidirectional
@@ -4895,66 +5147,127 @@ pub mod streaming_recognize_response {
         /// `latest_short` [model][google.cloud.speech.v2.Recognizer.model].
         ///
         /// [google.cloud.speech.v2.Recognizer.model]: crate::model::Recognizer::model
-        pub const END_OF_SINGLE_UTTERANCE: SpeechEventType = SpeechEventType::new(1);
-
+        EndOfSingleUtterance,
         /// This event indicates that the server has detected the beginning of human
         /// voice activity in the stream. This event can be returned multiple times
         /// if speech starts and stops repeatedly throughout the stream. This event
         /// is only sent if `voice_activity_events` is set to true.
-        pub const SPEECH_ACTIVITY_BEGIN: SpeechEventType = SpeechEventType::new(2);
-
+        SpeechActivityBegin,
         /// This event indicates that the server has detected the end of human voice
         /// activity in the stream. This event can be returned multiple times if
         /// speech starts and stops repeatedly throughout the stream. This event is
         /// only sent if `voice_activity_events` is set to true.
-        pub const SPEECH_ACTIVITY_END: SpeechEventType = SpeechEventType::new(3);
+        SpeechActivityEnd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SpeechEventType::value] or
+        /// [SpeechEventType::name].
+        UnknownValue(speech_event_type::UnknownValue),
+    }
 
-        /// Creates a new SpeechEventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod speech_event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SpeechEventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::EndOfSingleUtterance => std::option::Option::Some(1),
+                Self::SpeechActivityBegin => std::option::Option::Some(2),
+                Self::SpeechActivityEnd => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SPEECH_EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("END_OF_SINGLE_UTTERANCE"),
-                2 => std::borrow::Cow::Borrowed("SPEECH_ACTIVITY_BEGIN"),
-                3 => std::borrow::Cow::Borrowed("SPEECH_ACTIVITY_END"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SPEECH_EVENT_TYPE_UNSPECIFIED"),
+                Self::EndOfSingleUtterance => std::option::Option::Some("END_OF_SINGLE_UTTERANCE"),
+                Self::SpeechActivityBegin => std::option::Option::Some("SPEECH_ACTIVITY_BEGIN"),
+                Self::SpeechActivityEnd => std::option::Option::Some("SPEECH_ACTIVITY_END"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SPEECH_EVENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SPEECH_EVENT_TYPE_UNSPECIFIED)
-                }
-                "END_OF_SINGLE_UTTERANCE" => {
-                    std::option::Option::Some(Self::END_OF_SINGLE_UTTERANCE)
-                }
-                "SPEECH_ACTIVITY_BEGIN" => std::option::Option::Some(Self::SPEECH_ACTIVITY_BEGIN),
-                "SPEECH_ACTIVITY_END" => std::option::Option::Some(Self::SPEECH_ACTIVITY_END),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SpeechEventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SpeechEventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SpeechEventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SpeechEventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::EndOfSingleUtterance,
+                2 => Self::SpeechActivityBegin,
+                3 => Self::SpeechActivityEnd,
+                _ => Self::UnknownValue(speech_event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SpeechEventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SPEECH_EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "END_OF_SINGLE_UTTERANCE" => Self::EndOfSingleUtterance,
+                "SPEECH_ACTIVITY_BEGIN" => Self::SpeechActivityBegin,
+                "SPEECH_ACTIVITY_END" => Self::SpeechActivityEnd,
+                _ => Self::UnknownValue(speech_event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SpeechEventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::EndOfSingleUtterance => serializer.serialize_i32(1),
+                Self::SpeechActivityBegin => serializer.serialize_i32(2),
+                Self::SpeechActivityEnd => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SpeechEventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SpeechEventType>::new(
+                ".google.cloud.speech.v2.StreamingRecognizeResponse.SpeechEventType",
+            ))
         }
     }
 }
@@ -5358,60 +5671,121 @@ pub mod custom_class {
     }
 
     /// Set of states that define the lifecycle of a CustomClass.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.  This is only used/useful for distinguishing
         /// unset values.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The normal and active state.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// This CustomClass has been deleted.
-        pub const DELETED: State = State::new(4);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Active,
+                4 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.speech.v2.CustomClass.State",
+            ))
         }
     }
 }
@@ -5700,60 +6074,121 @@ pub mod phrase_set {
     }
 
     /// Set of states that define the lifecycle of a PhraseSet.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.  This is only used/useful for distinguishing
         /// unset values.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The normal and active state.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// This PhraseSet has been deleted.
-        pub const DELETED: State = State::new(4);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Active,
+                4 => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.speech.v2.PhraseSet.State",
+            ))
         }
     }
 }
@@ -6870,59 +7305,117 @@ pub mod access_metadata {
 
     /// Describes the different types of constraints that can be applied on a
     /// region.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConstraintType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConstraintType {
+        /// Unspecified constraint applied.
+        Unspecified,
+        /// The project's org policy disallows the given region.
+        ResourceLocationsOrgPolicyCreateConstraint,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConstraintType::value] or
+        /// [ConstraintType::name].
+        UnknownValue(constraint_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod constraint_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConstraintType {
-        /// Unspecified constraint applied.
-        pub const CONSTRAINT_TYPE_UNSPECIFIED: ConstraintType = ConstraintType::new(0);
-
-        /// The project's org policy disallows the given region.
-        pub const RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT: ConstraintType =
-            ConstraintType::new(1);
-
-        /// Creates a new ConstraintType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ResourceLocationsOrgPolicyCreateConstraint => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONSTRAINT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONSTRAINT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONSTRAINT_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONSTRAINT_TYPE_UNSPECIFIED"),
+                Self::ResourceLocationsOrgPolicyCreateConstraint => {
+                    std::option::Option::Some("RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT")
                 }
-                "RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT" => {
-                    std::option::Option::Some(Self::RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ConstraintType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConstraintType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConstraintType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConstraintType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ResourceLocationsOrgPolicyCreateConstraint,
+                _ => Self::UnknownValue(constraint_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConstraintType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONSTRAINT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "RESOURCE_LOCATIONS_ORG_POLICY_CREATE_CONSTRAINT" => {
+                    Self::ResourceLocationsOrgPolicyCreateConstraint
+                }
+                _ => Self::UnknownValue(constraint_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConstraintType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ResourceLocationsOrgPolicyCreateConstraint => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConstraintType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConstraintType>::new(
+                ".google.cloud.speech.v2.AccessMetadata.ConstraintType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -722,61 +722,116 @@ pub mod connect_settings {
 
 
     /// Various Certificate Authority (CA) modes for certificate signing.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CaMode(i32);
-
-    impl CaMode {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CaMode {
         /// CA mode is unknown.
-        pub const CA_MODE_UNSPECIFIED: CaMode = CaMode::new(0);
-
+        Unspecified,
         /// Google-managed self-signed internal CA.
-        pub const GOOGLE_MANAGED_INTERNAL_CA: CaMode = CaMode::new(1);
-
+        GoogleManagedInternalCa,
         /// Google-managed regional CA part of root CA hierarchy hosted on Google
         /// Cloud's Certificate Authority Service (CAS).
-        pub const GOOGLE_MANAGED_CAS_CA: CaMode = CaMode::new(2);
-
-        /// Creates a new CaMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CA_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_INTERNAL_CA"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_CAS_CA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CA_MODE_UNSPECIFIED" => std::option::Option::Some(Self::CA_MODE_UNSPECIFIED),
-                "GOOGLE_MANAGED_INTERNAL_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_INTERNAL_CA),
-                "GOOGLE_MANAGED_CAS_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_CAS_CA),
-                _ => std::option::Option::None,
-            }
-        }
+        GoogleManagedCasCa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CaMode::value] or
+        /// [CaMode::name].
+        UnknownValue(ca_mode::UnknownValue),
     }
 
-    impl std::convert::From<i32> for CaMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod ca_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl CaMode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleManagedInternalCa => std::option::Option::Some(1),
+                Self::GoogleManagedCasCa => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CA_MODE_UNSPECIFIED"),
+                Self::GoogleManagedInternalCa => std::option::Option::Some("GOOGLE_MANAGED_INTERNAL_CA"),
+                Self::GoogleManagedCasCa => std::option::Option::Some("GOOGLE_MANAGED_CAS_CA"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for CaMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CaMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CaMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleManagedInternalCa,
+                2 => Self::GoogleManagedCasCa,
+                _ => Self::UnknownValue(ca_mode::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CaMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CA_MODE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_MANAGED_INTERNAL_CA" => Self::GoogleManagedInternalCa,
+                "GOOGLE_MANAGED_CAS_CA" => Self::GoogleManagedCasCa,
+                _ => Self::UnknownValue(ca_mode::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CaMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleManagedInternalCa => serializer.serialize_i32(1),
+                Self::GoogleManagedCasCa => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CaMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CaMode>::new(
+                ".google.cloud.sql.v1.ConnectSettings.CaMode"))
         }
     }
 }
@@ -2839,60 +2894,115 @@ pub mod backup_reencryption_config {
 
 
     /// Backup type for re-encryption
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BackupType(i32);
-
-    impl BackupType {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BackupType {
         /// Unknown backup type, will be defaulted to AUTOMATIC backup type
-        pub const BACKUP_TYPE_UNSPECIFIED: BackupType = BackupType::new(0);
-
+        Unspecified,
         /// Reencrypt automatic backups
-        pub const AUTOMATED: BackupType = BackupType::new(1);
-
+        Automated,
         /// Reencrypt on-demand backups
-        pub const ON_DEMAND: BackupType = BackupType::new(2);
-
-        /// Creates a new BackupType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BACKUP_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATED"),
-                2 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BACKUP_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::BACKUP_TYPE_UNSPECIFIED),
-                "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                _ => std::option::Option::None,
-            }
-        }
+        OnDemand,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BackupType::value] or
+        /// [BackupType::name].
+        UnknownValue(backup_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for BackupType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod backup_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl BackupType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Automated => std::option::Option::Some(1),
+                Self::OnDemand => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BACKUP_TYPE_UNSPECIFIED"),
+                Self::Automated => std::option::Option::Some("AUTOMATED"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for BackupType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BackupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BackupType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Automated,
+                2 => Self::OnDemand,
+                _ => Self::UnknownValue(backup_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BackupType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BACKUP_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATED" => Self::Automated,
+                "ON_DEMAND" => Self::OnDemand,
+                _ => Self::UnknownValue(backup_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BackupType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Automated => serializer.serialize_i32(1),
+                Self::OnDemand => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BackupType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BackupType>::new(
+                ".google.cloud.sql.v1.BackupReencryptionConfig.BackupType"))
         }
     }
 }
@@ -3077,121 +3187,231 @@ pub mod sql_instances_verify_external_sync_settings_request {
     use super::*;
 
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExternalSyncMode(i32);
-
-    impl ExternalSyncMode {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExternalSyncMode {
         /// Unknown external sync mode, will be defaulted to ONLINE mode
-        pub const EXTERNAL_SYNC_MODE_UNSPECIFIED: ExternalSyncMode = ExternalSyncMode::new(0);
-
+        Unspecified,
         /// Online external sync will set up replication after initial data external
         /// sync
-        pub const ONLINE: ExternalSyncMode = ExternalSyncMode::new(1);
-
+        Online,
         /// Offline external sync only dumps and loads a one-time snapshot of
         /// the primary instance's data
-        pub const OFFLINE: ExternalSyncMode = ExternalSyncMode::new(2);
-
-        /// Creates a new ExternalSyncMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXTERNAL_SYNC_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ONLINE"),
-                2 => std::borrow::Cow::Borrowed("OFFLINE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXTERNAL_SYNC_MODE_UNSPECIFIED" => std::option::Option::Some(Self::EXTERNAL_SYNC_MODE_UNSPECIFIED),
-                "ONLINE" => std::option::Option::Some(Self::ONLINE),
-                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
-                _ => std::option::Option::None,
-            }
-        }
+        Offline,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExternalSyncMode::value] or
+        /// [ExternalSyncMode::name].
+        UnknownValue(external_sync_mode::UnknownValue),
     }
 
-    impl std::convert::From<i32> for ExternalSyncMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod external_sync_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl ExternalSyncMode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Online => std::option::Option::Some(1),
+                Self::Offline => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXTERNAL_SYNC_MODE_UNSPECIFIED"),
+                Self::Online => std::option::Option::Some("ONLINE"),
+                Self::Offline => std::option::Option::Some("OFFLINE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for ExternalSyncMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExternalSyncMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExternalSyncMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Online,
+                2 => Self::Offline,
+                _ => Self::UnknownValue(external_sync_mode::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExternalSyncMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXTERNAL_SYNC_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ONLINE" => Self::Online,
+                "OFFLINE" => Self::Offline,
+                _ => Self::UnknownValue(external_sync_mode::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExternalSyncMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Online => serializer.serialize_i32(1),
+                Self::Offline => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExternalSyncMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExternalSyncMode>::new(
+                ".google.cloud.sql.v1.SqlInstancesVerifyExternalSyncSettingsRequest.ExternalSyncMode"))
         }
     }
 
     /// MigrationType determines whether the migration is a physical file-based
     /// migration or a logical dump file-based migration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MigrationType(i32);
-
-    impl MigrationType {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MigrationType {
         /// Default value is a logical dump file-based migration
-        pub const MIGRATION_TYPE_UNSPECIFIED: MigrationType = MigrationType::new(0);
-
+        Unspecified,
         /// Logical dump file-based migration
-        pub const LOGICAL: MigrationType = MigrationType::new(1);
-
+        Logical,
         /// Physical file-based migration
-        pub const PHYSICAL: MigrationType = MigrationType::new(2);
-
-        /// Creates a new MigrationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MIGRATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOGICAL"),
-                2 => std::borrow::Cow::Borrowed("PHYSICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MIGRATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::MIGRATION_TYPE_UNSPECIFIED),
-                "LOGICAL" => std::option::Option::Some(Self::LOGICAL),
-                "PHYSICAL" => std::option::Option::Some(Self::PHYSICAL),
-                _ => std::option::Option::None,
-            }
-        }
+        Physical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MigrationType::value] or
+        /// [MigrationType::name].
+        UnknownValue(migration_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for MigrationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod migration_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl MigrationType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Logical => std::option::Option::Some(1),
+                Self::Physical => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MIGRATION_TYPE_UNSPECIFIED"),
+                Self::Logical => std::option::Option::Some("LOGICAL"),
+                Self::Physical => std::option::Option::Some("PHYSICAL"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for MigrationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MigrationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MigrationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Logical,
+                2 => Self::Physical,
+                _ => Self::UnknownValue(migration_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MigrationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MIGRATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LOGICAL" => Self::Logical,
+                "PHYSICAL" => Self::Physical,
+                _ => Self::UnknownValue(migration_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MigrationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Logical => serializer.serialize_i32(1),
+                Self::Physical => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MigrationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MigrationType>::new(
+                ".google.cloud.sql.v1.SqlInstancesVerifyExternalSyncSettingsRequest.MigrationType"))
         }
     }
 
@@ -5048,203 +5268,378 @@ pub mod database_instance {
 
 
         /// This enum lists all possible states regarding out-of-disk issues.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SqlOutOfDiskState(i32);
-
-        impl SqlOutOfDiskState {
-
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SqlOutOfDiskState {
             /// Unspecified state
-            pub const SQL_OUT_OF_DISK_STATE_UNSPECIFIED: SqlOutOfDiskState = SqlOutOfDiskState::new(0);
-
+            Unspecified,
             /// The instance has plenty space on data disk
-            pub const NORMAL: SqlOutOfDiskState = SqlOutOfDiskState::new(1);
-
+            Normal,
             /// Data disk is almost used up. It is shutdown to prevent data
             /// corruption.
-            pub const SOFT_SHUTDOWN: SqlOutOfDiskState = SqlOutOfDiskState::new(2);
-
-            /// Creates a new SqlOutOfDiskState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
-            /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
-            }
-            
-            /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SQL_OUT_OF_DISK_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NORMAL"),
-                    2 => std::borrow::Cow::Borrowed("SOFT_SHUTDOWN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SQL_OUT_OF_DISK_STATE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_OUT_OF_DISK_STATE_UNSPECIFIED),
-                    "NORMAL" => std::option::Option::Some(Self::NORMAL),
-                    "SOFT_SHUTDOWN" => std::option::Option::Some(Self::SOFT_SHUTDOWN),
-                    _ => std::option::Option::None,
-                }
-            }
+            SoftShutdown,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SqlOutOfDiskState::value] or
+            /// [SqlOutOfDiskState::name].
+            UnknownValue(sql_out_of_disk_state::UnknownValue),
         }
 
-        impl std::convert::From<i32> for SqlOutOfDiskState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
+        #[doc(hidden)]
+        pub mod sql_out_of_disk_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
+
+        impl SqlOutOfDiskState {
+            /// Gets the enum value.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Normal => std::option::Option::Some(1),
+                    Self::SoftShutdown => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
+            }
+
+            /// Gets the enum value as a string.
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SQL_OUT_OF_DISK_STATE_UNSPECIFIED"),
+                    Self::Normal => std::option::Option::Some("NORMAL"),
+                    Self::SoftShutdown => std::option::Option::Some("SOFT_SHUTDOWN"),
+                    Self::UnknownValue(u) => u.0.name(),
+                }
             }
         }
 
         impl std::default::Default for SqlOutOfDiskState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SqlOutOfDiskState {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SqlOutOfDiskState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Normal,
+                    2 => Self::SoftShutdown,
+                    _ => Self::UnknownValue(sql_out_of_disk_state::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SqlOutOfDiskState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SQL_OUT_OF_DISK_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "NORMAL" => Self::Normal,
+                    "SOFT_SHUTDOWN" => Self::SoftShutdown,
+                    _ => Self::UnknownValue(sql_out_of_disk_state::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SqlOutOfDiskState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Normal => serializer.serialize_i32(1),
+                    Self::SoftShutdown => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SqlOutOfDiskState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlOutOfDiskState>::new(
+                    ".google.cloud.sql.v1.DatabaseInstance.SqlOutOfDiskReport.SqlOutOfDiskState"))
             }
         }
     }
 
     /// The current serving state of the database instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlInstanceState(i32);
-
-    impl SqlInstanceState {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlInstanceState {
         /// The state of the instance is unknown.
-        pub const SQL_INSTANCE_STATE_UNSPECIFIED: SqlInstanceState = SqlInstanceState::new(0);
-
+        Unspecified,
         /// The instance is running, or has been stopped by owner.
-        pub const RUNNABLE: SqlInstanceState = SqlInstanceState::new(1);
-
+        Runnable,
         /// The instance is not available, for example due to problems with billing.
-        pub const SUSPENDED: SqlInstanceState = SqlInstanceState::new(2);
-
+        Suspended,
         /// The instance is being deleted.
-        pub const PENDING_DELETE: SqlInstanceState = SqlInstanceState::new(3);
-
+        PendingDelete,
         /// The instance is being created.
-        pub const PENDING_CREATE: SqlInstanceState = SqlInstanceState::new(4);
-
+        PendingCreate,
         /// The instance is down for maintenance.
-        pub const MAINTENANCE: SqlInstanceState = SqlInstanceState::new(5);
-
+        Maintenance,
         /// The creation of the instance failed or a fatal error occurred during
         /// maintenance.
-        pub const FAILED: SqlInstanceState = SqlInstanceState::new(6);
-
+        Failed,
         /// Deprecated
-        pub const ONLINE_MAINTENANCE: SqlInstanceState = SqlInstanceState::new(7);
-
-        /// Creates a new SqlInstanceState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_INSTANCE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNABLE"),
-                2 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                3 => std::borrow::Cow::Borrowed("PENDING_DELETE"),
-                4 => std::borrow::Cow::Borrowed("PENDING_CREATE"),
-                5 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("ONLINE_MAINTENANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_INSTANCE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_INSTANCE_STATE_UNSPECIFIED),
-                "RUNNABLE" => std::option::Option::Some(Self::RUNNABLE),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "PENDING_DELETE" => std::option::Option::Some(Self::PENDING_DELETE),
-                "PENDING_CREATE" => std::option::Option::Some(Self::PENDING_CREATE),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ONLINE_MAINTENANCE" => std::option::Option::Some(Self::ONLINE_MAINTENANCE),
-                _ => std::option::Option::None,
-            }
-        }
+        OnlineMaintenance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlInstanceState::value] or
+        /// [SqlInstanceState::name].
+        UnknownValue(sql_instance_state::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlInstanceState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_instance_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlInstanceState {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Runnable => std::option::Option::Some(1),
+                Self::Suspended => std::option::Option::Some(2),
+                Self::PendingDelete => std::option::Option::Some(3),
+                Self::PendingCreate => std::option::Option::Some(4),
+                Self::Maintenance => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::OnlineMaintenance => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_INSTANCE_STATE_UNSPECIFIED"),
+                Self::Runnable => std::option::Option::Some("RUNNABLE"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::PendingDelete => std::option::Option::Some("PENDING_DELETE"),
+                Self::PendingCreate => std::option::Option::Some("PENDING_CREATE"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::OnlineMaintenance => std::option::Option::Some("ONLINE_MAINTENANCE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlInstanceState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlInstanceState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlInstanceState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Runnable,
+                2 => Self::Suspended,
+                3 => Self::PendingDelete,
+                4 => Self::PendingCreate,
+                5 => Self::Maintenance,
+                6 => Self::Failed,
+                7 => Self::OnlineMaintenance,
+                _ => Self::UnknownValue(sql_instance_state::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlInstanceState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_INSTANCE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNABLE" => Self::Runnable,
+                "SUSPENDED" => Self::Suspended,
+                "PENDING_DELETE" => Self::PendingDelete,
+                "PENDING_CREATE" => Self::PendingCreate,
+                "MAINTENANCE" => Self::Maintenance,
+                "FAILED" => Self::Failed,
+                "ONLINE_MAINTENANCE" => Self::OnlineMaintenance,
+                _ => Self::UnknownValue(sql_instance_state::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlInstanceState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Runnable => serializer.serialize_i32(1),
+                Self::Suspended => serializer.serialize_i32(2),
+                Self::PendingDelete => serializer.serialize_i32(3),
+                Self::PendingCreate => serializer.serialize_i32(4),
+                Self::Maintenance => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::OnlineMaintenance => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlInstanceState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlInstanceState>::new(
+                ".google.cloud.sql.v1.DatabaseInstance.SqlInstanceState"))
         }
     }
 
     /// The SQL network architecture for the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlNetworkArchitecture(i32);
-
-    impl SqlNetworkArchitecture {
-
-        pub const SQL_NETWORK_ARCHITECTURE_UNSPECIFIED: SqlNetworkArchitecture = SqlNetworkArchitecture::new(0);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlNetworkArchitecture {
+        Unspecified,
         /// The instance uses the new network architecture.
-        pub const NEW_NETWORK_ARCHITECTURE: SqlNetworkArchitecture = SqlNetworkArchitecture::new(1);
-
+        NewNetworkArchitecture,
         /// The instance uses the old network architecture.
-        pub const OLD_NETWORK_ARCHITECTURE: SqlNetworkArchitecture = SqlNetworkArchitecture::new(2);
-
-        /// Creates a new SqlNetworkArchitecture instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_NETWORK_ARCHITECTURE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEW_NETWORK_ARCHITECTURE"),
-                2 => std::borrow::Cow::Borrowed("OLD_NETWORK_ARCHITECTURE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_NETWORK_ARCHITECTURE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_NETWORK_ARCHITECTURE_UNSPECIFIED),
-                "NEW_NETWORK_ARCHITECTURE" => std::option::Option::Some(Self::NEW_NETWORK_ARCHITECTURE),
-                "OLD_NETWORK_ARCHITECTURE" => std::option::Option::Some(Self::OLD_NETWORK_ARCHITECTURE),
-                _ => std::option::Option::None,
-            }
-        }
+        OldNetworkArchitecture,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlNetworkArchitecture::value] or
+        /// [SqlNetworkArchitecture::name].
+        UnknownValue(sql_network_architecture::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlNetworkArchitecture {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_network_architecture {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlNetworkArchitecture {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NewNetworkArchitecture => std::option::Option::Some(1),
+                Self::OldNetworkArchitecture => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_NETWORK_ARCHITECTURE_UNSPECIFIED"),
+                Self::NewNetworkArchitecture => std::option::Option::Some("NEW_NETWORK_ARCHITECTURE"),
+                Self::OldNetworkArchitecture => std::option::Option::Some("OLD_NETWORK_ARCHITECTURE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlNetworkArchitecture {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlNetworkArchitecture {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlNetworkArchitecture {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NewNetworkArchitecture,
+                2 => Self::OldNetworkArchitecture,
+                _ => Self::UnknownValue(sql_network_architecture::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlNetworkArchitecture {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_NETWORK_ARCHITECTURE_UNSPECIFIED" => Self::Unspecified,
+                "NEW_NETWORK_ARCHITECTURE" => Self::NewNetworkArchitecture,
+                "OLD_NETWORK_ARCHITECTURE" => Self::OldNetworkArchitecture,
+                _ => Self::UnknownValue(sql_network_architecture::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlNetworkArchitecture {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NewNetworkArchitecture => serializer.serialize_i32(1),
+                Self::OldNetworkArchitecture => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlNetworkArchitecture {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlNetworkArchitecture>::new(
+                ".google.cloud.sql.v1.DatabaseInstance.SqlNetworkArchitecture"))
         }
     }
 }
@@ -5537,65 +5932,122 @@ pub mod sql_instances_reschedule_maintenance_request_body {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RescheduleType(i32);
-
-    impl RescheduleType {
-
-        pub const RESCHEDULE_TYPE_UNSPECIFIED: RescheduleType = RescheduleType::new(0);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RescheduleType {
+        Unspecified,
         /// Reschedules maintenance to happen now (within 5 minutes).
-        pub const IMMEDIATE: RescheduleType = RescheduleType::new(1);
-
+        Immediate,
         /// Reschedules maintenance to occur within one week from the originally
         /// scheduled day and time.
-        pub const NEXT_AVAILABLE_WINDOW: RescheduleType = RescheduleType::new(2);
-
+        NextAvailableWindow,
         /// Reschedules maintenance to a specific time and day.
-        pub const SPECIFIC_TIME: RescheduleType = RescheduleType::new(3);
-
-        /// Creates a new RescheduleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESCHEDULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMMEDIATE"),
-                2 => std::borrow::Cow::Borrowed("NEXT_AVAILABLE_WINDOW"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESCHEDULE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::RESCHEDULE_TYPE_UNSPECIFIED),
-                "IMMEDIATE" => std::option::Option::Some(Self::IMMEDIATE),
-                "NEXT_AVAILABLE_WINDOW" => std::option::Option::Some(Self::NEXT_AVAILABLE_WINDOW),
-                "SPECIFIC_TIME" => std::option::Option::Some(Self::SPECIFIC_TIME),
-                _ => std::option::Option::None,
-            }
-        }
+        SpecificTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RescheduleType::value] or
+        /// [RescheduleType::name].
+        UnknownValue(reschedule_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for RescheduleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod reschedule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl RescheduleType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Immediate => std::option::Option::Some(1),
+                Self::NextAvailableWindow => std::option::Option::Some(2),
+                Self::SpecificTime => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESCHEDULE_TYPE_UNSPECIFIED"),
+                Self::Immediate => std::option::Option::Some("IMMEDIATE"),
+                Self::NextAvailableWindow => std::option::Option::Some("NEXT_AVAILABLE_WINDOW"),
+                Self::SpecificTime => std::option::Option::Some("SPECIFIC_TIME"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for RescheduleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RescheduleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RescheduleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Immediate,
+                2 => Self::NextAvailableWindow,
+                3 => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RescheduleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESCHEDULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMMEDIATE" => Self::Immediate,
+                "NEXT_AVAILABLE_WINDOW" => Self::NextAvailableWindow,
+                "SPECIFIC_TIME" => Self::SpecificTime,
+                _ => Self::UnknownValue(reschedule_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RescheduleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Immediate => serializer.serialize_i32(1),
+                Self::NextAvailableWindow => serializer.serialize_i32(2),
+                Self::SpecificTime => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RescheduleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RescheduleType>::new(
+                ".google.cloud.sql.v1.SqlInstancesRescheduleMaintenanceRequestBody.RescheduleType"))
         }
     }
 }
@@ -5984,311 +6436,460 @@ pub mod sql_external_sync_setting_error {
     use super::*;
 
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlExternalSyncSettingErrorType(i32);
-
-    impl SqlExternalSyncSettingErrorType {
-
-        pub const SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(0);
-
-        pub const CONNECTION_FAILURE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(1);
-
-        pub const BINLOG_NOT_ENABLED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(2);
-
-        pub const INCOMPATIBLE_DATABASE_VERSION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(3);
-
-        pub const REPLICA_ALREADY_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(4);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlExternalSyncSettingErrorType {
+        Unspecified,
+        ConnectionFailure,
+        BinlogNotEnabled,
+        IncompatibleDatabaseVersion,
+        ReplicaAlreadySetup,
         /// The replication user is missing privileges that are required.
-        pub const INSUFFICIENT_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(5);
-
+        InsufficientPrivilege,
         /// Unsupported migration type.
-        pub const UNSUPPORTED_MIGRATION_TYPE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(6);
-
+        UnsupportedMigrationType,
         /// No pglogical extension installed on databases, applicable for postgres.
-        pub const NO_PGLOGICAL_INSTALLED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(7);
-
+        NoPglogicalInstalled,
         /// pglogical node already exists on databases, applicable for postgres.
-        pub const PGLOGICAL_NODE_ALREADY_EXISTS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(8);
-
+        PglogicalNodeAlreadyExists,
         /// The value of parameter wal_level is not set to logical.
-        pub const INVALID_WAL_LEVEL: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(9);
-
+        InvalidWalLevel,
         /// The value of parameter shared_preload_libraries does not include
         /// pglogical.
-        pub const INVALID_SHARED_PRELOAD_LIBRARY: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(10);
-
+        InvalidSharedPreloadLibrary,
         /// The value of parameter max_replication_slots is not sufficient.
-        pub const INSUFFICIENT_MAX_REPLICATION_SLOTS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(11);
-
+        InsufficientMaxReplicationSlots,
         /// The value of parameter max_wal_senders is not sufficient.
-        pub const INSUFFICIENT_MAX_WAL_SENDERS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(12);
-
+        InsufficientMaxWalSenders,
         /// The value of parameter max_worker_processes is not sufficient.
-        pub const INSUFFICIENT_MAX_WORKER_PROCESSES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(13);
-
+        InsufficientMaxWorkerProcesses,
         /// Extensions installed are either not supported or having unsupported
         /// versions.
-        pub const UNSUPPORTED_EXTENSIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(14);
-
+        UnsupportedExtensions,
         /// The value of parameter rds.logical_replication is not set to 1.
-        pub const INVALID_RDS_LOGICAL_REPLICATION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(15);
-
+        InvalidRdsLogicalReplication,
         /// The primary instance logging setup doesn't allow EM sync.
-        pub const INVALID_LOGGING_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(16);
-
+        InvalidLoggingSetup,
         /// The primary instance database parameter setup doesn't allow EM sync.
-        pub const INVALID_DB_PARAM: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(17);
-
+        InvalidDbParam,
         /// The gtid_mode is not supported, applicable for MySQL.
-        pub const UNSUPPORTED_GTID_MODE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(18);
-
+        UnsupportedGtidMode,
         /// SQL Server Agent is not running.
-        pub const SQLSERVER_AGENT_NOT_RUNNING: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(19);
-
+        SqlserverAgentNotRunning,
         /// The table definition is not support due to missing primary key or replica
         /// identity, applicable for postgres.
-        pub const UNSUPPORTED_TABLE_DEFINITION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(20);
-
+        UnsupportedTableDefinition,
         /// The customer has a definer that will break EM setup.
-        pub const UNSUPPORTED_DEFINER: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(21);
-
+        UnsupportedDefiner,
         /// SQL Server @@SERVERNAME does not match actual host name.
-        pub const SQLSERVER_SERVERNAME_MISMATCH: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(22);
-
+        SqlserverServernameMismatch,
         /// The primary instance has been setup and will fail the setup.
-        pub const PRIMARY_ALREADY_SETUP: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(23);
-
+        PrimaryAlreadySetup,
         /// The primary instance has unsupported binary log format.
-        pub const UNSUPPORTED_BINLOG_FORMAT: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(24);
-
+        UnsupportedBinlogFormat,
         /// The primary instance's binary log retention setting.
-        pub const BINLOG_RETENTION_SETTING: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(25);
-
+        BinlogRetentionSetting,
         /// The primary instance has tables with unsupported storage engine.
-        pub const UNSUPPORTED_STORAGE_ENGINE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(26);
-
+        UnsupportedStorageEngine,
         /// Source has tables with limited support
         /// eg: PostgreSQL tables without primary keys.
-        pub const LIMITED_SUPPORT_TABLES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(27);
-
+        LimitedSupportTables,
         /// The replica instance contains existing data.
-        pub const EXISTING_DATA_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(28);
-
+        ExistingDataInReplica,
         /// The replication user is missing privileges that are optional.
-        pub const MISSING_OPTIONAL_PRIVILEGES: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(29);
-
+        MissingOptionalPrivileges,
         /// Additional BACKUP_ADMIN privilege is granted to the replication user
         /// which may lock source MySQL 8 instance for DDLs during initial sync.
-        pub const RISKY_BACKUP_ADMIN_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(30);
-
+        RiskyBackupAdminPrivilege,
         /// The Cloud Storage bucket is missing necessary permissions.
-        pub const INSUFFICIENT_GCS_PERMISSIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(31);
-
+        InsufficientGcsPermissions,
         /// The Cloud Storage bucket has an error in the file or contains invalid
         /// file information.
-        pub const INVALID_FILE_INFO: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(32);
-
+        InvalidFileInfo,
         /// The source instance has unsupported database settings for migration.
-        pub const UNSUPPORTED_DATABASE_SETTINGS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(33);
-
+        UnsupportedDatabaseSettings,
         /// The replication user is missing parallel import specific privileges.
         /// (e.g. LOCK TABLES) for MySQL.
-        pub const MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(34);
-
+        MysqlParallelImportInsufficientPrivilege,
         /// The global variable local_infile is off on external server replica.
-        pub const LOCAL_INFILE_OFF: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(35);
-
+        LocalInfileOff,
         /// This code instructs customers to turn on point-in-time recovery manually
         /// for the instance after promoting the Cloud SQL for PostgreSQL instance.
-        pub const TURN_ON_PITR_AFTER_PROMOTE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(36);
-
+        TurnOnPitrAfterPromote,
         /// The minor version of replica database is incompatible with the source.
-        pub const INCOMPATIBLE_DATABASE_MINOR_VERSION: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(37);
-
+        IncompatibleDatabaseMinorVersion,
         /// This warning message indicates that Cloud SQL uses the maximum number of
         /// subscriptions to migrate data from the source to the destination.
-        pub const SOURCE_MAX_SUBSCRIPTIONS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(38);
-
+        SourceMaxSubscriptions,
         /// Unable to verify definers on the source for MySQL.
-        pub const UNABLE_TO_VERIFY_DEFINERS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(39);
-
+        UnableToVerifyDefiners,
         /// If a time out occurs while the subscription counts are calculated, then
         /// this value is set to 1. Otherwise, this value is set to 2.
-        pub const SUBSCRIPTION_CALCULATION_STATUS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(40);
-
+        SubscriptionCalculationStatus,
         /// Count of subscriptions needed to sync source data for PostgreSQL
         /// database.
-        pub const PG_SUBSCRIPTION_COUNT: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(41);
-
+        PgSubscriptionCount,
         /// Final parallel level that is used to do migration.
-        pub const PG_SYNC_PARALLEL_LEVEL: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(42);
-
+        PgSyncParallelLevel,
         /// The disk size of the replica instance is smaller than the data size of
         /// the source instance.
-        pub const INSUFFICIENT_DISK_SIZE: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(43);
-
+        InsufficientDiskSize,
         /// The data size of the source instance is greater than 1 TB, the number of
         /// cores of the replica instance is less than 8, and the memory of the
         /// replica is less than 32 GB.
-        pub const INSUFFICIENT_MACHINE_TIER: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(44);
-
+        InsufficientMachineTier,
         /// The warning message indicates the unsupported extensions will not be
         /// migrated to the destination.
-        pub const UNSUPPORTED_EXTENSIONS_NOT_MIGRATED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(45);
-
+        UnsupportedExtensionsNotMigrated,
         /// The warning message indicates the pg_cron extension and settings will not
         /// be migrated to the destination.
-        pub const EXTENSIONS_NOT_MIGRATED: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(46);
-
+        ExtensionsNotMigrated,
         /// The error message indicates that pg_cron flags are enabled on the
         /// destination which is not supported during the migration.
-        pub const PG_CRON_FLAG_ENABLED_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(47);
-
+        PgCronFlagEnabledInReplica,
         /// This error message indicates that the specified extensions are not
         /// enabled on destination instance. For example, before you can migrate
         /// data to the destination instance, you must enable the PGAudit extension
         /// on the instance.
-        pub const EXTENSIONS_NOT_ENABLED_IN_REPLICA: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(48);
-
+        ExtensionsNotEnabledInReplica,
         /// The source database has generated columns that can't be migrated. Please
         /// change them to regular columns before migration.
-        pub const UNSUPPORTED_COLUMNS: SqlExternalSyncSettingErrorType = SqlExternalSyncSettingErrorType::new(49);
-
-        /// Creates a new SqlExternalSyncSettingErrorType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONNECTION_FAILURE"),
-                2 => std::borrow::Cow::Borrowed("BINLOG_NOT_ENABLED"),
-                3 => std::borrow::Cow::Borrowed("INCOMPATIBLE_DATABASE_VERSION"),
-                4 => std::borrow::Cow::Borrowed("REPLICA_ALREADY_SETUP"),
-                5 => std::borrow::Cow::Borrowed("INSUFFICIENT_PRIVILEGE"),
-                6 => std::borrow::Cow::Borrowed("UNSUPPORTED_MIGRATION_TYPE"),
-                7 => std::borrow::Cow::Borrowed("NO_PGLOGICAL_INSTALLED"),
-                8 => std::borrow::Cow::Borrowed("PGLOGICAL_NODE_ALREADY_EXISTS"),
-                9 => std::borrow::Cow::Borrowed("INVALID_WAL_LEVEL"),
-                10 => std::borrow::Cow::Borrowed("INVALID_SHARED_PRELOAD_LIBRARY"),
-                11 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_REPLICATION_SLOTS"),
-                12 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WAL_SENDERS"),
-                13 => std::borrow::Cow::Borrowed("INSUFFICIENT_MAX_WORKER_PROCESSES"),
-                14 => std::borrow::Cow::Borrowed("UNSUPPORTED_EXTENSIONS"),
-                15 => std::borrow::Cow::Borrowed("INVALID_RDS_LOGICAL_REPLICATION"),
-                16 => std::borrow::Cow::Borrowed("INVALID_LOGGING_SETUP"),
-                17 => std::borrow::Cow::Borrowed("INVALID_DB_PARAM"),
-                18 => std::borrow::Cow::Borrowed("UNSUPPORTED_GTID_MODE"),
-                19 => std::borrow::Cow::Borrowed("SQLSERVER_AGENT_NOT_RUNNING"),
-                20 => std::borrow::Cow::Borrowed("UNSUPPORTED_TABLE_DEFINITION"),
-                21 => std::borrow::Cow::Borrowed("UNSUPPORTED_DEFINER"),
-                22 => std::borrow::Cow::Borrowed("SQLSERVER_SERVERNAME_MISMATCH"),
-                23 => std::borrow::Cow::Borrowed("PRIMARY_ALREADY_SETUP"),
-                24 => std::borrow::Cow::Borrowed("UNSUPPORTED_BINLOG_FORMAT"),
-                25 => std::borrow::Cow::Borrowed("BINLOG_RETENTION_SETTING"),
-                26 => std::borrow::Cow::Borrowed("UNSUPPORTED_STORAGE_ENGINE"),
-                27 => std::borrow::Cow::Borrowed("LIMITED_SUPPORT_TABLES"),
-                28 => std::borrow::Cow::Borrowed("EXISTING_DATA_IN_REPLICA"),
-                29 => std::borrow::Cow::Borrowed("MISSING_OPTIONAL_PRIVILEGES"),
-                30 => std::borrow::Cow::Borrowed("RISKY_BACKUP_ADMIN_PRIVILEGE"),
-                31 => std::borrow::Cow::Borrowed("INSUFFICIENT_GCS_PERMISSIONS"),
-                32 => std::borrow::Cow::Borrowed("INVALID_FILE_INFO"),
-                33 => std::borrow::Cow::Borrowed("UNSUPPORTED_DATABASE_SETTINGS"),
-                34 => std::borrow::Cow::Borrowed("MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE"),
-                35 => std::borrow::Cow::Borrowed("LOCAL_INFILE_OFF"),
-                36 => std::borrow::Cow::Borrowed("TURN_ON_PITR_AFTER_PROMOTE"),
-                37 => std::borrow::Cow::Borrowed("INCOMPATIBLE_DATABASE_MINOR_VERSION"),
-                38 => std::borrow::Cow::Borrowed("SOURCE_MAX_SUBSCRIPTIONS"),
-                39 => std::borrow::Cow::Borrowed("UNABLE_TO_VERIFY_DEFINERS"),
-                40 => std::borrow::Cow::Borrowed("SUBSCRIPTION_CALCULATION_STATUS"),
-                41 => std::borrow::Cow::Borrowed("PG_SUBSCRIPTION_COUNT"),
-                42 => std::borrow::Cow::Borrowed("PG_SYNC_PARALLEL_LEVEL"),
-                43 => std::borrow::Cow::Borrowed("INSUFFICIENT_DISK_SIZE"),
-                44 => std::borrow::Cow::Borrowed("INSUFFICIENT_MACHINE_TIER"),
-                45 => std::borrow::Cow::Borrowed("UNSUPPORTED_EXTENSIONS_NOT_MIGRATED"),
-                46 => std::borrow::Cow::Borrowed("EXTENSIONS_NOT_MIGRATED"),
-                47 => std::borrow::Cow::Borrowed("PG_CRON_FLAG_ENABLED_IN_REPLICA"),
-                48 => std::borrow::Cow::Borrowed("EXTENSIONS_NOT_ENABLED_IN_REPLICA"),
-                49 => std::borrow::Cow::Borrowed("UNSUPPORTED_COLUMNS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED),
-                "CONNECTION_FAILURE" => std::option::Option::Some(Self::CONNECTION_FAILURE),
-                "BINLOG_NOT_ENABLED" => std::option::Option::Some(Self::BINLOG_NOT_ENABLED),
-                "INCOMPATIBLE_DATABASE_VERSION" => std::option::Option::Some(Self::INCOMPATIBLE_DATABASE_VERSION),
-                "REPLICA_ALREADY_SETUP" => std::option::Option::Some(Self::REPLICA_ALREADY_SETUP),
-                "INSUFFICIENT_PRIVILEGE" => std::option::Option::Some(Self::INSUFFICIENT_PRIVILEGE),
-                "UNSUPPORTED_MIGRATION_TYPE" => std::option::Option::Some(Self::UNSUPPORTED_MIGRATION_TYPE),
-                "NO_PGLOGICAL_INSTALLED" => std::option::Option::Some(Self::NO_PGLOGICAL_INSTALLED),
-                "PGLOGICAL_NODE_ALREADY_EXISTS" => std::option::Option::Some(Self::PGLOGICAL_NODE_ALREADY_EXISTS),
-                "INVALID_WAL_LEVEL" => std::option::Option::Some(Self::INVALID_WAL_LEVEL),
-                "INVALID_SHARED_PRELOAD_LIBRARY" => std::option::Option::Some(Self::INVALID_SHARED_PRELOAD_LIBRARY),
-                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => std::option::Option::Some(Self::INSUFFICIENT_MAX_REPLICATION_SLOTS),
-                "INSUFFICIENT_MAX_WAL_SENDERS" => std::option::Option::Some(Self::INSUFFICIENT_MAX_WAL_SENDERS),
-                "INSUFFICIENT_MAX_WORKER_PROCESSES" => std::option::Option::Some(Self::INSUFFICIENT_MAX_WORKER_PROCESSES),
-                "UNSUPPORTED_EXTENSIONS" => std::option::Option::Some(Self::UNSUPPORTED_EXTENSIONS),
-                "INVALID_RDS_LOGICAL_REPLICATION" => std::option::Option::Some(Self::INVALID_RDS_LOGICAL_REPLICATION),
-                "INVALID_LOGGING_SETUP" => std::option::Option::Some(Self::INVALID_LOGGING_SETUP),
-                "INVALID_DB_PARAM" => std::option::Option::Some(Self::INVALID_DB_PARAM),
-                "UNSUPPORTED_GTID_MODE" => std::option::Option::Some(Self::UNSUPPORTED_GTID_MODE),
-                "SQLSERVER_AGENT_NOT_RUNNING" => std::option::Option::Some(Self::SQLSERVER_AGENT_NOT_RUNNING),
-                "UNSUPPORTED_TABLE_DEFINITION" => std::option::Option::Some(Self::UNSUPPORTED_TABLE_DEFINITION),
-                "UNSUPPORTED_DEFINER" => std::option::Option::Some(Self::UNSUPPORTED_DEFINER),
-                "SQLSERVER_SERVERNAME_MISMATCH" => std::option::Option::Some(Self::SQLSERVER_SERVERNAME_MISMATCH),
-                "PRIMARY_ALREADY_SETUP" => std::option::Option::Some(Self::PRIMARY_ALREADY_SETUP),
-                "UNSUPPORTED_BINLOG_FORMAT" => std::option::Option::Some(Self::UNSUPPORTED_BINLOG_FORMAT),
-                "BINLOG_RETENTION_SETTING" => std::option::Option::Some(Self::BINLOG_RETENTION_SETTING),
-                "UNSUPPORTED_STORAGE_ENGINE" => std::option::Option::Some(Self::UNSUPPORTED_STORAGE_ENGINE),
-                "LIMITED_SUPPORT_TABLES" => std::option::Option::Some(Self::LIMITED_SUPPORT_TABLES),
-                "EXISTING_DATA_IN_REPLICA" => std::option::Option::Some(Self::EXISTING_DATA_IN_REPLICA),
-                "MISSING_OPTIONAL_PRIVILEGES" => std::option::Option::Some(Self::MISSING_OPTIONAL_PRIVILEGES),
-                "RISKY_BACKUP_ADMIN_PRIVILEGE" => std::option::Option::Some(Self::RISKY_BACKUP_ADMIN_PRIVILEGE),
-                "INSUFFICIENT_GCS_PERMISSIONS" => std::option::Option::Some(Self::INSUFFICIENT_GCS_PERMISSIONS),
-                "INVALID_FILE_INFO" => std::option::Option::Some(Self::INVALID_FILE_INFO),
-                "UNSUPPORTED_DATABASE_SETTINGS" => std::option::Option::Some(Self::UNSUPPORTED_DATABASE_SETTINGS),
-                "MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => std::option::Option::Some(Self::MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE),
-                "LOCAL_INFILE_OFF" => std::option::Option::Some(Self::LOCAL_INFILE_OFF),
-                "TURN_ON_PITR_AFTER_PROMOTE" => std::option::Option::Some(Self::TURN_ON_PITR_AFTER_PROMOTE),
-                "INCOMPATIBLE_DATABASE_MINOR_VERSION" => std::option::Option::Some(Self::INCOMPATIBLE_DATABASE_MINOR_VERSION),
-                "SOURCE_MAX_SUBSCRIPTIONS" => std::option::Option::Some(Self::SOURCE_MAX_SUBSCRIPTIONS),
-                "UNABLE_TO_VERIFY_DEFINERS" => std::option::Option::Some(Self::UNABLE_TO_VERIFY_DEFINERS),
-                "SUBSCRIPTION_CALCULATION_STATUS" => std::option::Option::Some(Self::SUBSCRIPTION_CALCULATION_STATUS),
-                "PG_SUBSCRIPTION_COUNT" => std::option::Option::Some(Self::PG_SUBSCRIPTION_COUNT),
-                "PG_SYNC_PARALLEL_LEVEL" => std::option::Option::Some(Self::PG_SYNC_PARALLEL_LEVEL),
-                "INSUFFICIENT_DISK_SIZE" => std::option::Option::Some(Self::INSUFFICIENT_DISK_SIZE),
-                "INSUFFICIENT_MACHINE_TIER" => std::option::Option::Some(Self::INSUFFICIENT_MACHINE_TIER),
-                "UNSUPPORTED_EXTENSIONS_NOT_MIGRATED" => std::option::Option::Some(Self::UNSUPPORTED_EXTENSIONS_NOT_MIGRATED),
-                "EXTENSIONS_NOT_MIGRATED" => std::option::Option::Some(Self::EXTENSIONS_NOT_MIGRATED),
-                "PG_CRON_FLAG_ENABLED_IN_REPLICA" => std::option::Option::Some(Self::PG_CRON_FLAG_ENABLED_IN_REPLICA),
-                "EXTENSIONS_NOT_ENABLED_IN_REPLICA" => std::option::Option::Some(Self::EXTENSIONS_NOT_ENABLED_IN_REPLICA),
-                "UNSUPPORTED_COLUMNS" => std::option::Option::Some(Self::UNSUPPORTED_COLUMNS),
-                _ => std::option::Option::None,
-            }
-        }
+        UnsupportedColumns,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlExternalSyncSettingErrorType::value] or
+        /// [SqlExternalSyncSettingErrorType::name].
+        UnknownValue(sql_external_sync_setting_error_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlExternalSyncSettingErrorType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_external_sync_setting_error_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlExternalSyncSettingErrorType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ConnectionFailure => std::option::Option::Some(1),
+                Self::BinlogNotEnabled => std::option::Option::Some(2),
+                Self::IncompatibleDatabaseVersion => std::option::Option::Some(3),
+                Self::ReplicaAlreadySetup => std::option::Option::Some(4),
+                Self::InsufficientPrivilege => std::option::Option::Some(5),
+                Self::UnsupportedMigrationType => std::option::Option::Some(6),
+                Self::NoPglogicalInstalled => std::option::Option::Some(7),
+                Self::PglogicalNodeAlreadyExists => std::option::Option::Some(8),
+                Self::InvalidWalLevel => std::option::Option::Some(9),
+                Self::InvalidSharedPreloadLibrary => std::option::Option::Some(10),
+                Self::InsufficientMaxReplicationSlots => std::option::Option::Some(11),
+                Self::InsufficientMaxWalSenders => std::option::Option::Some(12),
+                Self::InsufficientMaxWorkerProcesses => std::option::Option::Some(13),
+                Self::UnsupportedExtensions => std::option::Option::Some(14),
+                Self::InvalidRdsLogicalReplication => std::option::Option::Some(15),
+                Self::InvalidLoggingSetup => std::option::Option::Some(16),
+                Self::InvalidDbParam => std::option::Option::Some(17),
+                Self::UnsupportedGtidMode => std::option::Option::Some(18),
+                Self::SqlserverAgentNotRunning => std::option::Option::Some(19),
+                Self::UnsupportedTableDefinition => std::option::Option::Some(20),
+                Self::UnsupportedDefiner => std::option::Option::Some(21),
+                Self::SqlserverServernameMismatch => std::option::Option::Some(22),
+                Self::PrimaryAlreadySetup => std::option::Option::Some(23),
+                Self::UnsupportedBinlogFormat => std::option::Option::Some(24),
+                Self::BinlogRetentionSetting => std::option::Option::Some(25),
+                Self::UnsupportedStorageEngine => std::option::Option::Some(26),
+                Self::LimitedSupportTables => std::option::Option::Some(27),
+                Self::ExistingDataInReplica => std::option::Option::Some(28),
+                Self::MissingOptionalPrivileges => std::option::Option::Some(29),
+                Self::RiskyBackupAdminPrivilege => std::option::Option::Some(30),
+                Self::InsufficientGcsPermissions => std::option::Option::Some(31),
+                Self::InvalidFileInfo => std::option::Option::Some(32),
+                Self::UnsupportedDatabaseSettings => std::option::Option::Some(33),
+                Self::MysqlParallelImportInsufficientPrivilege => std::option::Option::Some(34),
+                Self::LocalInfileOff => std::option::Option::Some(35),
+                Self::TurnOnPitrAfterPromote => std::option::Option::Some(36),
+                Self::IncompatibleDatabaseMinorVersion => std::option::Option::Some(37),
+                Self::SourceMaxSubscriptions => std::option::Option::Some(38),
+                Self::UnableToVerifyDefiners => std::option::Option::Some(39),
+                Self::SubscriptionCalculationStatus => std::option::Option::Some(40),
+                Self::PgSubscriptionCount => std::option::Option::Some(41),
+                Self::PgSyncParallelLevel => std::option::Option::Some(42),
+                Self::InsufficientDiskSize => std::option::Option::Some(43),
+                Self::InsufficientMachineTier => std::option::Option::Some(44),
+                Self::UnsupportedExtensionsNotMigrated => std::option::Option::Some(45),
+                Self::ExtensionsNotMigrated => std::option::Option::Some(46),
+                Self::PgCronFlagEnabledInReplica => std::option::Option::Some(47),
+                Self::ExtensionsNotEnabledInReplica => std::option::Option::Some(48),
+                Self::UnsupportedColumns => std::option::Option::Some(49),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED"),
+                Self::ConnectionFailure => std::option::Option::Some("CONNECTION_FAILURE"),
+                Self::BinlogNotEnabled => std::option::Option::Some("BINLOG_NOT_ENABLED"),
+                Self::IncompatibleDatabaseVersion => std::option::Option::Some("INCOMPATIBLE_DATABASE_VERSION"),
+                Self::ReplicaAlreadySetup => std::option::Option::Some("REPLICA_ALREADY_SETUP"),
+                Self::InsufficientPrivilege => std::option::Option::Some("INSUFFICIENT_PRIVILEGE"),
+                Self::UnsupportedMigrationType => std::option::Option::Some("UNSUPPORTED_MIGRATION_TYPE"),
+                Self::NoPglogicalInstalled => std::option::Option::Some("NO_PGLOGICAL_INSTALLED"),
+                Self::PglogicalNodeAlreadyExists => std::option::Option::Some("PGLOGICAL_NODE_ALREADY_EXISTS"),
+                Self::InvalidWalLevel => std::option::Option::Some("INVALID_WAL_LEVEL"),
+                Self::InvalidSharedPreloadLibrary => std::option::Option::Some("INVALID_SHARED_PRELOAD_LIBRARY"),
+                Self::InsufficientMaxReplicationSlots => std::option::Option::Some("INSUFFICIENT_MAX_REPLICATION_SLOTS"),
+                Self::InsufficientMaxWalSenders => std::option::Option::Some("INSUFFICIENT_MAX_WAL_SENDERS"),
+                Self::InsufficientMaxWorkerProcesses => std::option::Option::Some("INSUFFICIENT_MAX_WORKER_PROCESSES"),
+                Self::UnsupportedExtensions => std::option::Option::Some("UNSUPPORTED_EXTENSIONS"),
+                Self::InvalidRdsLogicalReplication => std::option::Option::Some("INVALID_RDS_LOGICAL_REPLICATION"),
+                Self::InvalidLoggingSetup => std::option::Option::Some("INVALID_LOGGING_SETUP"),
+                Self::InvalidDbParam => std::option::Option::Some("INVALID_DB_PARAM"),
+                Self::UnsupportedGtidMode => std::option::Option::Some("UNSUPPORTED_GTID_MODE"),
+                Self::SqlserverAgentNotRunning => std::option::Option::Some("SQLSERVER_AGENT_NOT_RUNNING"),
+                Self::UnsupportedTableDefinition => std::option::Option::Some("UNSUPPORTED_TABLE_DEFINITION"),
+                Self::UnsupportedDefiner => std::option::Option::Some("UNSUPPORTED_DEFINER"),
+                Self::SqlserverServernameMismatch => std::option::Option::Some("SQLSERVER_SERVERNAME_MISMATCH"),
+                Self::PrimaryAlreadySetup => std::option::Option::Some("PRIMARY_ALREADY_SETUP"),
+                Self::UnsupportedBinlogFormat => std::option::Option::Some("UNSUPPORTED_BINLOG_FORMAT"),
+                Self::BinlogRetentionSetting => std::option::Option::Some("BINLOG_RETENTION_SETTING"),
+                Self::UnsupportedStorageEngine => std::option::Option::Some("UNSUPPORTED_STORAGE_ENGINE"),
+                Self::LimitedSupportTables => std::option::Option::Some("LIMITED_SUPPORT_TABLES"),
+                Self::ExistingDataInReplica => std::option::Option::Some("EXISTING_DATA_IN_REPLICA"),
+                Self::MissingOptionalPrivileges => std::option::Option::Some("MISSING_OPTIONAL_PRIVILEGES"),
+                Self::RiskyBackupAdminPrivilege => std::option::Option::Some("RISKY_BACKUP_ADMIN_PRIVILEGE"),
+                Self::InsufficientGcsPermissions => std::option::Option::Some("INSUFFICIENT_GCS_PERMISSIONS"),
+                Self::InvalidFileInfo => std::option::Option::Some("INVALID_FILE_INFO"),
+                Self::UnsupportedDatabaseSettings => std::option::Option::Some("UNSUPPORTED_DATABASE_SETTINGS"),
+                Self::MysqlParallelImportInsufficientPrivilege => std::option::Option::Some("MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE"),
+                Self::LocalInfileOff => std::option::Option::Some("LOCAL_INFILE_OFF"),
+                Self::TurnOnPitrAfterPromote => std::option::Option::Some("TURN_ON_PITR_AFTER_PROMOTE"),
+                Self::IncompatibleDatabaseMinorVersion => std::option::Option::Some("INCOMPATIBLE_DATABASE_MINOR_VERSION"),
+                Self::SourceMaxSubscriptions => std::option::Option::Some("SOURCE_MAX_SUBSCRIPTIONS"),
+                Self::UnableToVerifyDefiners => std::option::Option::Some("UNABLE_TO_VERIFY_DEFINERS"),
+                Self::SubscriptionCalculationStatus => std::option::Option::Some("SUBSCRIPTION_CALCULATION_STATUS"),
+                Self::PgSubscriptionCount => std::option::Option::Some("PG_SUBSCRIPTION_COUNT"),
+                Self::PgSyncParallelLevel => std::option::Option::Some("PG_SYNC_PARALLEL_LEVEL"),
+                Self::InsufficientDiskSize => std::option::Option::Some("INSUFFICIENT_DISK_SIZE"),
+                Self::InsufficientMachineTier => std::option::Option::Some("INSUFFICIENT_MACHINE_TIER"),
+                Self::UnsupportedExtensionsNotMigrated => std::option::Option::Some("UNSUPPORTED_EXTENSIONS_NOT_MIGRATED"),
+                Self::ExtensionsNotMigrated => std::option::Option::Some("EXTENSIONS_NOT_MIGRATED"),
+                Self::PgCronFlagEnabledInReplica => std::option::Option::Some("PG_CRON_FLAG_ENABLED_IN_REPLICA"),
+                Self::ExtensionsNotEnabledInReplica => std::option::Option::Some("EXTENSIONS_NOT_ENABLED_IN_REPLICA"),
+                Self::UnsupportedColumns => std::option::Option::Some("UNSUPPORTED_COLUMNS"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlExternalSyncSettingErrorType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlExternalSyncSettingErrorType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlExternalSyncSettingErrorType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ConnectionFailure,
+                2 => Self::BinlogNotEnabled,
+                3 => Self::IncompatibleDatabaseVersion,
+                4 => Self::ReplicaAlreadySetup,
+                5 => Self::InsufficientPrivilege,
+                6 => Self::UnsupportedMigrationType,
+                7 => Self::NoPglogicalInstalled,
+                8 => Self::PglogicalNodeAlreadyExists,
+                9 => Self::InvalidWalLevel,
+                10 => Self::InvalidSharedPreloadLibrary,
+                11 => Self::InsufficientMaxReplicationSlots,
+                12 => Self::InsufficientMaxWalSenders,
+                13 => Self::InsufficientMaxWorkerProcesses,
+                14 => Self::UnsupportedExtensions,
+                15 => Self::InvalidRdsLogicalReplication,
+                16 => Self::InvalidLoggingSetup,
+                17 => Self::InvalidDbParam,
+                18 => Self::UnsupportedGtidMode,
+                19 => Self::SqlserverAgentNotRunning,
+                20 => Self::UnsupportedTableDefinition,
+                21 => Self::UnsupportedDefiner,
+                22 => Self::SqlserverServernameMismatch,
+                23 => Self::PrimaryAlreadySetup,
+                24 => Self::UnsupportedBinlogFormat,
+                25 => Self::BinlogRetentionSetting,
+                26 => Self::UnsupportedStorageEngine,
+                27 => Self::LimitedSupportTables,
+                28 => Self::ExistingDataInReplica,
+                29 => Self::MissingOptionalPrivileges,
+                30 => Self::RiskyBackupAdminPrivilege,
+                31 => Self::InsufficientGcsPermissions,
+                32 => Self::InvalidFileInfo,
+                33 => Self::UnsupportedDatabaseSettings,
+                34 => Self::MysqlParallelImportInsufficientPrivilege,
+                35 => Self::LocalInfileOff,
+                36 => Self::TurnOnPitrAfterPromote,
+                37 => Self::IncompatibleDatabaseMinorVersion,
+                38 => Self::SourceMaxSubscriptions,
+                39 => Self::UnableToVerifyDefiners,
+                40 => Self::SubscriptionCalculationStatus,
+                41 => Self::PgSubscriptionCount,
+                42 => Self::PgSyncParallelLevel,
+                43 => Self::InsufficientDiskSize,
+                44 => Self::InsufficientMachineTier,
+                45 => Self::UnsupportedExtensionsNotMigrated,
+                46 => Self::ExtensionsNotMigrated,
+                47 => Self::PgCronFlagEnabledInReplica,
+                48 => Self::ExtensionsNotEnabledInReplica,
+                49 => Self::UnsupportedColumns,
+                _ => Self::UnknownValue(sql_external_sync_setting_error_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlExternalSyncSettingErrorType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_EXTERNAL_SYNC_SETTING_ERROR_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CONNECTION_FAILURE" => Self::ConnectionFailure,
+                "BINLOG_NOT_ENABLED" => Self::BinlogNotEnabled,
+                "INCOMPATIBLE_DATABASE_VERSION" => Self::IncompatibleDatabaseVersion,
+                "REPLICA_ALREADY_SETUP" => Self::ReplicaAlreadySetup,
+                "INSUFFICIENT_PRIVILEGE" => Self::InsufficientPrivilege,
+                "UNSUPPORTED_MIGRATION_TYPE" => Self::UnsupportedMigrationType,
+                "NO_PGLOGICAL_INSTALLED" => Self::NoPglogicalInstalled,
+                "PGLOGICAL_NODE_ALREADY_EXISTS" => Self::PglogicalNodeAlreadyExists,
+                "INVALID_WAL_LEVEL" => Self::InvalidWalLevel,
+                "INVALID_SHARED_PRELOAD_LIBRARY" => Self::InvalidSharedPreloadLibrary,
+                "INSUFFICIENT_MAX_REPLICATION_SLOTS" => Self::InsufficientMaxReplicationSlots,
+                "INSUFFICIENT_MAX_WAL_SENDERS" => Self::InsufficientMaxWalSenders,
+                "INSUFFICIENT_MAX_WORKER_PROCESSES" => Self::InsufficientMaxWorkerProcesses,
+                "UNSUPPORTED_EXTENSIONS" => Self::UnsupportedExtensions,
+                "INVALID_RDS_LOGICAL_REPLICATION" => Self::InvalidRdsLogicalReplication,
+                "INVALID_LOGGING_SETUP" => Self::InvalidLoggingSetup,
+                "INVALID_DB_PARAM" => Self::InvalidDbParam,
+                "UNSUPPORTED_GTID_MODE" => Self::UnsupportedGtidMode,
+                "SQLSERVER_AGENT_NOT_RUNNING" => Self::SqlserverAgentNotRunning,
+                "UNSUPPORTED_TABLE_DEFINITION" => Self::UnsupportedTableDefinition,
+                "UNSUPPORTED_DEFINER" => Self::UnsupportedDefiner,
+                "SQLSERVER_SERVERNAME_MISMATCH" => Self::SqlserverServernameMismatch,
+                "PRIMARY_ALREADY_SETUP" => Self::PrimaryAlreadySetup,
+                "UNSUPPORTED_BINLOG_FORMAT" => Self::UnsupportedBinlogFormat,
+                "BINLOG_RETENTION_SETTING" => Self::BinlogRetentionSetting,
+                "UNSUPPORTED_STORAGE_ENGINE" => Self::UnsupportedStorageEngine,
+                "LIMITED_SUPPORT_TABLES" => Self::LimitedSupportTables,
+                "EXISTING_DATA_IN_REPLICA" => Self::ExistingDataInReplica,
+                "MISSING_OPTIONAL_PRIVILEGES" => Self::MissingOptionalPrivileges,
+                "RISKY_BACKUP_ADMIN_PRIVILEGE" => Self::RiskyBackupAdminPrivilege,
+                "INSUFFICIENT_GCS_PERMISSIONS" => Self::InsufficientGcsPermissions,
+                "INVALID_FILE_INFO" => Self::InvalidFileInfo,
+                "UNSUPPORTED_DATABASE_SETTINGS" => Self::UnsupportedDatabaseSettings,
+                "MYSQL_PARALLEL_IMPORT_INSUFFICIENT_PRIVILEGE" => Self::MysqlParallelImportInsufficientPrivilege,
+                "LOCAL_INFILE_OFF" => Self::LocalInfileOff,
+                "TURN_ON_PITR_AFTER_PROMOTE" => Self::TurnOnPitrAfterPromote,
+                "INCOMPATIBLE_DATABASE_MINOR_VERSION" => Self::IncompatibleDatabaseMinorVersion,
+                "SOURCE_MAX_SUBSCRIPTIONS" => Self::SourceMaxSubscriptions,
+                "UNABLE_TO_VERIFY_DEFINERS" => Self::UnableToVerifyDefiners,
+                "SUBSCRIPTION_CALCULATION_STATUS" => Self::SubscriptionCalculationStatus,
+                "PG_SUBSCRIPTION_COUNT" => Self::PgSubscriptionCount,
+                "PG_SYNC_PARALLEL_LEVEL" => Self::PgSyncParallelLevel,
+                "INSUFFICIENT_DISK_SIZE" => Self::InsufficientDiskSize,
+                "INSUFFICIENT_MACHINE_TIER" => Self::InsufficientMachineTier,
+                "UNSUPPORTED_EXTENSIONS_NOT_MIGRATED" => Self::UnsupportedExtensionsNotMigrated,
+                "EXTENSIONS_NOT_MIGRATED" => Self::ExtensionsNotMigrated,
+                "PG_CRON_FLAG_ENABLED_IN_REPLICA" => Self::PgCronFlagEnabledInReplica,
+                "EXTENSIONS_NOT_ENABLED_IN_REPLICA" => Self::ExtensionsNotEnabledInReplica,
+                "UNSUPPORTED_COLUMNS" => Self::UnsupportedColumns,
+                _ => Self::UnknownValue(sql_external_sync_setting_error_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlExternalSyncSettingErrorType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ConnectionFailure => serializer.serialize_i32(1),
+                Self::BinlogNotEnabled => serializer.serialize_i32(2),
+                Self::IncompatibleDatabaseVersion => serializer.serialize_i32(3),
+                Self::ReplicaAlreadySetup => serializer.serialize_i32(4),
+                Self::InsufficientPrivilege => serializer.serialize_i32(5),
+                Self::UnsupportedMigrationType => serializer.serialize_i32(6),
+                Self::NoPglogicalInstalled => serializer.serialize_i32(7),
+                Self::PglogicalNodeAlreadyExists => serializer.serialize_i32(8),
+                Self::InvalidWalLevel => serializer.serialize_i32(9),
+                Self::InvalidSharedPreloadLibrary => serializer.serialize_i32(10),
+                Self::InsufficientMaxReplicationSlots => serializer.serialize_i32(11),
+                Self::InsufficientMaxWalSenders => serializer.serialize_i32(12),
+                Self::InsufficientMaxWorkerProcesses => serializer.serialize_i32(13),
+                Self::UnsupportedExtensions => serializer.serialize_i32(14),
+                Self::InvalidRdsLogicalReplication => serializer.serialize_i32(15),
+                Self::InvalidLoggingSetup => serializer.serialize_i32(16),
+                Self::InvalidDbParam => serializer.serialize_i32(17),
+                Self::UnsupportedGtidMode => serializer.serialize_i32(18),
+                Self::SqlserverAgentNotRunning => serializer.serialize_i32(19),
+                Self::UnsupportedTableDefinition => serializer.serialize_i32(20),
+                Self::UnsupportedDefiner => serializer.serialize_i32(21),
+                Self::SqlserverServernameMismatch => serializer.serialize_i32(22),
+                Self::PrimaryAlreadySetup => serializer.serialize_i32(23),
+                Self::UnsupportedBinlogFormat => serializer.serialize_i32(24),
+                Self::BinlogRetentionSetting => serializer.serialize_i32(25),
+                Self::UnsupportedStorageEngine => serializer.serialize_i32(26),
+                Self::LimitedSupportTables => serializer.serialize_i32(27),
+                Self::ExistingDataInReplica => serializer.serialize_i32(28),
+                Self::MissingOptionalPrivileges => serializer.serialize_i32(29),
+                Self::RiskyBackupAdminPrivilege => serializer.serialize_i32(30),
+                Self::InsufficientGcsPermissions => serializer.serialize_i32(31),
+                Self::InvalidFileInfo => serializer.serialize_i32(32),
+                Self::UnsupportedDatabaseSettings => serializer.serialize_i32(33),
+                Self::MysqlParallelImportInsufficientPrivilege => serializer.serialize_i32(34),
+                Self::LocalInfileOff => serializer.serialize_i32(35),
+                Self::TurnOnPitrAfterPromote => serializer.serialize_i32(36),
+                Self::IncompatibleDatabaseMinorVersion => serializer.serialize_i32(37),
+                Self::SourceMaxSubscriptions => serializer.serialize_i32(38),
+                Self::UnableToVerifyDefiners => serializer.serialize_i32(39),
+                Self::SubscriptionCalculationStatus => serializer.serialize_i32(40),
+                Self::PgSubscriptionCount => serializer.serialize_i32(41),
+                Self::PgSyncParallelLevel => serializer.serialize_i32(42),
+                Self::InsufficientDiskSize => serializer.serialize_i32(43),
+                Self::InsufficientMachineTier => serializer.serialize_i32(44),
+                Self::UnsupportedExtensionsNotMigrated => serializer.serialize_i32(45),
+                Self::ExtensionsNotMigrated => serializer.serialize_i32(46),
+                Self::PgCronFlagEnabledInReplica => serializer.serialize_i32(47),
+                Self::ExtensionsNotEnabledInReplica => serializer.serialize_i32(48),
+                Self::UnsupportedColumns => serializer.serialize_i32(49),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlExternalSyncSettingErrorType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlExternalSyncSettingErrorType>::new(
+                ".google.cloud.sql.v1.SqlExternalSyncSettingError.SqlExternalSyncSettingErrorType"))
         }
     }
 }
@@ -6982,74 +7583,133 @@ pub mod api_warning {
     use super::*;
 
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlApiWarningCode(i32);
-
-    impl SqlApiWarningCode {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlApiWarningCode {
         /// An unknown or unset warning type from Cloud SQL API.
-        pub const SQL_API_WARNING_CODE_UNSPECIFIED: SqlApiWarningCode = SqlApiWarningCode::new(0);
-
+        Unspecified,
         /// Warning when one or more regions are not reachable.  The returned result
         /// set may be incomplete.
-        pub const REGION_UNREACHABLE: SqlApiWarningCode = SqlApiWarningCode::new(1);
-
+        RegionUnreachable,
         /// Warning when user provided maxResults parameter exceeds the limit.  The
         /// returned result set may be incomplete.
-        pub const MAX_RESULTS_EXCEEDS_LIMIT: SqlApiWarningCode = SqlApiWarningCode::new(2);
-
+        MaxResultsExceedsLimit,
         /// Warning when user tries to create/update a user with credentials that
         /// have previously been compromised by a public data breach.
-        pub const COMPROMISED_CREDENTIALS: SqlApiWarningCode = SqlApiWarningCode::new(3);
-
+        CompromisedCredentials,
         /// Warning when the operation succeeds but some non-critical workflow state
         /// failed.
-        pub const INTERNAL_STATE_FAILURE: SqlApiWarningCode = SqlApiWarningCode::new(4);
-
-        /// Creates a new SqlApiWarningCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_API_WARNING_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGION_UNREACHABLE"),
-                2 => std::borrow::Cow::Borrowed("MAX_RESULTS_EXCEEDS_LIMIT"),
-                3 => std::borrow::Cow::Borrowed("COMPROMISED_CREDENTIALS"),
-                4 => std::borrow::Cow::Borrowed("INTERNAL_STATE_FAILURE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_API_WARNING_CODE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_API_WARNING_CODE_UNSPECIFIED),
-                "REGION_UNREACHABLE" => std::option::Option::Some(Self::REGION_UNREACHABLE),
-                "MAX_RESULTS_EXCEEDS_LIMIT" => std::option::Option::Some(Self::MAX_RESULTS_EXCEEDS_LIMIT),
-                "COMPROMISED_CREDENTIALS" => std::option::Option::Some(Self::COMPROMISED_CREDENTIALS),
-                "INTERNAL_STATE_FAILURE" => std::option::Option::Some(Self::INTERNAL_STATE_FAILURE),
-                _ => std::option::Option::None,
-            }
-        }
+        InternalStateFailure,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlApiWarningCode::value] or
+        /// [SqlApiWarningCode::name].
+        UnknownValue(sql_api_warning_code::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlApiWarningCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_api_warning_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlApiWarningCode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RegionUnreachable => std::option::Option::Some(1),
+                Self::MaxResultsExceedsLimit => std::option::Option::Some(2),
+                Self::CompromisedCredentials => std::option::Option::Some(3),
+                Self::InternalStateFailure => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_API_WARNING_CODE_UNSPECIFIED"),
+                Self::RegionUnreachable => std::option::Option::Some("REGION_UNREACHABLE"),
+                Self::MaxResultsExceedsLimit => std::option::Option::Some("MAX_RESULTS_EXCEEDS_LIMIT"),
+                Self::CompromisedCredentials => std::option::Option::Some("COMPROMISED_CREDENTIALS"),
+                Self::InternalStateFailure => std::option::Option::Some("INTERNAL_STATE_FAILURE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlApiWarningCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlApiWarningCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlApiWarningCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RegionUnreachable,
+                2 => Self::MaxResultsExceedsLimit,
+                3 => Self::CompromisedCredentials,
+                4 => Self::InternalStateFailure,
+                _ => Self::UnknownValue(sql_api_warning_code::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlApiWarningCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_API_WARNING_CODE_UNSPECIFIED" => Self::Unspecified,
+                "REGION_UNREACHABLE" => Self::RegionUnreachable,
+                "MAX_RESULTS_EXCEEDS_LIMIT" => Self::MaxResultsExceedsLimit,
+                "COMPROMISED_CREDENTIALS" => Self::CompromisedCredentials,
+                "INTERNAL_STATE_FAILURE" => Self::InternalStateFailure,
+                _ => Self::UnknownValue(sql_api_warning_code::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlApiWarningCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RegionUnreachable => serializer.serialize_i32(1),
+                Self::MaxResultsExceedsLimit => serializer.serialize_i32(2),
+                Self::CompromisedCredentials => serializer.serialize_i32(3),
+                Self::InternalStateFailure => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlApiWarningCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlApiWarningCode>::new(
+                ".google.cloud.sql.v1.ApiWarning.SqlApiWarningCode"))
         }
     }
 }
@@ -7106,55 +7766,108 @@ pub mod backup_retention_settings {
 
 
     /// The units that retained_backups specifies, we only support COUNT.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RetentionUnit(i32);
-
-    impl RetentionUnit {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RetentionUnit {
         /// Backup retention unit is unspecified, will be treated as COUNT.
-        pub const RETENTION_UNIT_UNSPECIFIED: RetentionUnit = RetentionUnit::new(0);
-
+        Unspecified,
         /// Retention will be by count, eg. "retain the most recent 7 backups".
-        pub const COUNT: RetentionUnit = RetentionUnit::new(1);
-
-        /// Creates a new RetentionUnit instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RETENTION_UNIT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COUNT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RETENTION_UNIT_UNSPECIFIED" => std::option::Option::Some(Self::RETENTION_UNIT_UNSPECIFIED),
-                "COUNT" => std::option::Option::Some(Self::COUNT),
-                _ => std::option::Option::None,
-            }
-        }
+        Count,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RetentionUnit::value] or
+        /// [RetentionUnit::name].
+        UnknownValue(retention_unit::UnknownValue),
     }
 
-    impl std::convert::From<i32> for RetentionUnit {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod retention_unit {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl RetentionUnit {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Count => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RETENTION_UNIT_UNSPECIFIED"),
+                Self::Count => std::option::Option::Some("COUNT"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for RetentionUnit {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RetentionUnit {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RetentionUnit {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Count,
+                _ => Self::UnknownValue(retention_unit::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RetentionUnit {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RETENTION_UNIT_UNSPECIFIED" => Self::Unspecified,
+                "COUNT" => Self::Count,
+                _ => Self::UnknownValue(retention_unit::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RetentionUnit {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Count => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RetentionUnit {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RetentionUnit>::new(
+                ".google.cloud.sql.v1.BackupRetentionSettings.RetentionUnit"))
         }
     }
 }
@@ -7294,76 +8007,135 @@ pub mod backup_configuration {
 
     /// This value contains the storage location of the transactional logs
     /// used to perform point-in-time recovery (PITR) for the database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransactionalLogStorageState(i32);
-
-    impl TransactionalLogStorageState {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TransactionalLogStorageState {
         /// Unspecified.
-        pub const TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED: TransactionalLogStorageState = TransactionalLogStorageState::new(0);
-
+        Unspecified,
         /// The transaction logs used for PITR for the instance are stored
         /// on a data disk.
-        pub const DISK: TransactionalLogStorageState = TransactionalLogStorageState::new(1);
-
+        Disk,
         /// The transaction logs used for PITR for the instance are switching from
         /// being stored on a data disk to being stored in Cloud Storage.
         /// Only applicable to MySQL.
-        pub const SWITCHING_TO_CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new(2);
-
+        SwitchingToCloudStorage,
         /// The transaction logs used for PITR for the instance are now stored
         /// in Cloud Storage. Previously, they were stored on a data disk.
         /// Only applicable to MySQL.
-        pub const SWITCHED_TO_CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new(3);
-
+        SwitchedToCloudStorage,
         /// The transaction logs used for PITR for the instance are stored in
         /// Cloud Storage. Only applicable to MySQL and PostgreSQL.
-        pub const CLOUD_STORAGE: TransactionalLogStorageState = TransactionalLogStorageState::new(4);
-
-        /// Creates a new TransactionalLogStorageState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISK"),
-                2 => std::borrow::Cow::Borrowed("SWITCHING_TO_CLOUD_STORAGE"),
-                3 => std::borrow::Cow::Borrowed("SWITCHED_TO_CLOUD_STORAGE"),
-                4 => std::borrow::Cow::Borrowed("CLOUD_STORAGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED" => std::option::Option::Some(Self::TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED),
-                "DISK" => std::option::Option::Some(Self::DISK),
-                "SWITCHING_TO_CLOUD_STORAGE" => std::option::Option::Some(Self::SWITCHING_TO_CLOUD_STORAGE),
-                "SWITCHED_TO_CLOUD_STORAGE" => std::option::Option::Some(Self::SWITCHED_TO_CLOUD_STORAGE),
-                "CLOUD_STORAGE" => std::option::Option::Some(Self::CLOUD_STORAGE),
-                _ => std::option::Option::None,
-            }
-        }
+        CloudStorage,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TransactionalLogStorageState::value] or
+        /// [TransactionalLogStorageState::name].
+        UnknownValue(transactional_log_storage_state::UnknownValue),
     }
 
-    impl std::convert::From<i32> for TransactionalLogStorageState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod transactional_log_storage_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl TransactionalLogStorageState {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disk => std::option::Option::Some(1),
+                Self::SwitchingToCloudStorage => std::option::Option::Some(2),
+                Self::SwitchedToCloudStorage => std::option::Option::Some(3),
+                Self::CloudStorage => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED"),
+                Self::Disk => std::option::Option::Some("DISK"),
+                Self::SwitchingToCloudStorage => std::option::Option::Some("SWITCHING_TO_CLOUD_STORAGE"),
+                Self::SwitchedToCloudStorage => std::option::Option::Some("SWITCHED_TO_CLOUD_STORAGE"),
+                Self::CloudStorage => std::option::Option::Some("CLOUD_STORAGE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for TransactionalLogStorageState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TransactionalLogStorageState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TransactionalLogStorageState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disk,
+                2 => Self::SwitchingToCloudStorage,
+                3 => Self::SwitchedToCloudStorage,
+                4 => Self::CloudStorage,
+                _ => Self::UnknownValue(transactional_log_storage_state::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TransactionalLogStorageState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRANSACTIONAL_LOG_STORAGE_STATE_UNSPECIFIED" => Self::Unspecified,
+                "DISK" => Self::Disk,
+                "SWITCHING_TO_CLOUD_STORAGE" => Self::SwitchingToCloudStorage,
+                "SWITCHED_TO_CLOUD_STORAGE" => Self::SwitchedToCloudStorage,
+                "CLOUD_STORAGE" => Self::CloudStorage,
+                _ => Self::UnknownValue(transactional_log_storage_state::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TransactionalLogStorageState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disk => serializer.serialize_i32(1),
+                Self::SwitchingToCloudStorage => serializer.serialize_i32(2),
+                Self::SwitchedToCloudStorage => serializer.serialize_i32(3),
+                Self::CloudStorage => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TransactionalLogStorageState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransactionalLogStorageState>::new(
+                ".google.cloud.sql.v1.BackupConfiguration.TransactionalLogStorageState"))
         }
     }
 }
@@ -9065,30 +9837,25 @@ pub mod ip_configuration {
 
 
     /// The SSL options for database connections.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SslMode(i32);
-
-    impl SslMode {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SslMode {
         /// The SSL mode is unknown.
-        pub const SSL_MODE_UNSPECIFIED: SslMode = SslMode::new(0);
-
+        Unspecified,
         /// Allow non-SSL/non-TLS and SSL/TLS connections.
         /// For SSL connections to MySQL and PostgreSQL, the client certificate
         /// isn't verified.
         ///
         /// When this value is used, the legacy `require_ssl` flag must be false or
         /// cleared to avoid a conflict between the values of the two flags.
-        pub const ALLOW_UNENCRYPTED_AND_ENCRYPTED: SslMode = SslMode::new(1);
-
+        AllowUnencryptedAndEncrypted,
         /// Only allow connections encrypted with SSL/TLS.
         /// For SSL connections to MySQL and PostgreSQL, the client certificate
         /// isn't verified.
         ///
         /// When this value is used, the legacy `require_ssl` flag must be false or
         /// cleared to avoid a conflict between the values of the two flags.
-        pub const ENCRYPTED_ONLY: SslMode = SslMode::new(2);
-
+        EncryptedOnly,
         /// Only allow connections encrypted with SSL/TLS and with valid
         /// client certificates.
         ///
@@ -9103,109 +9870,226 @@ pub mod ip_configuration {
         /// to enforce client identity verification.
         ///
         /// Only applicable to MySQL and PostgreSQL. Not applicable to SQL Server.
-        pub const TRUSTED_CLIENT_CERTIFICATE_REQUIRED: SslMode = SslMode::new(3);
-
-        /// Creates a new SslMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SSL_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW_UNENCRYPTED_AND_ENCRYPTED"),
-                2 => std::borrow::Cow::Borrowed("ENCRYPTED_ONLY"),
-                3 => std::borrow::Cow::Borrowed("TRUSTED_CLIENT_CERTIFICATE_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SSL_MODE_UNSPECIFIED" => std::option::Option::Some(Self::SSL_MODE_UNSPECIFIED),
-                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => std::option::Option::Some(Self::ALLOW_UNENCRYPTED_AND_ENCRYPTED),
-                "ENCRYPTED_ONLY" => std::option::Option::Some(Self::ENCRYPTED_ONLY),
-                "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" => std::option::Option::Some(Self::TRUSTED_CLIENT_CERTIFICATE_REQUIRED),
-                _ => std::option::Option::None,
-            }
-        }
+        TrustedClientCertificateRequired,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SslMode::value] or
+        /// [SslMode::name].
+        UnknownValue(ssl_mode::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SslMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod ssl_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SslMode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllowUnencryptedAndEncrypted => std::option::Option::Some(1),
+                Self::EncryptedOnly => std::option::Option::Some(2),
+                Self::TrustedClientCertificateRequired => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SSL_MODE_UNSPECIFIED"),
+                Self::AllowUnencryptedAndEncrypted => std::option::Option::Some("ALLOW_UNENCRYPTED_AND_ENCRYPTED"),
+                Self::EncryptedOnly => std::option::Option::Some("ENCRYPTED_ONLY"),
+                Self::TrustedClientCertificateRequired => std::option::Option::Some("TRUSTED_CLIENT_CERTIFICATE_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SslMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SslMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SslMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllowUnencryptedAndEncrypted,
+                2 => Self::EncryptedOnly,
+                3 => Self::TrustedClientCertificateRequired,
+                _ => Self::UnknownValue(ssl_mode::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SslMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SSL_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW_UNENCRYPTED_AND_ENCRYPTED" => Self::AllowUnencryptedAndEncrypted,
+                "ENCRYPTED_ONLY" => Self::EncryptedOnly,
+                "TRUSTED_CLIENT_CERTIFICATE_REQUIRED" => Self::TrustedClientCertificateRequired,
+                _ => Self::UnknownValue(ssl_mode::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SslMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllowUnencryptedAndEncrypted => serializer.serialize_i32(1),
+                Self::EncryptedOnly => serializer.serialize_i32(2),
+                Self::TrustedClientCertificateRequired => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SslMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SslMode>::new(
+                ".google.cloud.sql.v1.IpConfiguration.SslMode"))
         }
     }
 
     /// Various Certificate Authority (CA) modes for certificate signing.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CaMode(i32);
-
-    impl CaMode {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CaMode {
         /// CA mode is unknown.
-        pub const CA_MODE_UNSPECIFIED: CaMode = CaMode::new(0);
-
+        Unspecified,
         /// Google-managed self-signed internal CA.
-        pub const GOOGLE_MANAGED_INTERNAL_CA: CaMode = CaMode::new(1);
-
+        GoogleManagedInternalCa,
         /// Google-managed regional CA part of root CA hierarchy hosted on Google
         /// Cloud's Certificate Authority Service (CAS).
-        pub const GOOGLE_MANAGED_CAS_CA: CaMode = CaMode::new(2);
-
-        /// Creates a new CaMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CA_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_INTERNAL_CA"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED_CAS_CA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CA_MODE_UNSPECIFIED" => std::option::Option::Some(Self::CA_MODE_UNSPECIFIED),
-                "GOOGLE_MANAGED_INTERNAL_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_INTERNAL_CA),
-                "GOOGLE_MANAGED_CAS_CA" => std::option::Option::Some(Self::GOOGLE_MANAGED_CAS_CA),
-                _ => std::option::Option::None,
-            }
-        }
+        GoogleManagedCasCa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CaMode::value] or
+        /// [CaMode::name].
+        UnknownValue(ca_mode::UnknownValue),
     }
 
-    impl std::convert::From<i32> for CaMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod ca_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl CaMode {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleManagedInternalCa => std::option::Option::Some(1),
+                Self::GoogleManagedCasCa => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CA_MODE_UNSPECIFIED"),
+                Self::GoogleManagedInternalCa => std::option::Option::Some("GOOGLE_MANAGED_INTERNAL_CA"),
+                Self::GoogleManagedCasCa => std::option::Option::Some("GOOGLE_MANAGED_CAS_CA"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for CaMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CaMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CaMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleManagedInternalCa,
+                2 => Self::GoogleManagedCasCa,
+                _ => Self::UnknownValue(ca_mode::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CaMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CA_MODE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_MANAGED_INTERNAL_CA" => Self::GoogleManagedInternalCa,
+                "GOOGLE_MANAGED_CAS_CA" => Self::GoogleManagedCasCa,
+                _ => Self::UnknownValue(ca_mode::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CaMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleManagedInternalCa => serializer.serialize_i32(1),
+                Self::GoogleManagedCasCa => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CaMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CaMode>::new(
+                ".google.cloud.sql.v1.IpConfiguration.CaMode"))
         }
     }
 }
@@ -10057,352 +10941,550 @@ pub mod operation {
 
 
     /// The type of Cloud SQL operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlOperationType(i32);
-
-    impl SqlOperationType {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlOperationType {
         /// Unknown operation type.
-        pub const SQL_OPERATION_TYPE_UNSPECIFIED: SqlOperationType = SqlOperationType::new(0);
-
+        Unspecified,
         /// Imports data into a Cloud SQL instance.
-        pub const IMPORT: SqlOperationType = SqlOperationType::new(1);
-
+        Import,
         /// Exports data from a Cloud SQL instance to a Cloud Storage
         /// bucket.
-        pub const EXPORT: SqlOperationType = SqlOperationType::new(2);
-
+        Export,
         /// Creates a new Cloud SQL instance.
-        pub const CREATE: SqlOperationType = SqlOperationType::new(3);
-
+        Create,
         /// Updates the settings of a Cloud SQL instance.
-        pub const UPDATE: SqlOperationType = SqlOperationType::new(4);
-
+        Update,
         /// Deletes a Cloud SQL instance.
-        pub const DELETE: SqlOperationType = SqlOperationType::new(5);
-
+        Delete,
         /// Restarts the Cloud SQL instance.
-        pub const RESTART: SqlOperationType = SqlOperationType::new(6);
-
-        pub const BACKUP: SqlOperationType = SqlOperationType::new(7);
-
-        pub const SNAPSHOT: SqlOperationType = SqlOperationType::new(8);
-
+        Restart,
+        Backup,
+        Snapshot,
         /// Performs instance backup.
-        pub const BACKUP_VOLUME: SqlOperationType = SqlOperationType::new(9);
-
+        BackupVolume,
         /// Deletes an instance backup.
-        pub const DELETE_VOLUME: SqlOperationType = SqlOperationType::new(10);
-
+        DeleteVolume,
         /// Restores an instance backup.
-        pub const RESTORE_VOLUME: SqlOperationType = SqlOperationType::new(11);
-
+        RestoreVolume,
         /// Injects a privileged user in mysql for MOB instances.
-        pub const INJECT_USER: SqlOperationType = SqlOperationType::new(12);
-
+        InjectUser,
         /// Clones a Cloud SQL instance.
-        pub const CLONE: SqlOperationType = SqlOperationType::new(14);
-
+        Clone,
         /// Stops replication on a Cloud SQL read replica instance.
-        pub const STOP_REPLICA: SqlOperationType = SqlOperationType::new(15);
-
+        StopReplica,
         /// Starts replication on a Cloud SQL read replica instance.
-        pub const START_REPLICA: SqlOperationType = SqlOperationType::new(16);
-
+        StartReplica,
         /// Promotes a Cloud SQL replica instance.
-        pub const PROMOTE_REPLICA: SqlOperationType = SqlOperationType::new(17);
-
+        PromoteReplica,
         /// Creates a Cloud SQL replica instance.
-        pub const CREATE_REPLICA: SqlOperationType = SqlOperationType::new(18);
-
+        CreateReplica,
         /// Creates a new user in a Cloud SQL instance.
-        pub const CREATE_USER: SqlOperationType = SqlOperationType::new(19);
-
+        CreateUser,
         /// Deletes a user from a Cloud SQL instance.
-        pub const DELETE_USER: SqlOperationType = SqlOperationType::new(20);
-
+        DeleteUser,
         /// Updates an existing user in a Cloud SQL instance.
-        pub const UPDATE_USER: SqlOperationType = SqlOperationType::new(21);
-
+        UpdateUser,
         /// Creates a database in the Cloud SQL instance.
-        pub const CREATE_DATABASE: SqlOperationType = SqlOperationType::new(22);
-
+        CreateDatabase,
         /// Deletes a database in the Cloud SQL instance.
-        pub const DELETE_DATABASE: SqlOperationType = SqlOperationType::new(23);
-
+        DeleteDatabase,
         /// Updates a database in the Cloud SQL instance.
-        pub const UPDATE_DATABASE: SqlOperationType = SqlOperationType::new(24);
-
+        UpdateDatabase,
         /// Performs failover of an HA-enabled Cloud SQL
         /// failover replica.
-        pub const FAILOVER: SqlOperationType = SqlOperationType::new(25);
-
+        Failover,
         /// Deletes the backup taken by a backup run.
-        pub const DELETE_BACKUP: SqlOperationType = SqlOperationType::new(26);
-
-        pub const RECREATE_REPLICA: SqlOperationType = SqlOperationType::new(27);
-
+        DeleteBackup,
+        RecreateReplica,
         /// Truncates a general or slow log table in MySQL.
-        pub const TRUNCATE_LOG: SqlOperationType = SqlOperationType::new(28);
-
+        TruncateLog,
         /// Demotes the stand-alone instance to be a Cloud SQL
         /// read replica for an external database server.
-        pub const DEMOTE_MASTER: SqlOperationType = SqlOperationType::new(29);
-
+        DemoteMaster,
         /// Indicates that the instance is currently in maintenance. Maintenance
         /// typically causes the instance to be unavailable for 1-3 minutes.
-        pub const MAINTENANCE: SqlOperationType = SqlOperationType::new(30);
-
+        Maintenance,
         /// This field is deprecated, and will be removed in future version of API.
-        pub const ENABLE_PRIVATE_IP: SqlOperationType = SqlOperationType::new(31);
-
-        pub const DEFER_MAINTENANCE: SqlOperationType = SqlOperationType::new(32);
-
+        EnablePrivateIp,
+        DeferMaintenance,
         /// Creates clone instance.
-        pub const CREATE_CLONE: SqlOperationType = SqlOperationType::new(33);
-
+        CreateClone,
         /// Reschedule maintenance to another time.
-        pub const RESCHEDULE_MAINTENANCE: SqlOperationType = SqlOperationType::new(34);
-
+        RescheduleMaintenance,
         /// Starts external sync of a Cloud SQL EM replica to an external primary
         /// instance.
-        pub const START_EXTERNAL_SYNC: SqlOperationType = SqlOperationType::new(35);
-
+        StartExternalSync,
         /// Recovers logs from an instance's old data disk.
-        pub const LOG_CLEANUP: SqlOperationType = SqlOperationType::new(36);
-
+        LogCleanup,
         /// Performs auto-restart of an HA-enabled Cloud SQL database for auto
         /// recovery.
-        pub const AUTO_RESTART: SqlOperationType = SqlOperationType::new(37);
-
+        AutoRestart,
         /// Re-encrypts CMEK instances with latest key version.
-        pub const REENCRYPT: SqlOperationType = SqlOperationType::new(38);
-
+        Reencrypt,
         /// Switches the roles of the primary and replica pair. The target instance
         /// should be the replica.
-        pub const SWITCHOVER: SqlOperationType = SqlOperationType::new(39);
-
+        Switchover,
         /// Acquire a lease for the setup of SQL Server Reporting Services (SSRS).
-        pub const ACQUIRE_SSRS_LEASE: SqlOperationType = SqlOperationType::new(42);
-
+        AcquireSsrsLease,
         /// Release a lease for the setup of SQL Server Reporting Services (SSRS).
-        pub const RELEASE_SSRS_LEASE: SqlOperationType = SqlOperationType::new(43);
-
+        ReleaseSsrsLease,
         /// Reconfigures old primary after a promote replica operation. Effect of a
         /// promote operation to the old primary is executed in this operation,
         /// asynchronously from the promote replica operation executed to the
         /// replica.
-        pub const RECONFIGURE_OLD_PRIMARY: SqlOperationType = SqlOperationType::new(44);
-
+        ReconfigureOldPrimary,
         /// Indicates that the instance, its read replicas, and its cascading
         /// replicas are in maintenance. Maintenance typically gets initiated on
         /// groups of replicas first, followed by the primary instance. For each
         /// instance, maintenance typically causes the instance to be unavailable for
         /// 1-3 minutes.
-        pub const CLUSTER_MAINTENANCE: SqlOperationType = SqlOperationType::new(45);
-
+        ClusterMaintenance,
         /// Indicates that the instance (and any of its replicas) are currently in
         /// maintenance. This is initiated as a self-service request by using SSM.
         /// Maintenance typically causes the instance to be unavailable for 1-3
         /// minutes.
-        pub const SELF_SERVICE_MAINTENANCE: SqlOperationType = SqlOperationType::new(46);
-
+        SelfServiceMaintenance,
         /// Switches a primary instance to a replica. This operation runs as part of
         /// a switchover operation to the original primary instance.
-        pub const SWITCHOVER_TO_REPLICA: SqlOperationType = SqlOperationType::new(47);
-
+        SwitchoverToReplica,
         /// Updates the major version of a Cloud SQL instance.
-        pub const MAJOR_VERSION_UPGRADE: SqlOperationType = SqlOperationType::new(48);
-
-        /// Creates a new SqlOperationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_OPERATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPORT"),
-                2 => std::borrow::Cow::Borrowed("EXPORT"),
-                3 => std::borrow::Cow::Borrowed("CREATE"),
-                4 => std::borrow::Cow::Borrowed("UPDATE"),
-                5 => std::borrow::Cow::Borrowed("DELETE"),
-                6 => std::borrow::Cow::Borrowed("RESTART"),
-                7 => std::borrow::Cow::Borrowed("BACKUP"),
-                8 => std::borrow::Cow::Borrowed("SNAPSHOT"),
-                9 => std::borrow::Cow::Borrowed("BACKUP_VOLUME"),
-                10 => std::borrow::Cow::Borrowed("DELETE_VOLUME"),
-                11 => std::borrow::Cow::Borrowed("RESTORE_VOLUME"),
-                12 => std::borrow::Cow::Borrowed("INJECT_USER"),
-                14 => std::borrow::Cow::Borrowed("CLONE"),
-                15 => std::borrow::Cow::Borrowed("STOP_REPLICA"),
-                16 => std::borrow::Cow::Borrowed("START_REPLICA"),
-                17 => std::borrow::Cow::Borrowed("PROMOTE_REPLICA"),
-                18 => std::borrow::Cow::Borrowed("CREATE_REPLICA"),
-                19 => std::borrow::Cow::Borrowed("CREATE_USER"),
-                20 => std::borrow::Cow::Borrowed("DELETE_USER"),
-                21 => std::borrow::Cow::Borrowed("UPDATE_USER"),
-                22 => std::borrow::Cow::Borrowed("CREATE_DATABASE"),
-                23 => std::borrow::Cow::Borrowed("DELETE_DATABASE"),
-                24 => std::borrow::Cow::Borrowed("UPDATE_DATABASE"),
-                25 => std::borrow::Cow::Borrowed("FAILOVER"),
-                26 => std::borrow::Cow::Borrowed("DELETE_BACKUP"),
-                27 => std::borrow::Cow::Borrowed("RECREATE_REPLICA"),
-                28 => std::borrow::Cow::Borrowed("TRUNCATE_LOG"),
-                29 => std::borrow::Cow::Borrowed("DEMOTE_MASTER"),
-                30 => std::borrow::Cow::Borrowed("MAINTENANCE"),
-                31 => std::borrow::Cow::Borrowed("ENABLE_PRIVATE_IP"),
-                32 => std::borrow::Cow::Borrowed("DEFER_MAINTENANCE"),
-                33 => std::borrow::Cow::Borrowed("CREATE_CLONE"),
-                34 => std::borrow::Cow::Borrowed("RESCHEDULE_MAINTENANCE"),
-                35 => std::borrow::Cow::Borrowed("START_EXTERNAL_SYNC"),
-                36 => std::borrow::Cow::Borrowed("LOG_CLEANUP"),
-                37 => std::borrow::Cow::Borrowed("AUTO_RESTART"),
-                38 => std::borrow::Cow::Borrowed("REENCRYPT"),
-                39 => std::borrow::Cow::Borrowed("SWITCHOVER"),
-                42 => std::borrow::Cow::Borrowed("ACQUIRE_SSRS_LEASE"),
-                43 => std::borrow::Cow::Borrowed("RELEASE_SSRS_LEASE"),
-                44 => std::borrow::Cow::Borrowed("RECONFIGURE_OLD_PRIMARY"),
-                45 => std::borrow::Cow::Borrowed("CLUSTER_MAINTENANCE"),
-                46 => std::borrow::Cow::Borrowed("SELF_SERVICE_MAINTENANCE"),
-                47 => std::borrow::Cow::Borrowed("SWITCHOVER_TO_REPLICA"),
-                48 => std::borrow::Cow::Borrowed("MAJOR_VERSION_UPGRADE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_OPERATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_OPERATION_TYPE_UNSPECIFIED),
-                "IMPORT" => std::option::Option::Some(Self::IMPORT),
-                "EXPORT" => std::option::Option::Some(Self::EXPORT),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "RESTART" => std::option::Option::Some(Self::RESTART),
-                "BACKUP" => std::option::Option::Some(Self::BACKUP),
-                "SNAPSHOT" => std::option::Option::Some(Self::SNAPSHOT),
-                "BACKUP_VOLUME" => std::option::Option::Some(Self::BACKUP_VOLUME),
-                "DELETE_VOLUME" => std::option::Option::Some(Self::DELETE_VOLUME),
-                "RESTORE_VOLUME" => std::option::Option::Some(Self::RESTORE_VOLUME),
-                "INJECT_USER" => std::option::Option::Some(Self::INJECT_USER),
-                "CLONE" => std::option::Option::Some(Self::CLONE),
-                "STOP_REPLICA" => std::option::Option::Some(Self::STOP_REPLICA),
-                "START_REPLICA" => std::option::Option::Some(Self::START_REPLICA),
-                "PROMOTE_REPLICA" => std::option::Option::Some(Self::PROMOTE_REPLICA),
-                "CREATE_REPLICA" => std::option::Option::Some(Self::CREATE_REPLICA),
-                "CREATE_USER" => std::option::Option::Some(Self::CREATE_USER),
-                "DELETE_USER" => std::option::Option::Some(Self::DELETE_USER),
-                "UPDATE_USER" => std::option::Option::Some(Self::UPDATE_USER),
-                "CREATE_DATABASE" => std::option::Option::Some(Self::CREATE_DATABASE),
-                "DELETE_DATABASE" => std::option::Option::Some(Self::DELETE_DATABASE),
-                "UPDATE_DATABASE" => std::option::Option::Some(Self::UPDATE_DATABASE),
-                "FAILOVER" => std::option::Option::Some(Self::FAILOVER),
-                "DELETE_BACKUP" => std::option::Option::Some(Self::DELETE_BACKUP),
-                "RECREATE_REPLICA" => std::option::Option::Some(Self::RECREATE_REPLICA),
-                "TRUNCATE_LOG" => std::option::Option::Some(Self::TRUNCATE_LOG),
-                "DEMOTE_MASTER" => std::option::Option::Some(Self::DEMOTE_MASTER),
-                "MAINTENANCE" => std::option::Option::Some(Self::MAINTENANCE),
-                "ENABLE_PRIVATE_IP" => std::option::Option::Some(Self::ENABLE_PRIVATE_IP),
-                "DEFER_MAINTENANCE" => std::option::Option::Some(Self::DEFER_MAINTENANCE),
-                "CREATE_CLONE" => std::option::Option::Some(Self::CREATE_CLONE),
-                "RESCHEDULE_MAINTENANCE" => std::option::Option::Some(Self::RESCHEDULE_MAINTENANCE),
-                "START_EXTERNAL_SYNC" => std::option::Option::Some(Self::START_EXTERNAL_SYNC),
-                "LOG_CLEANUP" => std::option::Option::Some(Self::LOG_CLEANUP),
-                "AUTO_RESTART" => std::option::Option::Some(Self::AUTO_RESTART),
-                "REENCRYPT" => std::option::Option::Some(Self::REENCRYPT),
-                "SWITCHOVER" => std::option::Option::Some(Self::SWITCHOVER),
-                "ACQUIRE_SSRS_LEASE" => std::option::Option::Some(Self::ACQUIRE_SSRS_LEASE),
-                "RELEASE_SSRS_LEASE" => std::option::Option::Some(Self::RELEASE_SSRS_LEASE),
-                "RECONFIGURE_OLD_PRIMARY" => std::option::Option::Some(Self::RECONFIGURE_OLD_PRIMARY),
-                "CLUSTER_MAINTENANCE" => std::option::Option::Some(Self::CLUSTER_MAINTENANCE),
-                "SELF_SERVICE_MAINTENANCE" => std::option::Option::Some(Self::SELF_SERVICE_MAINTENANCE),
-                "SWITCHOVER_TO_REPLICA" => std::option::Option::Some(Self::SWITCHOVER_TO_REPLICA),
-                "MAJOR_VERSION_UPGRADE" => std::option::Option::Some(Self::MAJOR_VERSION_UPGRADE),
-                _ => std::option::Option::None,
-            }
-        }
+        MajorVersionUpgrade,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlOperationType::value] or
+        /// [SqlOperationType::name].
+        UnknownValue(sql_operation_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlOperationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_operation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlOperationType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Import => std::option::Option::Some(1),
+                Self::Export => std::option::Option::Some(2),
+                Self::Create => std::option::Option::Some(3),
+                Self::Update => std::option::Option::Some(4),
+                Self::Delete => std::option::Option::Some(5),
+                Self::Restart => std::option::Option::Some(6),
+                Self::Backup => std::option::Option::Some(7),
+                Self::Snapshot => std::option::Option::Some(8),
+                Self::BackupVolume => std::option::Option::Some(9),
+                Self::DeleteVolume => std::option::Option::Some(10),
+                Self::RestoreVolume => std::option::Option::Some(11),
+                Self::InjectUser => std::option::Option::Some(12),
+                Self::Clone => std::option::Option::Some(14),
+                Self::StopReplica => std::option::Option::Some(15),
+                Self::StartReplica => std::option::Option::Some(16),
+                Self::PromoteReplica => std::option::Option::Some(17),
+                Self::CreateReplica => std::option::Option::Some(18),
+                Self::CreateUser => std::option::Option::Some(19),
+                Self::DeleteUser => std::option::Option::Some(20),
+                Self::UpdateUser => std::option::Option::Some(21),
+                Self::CreateDatabase => std::option::Option::Some(22),
+                Self::DeleteDatabase => std::option::Option::Some(23),
+                Self::UpdateDatabase => std::option::Option::Some(24),
+                Self::Failover => std::option::Option::Some(25),
+                Self::DeleteBackup => std::option::Option::Some(26),
+                Self::RecreateReplica => std::option::Option::Some(27),
+                Self::TruncateLog => std::option::Option::Some(28),
+                Self::DemoteMaster => std::option::Option::Some(29),
+                Self::Maintenance => std::option::Option::Some(30),
+                Self::EnablePrivateIp => std::option::Option::Some(31),
+                Self::DeferMaintenance => std::option::Option::Some(32),
+                Self::CreateClone => std::option::Option::Some(33),
+                Self::RescheduleMaintenance => std::option::Option::Some(34),
+                Self::StartExternalSync => std::option::Option::Some(35),
+                Self::LogCleanup => std::option::Option::Some(36),
+                Self::AutoRestart => std::option::Option::Some(37),
+                Self::Reencrypt => std::option::Option::Some(38),
+                Self::Switchover => std::option::Option::Some(39),
+                Self::AcquireSsrsLease => std::option::Option::Some(42),
+                Self::ReleaseSsrsLease => std::option::Option::Some(43),
+                Self::ReconfigureOldPrimary => std::option::Option::Some(44),
+                Self::ClusterMaintenance => std::option::Option::Some(45),
+                Self::SelfServiceMaintenance => std::option::Option::Some(46),
+                Self::SwitchoverToReplica => std::option::Option::Some(47),
+                Self::MajorVersionUpgrade => std::option::Option::Some(48),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_OPERATION_TYPE_UNSPECIFIED"),
+                Self::Import => std::option::Option::Some("IMPORT"),
+                Self::Export => std::option::Option::Some("EXPORT"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Restart => std::option::Option::Some("RESTART"),
+                Self::Backup => std::option::Option::Some("BACKUP"),
+                Self::Snapshot => std::option::Option::Some("SNAPSHOT"),
+                Self::BackupVolume => std::option::Option::Some("BACKUP_VOLUME"),
+                Self::DeleteVolume => std::option::Option::Some("DELETE_VOLUME"),
+                Self::RestoreVolume => std::option::Option::Some("RESTORE_VOLUME"),
+                Self::InjectUser => std::option::Option::Some("INJECT_USER"),
+                Self::Clone => std::option::Option::Some("CLONE"),
+                Self::StopReplica => std::option::Option::Some("STOP_REPLICA"),
+                Self::StartReplica => std::option::Option::Some("START_REPLICA"),
+                Self::PromoteReplica => std::option::Option::Some("PROMOTE_REPLICA"),
+                Self::CreateReplica => std::option::Option::Some("CREATE_REPLICA"),
+                Self::CreateUser => std::option::Option::Some("CREATE_USER"),
+                Self::DeleteUser => std::option::Option::Some("DELETE_USER"),
+                Self::UpdateUser => std::option::Option::Some("UPDATE_USER"),
+                Self::CreateDatabase => std::option::Option::Some("CREATE_DATABASE"),
+                Self::DeleteDatabase => std::option::Option::Some("DELETE_DATABASE"),
+                Self::UpdateDatabase => std::option::Option::Some("UPDATE_DATABASE"),
+                Self::Failover => std::option::Option::Some("FAILOVER"),
+                Self::DeleteBackup => std::option::Option::Some("DELETE_BACKUP"),
+                Self::RecreateReplica => std::option::Option::Some("RECREATE_REPLICA"),
+                Self::TruncateLog => std::option::Option::Some("TRUNCATE_LOG"),
+                Self::DemoteMaster => std::option::Option::Some("DEMOTE_MASTER"),
+                Self::Maintenance => std::option::Option::Some("MAINTENANCE"),
+                Self::EnablePrivateIp => std::option::Option::Some("ENABLE_PRIVATE_IP"),
+                Self::DeferMaintenance => std::option::Option::Some("DEFER_MAINTENANCE"),
+                Self::CreateClone => std::option::Option::Some("CREATE_CLONE"),
+                Self::RescheduleMaintenance => std::option::Option::Some("RESCHEDULE_MAINTENANCE"),
+                Self::StartExternalSync => std::option::Option::Some("START_EXTERNAL_SYNC"),
+                Self::LogCleanup => std::option::Option::Some("LOG_CLEANUP"),
+                Self::AutoRestart => std::option::Option::Some("AUTO_RESTART"),
+                Self::Reencrypt => std::option::Option::Some("REENCRYPT"),
+                Self::Switchover => std::option::Option::Some("SWITCHOVER"),
+                Self::AcquireSsrsLease => std::option::Option::Some("ACQUIRE_SSRS_LEASE"),
+                Self::ReleaseSsrsLease => std::option::Option::Some("RELEASE_SSRS_LEASE"),
+                Self::ReconfigureOldPrimary => std::option::Option::Some("RECONFIGURE_OLD_PRIMARY"),
+                Self::ClusterMaintenance => std::option::Option::Some("CLUSTER_MAINTENANCE"),
+                Self::SelfServiceMaintenance => std::option::Option::Some("SELF_SERVICE_MAINTENANCE"),
+                Self::SwitchoverToReplica => std::option::Option::Some("SWITCHOVER_TO_REPLICA"),
+                Self::MajorVersionUpgrade => std::option::Option::Some("MAJOR_VERSION_UPGRADE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlOperationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlOperationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlOperationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Import,
+                2 => Self::Export,
+                3 => Self::Create,
+                4 => Self::Update,
+                5 => Self::Delete,
+                6 => Self::Restart,
+                7 => Self::Backup,
+                8 => Self::Snapshot,
+                9 => Self::BackupVolume,
+                10 => Self::DeleteVolume,
+                11 => Self::RestoreVolume,
+                12 => Self::InjectUser,
+                14 => Self::Clone,
+                15 => Self::StopReplica,
+                16 => Self::StartReplica,
+                17 => Self::PromoteReplica,
+                18 => Self::CreateReplica,
+                19 => Self::CreateUser,
+                20 => Self::DeleteUser,
+                21 => Self::UpdateUser,
+                22 => Self::CreateDatabase,
+                23 => Self::DeleteDatabase,
+                24 => Self::UpdateDatabase,
+                25 => Self::Failover,
+                26 => Self::DeleteBackup,
+                27 => Self::RecreateReplica,
+                28 => Self::TruncateLog,
+                29 => Self::DemoteMaster,
+                30 => Self::Maintenance,
+                31 => Self::EnablePrivateIp,
+                32 => Self::DeferMaintenance,
+                33 => Self::CreateClone,
+                34 => Self::RescheduleMaintenance,
+                35 => Self::StartExternalSync,
+                36 => Self::LogCleanup,
+                37 => Self::AutoRestart,
+                38 => Self::Reencrypt,
+                39 => Self::Switchover,
+                42 => Self::AcquireSsrsLease,
+                43 => Self::ReleaseSsrsLease,
+                44 => Self::ReconfigureOldPrimary,
+                45 => Self::ClusterMaintenance,
+                46 => Self::SelfServiceMaintenance,
+                47 => Self::SwitchoverToReplica,
+                48 => Self::MajorVersionUpgrade,
+                _ => Self::UnknownValue(sql_operation_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlOperationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_OPERATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMPORT" => Self::Import,
+                "EXPORT" => Self::Export,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                "RESTART" => Self::Restart,
+                "BACKUP" => Self::Backup,
+                "SNAPSHOT" => Self::Snapshot,
+                "BACKUP_VOLUME" => Self::BackupVolume,
+                "DELETE_VOLUME" => Self::DeleteVolume,
+                "RESTORE_VOLUME" => Self::RestoreVolume,
+                "INJECT_USER" => Self::InjectUser,
+                "CLONE" => Self::Clone,
+                "STOP_REPLICA" => Self::StopReplica,
+                "START_REPLICA" => Self::StartReplica,
+                "PROMOTE_REPLICA" => Self::PromoteReplica,
+                "CREATE_REPLICA" => Self::CreateReplica,
+                "CREATE_USER" => Self::CreateUser,
+                "DELETE_USER" => Self::DeleteUser,
+                "UPDATE_USER" => Self::UpdateUser,
+                "CREATE_DATABASE" => Self::CreateDatabase,
+                "DELETE_DATABASE" => Self::DeleteDatabase,
+                "UPDATE_DATABASE" => Self::UpdateDatabase,
+                "FAILOVER" => Self::Failover,
+                "DELETE_BACKUP" => Self::DeleteBackup,
+                "RECREATE_REPLICA" => Self::RecreateReplica,
+                "TRUNCATE_LOG" => Self::TruncateLog,
+                "DEMOTE_MASTER" => Self::DemoteMaster,
+                "MAINTENANCE" => Self::Maintenance,
+                "ENABLE_PRIVATE_IP" => Self::EnablePrivateIp,
+                "DEFER_MAINTENANCE" => Self::DeferMaintenance,
+                "CREATE_CLONE" => Self::CreateClone,
+                "RESCHEDULE_MAINTENANCE" => Self::RescheduleMaintenance,
+                "START_EXTERNAL_SYNC" => Self::StartExternalSync,
+                "LOG_CLEANUP" => Self::LogCleanup,
+                "AUTO_RESTART" => Self::AutoRestart,
+                "REENCRYPT" => Self::Reencrypt,
+                "SWITCHOVER" => Self::Switchover,
+                "ACQUIRE_SSRS_LEASE" => Self::AcquireSsrsLease,
+                "RELEASE_SSRS_LEASE" => Self::ReleaseSsrsLease,
+                "RECONFIGURE_OLD_PRIMARY" => Self::ReconfigureOldPrimary,
+                "CLUSTER_MAINTENANCE" => Self::ClusterMaintenance,
+                "SELF_SERVICE_MAINTENANCE" => Self::SelfServiceMaintenance,
+                "SWITCHOVER_TO_REPLICA" => Self::SwitchoverToReplica,
+                "MAJOR_VERSION_UPGRADE" => Self::MajorVersionUpgrade,
+                _ => Self::UnknownValue(sql_operation_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlOperationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Import => serializer.serialize_i32(1),
+                Self::Export => serializer.serialize_i32(2),
+                Self::Create => serializer.serialize_i32(3),
+                Self::Update => serializer.serialize_i32(4),
+                Self::Delete => serializer.serialize_i32(5),
+                Self::Restart => serializer.serialize_i32(6),
+                Self::Backup => serializer.serialize_i32(7),
+                Self::Snapshot => serializer.serialize_i32(8),
+                Self::BackupVolume => serializer.serialize_i32(9),
+                Self::DeleteVolume => serializer.serialize_i32(10),
+                Self::RestoreVolume => serializer.serialize_i32(11),
+                Self::InjectUser => serializer.serialize_i32(12),
+                Self::Clone => serializer.serialize_i32(14),
+                Self::StopReplica => serializer.serialize_i32(15),
+                Self::StartReplica => serializer.serialize_i32(16),
+                Self::PromoteReplica => serializer.serialize_i32(17),
+                Self::CreateReplica => serializer.serialize_i32(18),
+                Self::CreateUser => serializer.serialize_i32(19),
+                Self::DeleteUser => serializer.serialize_i32(20),
+                Self::UpdateUser => serializer.serialize_i32(21),
+                Self::CreateDatabase => serializer.serialize_i32(22),
+                Self::DeleteDatabase => serializer.serialize_i32(23),
+                Self::UpdateDatabase => serializer.serialize_i32(24),
+                Self::Failover => serializer.serialize_i32(25),
+                Self::DeleteBackup => serializer.serialize_i32(26),
+                Self::RecreateReplica => serializer.serialize_i32(27),
+                Self::TruncateLog => serializer.serialize_i32(28),
+                Self::DemoteMaster => serializer.serialize_i32(29),
+                Self::Maintenance => serializer.serialize_i32(30),
+                Self::EnablePrivateIp => serializer.serialize_i32(31),
+                Self::DeferMaintenance => serializer.serialize_i32(32),
+                Self::CreateClone => serializer.serialize_i32(33),
+                Self::RescheduleMaintenance => serializer.serialize_i32(34),
+                Self::StartExternalSync => serializer.serialize_i32(35),
+                Self::LogCleanup => serializer.serialize_i32(36),
+                Self::AutoRestart => serializer.serialize_i32(37),
+                Self::Reencrypt => serializer.serialize_i32(38),
+                Self::Switchover => serializer.serialize_i32(39),
+                Self::AcquireSsrsLease => serializer.serialize_i32(42),
+                Self::ReleaseSsrsLease => serializer.serialize_i32(43),
+                Self::ReconfigureOldPrimary => serializer.serialize_i32(44),
+                Self::ClusterMaintenance => serializer.serialize_i32(45),
+                Self::SelfServiceMaintenance => serializer.serialize_i32(46),
+                Self::SwitchoverToReplica => serializer.serialize_i32(47),
+                Self::MajorVersionUpgrade => serializer.serialize_i32(48),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlOperationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlOperationType>::new(
+                ".google.cloud.sql.v1.Operation.SqlOperationType"))
         }
     }
 
     /// The status of an operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlOperationStatus(i32);
-
-    impl SqlOperationStatus {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlOperationStatus {
         /// The state of the operation is unknown.
-        pub const SQL_OPERATION_STATUS_UNSPECIFIED: SqlOperationStatus = SqlOperationStatus::new(0);
-
+        Unspecified,
         /// The operation has been queued, but has not started yet.
-        pub const PENDING: SqlOperationStatus = SqlOperationStatus::new(1);
-
+        Pending,
         /// The operation is running.
-        pub const RUNNING: SqlOperationStatus = SqlOperationStatus::new(2);
-
+        Running,
         /// The operation completed.
-        pub const DONE: SqlOperationStatus = SqlOperationStatus::new(3);
-
-        /// Creates a new SqlOperationStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_OPERATION_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_OPERATION_STATUS_UNSPECIFIED" => std::option::Option::Some(Self::SQL_OPERATION_STATUS_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlOperationStatus::value] or
+        /// [SqlOperationStatus::name].
+        UnknownValue(sql_operation_status::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlOperationStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_operation_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlOperationStatus {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_OPERATION_STATUS_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlOperationStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlOperationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlOperationStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Done,
+                _ => Self::UnknownValue(sql_operation_status::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlOperationStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_OPERATION_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(sql_operation_status::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlOperationStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlOperationStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlOperationStatus>::new(
+                ".google.cloud.sql.v1.Operation.SqlOperationStatus"))
         }
     }
 }
@@ -10609,56 +11691,109 @@ pub mod password_validation_policy {
 
 
     /// The complexity choices of the password.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Complexity(i32);
-
-    impl Complexity {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Complexity {
         /// Complexity check is not specified.
-        pub const COMPLEXITY_UNSPECIFIED: Complexity = Complexity::new(0);
-
+        Unspecified,
         /// A combination of lowercase, uppercase, numeric, and non-alphanumeric
         /// characters.
-        pub const COMPLEXITY_DEFAULT: Complexity = Complexity::new(1);
-
-        /// Creates a new Complexity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPLEXITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COMPLEXITY_DEFAULT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPLEXITY_UNSPECIFIED" => std::option::Option::Some(Self::COMPLEXITY_UNSPECIFIED),
-                "COMPLEXITY_DEFAULT" => std::option::Option::Some(Self::COMPLEXITY_DEFAULT),
-                _ => std::option::Option::None,
-            }
-        }
+        Default,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Complexity::value] or
+        /// [Complexity::name].
+        UnknownValue(complexity::UnknownValue),
     }
 
-    impl std::convert::From<i32> for Complexity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod complexity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl Complexity {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPLEXITY_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("COMPLEXITY_DEFAULT"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for Complexity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Complexity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Complexity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                _ => Self::UnknownValue(complexity::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Complexity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPLEXITY_UNSPECIFIED" => Self::Unspecified,
+                "COMPLEXITY_DEFAULT" => Self::Default,
+                _ => Self::UnknownValue(complexity::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Complexity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Complexity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Complexity>::new(
+                ".google.cloud.sql.v1.PasswordValidationPolicy.Complexity"))
         }
     }
 }
@@ -11134,183 +12269,350 @@ pub mod settings {
 
 
     /// Specifies when the instance is activated.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlActivationPolicy(i32);
-
-    impl SqlActivationPolicy {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlActivationPolicy {
         /// Unknown activation plan.
-        pub const SQL_ACTIVATION_POLICY_UNSPECIFIED: SqlActivationPolicy = SqlActivationPolicy::new(0);
-
+        Unspecified,
         /// The instance is always up and running.
-        pub const ALWAYS: SqlActivationPolicy = SqlActivationPolicy::new(1);
-
+        Always,
         /// The instance never starts.
-        pub const NEVER: SqlActivationPolicy = SqlActivationPolicy::new(2);
-
+        Never,
         /// The instance starts upon receiving requests.
-        pub const ON_DEMAND: SqlActivationPolicy = SqlActivationPolicy::new(3);
-
-        /// Creates a new SqlActivationPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SQL_ACTIVATION_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALWAYS"),
-                2 => std::borrow::Cow::Borrowed("NEVER"),
-                3 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SQL_ACTIVATION_POLICY_UNSPECIFIED" => std::option::Option::Some(Self::SQL_ACTIVATION_POLICY_UNSPECIFIED),
-                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
-                "NEVER" => std::option::Option::Some(Self::NEVER),
-                "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-                _ => std::option::Option::None,
-            }
-        }
+        OnDemand,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlActivationPolicy::value] or
+        /// [SqlActivationPolicy::name].
+        UnknownValue(sql_activation_policy::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlActivationPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_activation_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlActivationPolicy {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Always => std::option::Option::Some(1),
+                Self::Never => std::option::Option::Some(2),
+                Self::OnDemand => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SQL_ACTIVATION_POLICY_UNSPECIFIED"),
+                Self::Always => std::option::Option::Some("ALWAYS"),
+                Self::Never => std::option::Option::Some("NEVER"),
+                Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlActivationPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlActivationPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlActivationPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Always,
+                2 => Self::Never,
+                3 => Self::OnDemand,
+                _ => Self::UnknownValue(sql_activation_policy::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlActivationPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SQL_ACTIVATION_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "ALWAYS" => Self::Always,
+                "NEVER" => Self::Never,
+                "ON_DEMAND" => Self::OnDemand,
+                _ => Self::UnknownValue(sql_activation_policy::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlActivationPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Always => serializer.serialize_i32(1),
+                Self::Never => serializer.serialize_i32(2),
+                Self::OnDemand => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlActivationPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlActivationPolicy>::new(
+                ".google.cloud.sql.v1.Settings.SqlActivationPolicy"))
         }
     }
 
     /// The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Edition(i32);
-
-    impl Edition {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Edition {
         /// The instance did not specify the edition.
-        pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
-
+        Unspecified,
         /// The instance is an enterprise edition.
-        pub const ENTERPRISE: Edition = Edition::new(2);
-
+        Enterprise,
         /// The instance is an Enterprise Plus edition.
-        pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
-
-        /// Creates a new Edition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
-                _ => std::option::Option::None,
-            }
-        }
+        EnterprisePlus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Edition::value] or
+        /// [Edition::name].
+        UnknownValue(edition::UnknownValue),
     }
 
-    impl std::convert::From<i32> for Edition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod edition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl Edition {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::EnterprisePlus => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EDITION_UNSPECIFIED"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::EnterprisePlus => std::option::Option::Some("ENTERPRISE_PLUS"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for Edition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Edition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Edition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Enterprise,
+                3 => Self::EnterprisePlus,
+                _ => Self::UnknownValue(edition::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Edition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EDITION_UNSPECIFIED" => Self::Unspecified,
+                "ENTERPRISE" => Self::Enterprise,
+                "ENTERPRISE_PLUS" => Self::EnterprisePlus,
+                _ => Self::UnknownValue(edition::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Edition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::EnterprisePlus => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Edition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Edition>::new(
+                ".google.cloud.sql.v1.Settings.Edition"))
         }
     }
 
     /// The options for enforcing Cloud SQL connectors in the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConnectorEnforcement(i32);
-
-    impl ConnectorEnforcement {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConnectorEnforcement {
         /// The requirement for Cloud SQL connectors is unknown.
-        pub const CONNECTOR_ENFORCEMENT_UNSPECIFIED: ConnectorEnforcement = ConnectorEnforcement::new(0);
-
+        Unspecified,
         /// Do not require Cloud SQL connectors.
-        pub const NOT_REQUIRED: ConnectorEnforcement = ConnectorEnforcement::new(1);
-
+        NotRequired,
         /// Require all connections to use Cloud SQL connectors, including the
         /// Cloud SQL Auth Proxy and Cloud SQL Java, Python, and Go connectors.
         /// Note: This disables all existing authorized networks.
-        pub const REQUIRED: ConnectorEnforcement = ConnectorEnforcement::new(2);
-
-        /// Creates a new ConnectorEnforcement instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONNECTOR_ENFORCEMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NOT_REQUIRED"),
-                2 => std::borrow::Cow::Borrowed("REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONNECTOR_ENFORCEMENT_UNSPECIFIED" => std::option::Option::Some(Self::CONNECTOR_ENFORCEMENT_UNSPECIFIED),
-                "NOT_REQUIRED" => std::option::Option::Some(Self::NOT_REQUIRED),
-                "REQUIRED" => std::option::Option::Some(Self::REQUIRED),
-                _ => std::option::Option::None,
-            }
-        }
+        Required,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConnectorEnforcement::value] or
+        /// [ConnectorEnforcement::name].
+        UnknownValue(connector_enforcement::UnknownValue),
     }
 
-    impl std::convert::From<i32> for ConnectorEnforcement {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod connector_enforcement {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl ConnectorEnforcement {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NotRequired => std::option::Option::Some(1),
+                Self::Required => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONNECTOR_ENFORCEMENT_UNSPECIFIED"),
+                Self::NotRequired => std::option::Option::Some("NOT_REQUIRED"),
+                Self::Required => std::option::Option::Some("REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for ConnectorEnforcement {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConnectorEnforcement {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConnectorEnforcement {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NotRequired,
+                2 => Self::Required,
+                _ => Self::UnknownValue(connector_enforcement::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConnectorEnforcement {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONNECTOR_ENFORCEMENT_UNSPECIFIED" => Self::Unspecified,
+                "NOT_REQUIRED" => Self::NotRequired,
+                "REQUIRED" => Self::Required,
+                _ => Self::UnknownValue(connector_enforcement::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConnectorEnforcement {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NotRequired => serializer.serialize_i32(1),
+                Self::Required => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConnectorEnforcement {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectorEnforcement>::new(
+                ".google.cloud.sql.v1.Settings.ConnectorEnforcement"))
         }
     }
 }
@@ -12774,138 +14076,256 @@ pub mod user {
 
 
     /// The user type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SqlUserType(i32);
-
-    impl SqlUserType {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SqlUserType {
         /// The database's built-in user type.
-        pub const BUILT_IN: SqlUserType = SqlUserType::new(0);
-
+        BuiltIn,
         /// Cloud IAM user.
-        pub const CLOUD_IAM_USER: SqlUserType = SqlUserType::new(1);
-
+        CloudIamUser,
         /// Cloud IAM service account.
-        pub const CLOUD_IAM_SERVICE_ACCOUNT: SqlUserType = SqlUserType::new(2);
-
+        CloudIamServiceAccount,
         /// Cloud IAM group non-login user.
-        pub const CLOUD_IAM_GROUP: SqlUserType = SqlUserType::new(3);
-
+        CloudIamGroup,
         /// Cloud IAM group login user.
-        pub const CLOUD_IAM_GROUP_USER: SqlUserType = SqlUserType::new(4);
-
+        CloudIamGroupUser,
         /// Cloud IAM group login service account.
-        pub const CLOUD_IAM_GROUP_SERVICE_ACCOUNT: SqlUserType = SqlUserType::new(5);
-
-        /// Creates a new SqlUserType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BUILT_IN"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_IAM_USER"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_IAM_SERVICE_ACCOUNT"),
-                3 => std::borrow::Cow::Borrowed("CLOUD_IAM_GROUP"),
-                4 => std::borrow::Cow::Borrowed("CLOUD_IAM_GROUP_USER"),
-                5 => std::borrow::Cow::Borrowed("CLOUD_IAM_GROUP_SERVICE_ACCOUNT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BUILT_IN" => std::option::Option::Some(Self::BUILT_IN),
-                "CLOUD_IAM_USER" => std::option::Option::Some(Self::CLOUD_IAM_USER),
-                "CLOUD_IAM_SERVICE_ACCOUNT" => std::option::Option::Some(Self::CLOUD_IAM_SERVICE_ACCOUNT),
-                "CLOUD_IAM_GROUP" => std::option::Option::Some(Self::CLOUD_IAM_GROUP),
-                "CLOUD_IAM_GROUP_USER" => std::option::Option::Some(Self::CLOUD_IAM_GROUP_USER),
-                "CLOUD_IAM_GROUP_SERVICE_ACCOUNT" => std::option::Option::Some(Self::CLOUD_IAM_GROUP_SERVICE_ACCOUNT),
-                _ => std::option::Option::None,
-            }
-        }
+        CloudIamGroupServiceAccount,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SqlUserType::value] or
+        /// [SqlUserType::name].
+        UnknownValue(sql_user_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for SqlUserType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod sql_user_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl SqlUserType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::BuiltIn => std::option::Option::Some(0),
+                Self::CloudIamUser => std::option::Option::Some(1),
+                Self::CloudIamServiceAccount => std::option::Option::Some(2),
+                Self::CloudIamGroup => std::option::Option::Some(3),
+                Self::CloudIamGroupUser => std::option::Option::Some(4),
+                Self::CloudIamGroupServiceAccount => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::BuiltIn => std::option::Option::Some("BUILT_IN"),
+                Self::CloudIamUser => std::option::Option::Some("CLOUD_IAM_USER"),
+                Self::CloudIamServiceAccount => std::option::Option::Some("CLOUD_IAM_SERVICE_ACCOUNT"),
+                Self::CloudIamGroup => std::option::Option::Some("CLOUD_IAM_GROUP"),
+                Self::CloudIamGroupUser => std::option::Option::Some("CLOUD_IAM_GROUP_USER"),
+                Self::CloudIamGroupServiceAccount => std::option::Option::Some("CLOUD_IAM_GROUP_SERVICE_ACCOUNT"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for SqlUserType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SqlUserType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SqlUserType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::BuiltIn,
+                1 => Self::CloudIamUser,
+                2 => Self::CloudIamServiceAccount,
+                3 => Self::CloudIamGroup,
+                4 => Self::CloudIamGroupUser,
+                5 => Self::CloudIamGroupServiceAccount,
+                _ => Self::UnknownValue(sql_user_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SqlUserType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BUILT_IN" => Self::BuiltIn,
+                "CLOUD_IAM_USER" => Self::CloudIamUser,
+                "CLOUD_IAM_SERVICE_ACCOUNT" => Self::CloudIamServiceAccount,
+                "CLOUD_IAM_GROUP" => Self::CloudIamGroup,
+                "CLOUD_IAM_GROUP_USER" => Self::CloudIamGroupUser,
+                "CLOUD_IAM_GROUP_SERVICE_ACCOUNT" => Self::CloudIamGroupServiceAccount,
+                _ => Self::UnknownValue(sql_user_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SqlUserType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::BuiltIn => serializer.serialize_i32(0),
+                Self::CloudIamUser => serializer.serialize_i32(1),
+                Self::CloudIamServiceAccount => serializer.serialize_i32(2),
+                Self::CloudIamGroup => serializer.serialize_i32(3),
+                Self::CloudIamGroupUser => serializer.serialize_i32(4),
+                Self::CloudIamGroupServiceAccount => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SqlUserType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlUserType>::new(
+                ".google.cloud.sql.v1.User.SqlUserType"))
         }
     }
 
     /// The type of retained password.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DualPasswordType(i32);
-
-    impl DualPasswordType {
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DualPasswordType {
         /// The default value.
-        pub const DUAL_PASSWORD_TYPE_UNSPECIFIED: DualPasswordType = DualPasswordType::new(0);
-
+        Unspecified,
         /// Do not update the user's dual password status.
-        pub const NO_MODIFY_DUAL_PASSWORD: DualPasswordType = DualPasswordType::new(1);
-
+        NoModifyDualPassword,
         /// No dual password usable for connecting using this user.
-        pub const NO_DUAL_PASSWORD: DualPasswordType = DualPasswordType::new(2);
-
+        NoDualPassword,
         /// Dual password usable for connecting using this user.
-        pub const DUAL_PASSWORD: DualPasswordType = DualPasswordType::new(3);
-
-        /// Creates a new DualPasswordType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
-        /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
-        }
-        
-        /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DUAL_PASSWORD_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_MODIFY_DUAL_PASSWORD"),
-                2 => std::borrow::Cow::Borrowed("NO_DUAL_PASSWORD"),
-                3 => std::borrow::Cow::Borrowed("DUAL_PASSWORD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DUAL_PASSWORD_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DUAL_PASSWORD_TYPE_UNSPECIFIED),
-                "NO_MODIFY_DUAL_PASSWORD" => std::option::Option::Some(Self::NO_MODIFY_DUAL_PASSWORD),
-                "NO_DUAL_PASSWORD" => std::option::Option::Some(Self::NO_DUAL_PASSWORD),
-                "DUAL_PASSWORD" => std::option::Option::Some(Self::DUAL_PASSWORD),
-                _ => std::option::Option::None,
-            }
-        }
+        DualPassword,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DualPasswordType::value] or
+        /// [DualPasswordType::name].
+        UnknownValue(dual_password_type::UnknownValue),
     }
 
-    impl std::convert::From<i32> for DualPasswordType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
+    #[doc(hidden)]
+    pub mod dual_password_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
+
+    impl DualPasswordType {
+        /// Gets the enum value.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoModifyDualPassword => std::option::Option::Some(1),
+                Self::NoDualPassword => std::option::Option::Some(2),
+                Self::DualPassword => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
+        }
+
+        /// Gets the enum value as a string.
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DUAL_PASSWORD_TYPE_UNSPECIFIED"),
+                Self::NoModifyDualPassword => std::option::Option::Some("NO_MODIFY_DUAL_PASSWORD"),
+                Self::NoDualPassword => std::option::Option::Some("NO_DUAL_PASSWORD"),
+                Self::DualPassword => std::option::Option::Some("DUAL_PASSWORD"),
+                Self::UnknownValue(u) => u.0.name(),
+            }
         }
     }
 
     impl std::default::Default for DualPasswordType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DualPasswordType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DualPasswordType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoModifyDualPassword,
+                2 => Self::NoDualPassword,
+                3 => Self::DualPassword,
+                _ => Self::UnknownValue(dual_password_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DualPasswordType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DUAL_PASSWORD_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NO_MODIFY_DUAL_PASSWORD" => Self::NoModifyDualPassword,
+                "NO_DUAL_PASSWORD" => Self::NoDualPassword,
+                "DUAL_PASSWORD" => Self::DualPassword,
+                _ => Self::UnknownValue(dual_password_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DualPasswordType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoModifyDualPassword => serializer.serialize_i32(1),
+                Self::NoDualPassword => serializer.serialize_i32(2),
+                Self::DualPassword => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DualPasswordType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DualPasswordType>::new(
+                ".google.cloud.sql.v1.User.DualPasswordType"))
         }
     }
 
@@ -13025,1326 +14445,2389 @@ impl wkt::message::Message for UsersListResponse {
 }
 
 /// The status of a backup run.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackupRunStatus(i32);
-
-impl SqlBackupRunStatus {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlBackupRunStatus {
     /// The status of the run is unknown.
-    pub const SQL_BACKUP_RUN_STATUS_UNSPECIFIED: SqlBackupRunStatus = SqlBackupRunStatus::new(0);
-
+    Unspecified,
     /// The backup operation was enqueued.
-    pub const ENQUEUED: SqlBackupRunStatus = SqlBackupRunStatus::new(1);
-
+    Enqueued,
     /// The backup is overdue across a given backup window. Indicates a
     /// problem. Example: Long-running operation in progress during
     /// the whole window.
-    pub const OVERDUE: SqlBackupRunStatus = SqlBackupRunStatus::new(2);
-
+    Overdue,
     /// The backup is in progress.
-    pub const RUNNING: SqlBackupRunStatus = SqlBackupRunStatus::new(3);
-
+    Running,
     /// The backup failed.
-    pub const FAILED: SqlBackupRunStatus = SqlBackupRunStatus::new(4);
-
+    Failed,
     /// The backup was successful.
-    pub const SUCCESSFUL: SqlBackupRunStatus = SqlBackupRunStatus::new(5);
-
+    Successful,
     /// The backup was skipped (without problems) for a given backup
     /// window. Example: Instance was idle.
-    pub const SKIPPED: SqlBackupRunStatus = SqlBackupRunStatus::new(6);
-
+    Skipped,
     /// The backup is about to be deleted.
-    pub const DELETION_PENDING: SqlBackupRunStatus = SqlBackupRunStatus::new(7);
-
+    DeletionPending,
     /// The backup deletion failed.
-    pub const DELETION_FAILED: SqlBackupRunStatus = SqlBackupRunStatus::new(8);
-
+    DeletionFailed,
     /// The backup has been deleted.
-    pub const DELETED: SqlBackupRunStatus = SqlBackupRunStatus::new(9);
-
-    /// Creates a new SqlBackupRunStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_BACKUP_RUN_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENQUEUED"),
-            2 => std::borrow::Cow::Borrowed("OVERDUE"),
-            3 => std::borrow::Cow::Borrowed("RUNNING"),
-            4 => std::borrow::Cow::Borrowed("FAILED"),
-            5 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
-            6 => std::borrow::Cow::Borrowed("SKIPPED"),
-            7 => std::borrow::Cow::Borrowed("DELETION_PENDING"),
-            8 => std::borrow::Cow::Borrowed("DELETION_FAILED"),
-            9 => std::borrow::Cow::Borrowed("DELETED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_BACKUP_RUN_STATUS_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKUP_RUN_STATUS_UNSPECIFIED),
-            "ENQUEUED" => std::option::Option::Some(Self::ENQUEUED),
-            "OVERDUE" => std::option::Option::Some(Self::OVERDUE),
-            "RUNNING" => std::option::Option::Some(Self::RUNNING),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
-            "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-            "DELETION_PENDING" => std::option::Option::Some(Self::DELETION_PENDING),
-            "DELETION_FAILED" => std::option::Option::Some(Self::DELETION_FAILED),
-            "DELETED" => std::option::Option::Some(Self::DELETED),
-            _ => std::option::Option::None,
-        }
-    }
+    Deleted,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlBackupRunStatus::value] or
+    /// [SqlBackupRunStatus::name].
+    UnknownValue(sql_backup_run_status::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlBackupRunStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_backup_run_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlBackupRunStatus {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Enqueued => std::option::Option::Some(1),
+            Self::Overdue => std::option::Option::Some(2),
+            Self::Running => std::option::Option::Some(3),
+            Self::Failed => std::option::Option::Some(4),
+            Self::Successful => std::option::Option::Some(5),
+            Self::Skipped => std::option::Option::Some(6),
+            Self::DeletionPending => std::option::Option::Some(7),
+            Self::DeletionFailed => std::option::Option::Some(8),
+            Self::Deleted => std::option::Option::Some(9),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_BACKUP_RUN_STATUS_UNSPECIFIED"),
+            Self::Enqueued => std::option::Option::Some("ENQUEUED"),
+            Self::Overdue => std::option::Option::Some("OVERDUE"),
+            Self::Running => std::option::Option::Some("RUNNING"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::Successful => std::option::Option::Some("SUCCESSFUL"),
+            Self::Skipped => std::option::Option::Some("SKIPPED"),
+            Self::DeletionPending => std::option::Option::Some("DELETION_PENDING"),
+            Self::DeletionFailed => std::option::Option::Some("DELETION_FAILED"),
+            Self::Deleted => std::option::Option::Some("DELETED"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlBackupRunStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlBackupRunStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlBackupRunStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Enqueued,
+            2 => Self::Overdue,
+            3 => Self::Running,
+            4 => Self::Failed,
+            5 => Self::Successful,
+            6 => Self::Skipped,
+            7 => Self::DeletionPending,
+            8 => Self::DeletionFailed,
+            9 => Self::Deleted,
+            _ => Self::UnknownValue(sql_backup_run_status::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlBackupRunStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_BACKUP_RUN_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "ENQUEUED" => Self::Enqueued,
+            "OVERDUE" => Self::Overdue,
+            "RUNNING" => Self::Running,
+            "FAILED" => Self::Failed,
+            "SUCCESSFUL" => Self::Successful,
+            "SKIPPED" => Self::Skipped,
+            "DELETION_PENDING" => Self::DeletionPending,
+            "DELETION_FAILED" => Self::DeletionFailed,
+            "DELETED" => Self::Deleted,
+            _ => Self::UnknownValue(sql_backup_run_status::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlBackupRunStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Enqueued => serializer.serialize_i32(1),
+            Self::Overdue => serializer.serialize_i32(2),
+            Self::Running => serializer.serialize_i32(3),
+            Self::Failed => serializer.serialize_i32(4),
+            Self::Successful => serializer.serialize_i32(5),
+            Self::Skipped => serializer.serialize_i32(6),
+            Self::DeletionPending => serializer.serialize_i32(7),
+            Self::DeletionFailed => serializer.serialize_i32(8),
+            Self::Deleted => serializer.serialize_i32(9),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlBackupRunStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlBackupRunStatus>::new(
+            ".google.cloud.sql.v1.SqlBackupRunStatus"))
     }
 }
 
 /// Defines the supported backup kinds.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackupKind(i32);
-
-impl SqlBackupKind {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlBackupKind {
     /// This is an unknown BackupKind.
-    pub const SQL_BACKUP_KIND_UNSPECIFIED: SqlBackupKind = SqlBackupKind::new(0);
-
+    Unspecified,
     /// The snapshot based backups
-    pub const SNAPSHOT: SqlBackupKind = SqlBackupKind::new(1);
-
+    Snapshot,
     /// Physical backups
-    pub const PHYSICAL: SqlBackupKind = SqlBackupKind::new(2);
-
-    /// Creates a new SqlBackupKind instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_BACKUP_KIND_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SNAPSHOT"),
-            2 => std::borrow::Cow::Borrowed("PHYSICAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_BACKUP_KIND_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKUP_KIND_UNSPECIFIED),
-            "SNAPSHOT" => std::option::Option::Some(Self::SNAPSHOT),
-            "PHYSICAL" => std::option::Option::Some(Self::PHYSICAL),
-            _ => std::option::Option::None,
-        }
-    }
+    Physical,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlBackupKind::value] or
+    /// [SqlBackupKind::name].
+    UnknownValue(sql_backup_kind::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlBackupKind {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_backup_kind {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlBackupKind {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Snapshot => std::option::Option::Some(1),
+            Self::Physical => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_BACKUP_KIND_UNSPECIFIED"),
+            Self::Snapshot => std::option::Option::Some("SNAPSHOT"),
+            Self::Physical => std::option::Option::Some("PHYSICAL"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlBackupKind {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlBackupKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlBackupKind {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Snapshot,
+            2 => Self::Physical,
+            _ => Self::UnknownValue(sql_backup_kind::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlBackupKind {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_BACKUP_KIND_UNSPECIFIED" => Self::Unspecified,
+            "SNAPSHOT" => Self::Snapshot,
+            "PHYSICAL" => Self::Physical,
+            _ => Self::UnknownValue(sql_backup_kind::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlBackupKind {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Snapshot => serializer.serialize_i32(1),
+            Self::Physical => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlBackupKind {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlBackupKind>::new(
+            ".google.cloud.sql.v1.SqlBackupKind"))
     }
 }
 
 /// Type of backup (i.e. automated, on demand, etc).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackupRunType(i32);
-
-impl SqlBackupRunType {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlBackupRunType {
     /// This is an unknown BackupRun type.
-    pub const SQL_BACKUP_RUN_TYPE_UNSPECIFIED: SqlBackupRunType = SqlBackupRunType::new(0);
-
+    Unspecified,
     /// The backup schedule automatically triggers a backup.
-    pub const AUTOMATED: SqlBackupRunType = SqlBackupRunType::new(1);
-
+    Automated,
     /// The user manually triggers a backup.
-    pub const ON_DEMAND: SqlBackupRunType = SqlBackupRunType::new(2);
-
-    /// Creates a new SqlBackupRunType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_BACKUP_RUN_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AUTOMATED"),
-            2 => std::borrow::Cow::Borrowed("ON_DEMAND"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_BACKUP_RUN_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKUP_RUN_TYPE_UNSPECIFIED),
-            "AUTOMATED" => std::option::Option::Some(Self::AUTOMATED),
-            "ON_DEMAND" => std::option::Option::Some(Self::ON_DEMAND),
-            _ => std::option::Option::None,
-        }
-    }
+    OnDemand,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlBackupRunType::value] or
+    /// [SqlBackupRunType::name].
+    UnknownValue(sql_backup_run_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlBackupRunType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_backup_run_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlBackupRunType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Automated => std::option::Option::Some(1),
+            Self::OnDemand => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_BACKUP_RUN_TYPE_UNSPECIFIED"),
+            Self::Automated => std::option::Option::Some("AUTOMATED"),
+            Self::OnDemand => std::option::Option::Some("ON_DEMAND"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlBackupRunType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlFlagType(i32);
+impl std::fmt::Display for SqlBackupRunType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
 
-impl SqlFlagType {
+impl std::convert::From<i32> for SqlBackupRunType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Automated,
+            2 => Self::OnDemand,
+            _ => Self::UnknownValue(sql_backup_run_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
 
+impl std::convert::From<&str> for SqlBackupRunType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_BACKUP_RUN_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "AUTOMATED" => Self::Automated,
+            "ON_DEMAND" => Self::OnDemand,
+            _ => Self::UnknownValue(sql_backup_run_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlBackupRunType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Automated => serializer.serialize_i32(1),
+            Self::OnDemand => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlBackupRunType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlBackupRunType>::new(
+            ".google.cloud.sql.v1.SqlBackupRunType"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlFlagType {
     /// This is an unknown flag type.
-    pub const SQL_FLAG_TYPE_UNSPECIFIED: SqlFlagType = SqlFlagType::new(0);
-
+    Unspecified,
     /// Boolean type flag.
-    pub const BOOLEAN: SqlFlagType = SqlFlagType::new(1);
-
+    Boolean,
     /// String type flag.
-    pub const STRING: SqlFlagType = SqlFlagType::new(2);
-
+    String,
     /// Integer type flag.
-    pub const INTEGER: SqlFlagType = SqlFlagType::new(3);
-
+    Integer,
     /// Flag type used for a server startup option.
-    pub const NONE: SqlFlagType = SqlFlagType::new(4);
-
+    None,
     /// Type introduced specially for MySQL TimeZone offset. Accept a string value
     /// with the format [-12:59, 13:00].
-    pub const MYSQL_TIMEZONE_OFFSET: SqlFlagType = SqlFlagType::new(5);
-
+    MysqlTimezoneOffset,
     /// Float type flag.
-    pub const FLOAT: SqlFlagType = SqlFlagType::new(6);
-
+    Float,
     /// Comma-separated list of the strings in a SqlFlagType enum.
-    pub const REPEATED_STRING: SqlFlagType = SqlFlagType::new(7);
-
-    /// Creates a new SqlFlagType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_FLAG_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BOOLEAN"),
-            2 => std::borrow::Cow::Borrowed("STRING"),
-            3 => std::borrow::Cow::Borrowed("INTEGER"),
-            4 => std::borrow::Cow::Borrowed("NONE"),
-            5 => std::borrow::Cow::Borrowed("MYSQL_TIMEZONE_OFFSET"),
-            6 => std::borrow::Cow::Borrowed("FLOAT"),
-            7 => std::borrow::Cow::Borrowed("REPEATED_STRING"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_FLAG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_FLAG_TYPE_UNSPECIFIED),
-            "BOOLEAN" => std::option::Option::Some(Self::BOOLEAN),
-            "STRING" => std::option::Option::Some(Self::STRING),
-            "INTEGER" => std::option::Option::Some(Self::INTEGER),
-            "NONE" => std::option::Option::Some(Self::NONE),
-            "MYSQL_TIMEZONE_OFFSET" => std::option::Option::Some(Self::MYSQL_TIMEZONE_OFFSET),
-            "FLOAT" => std::option::Option::Some(Self::FLOAT),
-            "REPEATED_STRING" => std::option::Option::Some(Self::REPEATED_STRING),
-            _ => std::option::Option::None,
-        }
-    }
+    RepeatedString,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlFlagType::value] or
+    /// [SqlFlagType::name].
+    UnknownValue(sql_flag_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlFlagType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_flag_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlFlagType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Boolean => std::option::Option::Some(1),
+            Self::String => std::option::Option::Some(2),
+            Self::Integer => std::option::Option::Some(3),
+            Self::None => std::option::Option::Some(4),
+            Self::MysqlTimezoneOffset => std::option::Option::Some(5),
+            Self::Float => std::option::Option::Some(6),
+            Self::RepeatedString => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_FLAG_TYPE_UNSPECIFIED"),
+            Self::Boolean => std::option::Option::Some("BOOLEAN"),
+            Self::String => std::option::Option::Some("STRING"),
+            Self::Integer => std::option::Option::Some("INTEGER"),
+            Self::None => std::option::Option::Some("NONE"),
+            Self::MysqlTimezoneOffset => std::option::Option::Some("MYSQL_TIMEZONE_OFFSET"),
+            Self::Float => std::option::Option::Some("FLOAT"),
+            Self::RepeatedString => std::option::Option::Some("REPEATED_STRING"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlFlagType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlFlagType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlFlagType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Boolean,
+            2 => Self::String,
+            3 => Self::Integer,
+            4 => Self::None,
+            5 => Self::MysqlTimezoneOffset,
+            6 => Self::Float,
+            7 => Self::RepeatedString,
+            _ => Self::UnknownValue(sql_flag_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlFlagType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_FLAG_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BOOLEAN" => Self::Boolean,
+            "STRING" => Self::String,
+            "INTEGER" => Self::Integer,
+            "NONE" => Self::None,
+            "MYSQL_TIMEZONE_OFFSET" => Self::MysqlTimezoneOffset,
+            "FLOAT" => Self::Float,
+            "REPEATED_STRING" => Self::RepeatedString,
+            _ => Self::UnknownValue(sql_flag_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlFlagType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Boolean => serializer.serialize_i32(1),
+            Self::String => serializer.serialize_i32(2),
+            Self::Integer => serializer.serialize_i32(3),
+            Self::None => serializer.serialize_i32(4),
+            Self::MysqlTimezoneOffset => serializer.serialize_i32(5),
+            Self::Float => serializer.serialize_i32(6),
+            Self::RepeatedString => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlFlagType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlFlagType>::new(
+            ".google.cloud.sql.v1.SqlFlagType"))
     }
 }
 
 /// External Sync parallel level.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExternalSyncParallelLevel(i32);
-
-impl ExternalSyncParallelLevel {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ExternalSyncParallelLevel {
     /// Unknown sync parallel level. Will be defaulted to OPTIMAL.
-    pub const EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(0);
-
+    Unspecified,
     /// Minimal parallel level.
-    pub const MIN: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(1);
-
+    Min,
     /// Optimal parallel level.
-    pub const OPTIMAL: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(2);
-
+    Optimal,
     /// Maximum parallel level.
-    pub const MAX: ExternalSyncParallelLevel = ExternalSyncParallelLevel::new(3);
-
-    /// Creates a new ExternalSyncParallelLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MIN"),
-            2 => std::borrow::Cow::Borrowed("OPTIMAL"),
-            3 => std::borrow::Cow::Borrowed("MAX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED),
-            "MIN" => std::option::Option::Some(Self::MIN),
-            "OPTIMAL" => std::option::Option::Some(Self::OPTIMAL),
-            "MAX" => std::option::Option::Some(Self::MAX),
-            _ => std::option::Option::None,
-        }
-    }
+    Max,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ExternalSyncParallelLevel::value] or
+    /// [ExternalSyncParallelLevel::name].
+    UnknownValue(external_sync_parallel_level::UnknownValue),
 }
 
-impl std::convert::From<i32> for ExternalSyncParallelLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod external_sync_parallel_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl ExternalSyncParallelLevel {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Min => std::option::Option::Some(1),
+            Self::Optimal => std::option::Option::Some(2),
+            Self::Max => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED"),
+            Self::Min => std::option::Option::Some("MIN"),
+            Self::Optimal => std::option::Option::Some("OPTIMAL"),
+            Self::Max => std::option::Option::Some("MAX"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for ExternalSyncParallelLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlInstanceType(i32);
+impl std::fmt::Display for ExternalSyncParallelLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
 
-impl SqlInstanceType {
+impl std::convert::From<i32> for ExternalSyncParallelLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Min,
+            2 => Self::Optimal,
+            3 => Self::Max,
+            _ => Self::UnknownValue(external_sync_parallel_level::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
 
+impl std::convert::From<&str> for ExternalSyncParallelLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EXTERNAL_SYNC_PARALLEL_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "MIN" => Self::Min,
+            "OPTIMAL" => Self::Optimal,
+            "MAX" => Self::Max,
+            _ => Self::UnknownValue(external_sync_parallel_level::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ExternalSyncParallelLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Min => serializer.serialize_i32(1),
+            Self::Optimal => serializer.serialize_i32(2),
+            Self::Max => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ExternalSyncParallelLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExternalSyncParallelLevel>::new(
+            ".google.cloud.sql.v1.ExternalSyncParallelLevel"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlInstanceType {
     /// This is an unknown Cloud SQL instance type.
-    pub const SQL_INSTANCE_TYPE_UNSPECIFIED: SqlInstanceType = SqlInstanceType::new(0);
-
+    Unspecified,
     /// A regular Cloud SQL instance that is not replicating from a primary
     /// instance.
-    pub const CLOUD_SQL_INSTANCE: SqlInstanceType = SqlInstanceType::new(1);
-
+    CloudSqlInstance,
     /// An instance running on the customer's premises that is not managed by
     /// Cloud SQL.
-    pub const ON_PREMISES_INSTANCE: SqlInstanceType = SqlInstanceType::new(2);
-
+    OnPremisesInstance,
     /// A Cloud SQL instance acting as a read-replica.
-    pub const READ_REPLICA_INSTANCE: SqlInstanceType = SqlInstanceType::new(3);
-
-    /// Creates a new SqlInstanceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_INSTANCE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CLOUD_SQL_INSTANCE"),
-            2 => std::borrow::Cow::Borrowed("ON_PREMISES_INSTANCE"),
-            3 => std::borrow::Cow::Borrowed("READ_REPLICA_INSTANCE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_INSTANCE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_INSTANCE_TYPE_UNSPECIFIED),
-            "CLOUD_SQL_INSTANCE" => std::option::Option::Some(Self::CLOUD_SQL_INSTANCE),
-            "ON_PREMISES_INSTANCE" => std::option::Option::Some(Self::ON_PREMISES_INSTANCE),
-            "READ_REPLICA_INSTANCE" => std::option::Option::Some(Self::READ_REPLICA_INSTANCE),
-            _ => std::option::Option::None,
-        }
-    }
+    ReadReplicaInstance,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlInstanceType::value] or
+    /// [SqlInstanceType::name].
+    UnknownValue(sql_instance_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlInstanceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_instance_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlInstanceType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::CloudSqlInstance => std::option::Option::Some(1),
+            Self::OnPremisesInstance => std::option::Option::Some(2),
+            Self::ReadReplicaInstance => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_INSTANCE_TYPE_UNSPECIFIED"),
+            Self::CloudSqlInstance => std::option::Option::Some("CLOUD_SQL_INSTANCE"),
+            Self::OnPremisesInstance => std::option::Option::Some("ON_PREMISES_INSTANCE"),
+            Self::ReadReplicaInstance => std::option::Option::Some("READ_REPLICA_INSTANCE"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlInstanceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlInstanceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlInstanceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::CloudSqlInstance,
+            2 => Self::OnPremisesInstance,
+            3 => Self::ReadReplicaInstance,
+            _ => Self::UnknownValue(sql_instance_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlInstanceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_INSTANCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "CLOUD_SQL_INSTANCE" => Self::CloudSqlInstance,
+            "ON_PREMISES_INSTANCE" => Self::OnPremisesInstance,
+            "READ_REPLICA_INSTANCE" => Self::ReadReplicaInstance,
+            _ => Self::UnknownValue(sql_instance_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlInstanceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::CloudSqlInstance => serializer.serialize_i32(1),
+            Self::OnPremisesInstance => serializer.serialize_i32(2),
+            Self::ReadReplicaInstance => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlInstanceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlInstanceType>::new(
+            ".google.cloud.sql.v1.SqlInstanceType"))
     }
 }
 
 /// The suspension reason of the database instance if the state is SUSPENDED.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlSuspensionReason(i32);
-
-impl SqlSuspensionReason {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlSuspensionReason {
     /// This is an unknown suspension reason.
-    pub const SQL_SUSPENSION_REASON_UNSPECIFIED: SqlSuspensionReason = SqlSuspensionReason::new(0);
-
+    Unspecified,
     /// The instance is suspended due to billing issues (for example:, GCP account
     /// issue)
-    pub const BILLING_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(2);
-
+    BillingIssue,
     /// The instance is suspended due to illegal content (for example:, child
     /// pornography, copyrighted material, etc.).
-    pub const LEGAL_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(3);
-
+    LegalIssue,
     /// The instance is causing operational issues (for example:, causing the
     /// database to crash).
-    pub const OPERATIONAL_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(4);
-
+    OperationalIssue,
     /// The KMS key used by the instance is either revoked or denied access to
-    pub const KMS_KEY_ISSUE: SqlSuspensionReason = SqlSuspensionReason::new(5);
-
-    /// Creates a new SqlSuspensionReason instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_SUSPENSION_REASON_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("BILLING_ISSUE"),
-            3 => std::borrow::Cow::Borrowed("LEGAL_ISSUE"),
-            4 => std::borrow::Cow::Borrowed("OPERATIONAL_ISSUE"),
-            5 => std::borrow::Cow::Borrowed("KMS_KEY_ISSUE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_SUSPENSION_REASON_UNSPECIFIED" => std::option::Option::Some(Self::SQL_SUSPENSION_REASON_UNSPECIFIED),
-            "BILLING_ISSUE" => std::option::Option::Some(Self::BILLING_ISSUE),
-            "LEGAL_ISSUE" => std::option::Option::Some(Self::LEGAL_ISSUE),
-            "OPERATIONAL_ISSUE" => std::option::Option::Some(Self::OPERATIONAL_ISSUE),
-            "KMS_KEY_ISSUE" => std::option::Option::Some(Self::KMS_KEY_ISSUE),
-            _ => std::option::Option::None,
-        }
-    }
+    KmsKeyIssue,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlSuspensionReason::value] or
+    /// [SqlSuspensionReason::name].
+    UnknownValue(sql_suspension_reason::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlSuspensionReason {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_suspension_reason {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlSuspensionReason {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::BillingIssue => std::option::Option::Some(2),
+            Self::LegalIssue => std::option::Option::Some(3),
+            Self::OperationalIssue => std::option::Option::Some(4),
+            Self::KmsKeyIssue => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_SUSPENSION_REASON_UNSPECIFIED"),
+            Self::BillingIssue => std::option::Option::Some("BILLING_ISSUE"),
+            Self::LegalIssue => std::option::Option::Some("LEGAL_ISSUE"),
+            Self::OperationalIssue => std::option::Option::Some("OPERATIONAL_ISSUE"),
+            Self::KmsKeyIssue => std::option::Option::Some("KMS_KEY_ISSUE"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlSuspensionReason {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlFileType(i32);
+impl std::fmt::Display for SqlSuspensionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlSuspensionReason {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::BillingIssue,
+            3 => Self::LegalIssue,
+            4 => Self::OperationalIssue,
+            5 => Self::KmsKeyIssue,
+            _ => Self::UnknownValue(sql_suspension_reason::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlSuspensionReason {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_SUSPENSION_REASON_UNSPECIFIED" => Self::Unspecified,
+            "BILLING_ISSUE" => Self::BillingIssue,
+            "LEGAL_ISSUE" => Self::LegalIssue,
+            "OPERATIONAL_ISSUE" => Self::OperationalIssue,
+            "KMS_KEY_ISSUE" => Self::KmsKeyIssue,
+            _ => Self::UnknownValue(sql_suspension_reason::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlSuspensionReason {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::BillingIssue => serializer.serialize_i32(2),
+            Self::LegalIssue => serializer.serialize_i32(3),
+            Self::OperationalIssue => serializer.serialize_i32(4),
+            Self::KmsKeyIssue => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlSuspensionReason {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlSuspensionReason>::new(
+            ".google.cloud.sql.v1.SqlSuspensionReason"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlFileType {
+    /// Unknown file type.
+    Unspecified,
+    /// File containing SQL statements.
+    Sql,
+    /// File in CSV format.
+    Csv,
+    Bak,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlFileType::value] or
+    /// [SqlFileType::name].
+    UnknownValue(sql_file_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod sql_file_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SqlFileType {
-
-    /// Unknown file type.
-    pub const SQL_FILE_TYPE_UNSPECIFIED: SqlFileType = SqlFileType::new(0);
-
-    /// File containing SQL statements.
-    pub const SQL: SqlFileType = SqlFileType::new(1);
-
-    /// File in CSV format.
-    pub const CSV: SqlFileType = SqlFileType::new(2);
-
-    pub const BAK: SqlFileType = SqlFileType::new(4);
-
-    /// Creates a new SqlFileType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Sql => std::option::Option::Some(1),
+            Self::Csv => std::option::Option::Some(2),
+            Self::Bak => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
-    
+
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_FILE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SQL"),
-            2 => std::borrow::Cow::Borrowed("CSV"),
-            4 => std::borrow::Cow::Borrowed("BAK"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_FILE_TYPE_UNSPECIFIED"),
+            Self::Sql => std::option::Option::Some("SQL"),
+            Self::Csv => std::option::Option::Some("CSV"),
+            Self::Bak => std::option::Option::Some("BAK"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_FILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_FILE_TYPE_UNSPECIFIED),
-            "SQL" => std::option::Option::Some(Self::SQL),
-            "CSV" => std::option::Option::Some(Self::CSV),
-            "BAK" => std::option::Option::Some(Self::BAK),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SqlFileType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SqlFileType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BakType(i32);
+impl std::fmt::Display for SqlFileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlFileType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Sql,
+            2 => Self::Csv,
+            4 => Self::Bak,
+            _ => Self::UnknownValue(sql_file_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlFileType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_FILE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SQL" => Self::Sql,
+            "CSV" => Self::Csv,
+            "BAK" => Self::Bak,
+            _ => Self::UnknownValue(sql_file_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlFileType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Sql => serializer.serialize_i32(1),
+            Self::Csv => serializer.serialize_i32(2),
+            Self::Bak => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlFileType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlFileType>::new(
+            ".google.cloud.sql.v1.SqlFileType"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BakType {
+    /// Default type.
+    Unspecified,
+    /// Full backup.
+    Full,
+    /// Differential backup.
+    Diff,
+    /// Transaction Log backup
+    Tlog,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BakType::value] or
+    /// [BakType::name].
+    UnknownValue(bak_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod bak_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl BakType {
-
-    /// Default type.
-    pub const BAK_TYPE_UNSPECIFIED: BakType = BakType::new(0);
-
-    /// Full backup.
-    pub const FULL: BakType = BakType::new(1);
-
-    /// Differential backup.
-    pub const DIFF: BakType = BakType::new(2);
-
-    /// Transaction Log backup
-    pub const TLOG: BakType = BakType::new(3);
-
-    /// Creates a new BakType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Full => std::option::Option::Some(1),
+            Self::Diff => std::option::Option::Some(2),
+            Self::Tlog => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
-    
+
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BAK_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("FULL"),
-            2 => std::borrow::Cow::Borrowed("DIFF"),
-            3 => std::borrow::Cow::Borrowed("TLOG"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BAK_TYPE_UNSPECIFIED"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::Diff => std::option::Option::Some("DIFF"),
+            Self::Tlog => std::option::Option::Some("TLOG"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BAK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::BAK_TYPE_UNSPECIFIED),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            "DIFF" => std::option::Option::Some(Self::DIFF),
-            "TLOG" => std::option::Option::Some(Self::TLOG),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BakType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BakType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlBackendType(i32);
+impl std::fmt::Display for BakType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BakType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Full,
+            2 => Self::Diff,
+            3 => Self::Tlog,
+            _ => Self::UnknownValue(bak_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BakType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BAK_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "FULL" => Self::Full,
+            "DIFF" => Self::Diff,
+            "TLOG" => Self::Tlog,
+            _ => Self::UnknownValue(bak_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BakType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Full => serializer.serialize_i32(1),
+            Self::Diff => serializer.serialize_i32(2),
+            Self::Tlog => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BakType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BakType>::new(
+            ".google.cloud.sql.v1.BakType"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlBackendType {
+    /// This is an unknown backend type for instance.
+    Unspecified,
+    /// V1 speckle instance.
+    FirstGen,
+    /// V2 speckle instance.
+    SecondGen,
+    /// On premises instance.
+    External,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlBackendType::value] or
+    /// [SqlBackendType::name].
+    UnknownValue(sql_backend_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod sql_backend_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl SqlBackendType {
-
-    /// This is an unknown backend type for instance.
-    pub const SQL_BACKEND_TYPE_UNSPECIFIED: SqlBackendType = SqlBackendType::new(0);
-
-    /// V1 speckle instance.
-    pub const FIRST_GEN: SqlBackendType = SqlBackendType::new(1);
-
-    /// V2 speckle instance.
-    pub const SECOND_GEN: SqlBackendType = SqlBackendType::new(2);
-
-    /// On premises instance.
-    pub const EXTERNAL: SqlBackendType = SqlBackendType::new(3);
-
-    /// Creates a new SqlBackendType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::FirstGen => std::option::Option::Some(1),
+            Self::SecondGen => std::option::Option::Some(2),
+            Self::External => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
-    
+
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_BACKEND_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("FIRST_GEN"),
-            2 => std::borrow::Cow::Borrowed("SECOND_GEN"),
-            3 => std::borrow::Cow::Borrowed("EXTERNAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_BACKEND_TYPE_UNSPECIFIED"),
+            Self::FirstGen => std::option::Option::Some("FIRST_GEN"),
+            Self::SecondGen => std::option::Option::Some("SECOND_GEN"),
+            Self::External => std::option::Option::Some("EXTERNAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_BACKEND_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_BACKEND_TYPE_UNSPECIFIED),
-            "FIRST_GEN" => std::option::Option::Some(Self::FIRST_GEN),
-            "SECOND_GEN" => std::option::Option::Some(Self::SECOND_GEN),
-            "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SqlBackendType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SqlBackendType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlIpAddressType(i32);
+impl std::fmt::Display for SqlBackendType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
 
-impl SqlIpAddressType {
+impl std::convert::From<i32> for SqlBackendType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::FirstGen,
+            2 => Self::SecondGen,
+            3 => Self::External,
+            _ => Self::UnknownValue(sql_backend_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
 
+impl std::convert::From<&str> for SqlBackendType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_BACKEND_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "FIRST_GEN" => Self::FirstGen,
+            "SECOND_GEN" => Self::SecondGen,
+            "EXTERNAL" => Self::External,
+            _ => Self::UnknownValue(sql_backend_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlBackendType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::FirstGen => serializer.serialize_i32(1),
+            Self::SecondGen => serializer.serialize_i32(2),
+            Self::External => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlBackendType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlBackendType>::new(
+            ".google.cloud.sql.v1.SqlBackendType"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlIpAddressType {
     /// This is an unknown IP address type.
-    pub const SQL_IP_ADDRESS_TYPE_UNSPECIFIED: SqlIpAddressType = SqlIpAddressType::new(0);
-
+    Unspecified,
     /// IP address the customer is supposed to connect to. Usually this is the
     /// load balancer's IP address
-    pub const PRIMARY: SqlIpAddressType = SqlIpAddressType::new(1);
-
+    Primary,
     /// Source IP address of the connection a read replica establishes to its
     /// external primary instance. This IP address can be allowlisted by the
     /// customer in case it has a firewall that filters incoming connection to its
     /// on premises primary instance.
-    pub const OUTGOING: SqlIpAddressType = SqlIpAddressType::new(2);
-
+    Outgoing,
     /// Private IP used when using private IPs and network peering.
-    pub const PRIVATE: SqlIpAddressType = SqlIpAddressType::new(3);
-
+    Private,
     /// V1 IP of a migrated instance. We want the user to
     /// decommission this IP as soon as the migration is complete.
     /// Note: V1 instances with V1 ip addresses will be counted as PRIMARY.
-    pub const MIGRATED_1ST_GEN: SqlIpAddressType = SqlIpAddressType::new(4);
-
-    /// Creates a new SqlIpAddressType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_IP_ADDRESS_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PRIMARY"),
-            2 => std::borrow::Cow::Borrowed("OUTGOING"),
-            3 => std::borrow::Cow::Borrowed("PRIVATE"),
-            4 => std::borrow::Cow::Borrowed("MIGRATED_1ST_GEN"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_IP_ADDRESS_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_IP_ADDRESS_TYPE_UNSPECIFIED),
-            "PRIMARY" => std::option::Option::Some(Self::PRIMARY),
-            "OUTGOING" => std::option::Option::Some(Self::OUTGOING),
-            "PRIVATE" => std::option::Option::Some(Self::PRIVATE),
-            "MIGRATED_1ST_GEN" => std::option::Option::Some(Self::MIGRATED_1ST_GEN),
-            _ => std::option::Option::None,
-        }
-    }
+    Migrated1StGen,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlIpAddressType::value] or
+    /// [SqlIpAddressType::name].
+    UnknownValue(sql_ip_address_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlIpAddressType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_ip_address_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlIpAddressType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Primary => std::option::Option::Some(1),
+            Self::Outgoing => std::option::Option::Some(2),
+            Self::Private => std::option::Option::Some(3),
+            Self::Migrated1StGen => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_IP_ADDRESS_TYPE_UNSPECIFIED"),
+            Self::Primary => std::option::Option::Some("PRIMARY"),
+            Self::Outgoing => std::option::Option::Some("OUTGOING"),
+            Self::Private => std::option::Option::Some("PRIVATE"),
+            Self::Migrated1StGen => std::option::Option::Some("MIGRATED_1ST_GEN"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlIpAddressType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlIpAddressType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlIpAddressType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Primary,
+            2 => Self::Outgoing,
+            3 => Self::Private,
+            4 => Self::Migrated1StGen,
+            _ => Self::UnknownValue(sql_ip_address_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlIpAddressType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_IP_ADDRESS_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PRIMARY" => Self::Primary,
+            "OUTGOING" => Self::Outgoing,
+            "PRIVATE" => Self::Private,
+            "MIGRATED_1ST_GEN" => Self::Migrated1StGen,
+            _ => Self::UnknownValue(sql_ip_address_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlIpAddressType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Primary => serializer.serialize_i32(1),
+            Self::Outgoing => serializer.serialize_i32(2),
+            Self::Private => serializer.serialize_i32(3),
+            Self::Migrated1StGen => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlIpAddressType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlIpAddressType>::new(
+            ".google.cloud.sql.v1.SqlIpAddressType"))
     }
 }
 
 /// The database engine type and version.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlDatabaseVersion(i32);
-
-impl SqlDatabaseVersion {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlDatabaseVersion {
     /// This is an unknown database version.
-    pub const SQL_DATABASE_VERSION_UNSPECIFIED: SqlDatabaseVersion = SqlDatabaseVersion::new(0);
-
+    Unspecified,
     /// The database version is MySQL 5.1.
-    pub const MYSQL_5_1: SqlDatabaseVersion = SqlDatabaseVersion::new(2);
-
+    Mysql51,
     /// The database version is MySQL 5.5.
-    pub const MYSQL_5_5: SqlDatabaseVersion = SqlDatabaseVersion::new(3);
-
+    Mysql55,
     /// The database version is MySQL 5.6.
-    pub const MYSQL_5_6: SqlDatabaseVersion = SqlDatabaseVersion::new(5);
-
+    Mysql56,
     /// The database version is MySQL 5.7.
-    pub const MYSQL_5_7: SqlDatabaseVersion = SqlDatabaseVersion::new(6);
-
+    Mysql57,
     /// The database version is SQL Server 2017 Standard.
-    pub const SQLSERVER_2017_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new(11);
-
+    Sqlserver2017Standard,
     /// The database version is SQL Server 2017 Enterprise.
-    pub const SQLSERVER_2017_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new(14);
-
+    Sqlserver2017Enterprise,
     /// The database version is SQL Server 2017 Express.
-    pub const SQLSERVER_2017_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new(15);
-
+    Sqlserver2017Express,
     /// The database version is SQL Server 2017 Web.
-    pub const SQLSERVER_2017_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new(16);
-
+    Sqlserver2017Web,
     /// The database version is PostgreSQL 9.6.
-    pub const POSTGRES_9_6: SqlDatabaseVersion = SqlDatabaseVersion::new(9);
-
+    Postgres96,
     /// The database version is PostgreSQL 10.
-    pub const POSTGRES_10: SqlDatabaseVersion = SqlDatabaseVersion::new(18);
-
+    Postgres10,
     /// The database version is PostgreSQL 11.
-    pub const POSTGRES_11: SqlDatabaseVersion = SqlDatabaseVersion::new(10);
-
+    Postgres11,
     /// The database version is PostgreSQL 12.
-    pub const POSTGRES_12: SqlDatabaseVersion = SqlDatabaseVersion::new(19);
-
+    Postgres12,
     /// The database version is PostgreSQL 13.
-    pub const POSTGRES_13: SqlDatabaseVersion = SqlDatabaseVersion::new(23);
-
+    Postgres13,
     /// The database version is PostgreSQL 14.
-    pub const POSTGRES_14: SqlDatabaseVersion = SqlDatabaseVersion::new(110);
-
+    Postgres14,
     /// The database version is PostgreSQL 15.
-    pub const POSTGRES_15: SqlDatabaseVersion = SqlDatabaseVersion::new(172);
-
+    Postgres15,
     /// The database version is PostgreSQL 16.
-    pub const POSTGRES_16: SqlDatabaseVersion = SqlDatabaseVersion::new(272);
-
+    Postgres16,
     /// The database version is MySQL 8.
-    pub const MYSQL_8_0: SqlDatabaseVersion = SqlDatabaseVersion::new(20);
-
+    Mysql80,
     /// The database major version is MySQL 8.0 and the minor version is 18.
-    pub const MYSQL_8_0_18: SqlDatabaseVersion = SqlDatabaseVersion::new(41);
-
+    Mysql8018,
     /// The database major version is MySQL 8.0 and the minor version is 26.
-    pub const MYSQL_8_0_26: SqlDatabaseVersion = SqlDatabaseVersion::new(85);
-
+    Mysql8026,
     /// The database major version is MySQL 8.0 and the minor version is 27.
-    pub const MYSQL_8_0_27: SqlDatabaseVersion = SqlDatabaseVersion::new(111);
-
+    Mysql8027,
     /// The database major version is MySQL 8.0 and the minor version is 28.
-    pub const MYSQL_8_0_28: SqlDatabaseVersion = SqlDatabaseVersion::new(132);
-
+    Mysql8028,
     /// The database major version is MySQL 8.0 and the minor version is 29.
-    pub const MYSQL_8_0_29: SqlDatabaseVersion = SqlDatabaseVersion::new(148);
-
+    Mysql8029,
     /// The database major version is MySQL 8.0 and the minor version is 30.
-    pub const MYSQL_8_0_30: SqlDatabaseVersion = SqlDatabaseVersion::new(174);
-
+    Mysql8030,
     /// The database major version is MySQL 8.0 and the minor version is 31.
-    pub const MYSQL_8_0_31: SqlDatabaseVersion = SqlDatabaseVersion::new(197);
-
+    Mysql8031,
     /// The database major version is MySQL 8.0 and the minor version is 32.
-    pub const MYSQL_8_0_32: SqlDatabaseVersion = SqlDatabaseVersion::new(213);
-
+    Mysql8032,
     /// The database major version is MySQL 8.0 and the minor version is 33.
-    pub const MYSQL_8_0_33: SqlDatabaseVersion = SqlDatabaseVersion::new(238);
-
+    Mysql8033,
     /// The database major version is MySQL 8.0 and the minor version is 34.
-    pub const MYSQL_8_0_34: SqlDatabaseVersion = SqlDatabaseVersion::new(239);
-
+    Mysql8034,
     /// The database major version is MySQL 8.0 and the minor version is 35.
-    pub const MYSQL_8_0_35: SqlDatabaseVersion = SqlDatabaseVersion::new(240);
-
+    Mysql8035,
     /// The database major version is MySQL 8.0 and the minor version is 36.
-    pub const MYSQL_8_0_36: SqlDatabaseVersion = SqlDatabaseVersion::new(241);
-
+    Mysql8036,
     /// The database major version is MySQL 8.0 and the minor version is 37.
-    pub const MYSQL_8_0_37: SqlDatabaseVersion = SqlDatabaseVersion::new(355);
-
+    Mysql8037,
     /// The database major version is MySQL 8.0 and the minor version is 38.
-    pub const MYSQL_8_0_38: SqlDatabaseVersion = SqlDatabaseVersion::new(356);
-
+    Mysql8038,
     /// The database major version is MySQL 8.0 and the minor version is 39.
-    pub const MYSQL_8_0_39: SqlDatabaseVersion = SqlDatabaseVersion::new(357);
-
+    Mysql8039,
     /// The database major version is MySQL 8.0 and the minor version is 40.
-    pub const MYSQL_8_0_40: SqlDatabaseVersion = SqlDatabaseVersion::new(358);
-
+    Mysql8040,
     /// The database version is MySQL 8.4.
-    pub const MYSQL_8_4: SqlDatabaseVersion = SqlDatabaseVersion::new(398);
-
+    Mysql84,
     /// The database version is MySQL 8.4 and the patch version is 0.
-    pub const MYSQL_8_4_0: SqlDatabaseVersion = SqlDatabaseVersion::new(399);
-
+    Mysql840,
     /// The database version is SQL Server 2019 Standard.
-    pub const SQLSERVER_2019_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new(26);
-
+    Sqlserver2019Standard,
     /// The database version is SQL Server 2019 Enterprise.
-    pub const SQLSERVER_2019_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new(27);
-
+    Sqlserver2019Enterprise,
     /// The database version is SQL Server 2019 Express.
-    pub const SQLSERVER_2019_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new(28);
-
+    Sqlserver2019Express,
     /// The database version is SQL Server 2019 Web.
-    pub const SQLSERVER_2019_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new(29);
-
+    Sqlserver2019Web,
     /// The database version is SQL Server 2022 Standard.
-    pub const SQLSERVER_2022_STANDARD: SqlDatabaseVersion = SqlDatabaseVersion::new(199);
-
+    Sqlserver2022Standard,
     /// The database version is SQL Server 2022 Enterprise.
-    pub const SQLSERVER_2022_ENTERPRISE: SqlDatabaseVersion = SqlDatabaseVersion::new(200);
-
+    Sqlserver2022Enterprise,
     /// The database version is SQL Server 2022 Express.
-    pub const SQLSERVER_2022_EXPRESS: SqlDatabaseVersion = SqlDatabaseVersion::new(201);
-
+    Sqlserver2022Express,
     /// The database version is SQL Server 2022 Web.
-    pub const SQLSERVER_2022_WEB: SqlDatabaseVersion = SqlDatabaseVersion::new(202);
-
-    /// Creates a new SqlDatabaseVersion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_DATABASE_VERSION_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("MYSQL_5_1"),
-            3 => std::borrow::Cow::Borrowed("MYSQL_5_5"),
-            5 => std::borrow::Cow::Borrowed("MYSQL_5_6"),
-            6 => std::borrow::Cow::Borrowed("MYSQL_5_7"),
-            9 => std::borrow::Cow::Borrowed("POSTGRES_9_6"),
-            10 => std::borrow::Cow::Borrowed("POSTGRES_11"),
-            11 => std::borrow::Cow::Borrowed("SQLSERVER_2017_STANDARD"),
-            14 => std::borrow::Cow::Borrowed("SQLSERVER_2017_ENTERPRISE"),
-            15 => std::borrow::Cow::Borrowed("SQLSERVER_2017_EXPRESS"),
-            16 => std::borrow::Cow::Borrowed("SQLSERVER_2017_WEB"),
-            18 => std::borrow::Cow::Borrowed("POSTGRES_10"),
-            19 => std::borrow::Cow::Borrowed("POSTGRES_12"),
-            20 => std::borrow::Cow::Borrowed("MYSQL_8_0"),
-            23 => std::borrow::Cow::Borrowed("POSTGRES_13"),
-            26 => std::borrow::Cow::Borrowed("SQLSERVER_2019_STANDARD"),
-            27 => std::borrow::Cow::Borrowed("SQLSERVER_2019_ENTERPRISE"),
-            28 => std::borrow::Cow::Borrowed("SQLSERVER_2019_EXPRESS"),
-            29 => std::borrow::Cow::Borrowed("SQLSERVER_2019_WEB"),
-            41 => std::borrow::Cow::Borrowed("MYSQL_8_0_18"),
-            85 => std::borrow::Cow::Borrowed("MYSQL_8_0_26"),
-            110 => std::borrow::Cow::Borrowed("POSTGRES_14"),
-            111 => std::borrow::Cow::Borrowed("MYSQL_8_0_27"),
-            132 => std::borrow::Cow::Borrowed("MYSQL_8_0_28"),
-            148 => std::borrow::Cow::Borrowed("MYSQL_8_0_29"),
-            172 => std::borrow::Cow::Borrowed("POSTGRES_15"),
-            174 => std::borrow::Cow::Borrowed("MYSQL_8_0_30"),
-            197 => std::borrow::Cow::Borrowed("MYSQL_8_0_31"),
-            199 => std::borrow::Cow::Borrowed("SQLSERVER_2022_STANDARD"),
-            200 => std::borrow::Cow::Borrowed("SQLSERVER_2022_ENTERPRISE"),
-            201 => std::borrow::Cow::Borrowed("SQLSERVER_2022_EXPRESS"),
-            202 => std::borrow::Cow::Borrowed("SQLSERVER_2022_WEB"),
-            213 => std::borrow::Cow::Borrowed("MYSQL_8_0_32"),
-            238 => std::borrow::Cow::Borrowed("MYSQL_8_0_33"),
-            239 => std::borrow::Cow::Borrowed("MYSQL_8_0_34"),
-            240 => std::borrow::Cow::Borrowed("MYSQL_8_0_35"),
-            241 => std::borrow::Cow::Borrowed("MYSQL_8_0_36"),
-            272 => std::borrow::Cow::Borrowed("POSTGRES_16"),
-            355 => std::borrow::Cow::Borrowed("MYSQL_8_0_37"),
-            356 => std::borrow::Cow::Borrowed("MYSQL_8_0_38"),
-            357 => std::borrow::Cow::Borrowed("MYSQL_8_0_39"),
-            358 => std::borrow::Cow::Borrowed("MYSQL_8_0_40"),
-            398 => std::borrow::Cow::Borrowed("MYSQL_8_4"),
-            399 => std::borrow::Cow::Borrowed("MYSQL_8_4_0"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_DATABASE_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::SQL_DATABASE_VERSION_UNSPECIFIED),
-            "MYSQL_5_1" => std::option::Option::Some(Self::MYSQL_5_1),
-            "MYSQL_5_5" => std::option::Option::Some(Self::MYSQL_5_5),
-            "MYSQL_5_6" => std::option::Option::Some(Self::MYSQL_5_6),
-            "MYSQL_5_7" => std::option::Option::Some(Self::MYSQL_5_7),
-            "SQLSERVER_2017_STANDARD" => std::option::Option::Some(Self::SQLSERVER_2017_STANDARD),
-            "SQLSERVER_2017_ENTERPRISE" => std::option::Option::Some(Self::SQLSERVER_2017_ENTERPRISE),
-            "SQLSERVER_2017_EXPRESS" => std::option::Option::Some(Self::SQLSERVER_2017_EXPRESS),
-            "SQLSERVER_2017_WEB" => std::option::Option::Some(Self::SQLSERVER_2017_WEB),
-            "POSTGRES_9_6" => std::option::Option::Some(Self::POSTGRES_9_6),
-            "POSTGRES_10" => std::option::Option::Some(Self::POSTGRES_10),
-            "POSTGRES_11" => std::option::Option::Some(Self::POSTGRES_11),
-            "POSTGRES_12" => std::option::Option::Some(Self::POSTGRES_12),
-            "POSTGRES_13" => std::option::Option::Some(Self::POSTGRES_13),
-            "POSTGRES_14" => std::option::Option::Some(Self::POSTGRES_14),
-            "POSTGRES_15" => std::option::Option::Some(Self::POSTGRES_15),
-            "POSTGRES_16" => std::option::Option::Some(Self::POSTGRES_16),
-            "MYSQL_8_0" => std::option::Option::Some(Self::MYSQL_8_0),
-            "MYSQL_8_0_18" => std::option::Option::Some(Self::MYSQL_8_0_18),
-            "MYSQL_8_0_26" => std::option::Option::Some(Self::MYSQL_8_0_26),
-            "MYSQL_8_0_27" => std::option::Option::Some(Self::MYSQL_8_0_27),
-            "MYSQL_8_0_28" => std::option::Option::Some(Self::MYSQL_8_0_28),
-            "MYSQL_8_0_29" => std::option::Option::Some(Self::MYSQL_8_0_29),
-            "MYSQL_8_0_30" => std::option::Option::Some(Self::MYSQL_8_0_30),
-            "MYSQL_8_0_31" => std::option::Option::Some(Self::MYSQL_8_0_31),
-            "MYSQL_8_0_32" => std::option::Option::Some(Self::MYSQL_8_0_32),
-            "MYSQL_8_0_33" => std::option::Option::Some(Self::MYSQL_8_0_33),
-            "MYSQL_8_0_34" => std::option::Option::Some(Self::MYSQL_8_0_34),
-            "MYSQL_8_0_35" => std::option::Option::Some(Self::MYSQL_8_0_35),
-            "MYSQL_8_0_36" => std::option::Option::Some(Self::MYSQL_8_0_36),
-            "MYSQL_8_0_37" => std::option::Option::Some(Self::MYSQL_8_0_37),
-            "MYSQL_8_0_38" => std::option::Option::Some(Self::MYSQL_8_0_38),
-            "MYSQL_8_0_39" => std::option::Option::Some(Self::MYSQL_8_0_39),
-            "MYSQL_8_0_40" => std::option::Option::Some(Self::MYSQL_8_0_40),
-            "MYSQL_8_4" => std::option::Option::Some(Self::MYSQL_8_4),
-            "MYSQL_8_4_0" => std::option::Option::Some(Self::MYSQL_8_4_0),
-            "SQLSERVER_2019_STANDARD" => std::option::Option::Some(Self::SQLSERVER_2019_STANDARD),
-            "SQLSERVER_2019_ENTERPRISE" => std::option::Option::Some(Self::SQLSERVER_2019_ENTERPRISE),
-            "SQLSERVER_2019_EXPRESS" => std::option::Option::Some(Self::SQLSERVER_2019_EXPRESS),
-            "SQLSERVER_2019_WEB" => std::option::Option::Some(Self::SQLSERVER_2019_WEB),
-            "SQLSERVER_2022_STANDARD" => std::option::Option::Some(Self::SQLSERVER_2022_STANDARD),
-            "SQLSERVER_2022_ENTERPRISE" => std::option::Option::Some(Self::SQLSERVER_2022_ENTERPRISE),
-            "SQLSERVER_2022_EXPRESS" => std::option::Option::Some(Self::SQLSERVER_2022_EXPRESS),
-            "SQLSERVER_2022_WEB" => std::option::Option::Some(Self::SQLSERVER_2022_WEB),
-            _ => std::option::Option::None,
-        }
-    }
+    Sqlserver2022Web,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlDatabaseVersion::value] or
+    /// [SqlDatabaseVersion::name].
+    UnknownValue(sql_database_version::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlDatabaseVersion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_database_version {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlDatabaseVersion {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Mysql51 => std::option::Option::Some(2),
+            Self::Mysql55 => std::option::Option::Some(3),
+            Self::Mysql56 => std::option::Option::Some(5),
+            Self::Mysql57 => std::option::Option::Some(6),
+            Self::Sqlserver2017Standard => std::option::Option::Some(11),
+            Self::Sqlserver2017Enterprise => std::option::Option::Some(14),
+            Self::Sqlserver2017Express => std::option::Option::Some(15),
+            Self::Sqlserver2017Web => std::option::Option::Some(16),
+            Self::Postgres96 => std::option::Option::Some(9),
+            Self::Postgres10 => std::option::Option::Some(18),
+            Self::Postgres11 => std::option::Option::Some(10),
+            Self::Postgres12 => std::option::Option::Some(19),
+            Self::Postgres13 => std::option::Option::Some(23),
+            Self::Postgres14 => std::option::Option::Some(110),
+            Self::Postgres15 => std::option::Option::Some(172),
+            Self::Postgres16 => std::option::Option::Some(272),
+            Self::Mysql80 => std::option::Option::Some(20),
+            Self::Mysql8018 => std::option::Option::Some(41),
+            Self::Mysql8026 => std::option::Option::Some(85),
+            Self::Mysql8027 => std::option::Option::Some(111),
+            Self::Mysql8028 => std::option::Option::Some(132),
+            Self::Mysql8029 => std::option::Option::Some(148),
+            Self::Mysql8030 => std::option::Option::Some(174),
+            Self::Mysql8031 => std::option::Option::Some(197),
+            Self::Mysql8032 => std::option::Option::Some(213),
+            Self::Mysql8033 => std::option::Option::Some(238),
+            Self::Mysql8034 => std::option::Option::Some(239),
+            Self::Mysql8035 => std::option::Option::Some(240),
+            Self::Mysql8036 => std::option::Option::Some(241),
+            Self::Mysql8037 => std::option::Option::Some(355),
+            Self::Mysql8038 => std::option::Option::Some(356),
+            Self::Mysql8039 => std::option::Option::Some(357),
+            Self::Mysql8040 => std::option::Option::Some(358),
+            Self::Mysql84 => std::option::Option::Some(398),
+            Self::Mysql840 => std::option::Option::Some(399),
+            Self::Sqlserver2019Standard => std::option::Option::Some(26),
+            Self::Sqlserver2019Enterprise => std::option::Option::Some(27),
+            Self::Sqlserver2019Express => std::option::Option::Some(28),
+            Self::Sqlserver2019Web => std::option::Option::Some(29),
+            Self::Sqlserver2022Standard => std::option::Option::Some(199),
+            Self::Sqlserver2022Enterprise => std::option::Option::Some(200),
+            Self::Sqlserver2022Express => std::option::Option::Some(201),
+            Self::Sqlserver2022Web => std::option::Option::Some(202),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_DATABASE_VERSION_UNSPECIFIED"),
+            Self::Mysql51 => std::option::Option::Some("MYSQL_5_1"),
+            Self::Mysql55 => std::option::Option::Some("MYSQL_5_5"),
+            Self::Mysql56 => std::option::Option::Some("MYSQL_5_6"),
+            Self::Mysql57 => std::option::Option::Some("MYSQL_5_7"),
+            Self::Sqlserver2017Standard => std::option::Option::Some("SQLSERVER_2017_STANDARD"),
+            Self::Sqlserver2017Enterprise => std::option::Option::Some("SQLSERVER_2017_ENTERPRISE"),
+            Self::Sqlserver2017Express => std::option::Option::Some("SQLSERVER_2017_EXPRESS"),
+            Self::Sqlserver2017Web => std::option::Option::Some("SQLSERVER_2017_WEB"),
+            Self::Postgres96 => std::option::Option::Some("POSTGRES_9_6"),
+            Self::Postgres10 => std::option::Option::Some("POSTGRES_10"),
+            Self::Postgres11 => std::option::Option::Some("POSTGRES_11"),
+            Self::Postgres12 => std::option::Option::Some("POSTGRES_12"),
+            Self::Postgres13 => std::option::Option::Some("POSTGRES_13"),
+            Self::Postgres14 => std::option::Option::Some("POSTGRES_14"),
+            Self::Postgres15 => std::option::Option::Some("POSTGRES_15"),
+            Self::Postgres16 => std::option::Option::Some("POSTGRES_16"),
+            Self::Mysql80 => std::option::Option::Some("MYSQL_8_0"),
+            Self::Mysql8018 => std::option::Option::Some("MYSQL_8_0_18"),
+            Self::Mysql8026 => std::option::Option::Some("MYSQL_8_0_26"),
+            Self::Mysql8027 => std::option::Option::Some("MYSQL_8_0_27"),
+            Self::Mysql8028 => std::option::Option::Some("MYSQL_8_0_28"),
+            Self::Mysql8029 => std::option::Option::Some("MYSQL_8_0_29"),
+            Self::Mysql8030 => std::option::Option::Some("MYSQL_8_0_30"),
+            Self::Mysql8031 => std::option::Option::Some("MYSQL_8_0_31"),
+            Self::Mysql8032 => std::option::Option::Some("MYSQL_8_0_32"),
+            Self::Mysql8033 => std::option::Option::Some("MYSQL_8_0_33"),
+            Self::Mysql8034 => std::option::Option::Some("MYSQL_8_0_34"),
+            Self::Mysql8035 => std::option::Option::Some("MYSQL_8_0_35"),
+            Self::Mysql8036 => std::option::Option::Some("MYSQL_8_0_36"),
+            Self::Mysql8037 => std::option::Option::Some("MYSQL_8_0_37"),
+            Self::Mysql8038 => std::option::Option::Some("MYSQL_8_0_38"),
+            Self::Mysql8039 => std::option::Option::Some("MYSQL_8_0_39"),
+            Self::Mysql8040 => std::option::Option::Some("MYSQL_8_0_40"),
+            Self::Mysql84 => std::option::Option::Some("MYSQL_8_4"),
+            Self::Mysql840 => std::option::Option::Some("MYSQL_8_4_0"),
+            Self::Sqlserver2019Standard => std::option::Option::Some("SQLSERVER_2019_STANDARD"),
+            Self::Sqlserver2019Enterprise => std::option::Option::Some("SQLSERVER_2019_ENTERPRISE"),
+            Self::Sqlserver2019Express => std::option::Option::Some("SQLSERVER_2019_EXPRESS"),
+            Self::Sqlserver2019Web => std::option::Option::Some("SQLSERVER_2019_WEB"),
+            Self::Sqlserver2022Standard => std::option::Option::Some("SQLSERVER_2022_STANDARD"),
+            Self::Sqlserver2022Enterprise => std::option::Option::Some("SQLSERVER_2022_ENTERPRISE"),
+            Self::Sqlserver2022Express => std::option::Option::Some("SQLSERVER_2022_EXPRESS"),
+            Self::Sqlserver2022Web => std::option::Option::Some("SQLSERVER_2022_WEB"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlDatabaseVersion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlDatabaseVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlDatabaseVersion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::Mysql51,
+            3 => Self::Mysql55,
+            5 => Self::Mysql56,
+            6 => Self::Mysql57,
+            9 => Self::Postgres96,
+            10 => Self::Postgres11,
+            11 => Self::Sqlserver2017Standard,
+            14 => Self::Sqlserver2017Enterprise,
+            15 => Self::Sqlserver2017Express,
+            16 => Self::Sqlserver2017Web,
+            18 => Self::Postgres10,
+            19 => Self::Postgres12,
+            20 => Self::Mysql80,
+            23 => Self::Postgres13,
+            26 => Self::Sqlserver2019Standard,
+            27 => Self::Sqlserver2019Enterprise,
+            28 => Self::Sqlserver2019Express,
+            29 => Self::Sqlserver2019Web,
+            41 => Self::Mysql8018,
+            85 => Self::Mysql8026,
+            110 => Self::Postgres14,
+            111 => Self::Mysql8027,
+            132 => Self::Mysql8028,
+            148 => Self::Mysql8029,
+            172 => Self::Postgres15,
+            174 => Self::Mysql8030,
+            197 => Self::Mysql8031,
+            199 => Self::Sqlserver2022Standard,
+            200 => Self::Sqlserver2022Enterprise,
+            201 => Self::Sqlserver2022Express,
+            202 => Self::Sqlserver2022Web,
+            213 => Self::Mysql8032,
+            238 => Self::Mysql8033,
+            239 => Self::Mysql8034,
+            240 => Self::Mysql8035,
+            241 => Self::Mysql8036,
+            272 => Self::Postgres16,
+            355 => Self::Mysql8037,
+            356 => Self::Mysql8038,
+            357 => Self::Mysql8039,
+            358 => Self::Mysql8040,
+            398 => Self::Mysql84,
+            399 => Self::Mysql840,
+            _ => Self::UnknownValue(sql_database_version::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlDatabaseVersion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_DATABASE_VERSION_UNSPECIFIED" => Self::Unspecified,
+            "MYSQL_5_1" => Self::Mysql51,
+            "MYSQL_5_5" => Self::Mysql55,
+            "MYSQL_5_6" => Self::Mysql56,
+            "MYSQL_5_7" => Self::Mysql57,
+            "SQLSERVER_2017_STANDARD" => Self::Sqlserver2017Standard,
+            "SQLSERVER_2017_ENTERPRISE" => Self::Sqlserver2017Enterprise,
+            "SQLSERVER_2017_EXPRESS" => Self::Sqlserver2017Express,
+            "SQLSERVER_2017_WEB" => Self::Sqlserver2017Web,
+            "POSTGRES_9_6" => Self::Postgres96,
+            "POSTGRES_10" => Self::Postgres10,
+            "POSTGRES_11" => Self::Postgres11,
+            "POSTGRES_12" => Self::Postgres12,
+            "POSTGRES_13" => Self::Postgres13,
+            "POSTGRES_14" => Self::Postgres14,
+            "POSTGRES_15" => Self::Postgres15,
+            "POSTGRES_16" => Self::Postgres16,
+            "MYSQL_8_0" => Self::Mysql80,
+            "MYSQL_8_0_18" => Self::Mysql8018,
+            "MYSQL_8_0_26" => Self::Mysql8026,
+            "MYSQL_8_0_27" => Self::Mysql8027,
+            "MYSQL_8_0_28" => Self::Mysql8028,
+            "MYSQL_8_0_29" => Self::Mysql8029,
+            "MYSQL_8_0_30" => Self::Mysql8030,
+            "MYSQL_8_0_31" => Self::Mysql8031,
+            "MYSQL_8_0_32" => Self::Mysql8032,
+            "MYSQL_8_0_33" => Self::Mysql8033,
+            "MYSQL_8_0_34" => Self::Mysql8034,
+            "MYSQL_8_0_35" => Self::Mysql8035,
+            "MYSQL_8_0_36" => Self::Mysql8036,
+            "MYSQL_8_0_37" => Self::Mysql8037,
+            "MYSQL_8_0_38" => Self::Mysql8038,
+            "MYSQL_8_0_39" => Self::Mysql8039,
+            "MYSQL_8_0_40" => Self::Mysql8040,
+            "MYSQL_8_4" => Self::Mysql84,
+            "MYSQL_8_4_0" => Self::Mysql840,
+            "SQLSERVER_2019_STANDARD" => Self::Sqlserver2019Standard,
+            "SQLSERVER_2019_ENTERPRISE" => Self::Sqlserver2019Enterprise,
+            "SQLSERVER_2019_EXPRESS" => Self::Sqlserver2019Express,
+            "SQLSERVER_2019_WEB" => Self::Sqlserver2019Web,
+            "SQLSERVER_2022_STANDARD" => Self::Sqlserver2022Standard,
+            "SQLSERVER_2022_ENTERPRISE" => Self::Sqlserver2022Enterprise,
+            "SQLSERVER_2022_EXPRESS" => Self::Sqlserver2022Express,
+            "SQLSERVER_2022_WEB" => Self::Sqlserver2022Web,
+            _ => Self::UnknownValue(sql_database_version::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlDatabaseVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Mysql51 => serializer.serialize_i32(2),
+            Self::Mysql55 => serializer.serialize_i32(3),
+            Self::Mysql56 => serializer.serialize_i32(5),
+            Self::Mysql57 => serializer.serialize_i32(6),
+            Self::Sqlserver2017Standard => serializer.serialize_i32(11),
+            Self::Sqlserver2017Enterprise => serializer.serialize_i32(14),
+            Self::Sqlserver2017Express => serializer.serialize_i32(15),
+            Self::Sqlserver2017Web => serializer.serialize_i32(16),
+            Self::Postgres96 => serializer.serialize_i32(9),
+            Self::Postgres10 => serializer.serialize_i32(18),
+            Self::Postgres11 => serializer.serialize_i32(10),
+            Self::Postgres12 => serializer.serialize_i32(19),
+            Self::Postgres13 => serializer.serialize_i32(23),
+            Self::Postgres14 => serializer.serialize_i32(110),
+            Self::Postgres15 => serializer.serialize_i32(172),
+            Self::Postgres16 => serializer.serialize_i32(272),
+            Self::Mysql80 => serializer.serialize_i32(20),
+            Self::Mysql8018 => serializer.serialize_i32(41),
+            Self::Mysql8026 => serializer.serialize_i32(85),
+            Self::Mysql8027 => serializer.serialize_i32(111),
+            Self::Mysql8028 => serializer.serialize_i32(132),
+            Self::Mysql8029 => serializer.serialize_i32(148),
+            Self::Mysql8030 => serializer.serialize_i32(174),
+            Self::Mysql8031 => serializer.serialize_i32(197),
+            Self::Mysql8032 => serializer.serialize_i32(213),
+            Self::Mysql8033 => serializer.serialize_i32(238),
+            Self::Mysql8034 => serializer.serialize_i32(239),
+            Self::Mysql8035 => serializer.serialize_i32(240),
+            Self::Mysql8036 => serializer.serialize_i32(241),
+            Self::Mysql8037 => serializer.serialize_i32(355),
+            Self::Mysql8038 => serializer.serialize_i32(356),
+            Self::Mysql8039 => serializer.serialize_i32(357),
+            Self::Mysql8040 => serializer.serialize_i32(358),
+            Self::Mysql84 => serializer.serialize_i32(398),
+            Self::Mysql840 => serializer.serialize_i32(399),
+            Self::Sqlserver2019Standard => serializer.serialize_i32(26),
+            Self::Sqlserver2019Enterprise => serializer.serialize_i32(27),
+            Self::Sqlserver2019Express => serializer.serialize_i32(28),
+            Self::Sqlserver2019Web => serializer.serialize_i32(29),
+            Self::Sqlserver2022Standard => serializer.serialize_i32(199),
+            Self::Sqlserver2022Enterprise => serializer.serialize_i32(200),
+            Self::Sqlserver2022Express => serializer.serialize_i32(201),
+            Self::Sqlserver2022Web => serializer.serialize_i32(202),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlDatabaseVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlDatabaseVersion>::new(
+            ".google.cloud.sql.v1.SqlDatabaseVersion"))
     }
 }
 
 /// The pricing plan for this instance.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlPricingPlan(i32);
-
-impl SqlPricingPlan {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlPricingPlan {
     /// This is an unknown pricing plan for this instance.
-    pub const SQL_PRICING_PLAN_UNSPECIFIED: SqlPricingPlan = SqlPricingPlan::new(0);
-
+    Unspecified,
     /// The instance is billed at a monthly flat rate.
-    pub const PACKAGE: SqlPricingPlan = SqlPricingPlan::new(1);
-
+    Package,
     /// The instance is billed per usage.
-    pub const PER_USE: SqlPricingPlan = SqlPricingPlan::new(2);
-
-    /// Creates a new SqlPricingPlan instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_PRICING_PLAN_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PACKAGE"),
-            2 => std::borrow::Cow::Borrowed("PER_USE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_PRICING_PLAN_UNSPECIFIED" => std::option::Option::Some(Self::SQL_PRICING_PLAN_UNSPECIFIED),
-            "PACKAGE" => std::option::Option::Some(Self::PACKAGE),
-            "PER_USE" => std::option::Option::Some(Self::PER_USE),
-            _ => std::option::Option::None,
-        }
-    }
+    PerUse,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlPricingPlan::value] or
+    /// [SqlPricingPlan::name].
+    UnknownValue(sql_pricing_plan::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlPricingPlan {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_pricing_plan {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlPricingPlan {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Package => std::option::Option::Some(1),
+            Self::PerUse => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_PRICING_PLAN_UNSPECIFIED"),
+            Self::Package => std::option::Option::Some("PACKAGE"),
+            Self::PerUse => std::option::Option::Some("PER_USE"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlPricingPlan {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlReplicationType(i32);
+impl std::fmt::Display for SqlPricingPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
 
-impl SqlReplicationType {
+impl std::convert::From<i32> for SqlPricingPlan {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Package,
+            2 => Self::PerUse,
+            _ => Self::UnknownValue(sql_pricing_plan::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
 
+impl std::convert::From<&str> for SqlPricingPlan {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_PRICING_PLAN_UNSPECIFIED" => Self::Unspecified,
+            "PACKAGE" => Self::Package,
+            "PER_USE" => Self::PerUse,
+            _ => Self::UnknownValue(sql_pricing_plan::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlPricingPlan {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Package => serializer.serialize_i32(1),
+            Self::PerUse => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlPricingPlan {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlPricingPlan>::new(
+            ".google.cloud.sql.v1.SqlPricingPlan"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlReplicationType {
     /// This is an unknown replication type for a Cloud SQL instance.
-    pub const SQL_REPLICATION_TYPE_UNSPECIFIED: SqlReplicationType = SqlReplicationType::new(0);
-
+    Unspecified,
     /// The synchronous replication mode for First Generation instances. It is the
     /// default value.
-    pub const SYNCHRONOUS: SqlReplicationType = SqlReplicationType::new(1);
-
+    Synchronous,
     /// The asynchronous replication mode for First Generation instances. It
     /// provides a slight performance gain, but if an outage occurs while this
     /// option is set to asynchronous, you can lose up to a few seconds of updates
     /// to your data.
-    pub const ASYNCHRONOUS: SqlReplicationType = SqlReplicationType::new(2);
-
-    /// Creates a new SqlReplicationType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_REPLICATION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SYNCHRONOUS"),
-            2 => std::borrow::Cow::Borrowed("ASYNCHRONOUS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_REPLICATION_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_REPLICATION_TYPE_UNSPECIFIED),
-            "SYNCHRONOUS" => std::option::Option::Some(Self::SYNCHRONOUS),
-            "ASYNCHRONOUS" => std::option::Option::Some(Self::ASYNCHRONOUS),
-            _ => std::option::Option::None,
-        }
-    }
+    Asynchronous,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlReplicationType::value] or
+    /// [SqlReplicationType::name].
+    UnknownValue(sql_replication_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlReplicationType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_replication_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlReplicationType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Synchronous => std::option::Option::Some(1),
+            Self::Asynchronous => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_REPLICATION_TYPE_UNSPECIFIED"),
+            Self::Synchronous => std::option::Option::Some("SYNCHRONOUS"),
+            Self::Asynchronous => std::option::Option::Some("ASYNCHRONOUS"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlReplicationType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlReplicationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlReplicationType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Synchronous,
+            2 => Self::Asynchronous,
+            _ => Self::UnknownValue(sql_replication_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlReplicationType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_REPLICATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "SYNCHRONOUS" => Self::Synchronous,
+            "ASYNCHRONOUS" => Self::Asynchronous,
+            _ => Self::UnknownValue(sql_replication_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlReplicationType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Synchronous => serializer.serialize_i32(1),
+            Self::Asynchronous => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlReplicationType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlReplicationType>::new(
+            ".google.cloud.sql.v1.SqlReplicationType"))
     }
 }
 
 /// The type of disk that is used for a v2 instance to use.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlDataDiskType(i32);
-
-impl SqlDataDiskType {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlDataDiskType {
     /// This is an unknown data disk type.
-    pub const SQL_DATA_DISK_TYPE_UNSPECIFIED: SqlDataDiskType = SqlDataDiskType::new(0);
-
+    Unspecified,
     /// An SSD data disk.
-    pub const PD_SSD: SqlDataDiskType = SqlDataDiskType::new(1);
-
+    PdSsd,
     /// An HDD data disk.
-    pub const PD_HDD: SqlDataDiskType = SqlDataDiskType::new(2);
-
+    PdHdd,
     /// This field is deprecated and will be removed from a future version of the
     /// API.
-    pub const OBSOLETE_LOCAL_SSD: SqlDataDiskType = SqlDataDiskType::new(3);
-
-    /// Creates a new SqlDataDiskType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_DATA_DISK_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PD_SSD"),
-            2 => std::borrow::Cow::Borrowed("PD_HDD"),
-            3 => std::borrow::Cow::Borrowed("OBSOLETE_LOCAL_SSD"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_DATA_DISK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_DATA_DISK_TYPE_UNSPECIFIED),
-            "PD_SSD" => std::option::Option::Some(Self::PD_SSD),
-            "PD_HDD" => std::option::Option::Some(Self::PD_HDD),
-            "OBSOLETE_LOCAL_SSD" => std::option::Option::Some(Self::OBSOLETE_LOCAL_SSD),
-            _ => std::option::Option::None,
-        }
-    }
+    ObsoleteLocalSsd,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlDataDiskType::value] or
+    /// [SqlDataDiskType::name].
+    UnknownValue(sql_data_disk_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlDataDiskType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_data_disk_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlDataDiskType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PdSsd => std::option::Option::Some(1),
+            Self::PdHdd => std::option::Option::Some(2),
+            Self::ObsoleteLocalSsd => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_DATA_DISK_TYPE_UNSPECIFIED"),
+            Self::PdSsd => std::option::Option::Some("PD_SSD"),
+            Self::PdHdd => std::option::Option::Some("PD_HDD"),
+            Self::ObsoleteLocalSsd => std::option::Option::Some("OBSOLETE_LOCAL_SSD"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlDataDiskType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlDataDiskType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlDataDiskType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PdSsd,
+            2 => Self::PdHdd,
+            3 => Self::ObsoleteLocalSsd,
+            _ => Self::UnknownValue(sql_data_disk_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlDataDiskType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_DATA_DISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PD_SSD" => Self::PdSsd,
+            "PD_HDD" => Self::PdHdd,
+            "OBSOLETE_LOCAL_SSD" => Self::ObsoleteLocalSsd,
+            _ => Self::UnknownValue(sql_data_disk_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlDataDiskType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PdSsd => serializer.serialize_i32(1),
+            Self::PdHdd => serializer.serialize_i32(2),
+            Self::ObsoleteLocalSsd => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlDataDiskType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlDataDiskType>::new(
+            ".google.cloud.sql.v1.SqlDataDiskType"))
     }
 }
 
 /// The availability type of the given Cloud SQL instance.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlAvailabilityType(i32);
-
-impl SqlAvailabilityType {
-
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlAvailabilityType {
     /// This is an unknown Availability type.
-    pub const SQL_AVAILABILITY_TYPE_UNSPECIFIED: SqlAvailabilityType = SqlAvailabilityType::new(0);
-
+    Unspecified,
     /// Zonal available instance.
-    pub const ZONAL: SqlAvailabilityType = SqlAvailabilityType::new(1);
-
+    Zonal,
     /// Regional available instance.
-    pub const REGIONAL: SqlAvailabilityType = SqlAvailabilityType::new(2);
-
-    /// Creates a new SqlAvailabilityType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_AVAILABILITY_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ZONAL"),
-            2 => std::borrow::Cow::Borrowed("REGIONAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_AVAILABILITY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::SQL_AVAILABILITY_TYPE_UNSPECIFIED),
-            "ZONAL" => std::option::Option::Some(Self::ZONAL),
-            "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-            _ => std::option::Option::None,
-        }
-    }
+    Regional,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlAvailabilityType::value] or
+    /// [SqlAvailabilityType::name].
+    UnknownValue(sql_availability_type::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlAvailabilityType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_availability_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlAvailabilityType {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Zonal => std::option::Option::Some(1),
+            Self::Regional => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_AVAILABILITY_TYPE_UNSPECIFIED"),
+            Self::Zonal => std::option::Option::Some("ZONAL"),
+            Self::Regional => std::option::Option::Some("REGIONAL"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlAvailabilityType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SqlUpdateTrack(i32);
+impl std::fmt::Display for SqlAvailabilityType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
 
-impl SqlUpdateTrack {
+impl std::convert::From<i32> for SqlAvailabilityType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Zonal,
+            2 => Self::Regional,
+            _ => Self::UnknownValue(sql_availability_type::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
 
+impl std::convert::From<&str> for SqlAvailabilityType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_AVAILABILITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "ZONAL" => Self::Zonal,
+            "REGIONAL" => Self::Regional,
+            _ => Self::UnknownValue(sql_availability_type::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlAvailabilityType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Zonal => serializer.serialize_i32(1),
+            Self::Regional => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlAvailabilityType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlAvailabilityType>::new(
+            ".google.cloud.sql.v1.SqlAvailabilityType"))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SqlUpdateTrack {
     /// This is an unknown maintenance timing preference.
-    pub const SQL_UPDATE_TRACK_UNSPECIFIED: SqlUpdateTrack = SqlUpdateTrack::new(0);
-
+    Unspecified,
     /// For an instance with a scheduled maintenance window, this maintenance
     /// timing indicates that the maintenance update is scheduled 7 to 14 days
     /// after the notification is sent out. Also referred to as `Week 1` (Console)
     /// and `preview` (gcloud CLI).
-    pub const CANARY: SqlUpdateTrack = SqlUpdateTrack::new(1);
-
+    Canary,
     /// For an instance with a scheduled maintenance window, this maintenance
     /// timing indicates that the maintenance update is scheduled 15 to 21 days
     /// after the notification is sent out. Also referred to as `Week 2` (Console)
     /// and `production` (gcloud CLI).
-    pub const STABLE: SqlUpdateTrack = SqlUpdateTrack::new(2);
-
+    Stable,
     /// For instance with a scheduled maintenance window, this maintenance
     /// timing indicates that the maintenance update is scheduled 35 to 42 days
     /// after the notification is sent out.
-    pub const WEEK_5: SqlUpdateTrack = SqlUpdateTrack::new(3);
-
-    /// Creates a new SqlUpdateTrack instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
-    /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
-    }
-    
-    /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SQL_UPDATE_TRACK_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("canary"),
-            2 => std::borrow::Cow::Borrowed("stable"),
-            3 => std::borrow::Cow::Borrowed("week5"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SQL_UPDATE_TRACK_UNSPECIFIED" => std::option::Option::Some(Self::SQL_UPDATE_TRACK_UNSPECIFIED),
-            "canary" => std::option::Option::Some(Self::CANARY),
-            "stable" => std::option::Option::Some(Self::STABLE),
-            "week5" => std::option::Option::Some(Self::WEEK_5),
-            _ => std::option::Option::None,
-        }
-    }
+    Week5,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SqlUpdateTrack::value] or
+    /// [SqlUpdateTrack::name].
+    UnknownValue(sql_update_track::UnknownValue),
 }
 
-impl std::convert::From<i32> for SqlUpdateTrack {
-    fn from(value: i32) -> Self {
-        Self::new(value)
+#[doc(hidden)]
+pub mod sql_update_track {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
+
+impl SqlUpdateTrack {
+    /// Gets the enum value.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Canary => std::option::Option::Some(1),
+            Self::Stable => std::option::Option::Some(2),
+            Self::Week5 => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
+    }
+
+    /// Gets the enum value as a string.
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SQL_UPDATE_TRACK_UNSPECIFIED"),
+            Self::Canary => std::option::Option::Some("canary"),
+            Self::Stable => std::option::Option::Some("stable"),
+            Self::Week5 => std::option::Option::Some("week5"),
+            Self::UnknownValue(u) => u.0.name(),
+        }
     }
 }
 
 impl std::default::Default for SqlUpdateTrack {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SqlUpdateTrack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SqlUpdateTrack {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Canary,
+            2 => Self::Stable,
+            3 => Self::Week5,
+            _ => Self::UnknownValue(sql_update_track::UnknownValue(wkt::internal::UnknownEnumValue::Integer(value))),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SqlUpdateTrack {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SQL_UPDATE_TRACK_UNSPECIFIED" => Self::Unspecified,
+            "canary" => Self::Canary,
+            "stable" => Self::Stable,
+            "week5" => Self::Week5,
+            _ => Self::UnknownValue(sql_update_track::UnknownValue(wkt::internal::UnknownEnumValue::String(value.to_string()))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SqlUpdateTrack {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Canary => serializer.serialize_i32(1),
+            Self::Stable => serializer.serialize_i32(2),
+            Self::Week5 => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqlUpdateTrack {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SqlUpdateTrack>::new(
+            ".google.cloud.sql.v1.SqlUpdateTrack"))
     }
 }

--- a/src/generated/cloud/storagebatchoperations/v1/src/model.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/model.rs
@@ -815,69 +815,134 @@ pub mod job {
     use super::*;
 
     /// Describes state of a job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// In progress.
+        Running,
+        /// Completed successfully.
+        Succeeded,
+        /// Cancelled by the user.
+        Canceled,
+        /// Terminated due to an unrecoverable failure.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// In progress.
-        pub const RUNNING: State = State::new(1);
-
-        /// Completed successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// Cancelled by the user.
-        pub const CANCELED: State = State::new(3);
-
-        /// Terminated due to an unrecoverable failure.
-        pub const FAILED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Canceled => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("CANCELED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Canceled => std::option::Option::Some("CANCELED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELED" => std::option::Option::Some(Self::CANCELED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Canceled,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELED" => Self::Canceled,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Canceled => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.storagebatchoperations.v1.Job.State",
+            ))
         }
     }
 
@@ -1228,61 +1293,120 @@ pub mod put_object_hold {
     use super::*;
 
     /// Describes the status of the hold.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HoldStatus(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HoldStatus {
+        /// Default value, Object hold status will not be changed.
+        Unspecified,
+        /// Places the hold.
+        Set,
+        /// Releases the hold.
+        Unset,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HoldStatus::value] or
+        /// [HoldStatus::name].
+        UnknownValue(hold_status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod hold_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HoldStatus {
-        /// Default value, Object hold status will not be changed.
-        pub const HOLD_STATUS_UNSPECIFIED: HoldStatus = HoldStatus::new(0);
-
-        /// Places the hold.
-        pub const SET: HoldStatus = HoldStatus::new(1);
-
-        /// Releases the hold.
-        pub const UNSET: HoldStatus = HoldStatus::new(2);
-
-        /// Creates a new HoldStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Set => std::option::Option::Some(1),
+                Self::Unset => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HOLD_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SET"),
-                2 => std::borrow::Cow::Borrowed("UNSET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HOLD_STATUS_UNSPECIFIED"),
+                Self::Set => std::option::Option::Some("SET"),
+                Self::Unset => std::option::Option::Some("UNSET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HOLD_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::HOLD_STATUS_UNSPECIFIED)
-                }
-                "SET" => std::option::Option::Some(Self::SET),
-                "UNSET" => std::option::Option::Some(Self::UNSET),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HoldStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HoldStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HoldStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HoldStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Set,
+                2 => Self::Unset,
+                _ => Self::UnknownValue(hold_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HoldStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HOLD_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "SET" => Self::Set,
+                "UNSET" => Self::Unset,
+                _ => Self::UnknownValue(hold_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HoldStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Set => serializer.serialize_i32(1),
+                Self::Unset => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HoldStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HoldStatus>::new(
+                ".google.cloud.storagebatchoperations.v1.PutObjectHold.HoldStatus",
+            ))
         }
     }
 }
@@ -1735,118 +1859,233 @@ pub mod logging_config {
     use super::*;
 
     /// Loggable actions types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggableAction(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoggableAction {
+        /// Illegal value, to avoid allowing a default.
+        Unspecified,
+        /// The corresponding transform action in this job.
+        Transform,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoggableAction::value] or
+        /// [LoggableAction::name].
+        UnknownValue(loggable_action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod loggable_action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LoggableAction {
-        /// Illegal value, to avoid allowing a default.
-        pub const LOGGABLE_ACTION_UNSPECIFIED: LoggableAction = LoggableAction::new(0);
-
-        /// The corresponding transform action in this job.
-        pub const TRANSFORM: LoggableAction = LoggableAction::new(6);
-
-        /// Creates a new LoggableAction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Transform => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOGGABLE_ACTION_UNSPECIFIED"),
-                6 => std::borrow::Cow::Borrowed("TRANSFORM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOGGABLE_ACTION_UNSPECIFIED"),
+                Self::Transform => std::option::Option::Some("TRANSFORM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOGGABLE_ACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOGGABLE_ACTION_UNSPECIFIED)
-                }
-                "TRANSFORM" => std::option::Option::Some(Self::TRANSFORM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoggableAction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggableAction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoggableAction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoggableAction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                6 => Self::Transform,
+                _ => Self::UnknownValue(loggable_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoggableAction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOGGABLE_ACTION_UNSPECIFIED" => Self::Unspecified,
+                "TRANSFORM" => Self::Transform,
+                _ => Self::UnknownValue(loggable_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoggableAction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Transform => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoggableAction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoggableAction>::new(
+                ".google.cloud.storagebatchoperations.v1.LoggingConfig.LoggableAction",
+            ))
         }
     }
 
     /// Loggable action states filter.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggableActionState(i32);
-
-    impl LoggableActionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoggableActionState {
         /// Illegal value, to avoid allowing a default.
-        pub const LOGGABLE_ACTION_STATE_UNSPECIFIED: LoggableActionState =
-            LoggableActionState::new(0);
-
+        Unspecified,
         /// `LoggableAction` completed successfully. `SUCCEEDED` actions are
         /// logged as [INFO][google.logging.type.LogSeverity.INFO].
-        pub const SUCCEEDED: LoggableActionState = LoggableActionState::new(1);
-
+        Succeeded,
         /// `LoggableAction` terminated in an error state. `FAILED` actions
         /// are logged as [ERROR][google.logging.type.LogSeverity.ERROR].
-        pub const FAILED: LoggableActionState = LoggableActionState::new(2);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoggableActionState::value] or
+        /// [LoggableActionState::name].
+        UnknownValue(loggable_action_state::UnknownValue),
+    }
 
-        /// Creates a new LoggableActionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod loggable_action_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LoggableActionState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOGGABLE_ACTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOGGABLE_ACTION_STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOGGABLE_ACTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOGGABLE_ACTION_STATE_UNSPECIFIED)
-                }
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoggableActionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggableActionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoggableActionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoggableActionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                _ => Self::UnknownValue(loggable_action_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoggableActionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOGGABLE_ACTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(loggable_action_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoggableActionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoggableActionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoggableActionState>::new(
+                ".google.cloud.storagebatchoperations.v1.LoggingConfig.LoggableActionState",
+            ))
         }
     }
 }

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -957,59 +957,120 @@ pub mod frequency_options {
     use super::*;
 
     /// This ENUM specifies possible frequencies of report generation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Frequency(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Frequency {
+        /// Unspecified.
+        Unspecified,
+        /// Report will be generated daily.
+        Daily,
+        /// Report will be generated weekly.
+        Weekly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Frequency::value] or
+        /// [Frequency::name].
+        UnknownValue(frequency::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod frequency {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Frequency {
-        /// Unspecified.
-        pub const FREQUENCY_UNSPECIFIED: Frequency = Frequency::new(0);
-
-        /// Report will be generated daily.
-        pub const DAILY: Frequency = Frequency::new(1);
-
-        /// Report will be generated weekly.
-        pub const WEEKLY: Frequency = Frequency::new(2);
-
-        /// Creates a new Frequency instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Daily => std::option::Option::Some(1),
+                Self::Weekly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FREQUENCY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DAILY"),
-                2 => std::borrow::Cow::Borrowed("WEEKLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FREQUENCY_UNSPECIFIED"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Weekly => std::option::Option::Some("WEEKLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FREQUENCY_UNSPECIFIED" => std::option::Option::Some(Self::FREQUENCY_UNSPECIFIED),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Frequency {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Frequency {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Frequency {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Frequency {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Daily,
+                2 => Self::Weekly,
+                _ => Self::UnknownValue(frequency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Frequency {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FREQUENCY_UNSPECIFIED" => Self::Unspecified,
+                "DAILY" => Self::Daily,
+                "WEEKLY" => Self::Weekly,
+                _ => Self::UnknownValue(frequency::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Frequency {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Daily => serializer.serialize_i32(1),
+                Self::Weekly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Frequency {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Frequency>::new(
+                ".google.cloud.storageinsights.v1.FrequencyOptions.Frequency",
+            ))
         }
     }
 }

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -512,151 +512,285 @@ pub mod case {
     use super::*;
 
     /// The status of a support case.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Case is in an unknown state.
+        Unspecified,
+        /// The case has been created but no one is assigned to work on it yet.
+        New,
+        /// The case is currently being handled by Google support.
+        InProgressGoogleSupport,
+        /// Google is waiting for a response.
+        ActionRequired,
+        /// A solution has been offered for the case, but it isn't yet closed.
+        SolutionProvided,
+        /// The case has been resolved.
+        Closed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Case is in an unknown state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The case has been created but no one is assigned to work on it yet.
-        pub const NEW: State = State::new(1);
-
-        /// The case is currently being handled by Google support.
-        pub const IN_PROGRESS_GOOGLE_SUPPORT: State = State::new(2);
-
-        /// Google is waiting for a response.
-        pub const ACTION_REQUIRED: State = State::new(3);
-
-        /// A solution has been offered for the case, but it isn't yet closed.
-        pub const SOLUTION_PROVIDED: State = State::new(4);
-
-        /// The case has been resolved.
-        pub const CLOSED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::New => std::option::Option::Some(1),
+                Self::InProgressGoogleSupport => std::option::Option::Some(2),
+                Self::ActionRequired => std::option::Option::Some(3),
+                Self::SolutionProvided => std::option::Option::Some(4),
+                Self::Closed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEW"),
-                2 => std::borrow::Cow::Borrowed("IN_PROGRESS_GOOGLE_SUPPORT"),
-                3 => std::borrow::Cow::Borrowed("ACTION_REQUIRED"),
-                4 => std::borrow::Cow::Borrowed("SOLUTION_PROVIDED"),
-                5 => std::borrow::Cow::Borrowed("CLOSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "NEW" => std::option::Option::Some(Self::NEW),
-                "IN_PROGRESS_GOOGLE_SUPPORT" => {
-                    std::option::Option::Some(Self::IN_PROGRESS_GOOGLE_SUPPORT)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::New => std::option::Option::Some("NEW"),
+                Self::InProgressGoogleSupport => {
+                    std::option::Option::Some("IN_PROGRESS_GOOGLE_SUPPORT")
                 }
-                "ACTION_REQUIRED" => std::option::Option::Some(Self::ACTION_REQUIRED),
-                "SOLUTION_PROVIDED" => std::option::Option::Some(Self::SOLUTION_PROVIDED),
-                "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                _ => std::option::Option::None,
+                Self::ActionRequired => std::option::Option::Some("ACTION_REQUIRED"),
+                Self::SolutionProvided => std::option::Option::Some("SOLUTION_PROVIDED"),
+                Self::Closed => std::option::Option::Some("CLOSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::New,
+                2 => Self::InProgressGoogleSupport,
+                3 => Self::ActionRequired,
+                4 => Self::SolutionProvided,
+                5 => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "NEW" => Self::New,
+                "IN_PROGRESS_GOOGLE_SUPPORT" => Self::InProgressGoogleSupport,
+                "ACTION_REQUIRED" => Self::ActionRequired,
+                "SOLUTION_PROVIDED" => Self::SolutionProvided,
+                "CLOSED" => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::New => serializer.serialize_i32(1),
+                Self::InProgressGoogleSupport => serializer.serialize_i32(2),
+                Self::ActionRequired => serializer.serialize_i32(3),
+                Self::SolutionProvided => serializer.serialize_i32(4),
+                Self::Closed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.support.v2.Case.State",
+            ))
         }
     }
 
     /// The case Priority. P0 is most urgent and P4 the least.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Priority(i32);
-
-    impl Priority {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Priority {
         /// Priority is undefined or has not been set yet.
-        pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
-
+        Unspecified,
         /// Extreme impact on a production service. Service is hard down.
-        pub const P0: Priority = Priority::new(1);
-
+        P0,
         /// Critical impact on a production service. Service is currently unusable.
-        pub const P1: Priority = Priority::new(2);
-
+        P1,
         /// Severe impact on a production service. Service is usable but greatly
         /// impaired.
-        pub const P2: Priority = Priority::new(3);
-
+        P2,
         /// Medium impact on a production service.  Service is available, but
         /// moderately impaired.
-        pub const P3: Priority = Priority::new(4);
-
+        P3,
         /// General questions or minor issues.  Production service is fully
         /// available.
-        pub const P4: Priority = Priority::new(5);
+        P4,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Priority::value] or
+        /// [Priority::name].
+        UnknownValue(priority::UnknownValue),
+    }
 
-        /// Creates a new Priority instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod priority {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Priority {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::P0 => std::option::Option::Some(1),
+                Self::P1 => std::option::Option::Some(2),
+                Self::P2 => std::option::Option::Some(3),
+                Self::P3 => std::option::Option::Some(4),
+                Self::P4 => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("P0"),
-                2 => std::borrow::Cow::Borrowed("P1"),
-                3 => std::borrow::Cow::Borrowed("P2"),
-                4 => std::borrow::Cow::Borrowed("P3"),
-                5 => std::borrow::Cow::Borrowed("P4"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIORITY_UNSPECIFIED"),
+                Self::P0 => std::option::Option::Some("P0"),
+                Self::P1 => std::option::Option::Some("P1"),
+                Self::P2 => std::option::Option::Some("P2"),
+                Self::P3 => std::option::Option::Some("P3"),
+                Self::P4 => std::option::Option::Some("P4"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
-                "P0" => std::option::Option::Some(Self::P0),
-                "P1" => std::option::Option::Some(Self::P1),
-                "P2" => std::option::Option::Some(Self::P2),
-                "P3" => std::option::Option::Some(Self::P3),
-                "P4" => std::option::Option::Some(Self::P4),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Priority {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Priority {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Priority {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Priority {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::P0,
+                2 => Self::P1,
+                3 => Self::P2,
+                4 => Self::P3,
+                5 => Self::P4,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Priority {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIORITY_UNSPECIFIED" => Self::Unspecified,
+                "P0" => Self::P0,
+                "P1" => Self::P1,
+                "P2" => Self::P2,
+                "P3" => Self::P3,
+                "P4" => Self::P4,
+                _ => Self::UnknownValue(priority::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Priority {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::P0 => serializer.serialize_i32(1),
+                Self::P1 => serializer.serialize_i32(2),
+                Self::P2 => serializer.serialize_i32(3),
+                Self::P3 => serializer.serialize_i32(4),
+                Self::P4 => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Priority {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Priority>::new(
+                ".google.cloud.support.v2.Case.Priority",
+            ))
         }
     }
 }
@@ -1633,65 +1767,128 @@ pub mod escalation {
     use super::*;
 
     /// An enum detailing the possible reasons a case may be escalated.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reason(i32);
-
-    impl Reason {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Reason {
         /// The escalation reason is in an unknown state or has not been specified.
-        pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
-
+        Unspecified,
         /// The case is taking too long to resolve.
-        pub const RESOLUTION_TIME: Reason = Reason::new(1);
-
+        ResolutionTime,
         /// The support agent does not have the expertise required to successfully
         /// resolve the issue.
-        pub const TECHNICAL_EXPERTISE: Reason = Reason::new(2);
-
+        TechnicalExpertise,
         /// The issue is having a significant business impact.
-        pub const BUSINESS_IMPACT: Reason = Reason::new(3);
+        BusinessImpact,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Reason::value] or
+        /// [Reason::name].
+        UnknownValue(reason::UnknownValue),
+    }
 
-        /// Creates a new Reason instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reason {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Reason {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ResolutionTime => std::option::Option::Some(1),
+                Self::TechnicalExpertise => std::option::Option::Some(2),
+                Self::BusinessImpact => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RESOLUTION_TIME"),
-                2 => std::borrow::Cow::Borrowed("TECHNICAL_EXPERTISE"),
-                3 => std::borrow::Cow::Borrowed("BUSINESS_IMPACT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REASON_UNSPECIFIED"),
+                Self::ResolutionTime => std::option::Option::Some("RESOLUTION_TIME"),
+                Self::TechnicalExpertise => std::option::Option::Some("TECHNICAL_EXPERTISE"),
+                Self::BusinessImpact => std::option::Option::Some("BUSINESS_IMPACT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
-                "RESOLUTION_TIME" => std::option::Option::Some(Self::RESOLUTION_TIME),
-                "TECHNICAL_EXPERTISE" => std::option::Option::Some(Self::TECHNICAL_EXPERTISE),
-                "BUSINESS_IMPACT" => std::option::Option::Some(Self::BUSINESS_IMPACT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Reason {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Reason {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Reason {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ResolutionTime,
+                2 => Self::TechnicalExpertise,
+                3 => Self::BusinessImpact,
+                _ => Self::UnknownValue(reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Reason {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REASON_UNSPECIFIED" => Self::Unspecified,
+                "RESOLUTION_TIME" => Self::ResolutionTime,
+                "TECHNICAL_EXPERTISE" => Self::TechnicalExpertise,
+                "BUSINESS_IMPACT" => Self::BusinessImpact,
+                _ => Self::UnknownValue(reason::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Reason {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ResolutionTime => serializer.serialize_i32(1),
+                Self::TechnicalExpertise => serializer.serialize_i32(2),
+                Self::BusinessImpact => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Reason {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Reason>::new(
+                ".google.cloud.support.v2.Escalation.Reason",
+            ))
         }
     }
 }

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -95,8 +95,8 @@ pub struct Location {
     /// and "Kansas City, KS, USA" has a type of
     /// [LocationType.LOCALITY][google.cloud.talent.v4.Location.LocationType.LOCALITY].
     ///
-    /// [google.cloud.talent.v4.Location.LocationType.LOCALITY]: crate::model::location::location_type::LOCALITY
-    /// [google.cloud.talent.v4.Location.LocationType.NEIGHBORHOOD]: crate::model::location::location_type::NEIGHBORHOOD
+    /// [google.cloud.talent.v4.Location.LocationType.LOCALITY]: crate::model::location::LocationType::Locality
+    /// [google.cloud.talent.v4.Location.LocationType.NEIGHBORHOOD]: crate::model::location::LocationType::Neighborhood
     /// [google.type.PostalAddress]: gtype::model::PostalAddress
     pub location_type: crate::model::location::LocationType,
 
@@ -178,107 +178,180 @@ pub mod location {
     use super::*;
 
     /// An enum which represents the type of a location.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocationType(i32);
-
-    impl LocationType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LocationType {
         /// Default value if the type isn't specified.
-        pub const LOCATION_TYPE_UNSPECIFIED: LocationType = LocationType::new(0);
-
+        Unspecified,
         /// A country level location.
-        pub const COUNTRY: LocationType = LocationType::new(1);
-
+        Country,
         /// A state or equivalent level location.
-        pub const ADMINISTRATIVE_AREA: LocationType = LocationType::new(2);
-
+        AdministrativeArea,
         /// A county or equivalent level location.
-        pub const SUB_ADMINISTRATIVE_AREA: LocationType = LocationType::new(3);
-
+        SubAdministrativeArea,
         /// A city or equivalent level location.
-        pub const LOCALITY: LocationType = LocationType::new(4);
-
+        Locality,
         /// A postal code level location.
-        pub const POSTAL_CODE: LocationType = LocationType::new(5);
-
+        PostalCode,
         /// A sublocality is a subdivision of a locality, for example a city borough,
         /// ward, or arrondissement. Sublocalities are usually recognized by a local
         /// political authority. For example, Manhattan and Brooklyn are recognized
         /// as boroughs by the City of New York, and are therefore modeled as
         /// sublocalities.
-        pub const SUB_LOCALITY: LocationType = LocationType::new(6);
-
+        SubLocality,
         /// A district or equivalent level location.
-        pub const SUB_LOCALITY_1: LocationType = LocationType::new(7);
-
+        SubLocality1,
         /// A smaller district or equivalent level display.
-        pub const SUB_LOCALITY_2: LocationType = LocationType::new(8);
-
+        SubLocality2,
         /// A neighborhood level location.
-        pub const NEIGHBORHOOD: LocationType = LocationType::new(9);
-
+        Neighborhood,
         /// A street address level location.
-        pub const STREET_ADDRESS: LocationType = LocationType::new(10);
+        StreetAddress,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LocationType::value] or
+        /// [LocationType::name].
+        UnknownValue(location_type::UnknownValue),
+    }
 
-        /// Creates a new LocationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod location_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LocationType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Country => std::option::Option::Some(1),
+                Self::AdministrativeArea => std::option::Option::Some(2),
+                Self::SubAdministrativeArea => std::option::Option::Some(3),
+                Self::Locality => std::option::Option::Some(4),
+                Self::PostalCode => std::option::Option::Some(5),
+                Self::SubLocality => std::option::Option::Some(6),
+                Self::SubLocality1 => std::option::Option::Some(7),
+                Self::SubLocality2 => std::option::Option::Some(8),
+                Self::Neighborhood => std::option::Option::Some(9),
+                Self::StreetAddress => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COUNTRY"),
-                2 => std::borrow::Cow::Borrowed("ADMINISTRATIVE_AREA"),
-                3 => std::borrow::Cow::Borrowed("SUB_ADMINISTRATIVE_AREA"),
-                4 => std::borrow::Cow::Borrowed("LOCALITY"),
-                5 => std::borrow::Cow::Borrowed("POSTAL_CODE"),
-                6 => std::borrow::Cow::Borrowed("SUB_LOCALITY"),
-                7 => std::borrow::Cow::Borrowed("SUB_LOCALITY_1"),
-                8 => std::borrow::Cow::Borrowed("SUB_LOCALITY_2"),
-                9 => std::borrow::Cow::Borrowed("NEIGHBORHOOD"),
-                10 => std::borrow::Cow::Borrowed("STREET_ADDRESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOCATION_TYPE_UNSPECIFIED"),
+                Self::Country => std::option::Option::Some("COUNTRY"),
+                Self::AdministrativeArea => std::option::Option::Some("ADMINISTRATIVE_AREA"),
+                Self::SubAdministrativeArea => std::option::Option::Some("SUB_ADMINISTRATIVE_AREA"),
+                Self::Locality => std::option::Option::Some("LOCALITY"),
+                Self::PostalCode => std::option::Option::Some("POSTAL_CODE"),
+                Self::SubLocality => std::option::Option::Some("SUB_LOCALITY"),
+                Self::SubLocality1 => std::option::Option::Some("SUB_LOCALITY_1"),
+                Self::SubLocality2 => std::option::Option::Some("SUB_LOCALITY_2"),
+                Self::Neighborhood => std::option::Option::Some("NEIGHBORHOOD"),
+                Self::StreetAddress => std::option::Option::Some("STREET_ADDRESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOCATION_TYPE_UNSPECIFIED)
-                }
-                "COUNTRY" => std::option::Option::Some(Self::COUNTRY),
-                "ADMINISTRATIVE_AREA" => std::option::Option::Some(Self::ADMINISTRATIVE_AREA),
-                "SUB_ADMINISTRATIVE_AREA" => {
-                    std::option::Option::Some(Self::SUB_ADMINISTRATIVE_AREA)
-                }
-                "LOCALITY" => std::option::Option::Some(Self::LOCALITY),
-                "POSTAL_CODE" => std::option::Option::Some(Self::POSTAL_CODE),
-                "SUB_LOCALITY" => std::option::Option::Some(Self::SUB_LOCALITY),
-                "SUB_LOCALITY_1" => std::option::Option::Some(Self::SUB_LOCALITY_1),
-                "SUB_LOCALITY_2" => std::option::Option::Some(Self::SUB_LOCALITY_2),
-                "NEIGHBORHOOD" => std::option::Option::Some(Self::NEIGHBORHOOD),
-                "STREET_ADDRESS" => std::option::Option::Some(Self::STREET_ADDRESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LocationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LocationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LocationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LocationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Country,
+                2 => Self::AdministrativeArea,
+                3 => Self::SubAdministrativeArea,
+                4 => Self::Locality,
+                5 => Self::PostalCode,
+                6 => Self::SubLocality,
+                7 => Self::SubLocality1,
+                8 => Self::SubLocality2,
+                9 => Self::Neighborhood,
+                10 => Self::StreetAddress,
+                _ => Self::UnknownValue(location_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LocationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "COUNTRY" => Self::Country,
+                "ADMINISTRATIVE_AREA" => Self::AdministrativeArea,
+                "SUB_ADMINISTRATIVE_AREA" => Self::SubAdministrativeArea,
+                "LOCALITY" => Self::Locality,
+                "POSTAL_CODE" => Self::PostalCode,
+                "SUB_LOCALITY" => Self::SubLocality,
+                "SUB_LOCALITY_1" => Self::SubLocality1,
+                "SUB_LOCALITY_2" => Self::SubLocality2,
+                "NEIGHBORHOOD" => Self::Neighborhood,
+                "STREET_ADDRESS" => Self::StreetAddress,
+                _ => Self::UnknownValue(location_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LocationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Country => serializer.serialize_i32(1),
+                Self::AdministrativeArea => serializer.serialize_i32(2),
+                Self::SubAdministrativeArea => serializer.serialize_i32(3),
+                Self::Locality => serializer.serialize_i32(4),
+                Self::PostalCode => serializer.serialize_i32(5),
+                Self::SubLocality => serializer.serialize_i32(6),
+                Self::SubLocality1 => serializer.serialize_i32(7),
+                Self::SubLocality2 => serializer.serialize_i32(8),
+                Self::Neighborhood => serializer.serialize_i32(9),
+                Self::StreetAddress => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LocationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocationType>::new(
+                ".google.cloud.talent.v4.Location.LocationType",
+            ))
         }
     }
 }
@@ -507,84 +580,151 @@ pub mod device_info {
     use super::*;
 
     /// An enumeration describing an API access portal and exposure mechanism.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeviceType(i32);
-
-    impl DeviceType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DeviceType {
         /// The device type isn't specified.
-        pub const DEVICE_TYPE_UNSPECIFIED: DeviceType = DeviceType::new(0);
-
+        Unspecified,
         /// A desktop web browser, such as, Chrome, Firefox, Safari, or Internet
         /// Explorer)
-        pub const WEB: DeviceType = DeviceType::new(1);
-
+        Web,
         /// A mobile device web browser, such as a phone or tablet with a Chrome
         /// browser.
-        pub const MOBILE_WEB: DeviceType = DeviceType::new(2);
-
+        MobileWeb,
         /// An Android device native application.
-        pub const ANDROID: DeviceType = DeviceType::new(3);
-
+        Android,
         /// An iOS device native application.
-        pub const IOS: DeviceType = DeviceType::new(4);
-
+        Ios,
         /// A bot, as opposed to a device operated by human beings, such as a web
         /// crawler.
-        pub const BOT: DeviceType = DeviceType::new(5);
-
+        Bot,
         /// Other devices types.
-        pub const OTHER: DeviceType = DeviceType::new(6);
+        Other,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DeviceType::value] or
+        /// [DeviceType::name].
+        UnknownValue(device_type::UnknownValue),
+    }
 
-        /// Creates a new DeviceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod device_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DeviceType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Web => std::option::Option::Some(1),
+                Self::MobileWeb => std::option::Option::Some(2),
+                Self::Android => std::option::Option::Some(3),
+                Self::Ios => std::option::Option::Some(4),
+                Self::Bot => std::option::Option::Some(5),
+                Self::Other => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEVICE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WEB"),
-                2 => std::borrow::Cow::Borrowed("MOBILE_WEB"),
-                3 => std::borrow::Cow::Borrowed("ANDROID"),
-                4 => std::borrow::Cow::Borrowed("IOS"),
-                5 => std::borrow::Cow::Borrowed("BOT"),
-                6 => std::borrow::Cow::Borrowed("OTHER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DEVICE_TYPE_UNSPECIFIED"),
+                Self::Web => std::option::Option::Some("WEB"),
+                Self::MobileWeb => std::option::Option::Some("MOBILE_WEB"),
+                Self::Android => std::option::Option::Some("ANDROID"),
+                Self::Ios => std::option::Option::Some("IOS"),
+                Self::Bot => std::option::Option::Some("BOT"),
+                Self::Other => std::option::Option::Some("OTHER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEVICE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DEVICE_TYPE_UNSPECIFIED)
-                }
-                "WEB" => std::option::Option::Some(Self::WEB),
-                "MOBILE_WEB" => std::option::Option::Some(Self::MOBILE_WEB),
-                "ANDROID" => std::option::Option::Some(Self::ANDROID),
-                "IOS" => std::option::Option::Some(Self::IOS),
-                "BOT" => std::option::Option::Some(Self::BOT),
-                "OTHER" => std::option::Option::Some(Self::OTHER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DeviceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DeviceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DeviceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DeviceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Web,
+                2 => Self::MobileWeb,
+                3 => Self::Android,
+                4 => Self::Ios,
+                5 => Self::Bot,
+                6 => Self::Other,
+                _ => Self::UnknownValue(device_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DeviceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEVICE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "WEB" => Self::Web,
+                "MOBILE_WEB" => Self::MobileWeb,
+                "ANDROID" => Self::Android,
+                "IOS" => Self::Ios,
+                "BOT" => Self::Bot,
+                "OTHER" => Self::Other,
+                _ => Self::UnknownValue(device_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DeviceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Web => serializer.serialize_i32(1),
+                Self::MobileWeb => serializer.serialize_i32(2),
+                Self::Android => serializer.serialize_i32(3),
+                Self::Ios => serializer.serialize_i32(4),
+                Self::Bot => serializer.serialize_i32(5),
+                Self::Other => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DeviceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeviceType>::new(
+                ".google.cloud.talent.v4.DeviceInfo.DeviceType",
+            ))
         }
     }
 }
@@ -771,7 +911,7 @@ pub struct CompensationInfo {
     /// [CompensationInfo.CompensationType.BASE][google.cloud.talent.v4.CompensationInfo.CompensationType.BASE],
     /// which is referred as **base compensation entry** for the job.
     ///
-    /// [google.cloud.talent.v4.CompensationInfo.CompensationType.BASE]: crate::model::compensation_info::compensation_type::BASE
+    /// [google.cloud.talent.v4.CompensationInfo.CompensationType.BASE]: crate::model::compensation_info::CompensationType::Base
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub entries: std::vec::Vec<crate::model::compensation_info::CompensationEntry>,
 
@@ -894,7 +1034,7 @@ pub mod compensation_info {
         /// Default is
         /// [CompensationType.COMPENSATION_TYPE_UNSPECIFIED][google.cloud.talent.v4.CompensationInfo.CompensationType.COMPENSATION_TYPE_UNSPECIFIED].
         ///
-        /// [google.cloud.talent.v4.CompensationInfo.CompensationType.COMPENSATION_TYPE_UNSPECIFIED]: crate::model::compensation_info::compensation_type::COMPENSATION_TYPE_UNSPECIFIED
+        /// [google.cloud.talent.v4.CompensationInfo.CompensationType.COMPENSATION_TYPE_UNSPECIFIED]: crate::model::compensation_info::CompensationType::Unspecified
         #[serde(rename = "type")]
         pub r#type: crate::model::compensation_info::CompensationType,
 
@@ -903,7 +1043,7 @@ pub mod compensation_info {
         /// Default is
         /// [CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED][google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED].
         ///
-        /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED]: crate::model::compensation_info::compensation_unit::COMPENSATION_UNIT_UNSPECIFIED
+        /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED]: crate::model::compensation_info::CompensationUnit::Unspecified
         pub unit: crate::model::compensation_info::CompensationUnit,
 
         /// Compensation description.  For example, could
@@ -1182,183 +1322,319 @@ pub mod compensation_info {
     /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry.amount]: crate::model::compensation_info::CompensationEntry::compensation_amount
     /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry.description]: crate::model::compensation_info::CompensationEntry::description
     /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry.range]: crate::model::compensation_info::CompensationEntry::compensation_amount
-    /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED]: crate::model::compensation_info::compensation_unit::COMPENSATION_UNIT_UNSPECIFIED
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompensationType(i32);
-
-    impl CompensationType {
+    /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit.COMPENSATION_UNIT_UNSPECIFIED]: crate::model::compensation_info::CompensationUnit::Unspecified
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompensationType {
         /// Default value.
-        pub const COMPENSATION_TYPE_UNSPECIFIED: CompensationType = CompensationType::new(0);
-
+        Unspecified,
         /// Base compensation: Refers to the fixed amount of money paid to an
         /// employee by an employer in return for work performed. Base compensation
         /// does not include benefits, bonuses or any other potential compensation
         /// from an employer.
-        pub const BASE: CompensationType = CompensationType::new(1);
-
+        Base,
         /// Bonus.
-        pub const BONUS: CompensationType = CompensationType::new(2);
-
+        Bonus,
         /// Signing bonus.
-        pub const SIGNING_BONUS: CompensationType = CompensationType::new(3);
-
+        SigningBonus,
         /// Equity.
-        pub const EQUITY: CompensationType = CompensationType::new(4);
-
+        Equity,
         /// Profit sharing.
-        pub const PROFIT_SHARING: CompensationType = CompensationType::new(5);
-
+        ProfitSharing,
         /// Commission.
-        pub const COMMISSIONS: CompensationType = CompensationType::new(6);
-
+        Commissions,
         /// Tips.
-        pub const TIPS: CompensationType = CompensationType::new(7);
-
+        Tips,
         /// Other compensation type.
-        pub const OTHER_COMPENSATION_TYPE: CompensationType = CompensationType::new(8);
+        OtherCompensationType,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompensationType::value] or
+        /// [CompensationType::name].
+        UnknownValue(compensation_type::UnknownValue),
+    }
 
-        /// Creates a new CompensationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod compensation_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CompensationType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Base => std::option::Option::Some(1),
+                Self::Bonus => std::option::Option::Some(2),
+                Self::SigningBonus => std::option::Option::Some(3),
+                Self::Equity => std::option::Option::Some(4),
+                Self::ProfitSharing => std::option::Option::Some(5),
+                Self::Commissions => std::option::Option::Some(6),
+                Self::Tips => std::option::Option::Some(7),
+                Self::OtherCompensationType => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPENSATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASE"),
-                2 => std::borrow::Cow::Borrowed("BONUS"),
-                3 => std::borrow::Cow::Borrowed("SIGNING_BONUS"),
-                4 => std::borrow::Cow::Borrowed("EQUITY"),
-                5 => std::borrow::Cow::Borrowed("PROFIT_SHARING"),
-                6 => std::borrow::Cow::Borrowed("COMMISSIONS"),
-                7 => std::borrow::Cow::Borrowed("TIPS"),
-                8 => std::borrow::Cow::Borrowed("OTHER_COMPENSATION_TYPE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPENSATION_TYPE_UNSPECIFIED"),
+                Self::Base => std::option::Option::Some("BASE"),
+                Self::Bonus => std::option::Option::Some("BONUS"),
+                Self::SigningBonus => std::option::Option::Some("SIGNING_BONUS"),
+                Self::Equity => std::option::Option::Some("EQUITY"),
+                Self::ProfitSharing => std::option::Option::Some("PROFIT_SHARING"),
+                Self::Commissions => std::option::Option::Some("COMMISSIONS"),
+                Self::Tips => std::option::Option::Some("TIPS"),
+                Self::OtherCompensationType => std::option::Option::Some("OTHER_COMPENSATION_TYPE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPENSATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPENSATION_TYPE_UNSPECIFIED)
-                }
-                "BASE" => std::option::Option::Some(Self::BASE),
-                "BONUS" => std::option::Option::Some(Self::BONUS),
-                "SIGNING_BONUS" => std::option::Option::Some(Self::SIGNING_BONUS),
-                "EQUITY" => std::option::Option::Some(Self::EQUITY),
-                "PROFIT_SHARING" => std::option::Option::Some(Self::PROFIT_SHARING),
-                "COMMISSIONS" => std::option::Option::Some(Self::COMMISSIONS),
-                "TIPS" => std::option::Option::Some(Self::TIPS),
-                "OTHER_COMPENSATION_TYPE" => {
-                    std::option::Option::Some(Self::OTHER_COMPENSATION_TYPE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompensationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompensationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompensationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompensationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Base,
+                2 => Self::Bonus,
+                3 => Self::SigningBonus,
+                4 => Self::Equity,
+                5 => Self::ProfitSharing,
+                6 => Self::Commissions,
+                7 => Self::Tips,
+                8 => Self::OtherCompensationType,
+                _ => Self::UnknownValue(compensation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompensationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPENSATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BASE" => Self::Base,
+                "BONUS" => Self::Bonus,
+                "SIGNING_BONUS" => Self::SigningBonus,
+                "EQUITY" => Self::Equity,
+                "PROFIT_SHARING" => Self::ProfitSharing,
+                "COMMISSIONS" => Self::Commissions,
+                "TIPS" => Self::Tips,
+                "OTHER_COMPENSATION_TYPE" => Self::OtherCompensationType,
+                _ => Self::UnknownValue(compensation_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompensationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Base => serializer.serialize_i32(1),
+                Self::Bonus => serializer.serialize_i32(2),
+                Self::SigningBonus => serializer.serialize_i32(3),
+                Self::Equity => serializer.serialize_i32(4),
+                Self::ProfitSharing => serializer.serialize_i32(5),
+                Self::Commissions => serializer.serialize_i32(6),
+                Self::Tips => serializer.serialize_i32(7),
+                Self::OtherCompensationType => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompensationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompensationType>::new(
+                ".google.cloud.talent.v4.CompensationInfo.CompensationType",
+            ))
         }
     }
 
     /// Pay frequency.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompensationUnit(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompensationUnit {
+        /// Default value.
+        Unspecified,
+        /// Hourly.
+        Hourly,
+        /// Daily.
+        Daily,
+        /// Weekly
+        Weekly,
+        /// Monthly.
+        Monthly,
+        /// Yearly.
+        Yearly,
+        /// One time.
+        OneTime,
+        /// Other compensation units.
+        OtherCompensationUnit,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompensationUnit::value] or
+        /// [CompensationUnit::name].
+        UnknownValue(compensation_unit::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod compensation_unit {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CompensationUnit {
-        /// Default value.
-        pub const COMPENSATION_UNIT_UNSPECIFIED: CompensationUnit = CompensationUnit::new(0);
-
-        /// Hourly.
-        pub const HOURLY: CompensationUnit = CompensationUnit::new(1);
-
-        /// Daily.
-        pub const DAILY: CompensationUnit = CompensationUnit::new(2);
-
-        /// Weekly
-        pub const WEEKLY: CompensationUnit = CompensationUnit::new(3);
-
-        /// Monthly.
-        pub const MONTHLY: CompensationUnit = CompensationUnit::new(4);
-
-        /// Yearly.
-        pub const YEARLY: CompensationUnit = CompensationUnit::new(5);
-
-        /// One time.
-        pub const ONE_TIME: CompensationUnit = CompensationUnit::new(6);
-
-        /// Other compensation units.
-        pub const OTHER_COMPENSATION_UNIT: CompensationUnit = CompensationUnit::new(7);
-
-        /// Creates a new CompensationUnit instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hourly => std::option::Option::Some(1),
+                Self::Daily => std::option::Option::Some(2),
+                Self::Weekly => std::option::Option::Some(3),
+                Self::Monthly => std::option::Option::Some(4),
+                Self::Yearly => std::option::Option::Some(5),
+                Self::OneTime => std::option::Option::Some(6),
+                Self::OtherCompensationUnit => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPENSATION_UNIT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HOURLY"),
-                2 => std::borrow::Cow::Borrowed("DAILY"),
-                3 => std::borrow::Cow::Borrowed("WEEKLY"),
-                4 => std::borrow::Cow::Borrowed("MONTHLY"),
-                5 => std::borrow::Cow::Borrowed("YEARLY"),
-                6 => std::borrow::Cow::Borrowed("ONE_TIME"),
-                7 => std::borrow::Cow::Borrowed("OTHER_COMPENSATION_UNIT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPENSATION_UNIT_UNSPECIFIED"),
+                Self::Hourly => std::option::Option::Some("HOURLY"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Weekly => std::option::Option::Some("WEEKLY"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::Yearly => std::option::Option::Some("YEARLY"),
+                Self::OneTime => std::option::Option::Some("ONE_TIME"),
+                Self::OtherCompensationUnit => std::option::Option::Some("OTHER_COMPENSATION_UNIT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPENSATION_UNIT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPENSATION_UNIT_UNSPECIFIED)
-                }
-                "HOURLY" => std::option::Option::Some(Self::HOURLY),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                "YEARLY" => std::option::Option::Some(Self::YEARLY),
-                "ONE_TIME" => std::option::Option::Some(Self::ONE_TIME),
-                "OTHER_COMPENSATION_UNIT" => {
-                    std::option::Option::Some(Self::OTHER_COMPENSATION_UNIT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompensationUnit {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompensationUnit {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompensationUnit {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompensationUnit {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hourly,
+                2 => Self::Daily,
+                3 => Self::Weekly,
+                4 => Self::Monthly,
+                5 => Self::Yearly,
+                6 => Self::OneTime,
+                7 => Self::OtherCompensationUnit,
+                _ => Self::UnknownValue(compensation_unit::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompensationUnit {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPENSATION_UNIT_UNSPECIFIED" => Self::Unspecified,
+                "HOURLY" => Self::Hourly,
+                "DAILY" => Self::Daily,
+                "WEEKLY" => Self::Weekly,
+                "MONTHLY" => Self::Monthly,
+                "YEARLY" => Self::Yearly,
+                "ONE_TIME" => Self::OneTime,
+                "OTHER_COMPENSATION_UNIT" => Self::OtherCompensationUnit,
+                _ => Self::UnknownValue(compensation_unit::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompensationUnit {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hourly => serializer.serialize_i32(1),
+                Self::Daily => serializer.serialize_i32(2),
+                Self::Weekly => serializer.serialize_i32(3),
+                Self::Monthly => serializer.serialize_i32(4),
+                Self::Yearly => serializer.serialize_i32(5),
+                Self::OneTime => serializer.serialize_i32(6),
+                Self::OtherCompensationUnit => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompensationUnit {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompensationUnit>::new(
+                ".google.cloud.talent.v4.CompensationInfo.CompensationUnit",
+            ))
         }
     }
 }
@@ -1496,85 +1772,154 @@ pub mod batch_operation_metadata {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The batch operation is being prepared for processing.
-        pub const INITIALIZING: State = State::new(1);
-
+        Initializing,
         /// The batch operation is actively being processed.
-        pub const PROCESSING: State = State::new(2);
-
+        Processing,
         /// The batch operation is processed, and at least one item has been
         /// successfully processed.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The batch operation is done and no item has been successfully processed.
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// The batch operation is in the process of cancelling after
         /// [google.longrunning.Operations.CancelOperation][google.longrunning.Operations.CancelOperation]
         /// is called.
-        pub const CANCELLING: State = State::new(5);
-
+        Cancelling,
         /// The batch operation is done after
         /// [google.longrunning.Operations.CancelOperation][google.longrunning.Operations.CancelOperation]
         /// is called. Any items processed before cancelling are returned in the
         /// response.
-        pub const CANCELLED: State = State::new(6);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Initializing => std::option::Option::Some(1),
+                Self::Processing => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Cancelling => std::option::Option::Some(5),
+                Self::Cancelled => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INITIALIZING"),
-                2 => std::borrow::Cow::Borrowed("PROCESSING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLING"),
-                6 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Initializing => std::option::Option::Some("INITIALIZING"),
+                Self::Processing => std::option::Option::Some("PROCESSING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
-                "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Initializing,
+                2 => Self::Processing,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Cancelling,
+                6 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INITIALIZING" => Self::Initializing,
+                "PROCESSING" => Self::Processing,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Initializing => serializer.serialize_i32(1),
+                Self::Processing => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Cancelling => serializer.serialize_i32(5),
+                Self::Cancelled => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.talent.v4.BatchOperationMetadata.State",
+            ))
         }
     }
 }
@@ -2212,13 +2557,13 @@ pub struct CompleteQueryRequest {
     /// The scope of the completion. The defaults is
     /// [CompletionScope.PUBLIC][google.cloud.talent.v4.CompleteQueryRequest.CompletionScope.PUBLIC].
     ///
-    /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionScope.PUBLIC]: crate::model::complete_query_request::completion_scope::PUBLIC
+    /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionScope.PUBLIC]: crate::model::complete_query_request::CompletionScope::Public
     pub scope: crate::model::complete_query_request::CompletionScope,
 
     /// The completion topic. The default is
     /// [CompletionType.COMBINED][google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMBINED].
     ///
-    /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMBINED]: crate::model::complete_query_request::completion_type::COMBINED
+    /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMBINED]: crate::model::complete_query_request::CompletionType::Combined
     #[serde(rename = "type")]
     pub r#type: crate::model::complete_query_request::CompletionType,
 
@@ -2299,73 +2644,130 @@ pub mod complete_query_request {
     use super::*;
 
     /// Enum to specify the scope of completion.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompletionScope(i32);
-
-    impl CompletionScope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompletionScope {
         /// Default value.
-        pub const COMPLETION_SCOPE_UNSPECIFIED: CompletionScope = CompletionScope::new(0);
-
+        Unspecified,
         /// Suggestions are based only on the data provided by the client.
-        pub const TENANT: CompletionScope = CompletionScope::new(1);
-
+        Tenant,
         /// Suggestions are based on all jobs data in the system that's visible to
         /// the client
-        pub const PUBLIC: CompletionScope = CompletionScope::new(2);
+        Public,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompletionScope::value] or
+        /// [CompletionScope::name].
+        UnknownValue(completion_scope::UnknownValue),
+    }
 
-        /// Creates a new CompletionScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod completion_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CompletionScope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tenant => std::option::Option::Some(1),
+                Self::Public => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPLETION_SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TENANT"),
-                2 => std::borrow::Cow::Borrowed("PUBLIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPLETION_SCOPE_UNSPECIFIED"),
+                Self::Tenant => std::option::Option::Some("TENANT"),
+                Self::Public => std::option::Option::Some("PUBLIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPLETION_SCOPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPLETION_SCOPE_UNSPECIFIED)
-                }
-                "TENANT" => std::option::Option::Some(Self::TENANT),
-                "PUBLIC" => std::option::Option::Some(Self::PUBLIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompletionScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompletionScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompletionScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompletionScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tenant,
+                2 => Self::Public,
+                _ => Self::UnknownValue(completion_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompletionScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPLETION_SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "TENANT" => Self::Tenant,
+                "PUBLIC" => Self::Public,
+                _ => Self::UnknownValue(completion_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompletionScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tenant => serializer.serialize_i32(1),
+                Self::Public => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompletionScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompletionScope>::new(
+                ".google.cloud.talent.v4.CompleteQueryRequest.CompletionScope",
+            ))
         }
     }
 
     /// Enum to specify auto-completion topics.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CompletionType(i32);
-
-    impl CompletionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CompletionType {
         /// Default value.
-        pub const COMPLETION_TYPE_UNSPECIFIED: CompletionType = CompletionType::new(0);
-
+        Unspecified,
         /// Suggest job titles for jobs autocomplete.
         ///
         /// For
@@ -2374,10 +2776,9 @@ pub mod complete_query_request {
         /// [language_codes][google.cloud.talent.v4.CompleteQueryRequest.language_codes]
         /// are returned.
         ///
-        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.JOB_TITLE]: crate::model::complete_query_request::completion_type::JOB_TITLE
+        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.JOB_TITLE]: crate::model::complete_query_request::CompletionType::JobTitle
         /// [google.cloud.talent.v4.CompleteQueryRequest.language_codes]: crate::model::CompleteQueryRequest::language_codes
-        pub const JOB_TITLE: CompletionType = CompletionType::new(1);
-
+        JobTitle,
         /// Suggest company names for jobs autocomplete.
         ///
         /// For
@@ -2386,10 +2787,9 @@ pub mod complete_query_request {
         /// [language_codes][google.cloud.talent.v4.CompleteQueryRequest.language_codes]
         /// are returned.
         ///
-        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMPANY_NAME]: crate::model::complete_query_request::completion_type::COMPANY_NAME
+        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMPANY_NAME]: crate::model::complete_query_request::CompletionType::CompanyName
         /// [google.cloud.talent.v4.CompleteQueryRequest.language_codes]: crate::model::CompleteQueryRequest::language_codes
-        pub const COMPANY_NAME: CompletionType = CompletionType::new(2);
-
+        CompanyName,
         /// Suggest both job titles and company names for jobs autocomplete.
         ///
         /// For
@@ -2400,54 +2800,119 @@ pub mod complete_query_request {
         /// [language_codes][google.cloud.talent.v4.CompleteQueryRequest.language_codes]
         /// are returned.
         ///
-        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMBINED]: crate::model::complete_query_request::completion_type::COMBINED
+        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMBINED]: crate::model::complete_query_request::CompletionType::Combined
         /// [google.cloud.talent.v4.CompleteQueryRequest.language_codes]: crate::model::CompleteQueryRequest::language_codes
-        pub const COMBINED: CompletionType = CompletionType::new(3);
+        Combined,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CompletionType::value] or
+        /// [CompletionType::name].
+        UnknownValue(completion_type::UnknownValue),
+    }
 
-        /// Creates a new CompletionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod completion_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CompletionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::JobTitle => std::option::Option::Some(1),
+                Self::CompanyName => std::option::Option::Some(2),
+                Self::Combined => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPLETION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("JOB_TITLE"),
-                2 => std::borrow::Cow::Borrowed("COMPANY_NAME"),
-                3 => std::borrow::Cow::Borrowed("COMBINED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPLETION_TYPE_UNSPECIFIED"),
+                Self::JobTitle => std::option::Option::Some("JOB_TITLE"),
+                Self::CompanyName => std::option::Option::Some("COMPANY_NAME"),
+                Self::Combined => std::option::Option::Some("COMBINED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPLETION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMPLETION_TYPE_UNSPECIFIED)
-                }
-                "JOB_TITLE" => std::option::Option::Some(Self::JOB_TITLE),
-                "COMPANY_NAME" => std::option::Option::Some(Self::COMPANY_NAME),
-                "COMBINED" => std::option::Option::Some(Self::COMBINED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CompletionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CompletionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CompletionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CompletionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::JobTitle,
+                2 => Self::CompanyName,
+                3 => Self::Combined,
+                _ => Self::UnknownValue(completion_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CompletionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPLETION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "JOB_TITLE" => Self::JobTitle,
+                "COMPANY_NAME" => Self::CompanyName,
+                "COMBINED" => Self::Combined,
+                _ => Self::UnknownValue(completion_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CompletionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::JobTitle => serializer.serialize_i32(1),
+                Self::CompanyName => serializer.serialize_i32(2),
+                Self::Combined => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CompletionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompletionType>::new(
+                ".google.cloud.talent.v4.CompleteQueryRequest.CompletionType",
+            ))
         }
     }
 }
@@ -2527,7 +2992,7 @@ pub mod complete_query_response {
         /// The URI of the company image for
         /// [COMPANY_NAME][google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMPANY_NAME].
         ///
-        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMPANY_NAME]: crate::model::complete_query_request::completion_type::COMPANY_NAME
+        /// [google.cloud.talent.v4.CompleteQueryRequest.CompletionType.COMPANY_NAME]: crate::model::complete_query_request::CompletionType::CompanyName
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
         pub image_uri: std::string::String,
 
@@ -2736,8 +3201,8 @@ pub struct JobEvent {
     /// example, "projects/foo/tenants/bar/jobs/baz".
     ///
     /// [google.cloud.talent.v4.Job.name]: crate::model::Job::name
-    /// [google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]: crate::model::job_event::job_event_type::IMPRESSION
-    /// [google.cloud.talent.v4.JobEvent.JobEventType.VIEW]: crate::model::job_event::job_event_type::VIEW
+    /// [google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]: crate::model::job_event::JobEventType::Impression
+    /// [google.cloud.talent.v4.JobEvent.JobEventType.VIEW]: crate::model::job_event::JobEventType::View
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub jobs: std::vec::Vec<std::string::String>,
 
@@ -2784,41 +3249,34 @@ pub mod job_event {
 
     /// An enumeration of an event attributed to the behavior of the end user,
     /// such as a job seeker.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobEventType(i32);
-
-    impl JobEventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JobEventType {
         /// The event is unspecified by other provided values.
-        pub const JOB_EVENT_TYPE_UNSPECIFIED: JobEventType = JobEventType::new(0);
-
+        Unspecified,
         /// The job seeker or other entity interacting with the service has
         /// had a job rendered in their view, such as in a list of search results in
         /// a compressed or clipped format. This event is typically associated with
         /// the viewing of a jobs list on a single page by a job seeker.
-        pub const IMPRESSION: JobEventType = JobEventType::new(1);
-
+        Impression,
         /// The job seeker, or other entity interacting with the service, has
         /// viewed the details of a job, including the full description. This
         /// event doesn't apply to the viewing a snippet of a job appearing as a
         /// part of the job search results. Viewing a snippet is associated with an
         /// [impression][google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]).
         ///
-        /// [google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]: crate::model::job_event::job_event_type::IMPRESSION
-        pub const VIEW: JobEventType = JobEventType::new(2);
-
+        /// [google.cloud.talent.v4.JobEvent.JobEventType.IMPRESSION]: crate::model::job_event::JobEventType::Impression
+        View,
         /// The job seeker or other entity interacting with the service
         /// performed an action to view a job and was redirected to a different
         /// website for job.
-        pub const VIEW_REDIRECT: JobEventType = JobEventType::new(3);
-
+        ViewRedirect,
         /// The job seeker or other entity interacting with the service
         /// began the process or demonstrated the intention of applying for a job.
-        pub const APPLICATION_START: JobEventType = JobEventType::new(4);
-
+        ApplicationStart,
         /// The job seeker or other entity interacting with the service
         /// submitted an application for a job.
-        pub const APPLICATION_FINISH: JobEventType = JobEventType::new(5);
-
+        ApplicationFinish,
         /// The job seeker or other entity interacting with the service
         /// submitted an application for a job with a single click without
         /// entering information. If a job seeker performs this action, send only
@@ -2828,21 +3286,18 @@ pub mod job_event {
         /// [JobEventType.APPLICATION_FINISH][google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]
         /// events.
         ///
-        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]: crate::model::job_event::job_event_type::APPLICATION_FINISH
-        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_START]: crate::model::job_event::job_event_type::APPLICATION_START
-        pub const APPLICATION_QUICK_SUBMISSION: JobEventType = JobEventType::new(6);
-
+        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]: crate::model::job_event::JobEventType::ApplicationFinish
+        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_START]: crate::model::job_event::JobEventType::ApplicationStart
+        ApplicationQuickSubmission,
         /// The job seeker or other entity interacting with the service
         /// performed an action to apply to a job and was redirected to a different
         /// website to complete the application.
-        pub const APPLICATION_REDIRECT: JobEventType = JobEventType::new(7);
-
+        ApplicationRedirect,
         /// The job seeker or other entity interacting with the service began the
         /// process or demonstrated the intention of applying for a job from the
         /// search results page without viewing the details of the job posting.
         /// If sending this event, JobEventType.VIEW event shouldn't be sent.
-        pub const APPLICATION_START_FROM_SEARCH: JobEventType = JobEventType::new(8);
-
+        ApplicationStartFromSearch,
         /// The job seeker, or other entity interacting with the service, performs an
         /// action with a single click from the search results page to apply to a job
         /// (without viewing the details of the job posting), and is redirected
@@ -2854,120 +3309,215 @@ pub mod job_event {
         /// or [JobEventType.VIEW][google.cloud.talent.v4.JobEvent.JobEventType.VIEW]
         /// events.
         ///
-        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]: crate::model::job_event::job_event_type::APPLICATION_FINISH
-        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_START]: crate::model::job_event::job_event_type::APPLICATION_START
-        /// [google.cloud.talent.v4.JobEvent.JobEventType.VIEW]: crate::model::job_event::job_event_type::VIEW
-        pub const APPLICATION_REDIRECT_FROM_SEARCH: JobEventType = JobEventType::new(9);
-
+        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_FINISH]: crate::model::job_event::JobEventType::ApplicationFinish
+        /// [google.cloud.talent.v4.JobEvent.JobEventType.APPLICATION_START]: crate::model::job_event::JobEventType::ApplicationStart
+        /// [google.cloud.talent.v4.JobEvent.JobEventType.VIEW]: crate::model::job_event::JobEventType::View
+        ApplicationRedirectFromSearch,
         /// This event should be used when a company submits an application
         /// on behalf of a job seeker. This event is intended for use by staffing
         /// agencies attempting to place candidates.
-        pub const APPLICATION_COMPANY_SUBMIT: JobEventType = JobEventType::new(10);
-
+        ApplicationCompanySubmit,
         /// The job seeker or other entity interacting with the service demonstrated
         /// an interest in a job by bookmarking or saving it.
-        pub const BOOKMARK: JobEventType = JobEventType::new(11);
-
+        Bookmark,
         /// The job seeker or other entity interacting with the service was
         /// sent a notification, such as an email alert or device notification,
         /// containing one or more jobs listings generated by the service.
-        pub const NOTIFICATION: JobEventType = JobEventType::new(12);
-
+        Notification,
         /// The job seeker or other entity interacting with the service was
         /// employed by the hiring entity (employer). Send this event
         /// only if the job seeker was hired through an application that was
         /// initiated by a search conducted through the Cloud Talent Solution
         /// service.
-        pub const HIRED: JobEventType = JobEventType::new(13);
-
+        Hired,
         /// A recruiter or staffing agency submitted an application on behalf of the
         /// candidate after interacting with the service to identify a suitable job
         /// posting.
-        pub const SENT_CV: JobEventType = JobEventType::new(14);
-
+        SentCv,
         /// The entity interacting with the service (for example, the job seeker),
         /// was granted an initial interview by the hiring entity (employer). This
         /// event should only be sent if the job seeker was granted an interview as
         /// part of an application that was initiated by a search conducted through /
         /// recommendation provided by the Cloud Talent Solution service.
-        pub const INTERVIEW_GRANTED: JobEventType = JobEventType::new(15);
+        InterviewGranted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JobEventType::value] or
+        /// [JobEventType::name].
+        UnknownValue(job_event_type::UnknownValue),
+    }
 
-        /// Creates a new JobEventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod job_event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl JobEventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Impression => std::option::Option::Some(1),
+                Self::View => std::option::Option::Some(2),
+                Self::ViewRedirect => std::option::Option::Some(3),
+                Self::ApplicationStart => std::option::Option::Some(4),
+                Self::ApplicationFinish => std::option::Option::Some(5),
+                Self::ApplicationQuickSubmission => std::option::Option::Some(6),
+                Self::ApplicationRedirect => std::option::Option::Some(7),
+                Self::ApplicationStartFromSearch => std::option::Option::Some(8),
+                Self::ApplicationRedirectFromSearch => std::option::Option::Some(9),
+                Self::ApplicationCompanySubmit => std::option::Option::Some(10),
+                Self::Bookmark => std::option::Option::Some(11),
+                Self::Notification => std::option::Option::Some(12),
+                Self::Hired => std::option::Option::Some(13),
+                Self::SentCv => std::option::Option::Some(14),
+                Self::InterviewGranted => std::option::Option::Some(15),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JOB_EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPRESSION"),
-                2 => std::borrow::Cow::Borrowed("VIEW"),
-                3 => std::borrow::Cow::Borrowed("VIEW_REDIRECT"),
-                4 => std::borrow::Cow::Borrowed("APPLICATION_START"),
-                5 => std::borrow::Cow::Borrowed("APPLICATION_FINISH"),
-                6 => std::borrow::Cow::Borrowed("APPLICATION_QUICK_SUBMISSION"),
-                7 => std::borrow::Cow::Borrowed("APPLICATION_REDIRECT"),
-                8 => std::borrow::Cow::Borrowed("APPLICATION_START_FROM_SEARCH"),
-                9 => std::borrow::Cow::Borrowed("APPLICATION_REDIRECT_FROM_SEARCH"),
-                10 => std::borrow::Cow::Borrowed("APPLICATION_COMPANY_SUBMIT"),
-                11 => std::borrow::Cow::Borrowed("BOOKMARK"),
-                12 => std::borrow::Cow::Borrowed("NOTIFICATION"),
-                13 => std::borrow::Cow::Borrowed("HIRED"),
-                14 => std::borrow::Cow::Borrowed("SENT_CV"),
-                15 => std::borrow::Cow::Borrowed("INTERVIEW_GRANTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("JOB_EVENT_TYPE_UNSPECIFIED"),
+                Self::Impression => std::option::Option::Some("IMPRESSION"),
+                Self::View => std::option::Option::Some("VIEW"),
+                Self::ViewRedirect => std::option::Option::Some("VIEW_REDIRECT"),
+                Self::ApplicationStart => std::option::Option::Some("APPLICATION_START"),
+                Self::ApplicationFinish => std::option::Option::Some("APPLICATION_FINISH"),
+                Self::ApplicationQuickSubmission => {
+                    std::option::Option::Some("APPLICATION_QUICK_SUBMISSION")
+                }
+                Self::ApplicationRedirect => std::option::Option::Some("APPLICATION_REDIRECT"),
+                Self::ApplicationStartFromSearch => {
+                    std::option::Option::Some("APPLICATION_START_FROM_SEARCH")
+                }
+                Self::ApplicationRedirectFromSearch => {
+                    std::option::Option::Some("APPLICATION_REDIRECT_FROM_SEARCH")
+                }
+                Self::ApplicationCompanySubmit => {
+                    std::option::Option::Some("APPLICATION_COMPANY_SUBMIT")
+                }
+                Self::Bookmark => std::option::Option::Some("BOOKMARK"),
+                Self::Notification => std::option::Option::Some("NOTIFICATION"),
+                Self::Hired => std::option::Option::Some("HIRED"),
+                Self::SentCv => std::option::Option::Some("SENT_CV"),
+                Self::InterviewGranted => std::option::Option::Some("INTERVIEW_GRANTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JOB_EVENT_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::JOB_EVENT_TYPE_UNSPECIFIED)
-                }
-                "IMPRESSION" => std::option::Option::Some(Self::IMPRESSION),
-                "VIEW" => std::option::Option::Some(Self::VIEW),
-                "VIEW_REDIRECT" => std::option::Option::Some(Self::VIEW_REDIRECT),
-                "APPLICATION_START" => std::option::Option::Some(Self::APPLICATION_START),
-                "APPLICATION_FINISH" => std::option::Option::Some(Self::APPLICATION_FINISH),
-                "APPLICATION_QUICK_SUBMISSION" => {
-                    std::option::Option::Some(Self::APPLICATION_QUICK_SUBMISSION)
-                }
-                "APPLICATION_REDIRECT" => std::option::Option::Some(Self::APPLICATION_REDIRECT),
-                "APPLICATION_START_FROM_SEARCH" => {
-                    std::option::Option::Some(Self::APPLICATION_START_FROM_SEARCH)
-                }
-                "APPLICATION_REDIRECT_FROM_SEARCH" => {
-                    std::option::Option::Some(Self::APPLICATION_REDIRECT_FROM_SEARCH)
-                }
-                "APPLICATION_COMPANY_SUBMIT" => {
-                    std::option::Option::Some(Self::APPLICATION_COMPANY_SUBMIT)
-                }
-                "BOOKMARK" => std::option::Option::Some(Self::BOOKMARK),
-                "NOTIFICATION" => std::option::Option::Some(Self::NOTIFICATION),
-                "HIRED" => std::option::Option::Some(Self::HIRED),
-                "SENT_CV" => std::option::Option::Some(Self::SENT_CV),
-                "INTERVIEW_GRANTED" => std::option::Option::Some(Self::INTERVIEW_GRANTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JobEventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JobEventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JobEventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JobEventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Impression,
+                2 => Self::View,
+                3 => Self::ViewRedirect,
+                4 => Self::ApplicationStart,
+                5 => Self::ApplicationFinish,
+                6 => Self::ApplicationQuickSubmission,
+                7 => Self::ApplicationRedirect,
+                8 => Self::ApplicationStartFromSearch,
+                9 => Self::ApplicationRedirectFromSearch,
+                10 => Self::ApplicationCompanySubmit,
+                11 => Self::Bookmark,
+                12 => Self::Notification,
+                13 => Self::Hired,
+                14 => Self::SentCv,
+                15 => Self::InterviewGranted,
+                _ => Self::UnknownValue(job_event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JobEventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JOB_EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMPRESSION" => Self::Impression,
+                "VIEW" => Self::View,
+                "VIEW_REDIRECT" => Self::ViewRedirect,
+                "APPLICATION_START" => Self::ApplicationStart,
+                "APPLICATION_FINISH" => Self::ApplicationFinish,
+                "APPLICATION_QUICK_SUBMISSION" => Self::ApplicationQuickSubmission,
+                "APPLICATION_REDIRECT" => Self::ApplicationRedirect,
+                "APPLICATION_START_FROM_SEARCH" => Self::ApplicationStartFromSearch,
+                "APPLICATION_REDIRECT_FROM_SEARCH" => Self::ApplicationRedirectFromSearch,
+                "APPLICATION_COMPANY_SUBMIT" => Self::ApplicationCompanySubmit,
+                "BOOKMARK" => Self::Bookmark,
+                "NOTIFICATION" => Self::Notification,
+                "HIRED" => Self::Hired,
+                "SENT_CV" => Self::SentCv,
+                "INTERVIEW_GRANTED" => Self::InterviewGranted,
+                _ => Self::UnknownValue(job_event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JobEventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Impression => serializer.serialize_i32(1),
+                Self::View => serializer.serialize_i32(2),
+                Self::ViewRedirect => serializer.serialize_i32(3),
+                Self::ApplicationStart => serializer.serialize_i32(4),
+                Self::ApplicationFinish => serializer.serialize_i32(5),
+                Self::ApplicationQuickSubmission => serializer.serialize_i32(6),
+                Self::ApplicationRedirect => serializer.serialize_i32(7),
+                Self::ApplicationStartFromSearch => serializer.serialize_i32(8),
+                Self::ApplicationRedirectFromSearch => serializer.serialize_i32(9),
+                Self::ApplicationCompanySubmit => serializer.serialize_i32(10),
+                Self::Bookmark => serializer.serialize_i32(11),
+                Self::Notification => serializer.serialize_i32(12),
+                Self::Hired => serializer.serialize_i32(13),
+                Self::SentCv => serializer.serialize_i32(14),
+                Self::InterviewGranted => serializer.serialize_i32(15),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JobEventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobEventType>::new(
+                ".google.cloud.talent.v4.JobEvent.JobEventType",
+            ))
         }
     }
 }
@@ -3199,7 +3749,7 @@ pub struct JobQuery {
     /// If multiple values are specified, jobs in the search results include
     /// any of the specified employment types.
     ///
-    /// [google.cloud.talent.v4.EmploymentType.FULL_TIME]: crate::model::employment_type::FULL_TIME
+    /// [google.cloud.talent.v4.EmploymentType.FULL_TIME]: crate::model::EmploymentType::FullTime
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub employment_types: std::vec::Vec<crate::model::EmploymentType>,
 
@@ -3453,11 +4003,11 @@ pub struct LocationFilter {
     ///
     /// [google.cloud.talent.v4.Job.addresses]: crate::model::Job::addresses
     /// [google.cloud.talent.v4.Job.posting_region]: crate::model::Job::posting_region
-    /// [google.cloud.talent.v4.LocationFilter.TelecommutePreference.TELECOMMUTE_ALLOWED]: crate::model::location_filter::telecommute_preference::TELECOMMUTE_ALLOWED
-    /// [google.cloud.talent.v4.LocationFilter.TelecommutePreference.TELECOMMUTE_EXCLUDED]: crate::model::location_filter::telecommute_preference::TELECOMMUTE_EXCLUDED
+    /// [google.cloud.talent.v4.LocationFilter.TelecommutePreference.TELECOMMUTE_ALLOWED]: crate::model::location_filter::TelecommutePreference::TelecommuteAllowed
+    /// [google.cloud.talent.v4.LocationFilter.TelecommutePreference.TELECOMMUTE_EXCLUDED]: crate::model::location_filter::TelecommutePreference::TelecommuteExcluded
     /// [google.cloud.talent.v4.LocationFilter.address]: crate::model::LocationFilter::address
     /// [google.cloud.talent.v4.LocationFilter.lat_lng]: crate::model::LocationFilter::lat_lng
-    /// [google.cloud.talent.v4.PostingRegion.TELECOMMUTE]: crate::model::posting_region::TELECOMMUTE
+    /// [google.cloud.talent.v4.PostingRegion.TELECOMMUTE]: crate::model::PostingRegion::Telecommute
     pub telecommute_preference: crate::model::location_filter::TelecommutePreference,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3520,70 +4070,132 @@ pub mod location_filter {
     use super::*;
 
     /// Specify whether to include telecommute jobs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TelecommutePreference(i32);
-
-    impl TelecommutePreference {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TelecommutePreference {
         /// Default value if the telecommute preference isn't specified.
-        pub const TELECOMMUTE_PREFERENCE_UNSPECIFIED: TelecommutePreference =
-            TelecommutePreference::new(0);
-
+        Unspecified,
         /// Deprecated: Ignore telecommute status of jobs. Use
         /// TELECOMMUTE_JOBS_EXCLUDED if want to exclude telecommute jobs.
-        pub const TELECOMMUTE_EXCLUDED: TelecommutePreference = TelecommutePreference::new(1);
-
+        TelecommuteExcluded,
         /// Allow telecommute jobs.
-        pub const TELECOMMUTE_ALLOWED: TelecommutePreference = TelecommutePreference::new(2);
-
+        TelecommuteAllowed,
         /// Exclude telecommute jobs.
-        pub const TELECOMMUTE_JOBS_EXCLUDED: TelecommutePreference = TelecommutePreference::new(3);
+        TelecommuteJobsExcluded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TelecommutePreference::value] or
+        /// [TelecommutePreference::name].
+        UnknownValue(telecommute_preference::UnknownValue),
+    }
 
-        /// Creates a new TelecommutePreference instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod telecommute_preference {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TelecommutePreference {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TelecommuteExcluded => std::option::Option::Some(1),
+                Self::TelecommuteAllowed => std::option::Option::Some(2),
+                Self::TelecommuteJobsExcluded => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TELECOMMUTE_PREFERENCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TELECOMMUTE_EXCLUDED"),
-                2 => std::borrow::Cow::Borrowed("TELECOMMUTE_ALLOWED"),
-                3 => std::borrow::Cow::Borrowed("TELECOMMUTE_JOBS_EXCLUDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TELECOMMUTE_PREFERENCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TELECOMMUTE_PREFERENCE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("TELECOMMUTE_PREFERENCE_UNSPECIFIED")
                 }
-                "TELECOMMUTE_EXCLUDED" => std::option::Option::Some(Self::TELECOMMUTE_EXCLUDED),
-                "TELECOMMUTE_ALLOWED" => std::option::Option::Some(Self::TELECOMMUTE_ALLOWED),
-                "TELECOMMUTE_JOBS_EXCLUDED" => {
-                    std::option::Option::Some(Self::TELECOMMUTE_JOBS_EXCLUDED)
+                Self::TelecommuteExcluded => std::option::Option::Some("TELECOMMUTE_EXCLUDED"),
+                Self::TelecommuteAllowed => std::option::Option::Some("TELECOMMUTE_ALLOWED"),
+                Self::TelecommuteJobsExcluded => {
+                    std::option::Option::Some("TELECOMMUTE_JOBS_EXCLUDED")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TelecommutePreference {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TelecommutePreference {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TelecommutePreference {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TelecommutePreference {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TelecommuteExcluded,
+                2 => Self::TelecommuteAllowed,
+                3 => Self::TelecommuteJobsExcluded,
+                _ => Self::UnknownValue(telecommute_preference::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TelecommutePreference {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TELECOMMUTE_PREFERENCE_UNSPECIFIED" => Self::Unspecified,
+                "TELECOMMUTE_EXCLUDED" => Self::TelecommuteExcluded,
+                "TELECOMMUTE_ALLOWED" => Self::TelecommuteAllowed,
+                "TELECOMMUTE_JOBS_EXCLUDED" => Self::TelecommuteJobsExcluded,
+                _ => Self::UnknownValue(telecommute_preference::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TelecommutePreference {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TelecommuteExcluded => serializer.serialize_i32(1),
+                Self::TelecommuteAllowed => serializer.serialize_i32(2),
+                Self::TelecommuteJobsExcluded => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TelecommutePreference {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TelecommutePreference>::new(
+                ".google.cloud.talent.v4.LocationFilter.TelecommutePreference",
+            ))
         }
     }
 }
@@ -3676,13 +4288,11 @@ pub mod compensation_filter {
     use super::*;
 
     /// Specify the type of filtering.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FilterType(i32);
-
-    impl FilterType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FilterType {
         /// Filter type unspecified. Position holder, INVALID, should never be used.
-        pub const FILTER_TYPE_UNSPECIFIED: FilterType = FilterType::new(0);
-
+        Unspecified,
         /// Filter by `base compensation entry's` unit. A job is a match if and
         /// only if the job contains a base CompensationEntry and the base
         /// CompensationEntry's unit matches provided
@@ -3695,8 +4305,7 @@ pub mod compensation_filter {
         ///
         /// [google.cloud.talent.v4.CompensationFilter.units]: crate::model::CompensationFilter::units
         /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry]: crate::model::compensation_info::CompensationEntry
-        pub const UNIT_ONLY: FilterType = FilterType::new(1);
-
+        UnitOnly,
         /// Filter by `base compensation entry's` unit and amount / range. A job
         /// is a match if and only if the job contains a base CompensationEntry, and
         /// the base entry's unit matches provided
@@ -3716,8 +4325,7 @@ pub mod compensation_filter {
         /// [google.cloud.talent.v4.CompensationInfo.CompensationEntry]: crate::model::compensation_info::CompensationEntry
         /// [google.cloud.talent.v4.CompensationInfo.CompensationRange]: crate::model::compensation_info::CompensationRange
         /// [google.cloud.talent.v4.CompensationInfo.CompensationUnit]: crate::model::compensation_info::CompensationUnit
-        pub const UNIT_AND_AMOUNT: FilterType = FilterType::new(2);
-
+        UnitAndAmount,
         /// Filter by annualized base compensation amount and `base compensation
         /// entry's` unit. Populate
         /// [range][google.cloud.talent.v4.CompensationFilter.range] and zero or more
@@ -3725,8 +4333,7 @@ pub mod compensation_filter {
         ///
         /// [google.cloud.talent.v4.CompensationFilter.range]: crate::model::CompensationFilter::range
         /// [google.cloud.talent.v4.CompensationFilter.units]: crate::model::CompensationFilter::units
-        pub const ANNUALIZED_BASE_AMOUNT: FilterType = FilterType::new(3);
-
+        AnnualizedBaseAmount,
         /// Filter by annualized total compensation amount and `base compensation
         /// entry's` unit . Populate
         /// [range][google.cloud.talent.v4.CompensationFilter.range] and zero or more
@@ -3734,56 +4341,122 @@ pub mod compensation_filter {
         ///
         /// [google.cloud.talent.v4.CompensationFilter.range]: crate::model::CompensationFilter::range
         /// [google.cloud.talent.v4.CompensationFilter.units]: crate::model::CompensationFilter::units
-        pub const ANNUALIZED_TOTAL_AMOUNT: FilterType = FilterType::new(4);
+        AnnualizedTotalAmount,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FilterType::value] or
+        /// [FilterType::name].
+        UnknownValue(filter_type::UnknownValue),
+    }
 
-        /// Creates a new FilterType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod filter_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FilterType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UnitOnly => std::option::Option::Some(1),
+                Self::UnitAndAmount => std::option::Option::Some(2),
+                Self::AnnualizedBaseAmount => std::option::Option::Some(3),
+                Self::AnnualizedTotalAmount => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FILTER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNIT_ONLY"),
-                2 => std::borrow::Cow::Borrowed("UNIT_AND_AMOUNT"),
-                3 => std::borrow::Cow::Borrowed("ANNUALIZED_BASE_AMOUNT"),
-                4 => std::borrow::Cow::Borrowed("ANNUALIZED_TOTAL_AMOUNT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FILTER_TYPE_UNSPECIFIED"),
+                Self::UnitOnly => std::option::Option::Some("UNIT_ONLY"),
+                Self::UnitAndAmount => std::option::Option::Some("UNIT_AND_AMOUNT"),
+                Self::AnnualizedBaseAmount => std::option::Option::Some("ANNUALIZED_BASE_AMOUNT"),
+                Self::AnnualizedTotalAmount => std::option::Option::Some("ANNUALIZED_TOTAL_AMOUNT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FILTER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FILTER_TYPE_UNSPECIFIED)
-                }
-                "UNIT_ONLY" => std::option::Option::Some(Self::UNIT_ONLY),
-                "UNIT_AND_AMOUNT" => std::option::Option::Some(Self::UNIT_AND_AMOUNT),
-                "ANNUALIZED_BASE_AMOUNT" => std::option::Option::Some(Self::ANNUALIZED_BASE_AMOUNT),
-                "ANNUALIZED_TOTAL_AMOUNT" => {
-                    std::option::Option::Some(Self::ANNUALIZED_TOTAL_AMOUNT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FilterType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FilterType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FilterType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FilterType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UnitOnly,
+                2 => Self::UnitAndAmount,
+                3 => Self::AnnualizedBaseAmount,
+                4 => Self::AnnualizedTotalAmount,
+                _ => Self::UnknownValue(filter_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FilterType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FILTER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "UNIT_ONLY" => Self::UnitOnly,
+                "UNIT_AND_AMOUNT" => Self::UnitAndAmount,
+                "ANNUALIZED_BASE_AMOUNT" => Self::AnnualizedBaseAmount,
+                "ANNUALIZED_TOTAL_AMOUNT" => Self::AnnualizedTotalAmount,
+                _ => Self::UnknownValue(filter_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FilterType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UnitOnly => serializer.serialize_i32(1),
+                Self::UnitAndAmount => serializer.serialize_i32(2),
+                Self::AnnualizedBaseAmount => serializer.serialize_i32(3),
+                Self::AnnualizedTotalAmount => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FilterType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FilterType>::new(
+                ".google.cloud.talent.v4.CompensationFilter.FilterType",
+            ))
         }
     }
 }
@@ -3946,61 +4619,120 @@ pub mod commute_filter {
     use super::*;
 
     /// The traffic density to use when calculating commute time.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoadTraffic(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoadTraffic {
+        /// Road traffic situation isn't specified.
+        Unspecified,
+        /// Optimal commute time without considering any traffic impact.
+        TrafficFree,
+        /// Commute time calculation takes in account the peak traffic impact.
+        BusyHour,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoadTraffic::value] or
+        /// [RoadTraffic::name].
+        UnknownValue(road_traffic::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod road_traffic {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RoadTraffic {
-        /// Road traffic situation isn't specified.
-        pub const ROAD_TRAFFIC_UNSPECIFIED: RoadTraffic = RoadTraffic::new(0);
-
-        /// Optimal commute time without considering any traffic impact.
-        pub const TRAFFIC_FREE: RoadTraffic = RoadTraffic::new(1);
-
-        /// Commute time calculation takes in account the peak traffic impact.
-        pub const BUSY_HOUR: RoadTraffic = RoadTraffic::new(2);
-
-        /// Creates a new RoadTraffic instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TrafficFree => std::option::Option::Some(1),
+                Self::BusyHour => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROAD_TRAFFIC_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRAFFIC_FREE"),
-                2 => std::borrow::Cow::Borrowed("BUSY_HOUR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROAD_TRAFFIC_UNSPECIFIED"),
+                Self::TrafficFree => std::option::Option::Some("TRAFFIC_FREE"),
+                Self::BusyHour => std::option::Option::Some("BUSY_HOUR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROAD_TRAFFIC_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROAD_TRAFFIC_UNSPECIFIED)
-                }
-                "TRAFFIC_FREE" => std::option::Option::Some(Self::TRAFFIC_FREE),
-                "BUSY_HOUR" => std::option::Option::Some(Self::BUSY_HOUR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RoadTraffic {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoadTraffic {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoadTraffic {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoadTraffic {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TrafficFree,
+                2 => Self::BusyHour,
+                _ => Self::UnknownValue(road_traffic::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoadTraffic {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROAD_TRAFFIC_UNSPECIFIED" => Self::Unspecified,
+                "TRAFFIC_FREE" => Self::TrafficFree,
+                "BUSY_HOUR" => Self::BusyHour,
+                _ => Self::UnknownValue(road_traffic::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoadTraffic {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TrafficFree => serializer.serialize_i32(1),
+                Self::BusyHour => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoadTraffic {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoadTraffic>::new(
+                ".google.cloud.talent.v4.CommuteFilter.RoadTraffic",
+            ))
         }
     }
 
@@ -4235,8 +4967,8 @@ pub struct Job {
     /// [google.cloud.talent.v4.Job.language_code]: crate::model::Job::language_code
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
     /// [google.cloud.talent.v4.Location.LocationType]: crate::model::location::LocationType
-    /// [google.cloud.talent.v4.Location.LocationType.LOCALITY]: crate::model::location::location_type::LOCALITY
-    /// [google.cloud.talent.v4.Location.LocationType.STREET_ADDRESS]: crate::model::location::location_type::STREET_ADDRESS
+    /// [google.cloud.talent.v4.Location.LocationType.LOCALITY]: crate::model::location::LocationType::Locality
+    /// [google.cloud.talent.v4.Location.LocationType.STREET_ADDRESS]: crate::model::location::LocationType::StreetAddress
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub addresses: std::vec::Vec<std::string::String>,
 
@@ -4284,8 +5016,8 @@ pub struct Job {
     /// [full time][google.cloud.talent.v4.EmploymentType.FULL_TIME] or
     /// [part time][google.cloud.talent.v4.EmploymentType.PART_TIME].
     ///
-    /// [google.cloud.talent.v4.EmploymentType.FULL_TIME]: crate::model::employment_type::FULL_TIME
-    /// [google.cloud.talent.v4.EmploymentType.PART_TIME]: crate::model::employment_type::PART_TIME
+    /// [google.cloud.talent.v4.EmploymentType.FULL_TIME]: crate::model::EmploymentType::FullTime
+    /// [google.cloud.talent.v4.EmploymentType.PART_TIME]: crate::model::EmploymentType::PartTime
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub employment_types: std::vec::Vec<crate::model::EmploymentType>,
 
@@ -4367,8 +5099,8 @@ pub struct Job {
     /// [google.cloud.talent.v4.Job.addresses]: crate::model::Job::addresses
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
     /// [google.cloud.talent.v4.PostingRegion]: crate::model::PostingRegion
-    /// [google.cloud.talent.v4.PostingRegion.ADMINISTRATIVE_AREA]: crate::model::posting_region::ADMINISTRATIVE_AREA
-    /// [google.cloud.talent.v4.PostingRegion.NATION]: crate::model::posting_region::NATION
+    /// [google.cloud.talent.v4.PostingRegion.ADMINISTRATIVE_AREA]: crate::model::PostingRegion::AdministrativeArea
+    /// [google.cloud.talent.v4.PostingRegion.NATION]: crate::model::PostingRegion::Nation
     pub posting_region: crate::model::PostingRegion,
 
     /// Deprecated. The job is only visible to the owner.
@@ -4379,7 +5111,7 @@ pub struct Job {
     /// [Visibility.ACCOUNT_ONLY][google.cloud.talent.v4.Visibility.ACCOUNT_ONLY]
     /// if not specified.
     ///
-    /// [google.cloud.talent.v4.Visibility.ACCOUNT_ONLY]: crate::model::visibility::ACCOUNT_ONLY
+    /// [google.cloud.talent.v4.Visibility.ACCOUNT_ONLY]: crate::model::Visibility::AccountOnly
     pub visibility: crate::model::Visibility,
 
     /// The start timestamp of the job in UTC time zone. Typically this field
@@ -4921,7 +5653,7 @@ pub mod job {
         /// Defaults to
         /// [HtmlSanitization.SIMPLE_FORMATTING_ONLY][google.cloud.talent.v4.HtmlSanitization.SIMPLE_FORMATTING_ONLY].
         ///
-        /// [google.cloud.talent.v4.HtmlSanitization.SIMPLE_FORMATTING_ONLY]: crate::model::html_sanitization::SIMPLE_FORMATTING_ONLY
+        /// [google.cloud.talent.v4.HtmlSanitization.SIMPLE_FORMATTING_ONLY]: crate::model::HtmlSanitization::SimpleFormattingOnly
         pub html_sanitization: crate::model::HtmlSanitization,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5191,7 +5923,7 @@ pub struct ListJobsRequest {
     ///
     /// Default is 100 if empty or a number < 1 is specified.
     ///
-    /// [google.cloud.talent.v4.JobView.JOB_VIEW_ID_ONLY]: crate::model::job_view::JOB_VIEW_ID_ONLY
+    /// [google.cloud.talent.v4.JobView.JOB_VIEW_ID_ONLY]: crate::model::JobView::IdOnly
     /// [google.cloud.talent.v4.ListJobsRequest.job_view]: crate::model::ListJobsRequest::job_view
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub page_size: i32,
@@ -5201,7 +5933,7 @@ pub struct ListJobsRequest {
     /// [JobView.JOB_VIEW_FULL][google.cloud.talent.v4.JobView.JOB_VIEW_FULL] if no
     /// value is specified.
     ///
-    /// [google.cloud.talent.v4.JobView.JOB_VIEW_FULL]: crate::model::job_view::JOB_VIEW_FULL
+    /// [google.cloud.talent.v4.JobView.JOB_VIEW_FULL]: crate::model::JobView::Full
     pub job_view: crate::model::JobView,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5348,7 +6080,7 @@ pub struct SearchJobsRequest {
     /// Defaults to
     /// [SearchMode.JOB_SEARCH][google.cloud.talent.v4.SearchJobsRequest.SearchMode.JOB_SEARCH].
     ///
-    /// [google.cloud.talent.v4.SearchJobsRequest.SearchMode.JOB_SEARCH]: crate::model::search_jobs_request::search_mode::JOB_SEARCH
+    /// [google.cloud.talent.v4.SearchJobsRequest.SearchMode.JOB_SEARCH]: crate::model::search_jobs_request::SearchMode::JobSearch
     pub search_mode: crate::model::search_jobs_request::SearchMode,
 
     /// Required. The meta information collected about the job searcher, used to
@@ -5500,7 +6232,7 @@ pub struct SearchJobsRequest {
     /// [JobView.JOB_VIEW_SMALL][google.cloud.talent.v4.JobView.JOB_VIEW_SMALL] if
     /// no value is specified.
     ///
-    /// [google.cloud.talent.v4.JobView.JOB_VIEW_SMALL]: crate::model::job_view::JOB_VIEW_SMALL
+    /// [google.cloud.talent.v4.JobView.JOB_VIEW_SMALL]: crate::model::JobView::Small
     pub job_view: crate::model::JobView,
 
     /// An integer that specifies the current offset (that is, starting result
@@ -5610,7 +6342,7 @@ pub struct SearchJobsRequest {
     /// [DiversificationLevel.SIMPLE][google.cloud.talent.v4.SearchJobsRequest.DiversificationLevel.SIMPLE]
     /// if no value is specified.
     ///
-    /// [google.cloud.talent.v4.SearchJobsRequest.DiversificationLevel.SIMPLE]: crate::model::search_jobs_request::diversification_level::SIMPLE
+    /// [google.cloud.talent.v4.SearchJobsRequest.DiversificationLevel.SIMPLE]: crate::model::search_jobs_request::DiversificationLevel::Simple
     pub diversification_level: crate::model::search_jobs_request::DiversificationLevel,
 
     /// Controls over how job documents get ranked on top of existing relevance
@@ -5662,8 +6394,8 @@ pub struct SearchJobsRequest {
     /// [google.cloud.talent.v4.Job.description]: crate::model::Job::description
     /// [google.cloud.talent.v4.Job.qualifications]: crate::model::Job::qualifications
     /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-    /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::keyword_match_mode::KEYWORD_MATCH_ALL
-    /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_DISABLED]: crate::model::search_jobs_request::keyword_match_mode::KEYWORD_MATCH_DISABLED
+    /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::KeywordMatchMode::KeywordMatchAll
+    /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_DISABLED]: crate::model::search_jobs_request::KeywordMatchMode::KeywordMatchDisabled
     /// [google.cloud.talent.v4.SearchJobsRequest.keyword_match_mode]: crate::model::SearchJobsRequest::keyword_match_mode
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     pub disable_keyword_match: bool,
@@ -5675,7 +6407,7 @@ pub struct SearchJobsRequest {
     /// [KeywordMatchMode.KEYWORD_MATCH_ALL][google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]
     /// if no value is specified.
     ///
-    /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::keyword_match_mode::KEYWORD_MATCH_ALL
+    /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::KeywordMatchMode::KeywordMatchAll
     pub keyword_match_mode: crate::model::search_jobs_request::KeywordMatchMode,
 
     /// Optional. The relevance threshold of the search results.
@@ -5934,160 +6666,289 @@ pub mod search_jobs_request {
         /// [CustomRankingInfo.ranking_expression][google.cloud.talent.v4.SearchJobsRequest.CustomRankingInfo.ranking_expression].
         ///
         /// [google.cloud.talent.v4.SearchJobsRequest.CustomRankingInfo.ranking_expression]: crate::model::search_jobs_request::CustomRankingInfo::ranking_expression
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ImportanceLevel(i32);
-
-        impl ImportanceLevel {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ImportanceLevel {
             /// Default value if the importance level isn't specified.
-            pub const IMPORTANCE_LEVEL_UNSPECIFIED: ImportanceLevel = ImportanceLevel::new(0);
-
+            Unspecified,
             /// The given ranking expression is of None importance, existing relevance
             /// score (determined by API algorithm) dominates job's final ranking
             /// position.
-            pub const NONE: ImportanceLevel = ImportanceLevel::new(1);
-
+            None,
             /// The given ranking expression is of Low importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const LOW: ImportanceLevel = ImportanceLevel::new(2);
-
+            Low,
             /// The given ranking expression is of Mild importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const MILD: ImportanceLevel = ImportanceLevel::new(3);
-
+            Mild,
             /// The given ranking expression is of Medium importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const MEDIUM: ImportanceLevel = ImportanceLevel::new(4);
-
+            Medium,
             /// The given ranking expression is of High importance in terms of job's
             /// final ranking position compared to existing relevance
             /// score (determined by API algorithm).
-            pub const HIGH: ImportanceLevel = ImportanceLevel::new(5);
-
+            High,
             /// The given ranking expression is of Extreme importance, and dominates
             /// job's final ranking position with existing relevance
             /// score (determined by API algorithm) ignored.
-            pub const EXTREME: ImportanceLevel = ImportanceLevel::new(6);
+            Extreme,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ImportanceLevel::value] or
+            /// [ImportanceLevel::name].
+            UnknownValue(importance_level::UnknownValue),
+        }
 
-            /// Creates a new ImportanceLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod importance_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ImportanceLevel {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::None => std::option::Option::Some(1),
+                    Self::Low => std::option::Option::Some(2),
+                    Self::Mild => std::option::Option::Some(3),
+                    Self::Medium => std::option::Option::Some(4),
+                    Self::High => std::option::Option::Some(5),
+                    Self::Extreme => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("IMPORTANCE_LEVEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NONE"),
-                    2 => std::borrow::Cow::Borrowed("LOW"),
-                    3 => std::borrow::Cow::Borrowed("MILD"),
-                    4 => std::borrow::Cow::Borrowed("MEDIUM"),
-                    5 => std::borrow::Cow::Borrowed("HIGH"),
-                    6 => std::borrow::Cow::Borrowed("EXTREME"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("IMPORTANCE_LEVEL_UNSPECIFIED"),
+                    Self::None => std::option::Option::Some("NONE"),
+                    Self::Low => std::option::Option::Some("LOW"),
+                    Self::Mild => std::option::Option::Some("MILD"),
+                    Self::Medium => std::option::Option::Some("MEDIUM"),
+                    Self::High => std::option::Option::Some("HIGH"),
+                    Self::Extreme => std::option::Option::Some("EXTREME"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "IMPORTANCE_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::IMPORTANCE_LEVEL_UNSPECIFIED)
-                    }
-                    "NONE" => std::option::Option::Some(Self::NONE),
-                    "LOW" => std::option::Option::Some(Self::LOW),
-                    "MILD" => std::option::Option::Some(Self::MILD),
-                    "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                    "HIGH" => std::option::Option::Some(Self::HIGH),
-                    "EXTREME" => std::option::Option::Some(Self::EXTREME),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ImportanceLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ImportanceLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ImportanceLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ImportanceLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::None,
+                    2 => Self::Low,
+                    3 => Self::Mild,
+                    4 => Self::Medium,
+                    5 => Self::High,
+                    6 => Self::Extreme,
+                    _ => Self::UnknownValue(importance_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ImportanceLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "IMPORTANCE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "NONE" => Self::None,
+                    "LOW" => Self::Low,
+                    "MILD" => Self::Mild,
+                    "MEDIUM" => Self::Medium,
+                    "HIGH" => Self::High,
+                    "EXTREME" => Self::Extreme,
+                    _ => Self::UnknownValue(importance_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ImportanceLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::None => serializer.serialize_i32(1),
+                    Self::Low => serializer.serialize_i32(2),
+                    Self::Mild => serializer.serialize_i32(3),
+                    Self::Medium => serializer.serialize_i32(4),
+                    Self::High => serializer.serialize_i32(5),
+                    Self::Extreme => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ImportanceLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ImportanceLevel>::new(
+                    ".google.cloud.talent.v4.SearchJobsRequest.CustomRankingInfo.ImportanceLevel",
+                ))
             }
         }
     }
 
     /// A string-represented enumeration of the job search mode. The service
     /// operate differently for different modes of service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SearchMode(i32);
-
-    impl SearchMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SearchMode {
         /// The mode of the search method isn't specified. The default search
         /// behavior is identical to JOB_SEARCH search behavior.
-        pub const SEARCH_MODE_UNSPECIFIED: SearchMode = SearchMode::new(0);
-
+        Unspecified,
         /// The job search matches against all jobs, and featured jobs
         /// (jobs with promotionValue > 0) are not specially handled.
-        pub const JOB_SEARCH: SearchMode = SearchMode::new(1);
-
+        JobSearch,
         /// The job search matches only against featured jobs (jobs with a
         /// promotionValue > 0). This method doesn't return any jobs having a
         /// promotionValue <= 0. The search results order is determined by the
         /// promotionValue (jobs with a higher promotionValue are returned higher up
         /// in the search results), with relevance being used as a tiebreaker.
-        pub const FEATURED_JOB_SEARCH: SearchMode = SearchMode::new(2);
+        FeaturedJobSearch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SearchMode::value] or
+        /// [SearchMode::name].
+        UnknownValue(search_mode::UnknownValue),
+    }
 
-        /// Creates a new SearchMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod search_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SearchMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::JobSearch => std::option::Option::Some(1),
+                Self::FeaturedJobSearch => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEARCH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("JOB_SEARCH"),
-                2 => std::borrow::Cow::Borrowed("FEATURED_JOB_SEARCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEARCH_MODE_UNSPECIFIED"),
+                Self::JobSearch => std::option::Option::Some("JOB_SEARCH"),
+                Self::FeaturedJobSearch => std::option::Option::Some("FEATURED_JOB_SEARCH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEARCH_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SEARCH_MODE_UNSPECIFIED)
-                }
-                "JOB_SEARCH" => std::option::Option::Some(Self::JOB_SEARCH),
-                "FEATURED_JOB_SEARCH" => std::option::Option::Some(Self::FEATURED_JOB_SEARCH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SearchMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SearchMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SearchMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SearchMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::JobSearch,
+                2 => Self::FeaturedJobSearch,
+                _ => Self::UnknownValue(search_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SearchMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEARCH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "JOB_SEARCH" => Self::JobSearch,
+                "FEATURED_JOB_SEARCH" => Self::FeaturedJobSearch,
+                _ => Self::UnknownValue(search_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SearchMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::JobSearch => serializer.serialize_i32(1),
+                Self::FeaturedJobSearch => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SearchMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SearchMode>::new(
+                ".google.cloud.talent.v4.SearchJobsRequest.SearchMode",
+            ))
         }
     }
 
@@ -6102,97 +6963,162 @@ pub mod search_jobs_request {
     /// latency might be lower but we can't guarantee that all results are
     /// returned. If you are using page offset, latency might be higher but all
     /// results are returned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiversificationLevel(i32);
-
-    impl DiversificationLevel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiversificationLevel {
         /// The diversification level isn't specified.
-        pub const DIVERSIFICATION_LEVEL_UNSPECIFIED: DiversificationLevel =
-            DiversificationLevel::new(0);
-
+        Unspecified,
         /// Disables diversification. Jobs that would normally be pushed to the last
         /// page would not have their positions altered. This may result in highly
         /// similar jobs appearing in sequence in the search results.
-        pub const DISABLED: DiversificationLevel = DiversificationLevel::new(1);
-
+        Disabled,
         /// Default diversifying behavior. The result list is ordered so that
         /// highly similar results are pushed to the end of the last page of search
         /// results.
-        pub const SIMPLE: DiversificationLevel = DiversificationLevel::new(2);
-
+        Simple,
         /// Only one job from the same company will be shown at once, other jobs
         /// under same company are pushed to the end of the last page of search
         /// result.
-        pub const ONE_PER_COMPANY: DiversificationLevel = DiversificationLevel::new(3);
-
+        OnePerCompany,
         /// Similar to ONE_PER_COMPANY, but it allows at most two jobs in the
         /// same company to be shown at once, the other jobs under same company are
         /// pushed to the end of the last page of search result.
-        pub const TWO_PER_COMPANY: DiversificationLevel = DiversificationLevel::new(4);
-
+        TwoPerCompany,
         /// Similar to ONE_PER_COMPANY, but it allows at most three jobs in the
         /// same company to be shown at once, the other jobs under same company are
         /// dropped.
-        pub const MAX_THREE_PER_COMPANY: DiversificationLevel = DiversificationLevel::new(6);
-
+        MaxThreePerCompany,
         /// The result list is ordered such that somewhat similar results are pushed
         /// to the end of the last page of the search results. This option is
         /// recommended if SIMPLE diversification does not diversify enough.
-        pub const DIVERSIFY_BY_LOOSER_SIMILARITY: DiversificationLevel =
-            DiversificationLevel::new(5);
+        DiversifyByLooserSimilarity,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiversificationLevel::value] or
+        /// [DiversificationLevel::name].
+        UnknownValue(diversification_level::UnknownValue),
+    }
 
-        /// Creates a new DiversificationLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod diversification_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DiversificationLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Simple => std::option::Option::Some(2),
+                Self::OnePerCompany => std::option::Option::Some(3),
+                Self::TwoPerCompany => std::option::Option::Some(4),
+                Self::MaxThreePerCompany => std::option::Option::Some(6),
+                Self::DiversifyByLooserSimilarity => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIVERSIFICATION_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("SIMPLE"),
-                3 => std::borrow::Cow::Borrowed("ONE_PER_COMPANY"),
-                4 => std::borrow::Cow::Borrowed("TWO_PER_COMPANY"),
-                5 => std::borrow::Cow::Borrowed("DIVERSIFY_BY_LOOSER_SIMILARITY"),
-                6 => std::borrow::Cow::Borrowed("MAX_THREE_PER_COMPANY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIVERSIFICATION_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DIVERSIFICATION_LEVEL_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIVERSIFICATION_LEVEL_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Simple => std::option::Option::Some("SIMPLE"),
+                Self::OnePerCompany => std::option::Option::Some("ONE_PER_COMPANY"),
+                Self::TwoPerCompany => std::option::Option::Some("TWO_PER_COMPANY"),
+                Self::MaxThreePerCompany => std::option::Option::Some("MAX_THREE_PER_COMPANY"),
+                Self::DiversifyByLooserSimilarity => {
+                    std::option::Option::Some("DIVERSIFY_BY_LOOSER_SIMILARITY")
                 }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "SIMPLE" => std::option::Option::Some(Self::SIMPLE),
-                "ONE_PER_COMPANY" => std::option::Option::Some(Self::ONE_PER_COMPANY),
-                "TWO_PER_COMPANY" => std::option::Option::Some(Self::TWO_PER_COMPANY),
-                "MAX_THREE_PER_COMPANY" => std::option::Option::Some(Self::MAX_THREE_PER_COMPANY),
-                "DIVERSIFY_BY_LOOSER_SIMILARITY" => {
-                    std::option::Option::Some(Self::DIVERSIFY_BY_LOOSER_SIMILARITY)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DiversificationLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiversificationLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiversificationLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiversificationLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Simple,
+                3 => Self::OnePerCompany,
+                4 => Self::TwoPerCompany,
+                5 => Self::DiversifyByLooserSimilarity,
+                6 => Self::MaxThreePerCompany,
+                _ => Self::UnknownValue(diversification_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiversificationLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIVERSIFICATION_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "SIMPLE" => Self::Simple,
+                "ONE_PER_COMPANY" => Self::OnePerCompany,
+                "TWO_PER_COMPANY" => Self::TwoPerCompany,
+                "MAX_THREE_PER_COMPANY" => Self::MaxThreePerCompany,
+                "DIVERSIFY_BY_LOOSER_SIMILARITY" => Self::DiversifyByLooserSimilarity,
+                _ => Self::UnknownValue(diversification_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiversificationLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Simple => serializer.serialize_i32(2),
+                Self::OnePerCompany => serializer.serialize_i32(3),
+                Self::TwoPerCompany => serializer.serialize_i32(4),
+                Self::MaxThreePerCompany => serializer.serialize_i32(6),
+                Self::DiversifyByLooserSimilarity => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiversificationLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiversificationLevel>::new(
+                ".google.cloud.talent.v4.SearchJobsRequest.DiversificationLevel",
+            ))
         }
     }
 
@@ -6215,20 +7141,17 @@ pub mod search_jobs_request {
     /// requests.
     ///
     /// [google.cloud.talent.v4.Company.keyword_searchable_job_custom_attributes]: crate::model::Company::keyword_searchable_job_custom_attributes
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeywordMatchMode(i32);
-
-    impl KeywordMatchMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KeywordMatchMode {
         /// The keyword match option isn't specified. Defaults to
         /// [KeywordMatchMode.KEYWORD_MATCH_ALL][google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]
         /// behavior.
         ///
-        /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::keyword_match_mode::KEYWORD_MATCH_ALL
-        pub const KEYWORD_MATCH_MODE_UNSPECIFIED: KeywordMatchMode = KeywordMatchMode::new(0);
-
+        /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_ALL]: crate::model::search_jobs_request::KeywordMatchMode::KeywordMatchAll
+        Unspecified,
         /// Disables keyword matching.
-        pub const KEYWORD_MATCH_DISABLED: KeywordMatchMode = KeywordMatchMode::new(1);
-
+        KeywordMatchDisabled,
         /// Enable keyword matching over
         /// [Job.title][google.cloud.talent.v4.Job.title],
         /// [Job.description][google.cloud.talent.v4.Job.description],
@@ -6245,132 +7168,259 @@ pub mod search_jobs_request {
         /// [google.cloud.talent.v4.Job.description]: crate::model::Job::description
         /// [google.cloud.talent.v4.Job.qualifications]: crate::model::Job::qualifications
         /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-        pub const KEYWORD_MATCH_ALL: KeywordMatchMode = KeywordMatchMode::new(2);
-
+        KeywordMatchAll,
         /// Only enable keyword matching over
         /// [Job.title][google.cloud.talent.v4.Job.title].
         ///
         /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-        pub const KEYWORD_MATCH_TITLE_ONLY: KeywordMatchMode = KeywordMatchMode::new(3);
+        KeywordMatchTitleOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KeywordMatchMode::value] or
+        /// [KeywordMatchMode::name].
+        UnknownValue(keyword_match_mode::UnknownValue),
+    }
 
-        /// Creates a new KeywordMatchMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod keyword_match_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KeywordMatchMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::KeywordMatchDisabled => std::option::Option::Some(1),
+                Self::KeywordMatchAll => std::option::Option::Some(2),
+                Self::KeywordMatchTitleOnly => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_ALL"),
-                3 => std::borrow::Cow::Borrowed("KEYWORD_MATCH_TITLE_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KEYWORD_MATCH_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::KEYWORD_MATCH_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KEYWORD_MATCH_MODE_UNSPECIFIED"),
+                Self::KeywordMatchDisabled => std::option::Option::Some("KEYWORD_MATCH_DISABLED"),
+                Self::KeywordMatchAll => std::option::Option::Some("KEYWORD_MATCH_ALL"),
+                Self::KeywordMatchTitleOnly => {
+                    std::option::Option::Some("KEYWORD_MATCH_TITLE_ONLY")
                 }
-                "KEYWORD_MATCH_DISABLED" => std::option::Option::Some(Self::KEYWORD_MATCH_DISABLED),
-                "KEYWORD_MATCH_ALL" => std::option::Option::Some(Self::KEYWORD_MATCH_ALL),
-                "KEYWORD_MATCH_TITLE_ONLY" => {
-                    std::option::Option::Some(Self::KEYWORD_MATCH_TITLE_ONLY)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for KeywordMatchMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KeywordMatchMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KeywordMatchMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KeywordMatchMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::KeywordMatchDisabled,
+                2 => Self::KeywordMatchAll,
+                3 => Self::KeywordMatchTitleOnly,
+                _ => Self::UnknownValue(keyword_match_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KeywordMatchMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KEYWORD_MATCH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "KEYWORD_MATCH_DISABLED" => Self::KeywordMatchDisabled,
+                "KEYWORD_MATCH_ALL" => Self::KeywordMatchAll,
+                "KEYWORD_MATCH_TITLE_ONLY" => Self::KeywordMatchTitleOnly,
+                _ => Self::UnknownValue(keyword_match_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KeywordMatchMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::KeywordMatchDisabled => serializer.serialize_i32(1),
+                Self::KeywordMatchAll => serializer.serialize_i32(2),
+                Self::KeywordMatchTitleOnly => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KeywordMatchMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KeywordMatchMode>::new(
+                ".google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode",
+            ))
         }
     }
 
     /// The relevance threshold of the search results. The higher relevance
     /// threshold is, the higher relevant results are shown and the less number of
     /// results are returned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RelevanceThreshold(i32);
-
-    impl RelevanceThreshold {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RelevanceThreshold {
         /// Default value. In this case, server behavior defaults to Google defined
         /// threshold.
-        pub const RELEVANCE_THRESHOLD_UNSPECIFIED: RelevanceThreshold = RelevanceThreshold::new(0);
-
+        Unspecified,
         /// Lowest relevance threshold.
-        pub const LOWEST: RelevanceThreshold = RelevanceThreshold::new(1);
-
+        Lowest,
         /// Low relevance threshold.
-        pub const LOW: RelevanceThreshold = RelevanceThreshold::new(2);
-
+        Low,
         /// Medium relevance threshold.
-        pub const MEDIUM: RelevanceThreshold = RelevanceThreshold::new(3);
-
+        Medium,
         /// High relevance threshold.
-        pub const HIGH: RelevanceThreshold = RelevanceThreshold::new(4);
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RelevanceThreshold::value] or
+        /// [RelevanceThreshold::name].
+        UnknownValue(relevance_threshold::UnknownValue),
+    }
 
-        /// Creates a new RelevanceThreshold instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod relevance_threshold {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RelevanceThreshold {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Lowest => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::High => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RELEVANCE_THRESHOLD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOWEST"),
-                2 => std::borrow::Cow::Borrowed("LOW"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RELEVANCE_THRESHOLD_UNSPECIFIED"),
+                Self::Lowest => std::option::Option::Some("LOWEST"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RELEVANCE_THRESHOLD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RELEVANCE_THRESHOLD_UNSPECIFIED)
-                }
-                "LOWEST" => std::option::Option::Some(Self::LOWEST),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RelevanceThreshold {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RelevanceThreshold {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RelevanceThreshold {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RelevanceThreshold {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Lowest,
+                2 => Self::Low,
+                3 => Self::Medium,
+                4 => Self::High,
+                _ => Self::UnknownValue(relevance_threshold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RelevanceThreshold {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RELEVANCE_THRESHOLD_UNSPECIFIED" => Self::Unspecified,
+                "LOWEST" => Self::Lowest,
+                "LOW" => Self::Low,
+                "MEDIUM" => Self::Medium,
+                "HIGH" => Self::High,
+                _ => Self::UnknownValue(relevance_threshold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RelevanceThreshold {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Lowest => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::High => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RelevanceThreshold {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RelevanceThreshold>::new(
+                ".google.cloud.talent.v4.SearchJobsRequest.RelevanceThreshold",
+            ))
         }
     }
 }
@@ -6405,7 +7455,7 @@ pub struct SearchJobsResponse {
     /// [Location.location_type][google.cloud.talent.v4.Location.location_type] is
     /// [Location.LocationType.LOCATION_TYPE_UNSPECIFIED][google.cloud.talent.v4.Location.LocationType.LOCATION_TYPE_UNSPECIFIED].
     ///
-    /// [google.cloud.talent.v4.Location.LocationType.LOCATION_TYPE_UNSPECIFIED]: crate::model::location::location_type::LOCATION_TYPE_UNSPECIFIED
+    /// [google.cloud.talent.v4.Location.LocationType.LOCATION_TYPE_UNSPECIFIED]: crate::model::location::LocationType::Unspecified
     /// [google.cloud.talent.v4.Location.location_type]: crate::model::Location::location_type
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
     pub location_filters: std::vec::Vec<crate::model::Location>,
@@ -7447,733 +8497,1205 @@ impl gax::paginator::internal::PageableResponse for ListTenantsResponse {
 }
 
 /// An enum that represents the size of the company.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CompanySize(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CompanySize {
+    /// Default value if the size isn't specified.
+    Unspecified,
+    /// The company has less than 50 employees.
+    Mini,
+    /// The company has between 50 and 99 employees.
+    Small,
+    /// The company has between 100 and 499 employees.
+    Smedium,
+    /// The company has between 500 and 999 employees.
+    Medium,
+    /// The company has between 1,000 and 4,999 employees.
+    Big,
+    /// The company has between 5,000 and 9,999 employees.
+    Bigger,
+    /// The company has 10,000 or more employees.
+    Giant,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CompanySize::value] or
+    /// [CompanySize::name].
+    UnknownValue(company_size::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod company_size {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CompanySize {
-    /// Default value if the size isn't specified.
-    pub const COMPANY_SIZE_UNSPECIFIED: CompanySize = CompanySize::new(0);
-
-    /// The company has less than 50 employees.
-    pub const MINI: CompanySize = CompanySize::new(1);
-
-    /// The company has between 50 and 99 employees.
-    pub const SMALL: CompanySize = CompanySize::new(2);
-
-    /// The company has between 100 and 499 employees.
-    pub const SMEDIUM: CompanySize = CompanySize::new(3);
-
-    /// The company has between 500 and 999 employees.
-    pub const MEDIUM: CompanySize = CompanySize::new(4);
-
-    /// The company has between 1,000 and 4,999 employees.
-    pub const BIG: CompanySize = CompanySize::new(5);
-
-    /// The company has between 5,000 and 9,999 employees.
-    pub const BIGGER: CompanySize = CompanySize::new(6);
-
-    /// The company has 10,000 or more employees.
-    pub const GIANT: CompanySize = CompanySize::new(7);
-
-    /// Creates a new CompanySize instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Mini => std::option::Option::Some(1),
+            Self::Small => std::option::Option::Some(2),
+            Self::Smedium => std::option::Option::Some(3),
+            Self::Medium => std::option::Option::Some(4),
+            Self::Big => std::option::Option::Some(5),
+            Self::Bigger => std::option::Option::Some(6),
+            Self::Giant => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPANY_SIZE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MINI"),
-            2 => std::borrow::Cow::Borrowed("SMALL"),
-            3 => std::borrow::Cow::Borrowed("SMEDIUM"),
-            4 => std::borrow::Cow::Borrowed("MEDIUM"),
-            5 => std::borrow::Cow::Borrowed("BIG"),
-            6 => std::borrow::Cow::Borrowed("BIGGER"),
-            7 => std::borrow::Cow::Borrowed("GIANT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMPANY_SIZE_UNSPECIFIED"),
+            Self::Mini => std::option::Option::Some("MINI"),
+            Self::Small => std::option::Option::Some("SMALL"),
+            Self::Smedium => std::option::Option::Some("SMEDIUM"),
+            Self::Medium => std::option::Option::Some("MEDIUM"),
+            Self::Big => std::option::Option::Some("BIG"),
+            Self::Bigger => std::option::Option::Some("BIGGER"),
+            Self::Giant => std::option::Option::Some("GIANT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPANY_SIZE_UNSPECIFIED" => std::option::Option::Some(Self::COMPANY_SIZE_UNSPECIFIED),
-            "MINI" => std::option::Option::Some(Self::MINI),
-            "SMALL" => std::option::Option::Some(Self::SMALL),
-            "SMEDIUM" => std::option::Option::Some(Self::SMEDIUM),
-            "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-            "BIG" => std::option::Option::Some(Self::BIG),
-            "BIGGER" => std::option::Option::Some(Self::BIGGER),
-            "GIANT" => std::option::Option::Some(Self::GIANT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CompanySize {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CompanySize {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CompanySize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CompanySize {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Mini,
+            2 => Self::Small,
+            3 => Self::Smedium,
+            4 => Self::Medium,
+            5 => Self::Big,
+            6 => Self::Bigger,
+            7 => Self::Giant,
+            _ => Self::UnknownValue(company_size::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CompanySize {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPANY_SIZE_UNSPECIFIED" => Self::Unspecified,
+            "MINI" => Self::Mini,
+            "SMALL" => Self::Small,
+            "SMEDIUM" => Self::Smedium,
+            "MEDIUM" => Self::Medium,
+            "BIG" => Self::Big,
+            "BIGGER" => Self::Bigger,
+            "GIANT" => Self::Giant,
+            _ => Self::UnknownValue(company_size::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CompanySize {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Mini => serializer.serialize_i32(1),
+            Self::Small => serializer.serialize_i32(2),
+            Self::Smedium => serializer.serialize_i32(3),
+            Self::Medium => serializer.serialize_i32(4),
+            Self::Big => serializer.serialize_i32(5),
+            Self::Bigger => serializer.serialize_i32(6),
+            Self::Giant => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CompanySize {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompanySize>::new(
+            ".google.cloud.talent.v4.CompanySize",
+        ))
     }
 }
 
 /// An enum that represents employee benefits included with the job.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobBenefit(i32);
-
-impl JobBenefit {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum JobBenefit {
     /// Default value if the type isn't specified.
-    pub const JOB_BENEFIT_UNSPECIFIED: JobBenefit = JobBenefit::new(0);
-
+    Unspecified,
     /// The job includes access to programs that support child care, such
     /// as daycare.
-    pub const CHILD_CARE: JobBenefit = JobBenefit::new(1);
-
+    ChildCare,
     /// The job includes dental services covered by a dental
     /// insurance plan.
-    pub const DENTAL: JobBenefit = JobBenefit::new(2);
-
+    Dental,
     /// The job offers specific benefits to domestic partners.
-    pub const DOMESTIC_PARTNER: JobBenefit = JobBenefit::new(3);
-
+    DomesticPartner,
     /// The job allows for a flexible work schedule.
-    pub const FLEXIBLE_HOURS: JobBenefit = JobBenefit::new(4);
-
+    FlexibleHours,
     /// The job includes health services covered by a medical insurance plan.
-    pub const MEDICAL: JobBenefit = JobBenefit::new(5);
-
+    Medical,
     /// The job includes a life insurance plan provided by the employer or
     /// available for purchase by the employee.
-    pub const LIFE_INSURANCE: JobBenefit = JobBenefit::new(6);
-
+    LifeInsurance,
     /// The job allows for a leave of absence to a parent to care for a newborn
     /// child.
-    pub const PARENTAL_LEAVE: JobBenefit = JobBenefit::new(7);
-
+    ParentalLeave,
     /// The job includes a workplace retirement plan provided by the
     /// employer or available for purchase by the employee.
-    pub const RETIREMENT_PLAN: JobBenefit = JobBenefit::new(8);
-
+    RetirementPlan,
     /// The job allows for paid time off due to illness.
-    pub const SICK_DAYS: JobBenefit = JobBenefit::new(9);
-
+    SickDays,
     /// The job includes paid time off for vacation.
-    pub const VACATION: JobBenefit = JobBenefit::new(10);
-
+    Vacation,
     /// The job includes vision services covered by a vision
     /// insurance plan.
-    pub const VISION: JobBenefit = JobBenefit::new(11);
+    Vision,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [JobBenefit::value] or
+    /// [JobBenefit::name].
+    UnknownValue(job_benefit::UnknownValue),
+}
 
-    /// Creates a new JobBenefit instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod job_benefit {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl JobBenefit {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ChildCare => std::option::Option::Some(1),
+            Self::Dental => std::option::Option::Some(2),
+            Self::DomesticPartner => std::option::Option::Some(3),
+            Self::FlexibleHours => std::option::Option::Some(4),
+            Self::Medical => std::option::Option::Some(5),
+            Self::LifeInsurance => std::option::Option::Some(6),
+            Self::ParentalLeave => std::option::Option::Some(7),
+            Self::RetirementPlan => std::option::Option::Some(8),
+            Self::SickDays => std::option::Option::Some(9),
+            Self::Vacation => std::option::Option::Some(10),
+            Self::Vision => std::option::Option::Some(11),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("JOB_BENEFIT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CHILD_CARE"),
-            2 => std::borrow::Cow::Borrowed("DENTAL"),
-            3 => std::borrow::Cow::Borrowed("DOMESTIC_PARTNER"),
-            4 => std::borrow::Cow::Borrowed("FLEXIBLE_HOURS"),
-            5 => std::borrow::Cow::Borrowed("MEDICAL"),
-            6 => std::borrow::Cow::Borrowed("LIFE_INSURANCE"),
-            7 => std::borrow::Cow::Borrowed("PARENTAL_LEAVE"),
-            8 => std::borrow::Cow::Borrowed("RETIREMENT_PLAN"),
-            9 => std::borrow::Cow::Borrowed("SICK_DAYS"),
-            10 => std::borrow::Cow::Borrowed("VACATION"),
-            11 => std::borrow::Cow::Borrowed("VISION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("JOB_BENEFIT_UNSPECIFIED"),
+            Self::ChildCare => std::option::Option::Some("CHILD_CARE"),
+            Self::Dental => std::option::Option::Some("DENTAL"),
+            Self::DomesticPartner => std::option::Option::Some("DOMESTIC_PARTNER"),
+            Self::FlexibleHours => std::option::Option::Some("FLEXIBLE_HOURS"),
+            Self::Medical => std::option::Option::Some("MEDICAL"),
+            Self::LifeInsurance => std::option::Option::Some("LIFE_INSURANCE"),
+            Self::ParentalLeave => std::option::Option::Some("PARENTAL_LEAVE"),
+            Self::RetirementPlan => std::option::Option::Some("RETIREMENT_PLAN"),
+            Self::SickDays => std::option::Option::Some("SICK_DAYS"),
+            Self::Vacation => std::option::Option::Some("VACATION"),
+            Self::Vision => std::option::Option::Some("VISION"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "JOB_BENEFIT_UNSPECIFIED" => std::option::Option::Some(Self::JOB_BENEFIT_UNSPECIFIED),
-            "CHILD_CARE" => std::option::Option::Some(Self::CHILD_CARE),
-            "DENTAL" => std::option::Option::Some(Self::DENTAL),
-            "DOMESTIC_PARTNER" => std::option::Option::Some(Self::DOMESTIC_PARTNER),
-            "FLEXIBLE_HOURS" => std::option::Option::Some(Self::FLEXIBLE_HOURS),
-            "MEDICAL" => std::option::Option::Some(Self::MEDICAL),
-            "LIFE_INSURANCE" => std::option::Option::Some(Self::LIFE_INSURANCE),
-            "PARENTAL_LEAVE" => std::option::Option::Some(Self::PARENTAL_LEAVE),
-            "RETIREMENT_PLAN" => std::option::Option::Some(Self::RETIREMENT_PLAN),
-            "SICK_DAYS" => std::option::Option::Some(Self::SICK_DAYS),
-            "VACATION" => std::option::Option::Some(Self::VACATION),
-            "VISION" => std::option::Option::Some(Self::VISION),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for JobBenefit {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for JobBenefit {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for JobBenefit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for JobBenefit {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ChildCare,
+            2 => Self::Dental,
+            3 => Self::DomesticPartner,
+            4 => Self::FlexibleHours,
+            5 => Self::Medical,
+            6 => Self::LifeInsurance,
+            7 => Self::ParentalLeave,
+            8 => Self::RetirementPlan,
+            9 => Self::SickDays,
+            10 => Self::Vacation,
+            11 => Self::Vision,
+            _ => Self::UnknownValue(job_benefit::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for JobBenefit {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "JOB_BENEFIT_UNSPECIFIED" => Self::Unspecified,
+            "CHILD_CARE" => Self::ChildCare,
+            "DENTAL" => Self::Dental,
+            "DOMESTIC_PARTNER" => Self::DomesticPartner,
+            "FLEXIBLE_HOURS" => Self::FlexibleHours,
+            "MEDICAL" => Self::Medical,
+            "LIFE_INSURANCE" => Self::LifeInsurance,
+            "PARENTAL_LEAVE" => Self::ParentalLeave,
+            "RETIREMENT_PLAN" => Self::RetirementPlan,
+            "SICK_DAYS" => Self::SickDays,
+            "VACATION" => Self::Vacation,
+            "VISION" => Self::Vision,
+            _ => Self::UnknownValue(job_benefit::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for JobBenefit {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ChildCare => serializer.serialize_i32(1),
+            Self::Dental => serializer.serialize_i32(2),
+            Self::DomesticPartner => serializer.serialize_i32(3),
+            Self::FlexibleHours => serializer.serialize_i32(4),
+            Self::Medical => serializer.serialize_i32(5),
+            Self::LifeInsurance => serializer.serialize_i32(6),
+            Self::ParentalLeave => serializer.serialize_i32(7),
+            Self::RetirementPlan => serializer.serialize_i32(8),
+            Self::SickDays => serializer.serialize_i32(9),
+            Self::Vacation => serializer.serialize_i32(10),
+            Self::Vision => serializer.serialize_i32(11),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for JobBenefit {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobBenefit>::new(
+            ".google.cloud.talent.v4.JobBenefit",
+        ))
     }
 }
 
 /// Educational degree level defined in International Standard Classification
 /// of Education (ISCED).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DegreeType(i32);
-
-impl DegreeType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DegreeType {
     /// Default value. Represents no degree, or early childhood education.
     /// Maps to ISCED code 0.
     /// Ex) Kindergarten
-    pub const DEGREE_TYPE_UNSPECIFIED: DegreeType = DegreeType::new(0);
-
+    Unspecified,
     /// Primary education which is typically the first stage of compulsory
     /// education. ISCED code 1.
     /// Ex) Elementary school
-    pub const PRIMARY_EDUCATION: DegreeType = DegreeType::new(1);
-
+    PrimaryEducation,
     /// Lower secondary education; First stage of secondary education building on
     /// primary education, typically with a more subject-oriented curriculum.
     /// ISCED code 2.
     /// Ex) Middle school
-    pub const LOWER_SECONDARY_EDUCATION: DegreeType = DegreeType::new(2);
-
+    LowerSecondaryEducation,
     /// Middle education; Second/final stage of secondary education preparing for
     /// tertiary education and/or providing skills relevant to employment.
     /// Usually with an increased range of subject options and streams. ISCED
     /// code 3.
     /// Ex) High school
-    pub const UPPER_SECONDARY_EDUCATION: DegreeType = DegreeType::new(3);
-
+    UpperSecondaryEducation,
     /// Adult Remedial Education; Programmes providing learning experiences that
     /// build on secondary education and prepare for labour market entry and/or
     /// tertiary education. The content is broader than secondary but not as
     /// complex as tertiary education. ISCED code 4.
-    pub const ADULT_REMEDIAL_EDUCATION: DegreeType = DegreeType::new(4);
-
+    AdultRemedialEducation,
     /// Associate's or equivalent; Short first tertiary programmes that are
     /// typically practically-based, occupationally-specific and prepare for
     /// labour market entry. These programmes may also provide a pathway to other
     /// tertiary programmes. ISCED code 5.
-    pub const ASSOCIATES_OR_EQUIVALENT: DegreeType = DegreeType::new(5);
-
+    AssociatesOrEquivalent,
     /// Bachelor's or equivalent; Programmes designed to provide intermediate
     /// academic and/or professional knowledge, skills and competencies leading
     /// to a first tertiary degree or equivalent qualification. ISCED code 6.
-    pub const BACHELORS_OR_EQUIVALENT: DegreeType = DegreeType::new(6);
-
+    BachelorsOrEquivalent,
     /// Master's or equivalent; Programmes designed to provide advanced academic
     /// and/or professional knowledge, skills and competencies leading to a
     /// second tertiary degree or equivalent qualification. ISCED code 7.
-    pub const MASTERS_OR_EQUIVALENT: DegreeType = DegreeType::new(7);
-
+    MastersOrEquivalent,
     /// Doctoral or equivalent; Programmes designed primarily to lead to an
     /// advanced research qualification, usually concluding with the submission
     /// and defense of a substantive dissertation of publishable quality based on
     /// original research. ISCED code 8.
-    pub const DOCTORAL_OR_EQUIVALENT: DegreeType = DegreeType::new(8);
+    DoctoralOrEquivalent,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DegreeType::value] or
+    /// [DegreeType::name].
+    UnknownValue(degree_type::UnknownValue),
+}
 
-    /// Creates a new DegreeType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod degree_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DegreeType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::PrimaryEducation => std::option::Option::Some(1),
+            Self::LowerSecondaryEducation => std::option::Option::Some(2),
+            Self::UpperSecondaryEducation => std::option::Option::Some(3),
+            Self::AdultRemedialEducation => std::option::Option::Some(4),
+            Self::AssociatesOrEquivalent => std::option::Option::Some(5),
+            Self::BachelorsOrEquivalent => std::option::Option::Some(6),
+            Self::MastersOrEquivalent => std::option::Option::Some(7),
+            Self::DoctoralOrEquivalent => std::option::Option::Some(8),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DEGREE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PRIMARY_EDUCATION"),
-            2 => std::borrow::Cow::Borrowed("LOWER_SECONDARY_EDUCATION"),
-            3 => std::borrow::Cow::Borrowed("UPPER_SECONDARY_EDUCATION"),
-            4 => std::borrow::Cow::Borrowed("ADULT_REMEDIAL_EDUCATION"),
-            5 => std::borrow::Cow::Borrowed("ASSOCIATES_OR_EQUIVALENT"),
-            6 => std::borrow::Cow::Borrowed("BACHELORS_OR_EQUIVALENT"),
-            7 => std::borrow::Cow::Borrowed("MASTERS_OR_EQUIVALENT"),
-            8 => std::borrow::Cow::Borrowed("DOCTORAL_OR_EQUIVALENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DEGREE_TYPE_UNSPECIFIED"),
+            Self::PrimaryEducation => std::option::Option::Some("PRIMARY_EDUCATION"),
+            Self::LowerSecondaryEducation => std::option::Option::Some("LOWER_SECONDARY_EDUCATION"),
+            Self::UpperSecondaryEducation => std::option::Option::Some("UPPER_SECONDARY_EDUCATION"),
+            Self::AdultRemedialEducation => std::option::Option::Some("ADULT_REMEDIAL_EDUCATION"),
+            Self::AssociatesOrEquivalent => std::option::Option::Some("ASSOCIATES_OR_EQUIVALENT"),
+            Self::BachelorsOrEquivalent => std::option::Option::Some("BACHELORS_OR_EQUIVALENT"),
+            Self::MastersOrEquivalent => std::option::Option::Some("MASTERS_OR_EQUIVALENT"),
+            Self::DoctoralOrEquivalent => std::option::Option::Some("DOCTORAL_OR_EQUIVALENT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DEGREE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DEGREE_TYPE_UNSPECIFIED),
-            "PRIMARY_EDUCATION" => std::option::Option::Some(Self::PRIMARY_EDUCATION),
-            "LOWER_SECONDARY_EDUCATION" => {
-                std::option::Option::Some(Self::LOWER_SECONDARY_EDUCATION)
-            }
-            "UPPER_SECONDARY_EDUCATION" => {
-                std::option::Option::Some(Self::UPPER_SECONDARY_EDUCATION)
-            }
-            "ADULT_REMEDIAL_EDUCATION" => std::option::Option::Some(Self::ADULT_REMEDIAL_EDUCATION),
-            "ASSOCIATES_OR_EQUIVALENT" => std::option::Option::Some(Self::ASSOCIATES_OR_EQUIVALENT),
-            "BACHELORS_OR_EQUIVALENT" => std::option::Option::Some(Self::BACHELORS_OR_EQUIVALENT),
-            "MASTERS_OR_EQUIVALENT" => std::option::Option::Some(Self::MASTERS_OR_EQUIVALENT),
-            "DOCTORAL_OR_EQUIVALENT" => std::option::Option::Some(Self::DOCTORAL_OR_EQUIVALENT),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DegreeType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DegreeType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DegreeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DegreeType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::PrimaryEducation,
+            2 => Self::LowerSecondaryEducation,
+            3 => Self::UpperSecondaryEducation,
+            4 => Self::AdultRemedialEducation,
+            5 => Self::AssociatesOrEquivalent,
+            6 => Self::BachelorsOrEquivalent,
+            7 => Self::MastersOrEquivalent,
+            8 => Self::DoctoralOrEquivalent,
+            _ => Self::UnknownValue(degree_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DegreeType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DEGREE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "PRIMARY_EDUCATION" => Self::PrimaryEducation,
+            "LOWER_SECONDARY_EDUCATION" => Self::LowerSecondaryEducation,
+            "UPPER_SECONDARY_EDUCATION" => Self::UpperSecondaryEducation,
+            "ADULT_REMEDIAL_EDUCATION" => Self::AdultRemedialEducation,
+            "ASSOCIATES_OR_EQUIVALENT" => Self::AssociatesOrEquivalent,
+            "BACHELORS_OR_EQUIVALENT" => Self::BachelorsOrEquivalent,
+            "MASTERS_OR_EQUIVALENT" => Self::MastersOrEquivalent,
+            "DOCTORAL_OR_EQUIVALENT" => Self::DoctoralOrEquivalent,
+            _ => Self::UnknownValue(degree_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DegreeType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::PrimaryEducation => serializer.serialize_i32(1),
+            Self::LowerSecondaryEducation => serializer.serialize_i32(2),
+            Self::UpperSecondaryEducation => serializer.serialize_i32(3),
+            Self::AdultRemedialEducation => serializer.serialize_i32(4),
+            Self::AssociatesOrEquivalent => serializer.serialize_i32(5),
+            Self::BachelorsOrEquivalent => serializer.serialize_i32(6),
+            Self::MastersOrEquivalent => serializer.serialize_i32(7),
+            Self::DoctoralOrEquivalent => serializer.serialize_i32(8),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DegreeType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DegreeType>::new(
+            ".google.cloud.talent.v4.DegreeType",
+        ))
     }
 }
 
 /// An enum that represents the employment type of a job.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EmploymentType(i32);
-
-impl EmploymentType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EmploymentType {
     /// The default value if the employment type isn't specified.
-    pub const EMPLOYMENT_TYPE_UNSPECIFIED: EmploymentType = EmploymentType::new(0);
-
+    Unspecified,
     /// The job requires working a number of hours that constitute full
     /// time employment, typically 40 or more hours per week.
-    pub const FULL_TIME: EmploymentType = EmploymentType::new(1);
-
+    FullTime,
     /// The job entails working fewer hours than a full time job,
     /// typically less than 40 hours a week.
-    pub const PART_TIME: EmploymentType = EmploymentType::new(2);
-
+    PartTime,
     /// The job is offered as a contracted, as opposed to a salaried employee,
     /// position.
-    pub const CONTRACTOR: EmploymentType = EmploymentType::new(3);
-
+    Contractor,
     /// The job is offered as a contracted position with the understanding
     /// that it's converted into a full-time position at the end of the
     /// contract. Jobs of this type are also returned by a search for
     /// [EmploymentType.CONTRACTOR][google.cloud.talent.v4.EmploymentType.CONTRACTOR]
     /// jobs.
     ///
-    /// [google.cloud.talent.v4.EmploymentType.CONTRACTOR]: crate::model::employment_type::CONTRACTOR
-    pub const CONTRACT_TO_HIRE: EmploymentType = EmploymentType::new(4);
-
+    /// [google.cloud.talent.v4.EmploymentType.CONTRACTOR]: crate::model::EmploymentType::Contractor
+    ContractToHire,
     /// The job is offered as a temporary employment opportunity, usually
     /// a short-term engagement.
-    pub const TEMPORARY: EmploymentType = EmploymentType::new(5);
-
+    Temporary,
     /// The job is a fixed-term opportunity for students or entry-level job
     /// seekers to obtain on-the-job training, typically offered as a summer
     /// position.
-    pub const INTERN: EmploymentType = EmploymentType::new(6);
-
+    Intern,
     /// The is an opportunity for an individual to volunteer, where there's no
     /// expectation of compensation for the provided services.
-    pub const VOLUNTEER: EmploymentType = EmploymentType::new(7);
-
+    Volunteer,
     /// The job requires an employee to work on an as-needed basis with a
     /// flexible schedule.
-    pub const PER_DIEM: EmploymentType = EmploymentType::new(8);
-
+    PerDiem,
     /// The job involves employing people in remote areas and flying them
     /// temporarily to the work site instead of relocating employees and their
     /// families permanently.
-    pub const FLY_IN_FLY_OUT: EmploymentType = EmploymentType::new(9);
-
+    FlyInFlyOut,
     /// The job does not fit any of the other listed types.
-    pub const OTHER_EMPLOYMENT_TYPE: EmploymentType = EmploymentType::new(10);
+    OtherEmploymentType,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EmploymentType::value] or
+    /// [EmploymentType::name].
+    UnknownValue(employment_type::UnknownValue),
+}
 
-    /// Creates a new EmploymentType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod employment_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl EmploymentType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::FullTime => std::option::Option::Some(1),
+            Self::PartTime => std::option::Option::Some(2),
+            Self::Contractor => std::option::Option::Some(3),
+            Self::ContractToHire => std::option::Option::Some(4),
+            Self::Temporary => std::option::Option::Some(5),
+            Self::Intern => std::option::Option::Some(6),
+            Self::Volunteer => std::option::Option::Some(7),
+            Self::PerDiem => std::option::Option::Some(8),
+            Self::FlyInFlyOut => std::option::Option::Some(9),
+            Self::OtherEmploymentType => std::option::Option::Some(10),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EMPLOYMENT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("FULL_TIME"),
-            2 => std::borrow::Cow::Borrowed("PART_TIME"),
-            3 => std::borrow::Cow::Borrowed("CONTRACTOR"),
-            4 => std::borrow::Cow::Borrowed("CONTRACT_TO_HIRE"),
-            5 => std::borrow::Cow::Borrowed("TEMPORARY"),
-            6 => std::borrow::Cow::Borrowed("INTERN"),
-            7 => std::borrow::Cow::Borrowed("VOLUNTEER"),
-            8 => std::borrow::Cow::Borrowed("PER_DIEM"),
-            9 => std::borrow::Cow::Borrowed("FLY_IN_FLY_OUT"),
-            10 => std::borrow::Cow::Borrowed("OTHER_EMPLOYMENT_TYPE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EMPLOYMENT_TYPE_UNSPECIFIED"),
+            Self::FullTime => std::option::Option::Some("FULL_TIME"),
+            Self::PartTime => std::option::Option::Some("PART_TIME"),
+            Self::Contractor => std::option::Option::Some("CONTRACTOR"),
+            Self::ContractToHire => std::option::Option::Some("CONTRACT_TO_HIRE"),
+            Self::Temporary => std::option::Option::Some("TEMPORARY"),
+            Self::Intern => std::option::Option::Some("INTERN"),
+            Self::Volunteer => std::option::Option::Some("VOLUNTEER"),
+            Self::PerDiem => std::option::Option::Some("PER_DIEM"),
+            Self::FlyInFlyOut => std::option::Option::Some("FLY_IN_FLY_OUT"),
+            Self::OtherEmploymentType => std::option::Option::Some("OTHER_EMPLOYMENT_TYPE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EMPLOYMENT_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::EMPLOYMENT_TYPE_UNSPECIFIED)
-            }
-            "FULL_TIME" => std::option::Option::Some(Self::FULL_TIME),
-            "PART_TIME" => std::option::Option::Some(Self::PART_TIME),
-            "CONTRACTOR" => std::option::Option::Some(Self::CONTRACTOR),
-            "CONTRACT_TO_HIRE" => std::option::Option::Some(Self::CONTRACT_TO_HIRE),
-            "TEMPORARY" => std::option::Option::Some(Self::TEMPORARY),
-            "INTERN" => std::option::Option::Some(Self::INTERN),
-            "VOLUNTEER" => std::option::Option::Some(Self::VOLUNTEER),
-            "PER_DIEM" => std::option::Option::Some(Self::PER_DIEM),
-            "FLY_IN_FLY_OUT" => std::option::Option::Some(Self::FLY_IN_FLY_OUT),
-            "OTHER_EMPLOYMENT_TYPE" => std::option::Option::Some(Self::OTHER_EMPLOYMENT_TYPE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EmploymentType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EmploymentType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EmploymentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EmploymentType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::FullTime,
+            2 => Self::PartTime,
+            3 => Self::Contractor,
+            4 => Self::ContractToHire,
+            5 => Self::Temporary,
+            6 => Self::Intern,
+            7 => Self::Volunteer,
+            8 => Self::PerDiem,
+            9 => Self::FlyInFlyOut,
+            10 => Self::OtherEmploymentType,
+            _ => Self::UnknownValue(employment_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EmploymentType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EMPLOYMENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "FULL_TIME" => Self::FullTime,
+            "PART_TIME" => Self::PartTime,
+            "CONTRACTOR" => Self::Contractor,
+            "CONTRACT_TO_HIRE" => Self::ContractToHire,
+            "TEMPORARY" => Self::Temporary,
+            "INTERN" => Self::Intern,
+            "VOLUNTEER" => Self::Volunteer,
+            "PER_DIEM" => Self::PerDiem,
+            "FLY_IN_FLY_OUT" => Self::FlyInFlyOut,
+            "OTHER_EMPLOYMENT_TYPE" => Self::OtherEmploymentType,
+            _ => Self::UnknownValue(employment_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EmploymentType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::FullTime => serializer.serialize_i32(1),
+            Self::PartTime => serializer.serialize_i32(2),
+            Self::Contractor => serializer.serialize_i32(3),
+            Self::ContractToHire => serializer.serialize_i32(4),
+            Self::Temporary => serializer.serialize_i32(5),
+            Self::Intern => serializer.serialize_i32(6),
+            Self::Volunteer => serializer.serialize_i32(7),
+            Self::PerDiem => serializer.serialize_i32(8),
+            Self::FlyInFlyOut => serializer.serialize_i32(9),
+            Self::OtherEmploymentType => serializer.serialize_i32(10),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EmploymentType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EmploymentType>::new(
+            ".google.cloud.talent.v4.EmploymentType",
+        ))
     }
 }
 
 /// An enum that represents the required experience level required for the job.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobLevel(i32);
-
-impl JobLevel {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum JobLevel {
     /// The default value if the level isn't specified.
-    pub const JOB_LEVEL_UNSPECIFIED: JobLevel = JobLevel::new(0);
-
+    Unspecified,
     /// Entry-level individual contributors, typically with less than 2 years of
     /// experience in a similar role. Includes interns.
-    pub const ENTRY_LEVEL: JobLevel = JobLevel::new(1);
-
+    EntryLevel,
     /// Experienced individual contributors, typically with 2+ years of
     /// experience in a similar role.
-    pub const EXPERIENCED: JobLevel = JobLevel::new(2);
-
+    Experienced,
     /// Entry- to mid-level managers responsible for managing a team of people.
-    pub const MANAGER: JobLevel = JobLevel::new(3);
-
+    Manager,
     /// Senior-level managers responsible for managing teams of managers.
-    pub const DIRECTOR: JobLevel = JobLevel::new(4);
-
+    Director,
     /// Executive-level managers and above, including C-level positions.
-    pub const EXECUTIVE: JobLevel = JobLevel::new(5);
+    Executive,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [JobLevel::value] or
+    /// [JobLevel::name].
+    UnknownValue(job_level::UnknownValue),
+}
 
-    /// Creates a new JobLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod job_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl JobLevel {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::EntryLevel => std::option::Option::Some(1),
+            Self::Experienced => std::option::Option::Some(2),
+            Self::Manager => std::option::Option::Some(3),
+            Self::Director => std::option::Option::Some(4),
+            Self::Executive => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("JOB_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENTRY_LEVEL"),
-            2 => std::borrow::Cow::Borrowed("EXPERIENCED"),
-            3 => std::borrow::Cow::Borrowed("MANAGER"),
-            4 => std::borrow::Cow::Borrowed("DIRECTOR"),
-            5 => std::borrow::Cow::Borrowed("EXECUTIVE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("JOB_LEVEL_UNSPECIFIED"),
+            Self::EntryLevel => std::option::Option::Some("ENTRY_LEVEL"),
+            Self::Experienced => std::option::Option::Some("EXPERIENCED"),
+            Self::Manager => std::option::Option::Some("MANAGER"),
+            Self::Director => std::option::Option::Some("DIRECTOR"),
+            Self::Executive => std::option::Option::Some("EXECUTIVE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "JOB_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::JOB_LEVEL_UNSPECIFIED),
-            "ENTRY_LEVEL" => std::option::Option::Some(Self::ENTRY_LEVEL),
-            "EXPERIENCED" => std::option::Option::Some(Self::EXPERIENCED),
-            "MANAGER" => std::option::Option::Some(Self::MANAGER),
-            "DIRECTOR" => std::option::Option::Some(Self::DIRECTOR),
-            "EXECUTIVE" => std::option::Option::Some(Self::EXECUTIVE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for JobLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for JobLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for JobLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for JobLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::EntryLevel,
+            2 => Self::Experienced,
+            3 => Self::Manager,
+            4 => Self::Director,
+            5 => Self::Executive,
+            _ => Self::UnknownValue(job_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for JobLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "JOB_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "ENTRY_LEVEL" => Self::EntryLevel,
+            "EXPERIENCED" => Self::Experienced,
+            "MANAGER" => Self::Manager,
+            "DIRECTOR" => Self::Director,
+            "EXECUTIVE" => Self::Executive,
+            _ => Self::UnknownValue(job_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for JobLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::EntryLevel => serializer.serialize_i32(1),
+            Self::Experienced => serializer.serialize_i32(2),
+            Self::Manager => serializer.serialize_i32(3),
+            Self::Director => serializer.serialize_i32(4),
+            Self::Executive => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for JobLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobLevel>::new(
+            ".google.cloud.talent.v4.JobLevel",
+        ))
     }
 }
 
 /// An enum that represents the categorization or primary focus of specific
 /// role. This value is different than the "industry" associated with a role,
 /// which is related to the categorization of the company listing the job.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobCategory(i32);
-
-impl JobCategory {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum JobCategory {
     /// The default value if the category isn't specified.
-    pub const JOB_CATEGORY_UNSPECIFIED: JobCategory = JobCategory::new(0);
-
+    Unspecified,
     /// An accounting and finance job, such as an Accountant.
-    pub const ACCOUNTING_AND_FINANCE: JobCategory = JobCategory::new(1);
-
+    AccountingAndFinance,
     /// An administrative and office job, such as an Administrative Assistant.
-    pub const ADMINISTRATIVE_AND_OFFICE: JobCategory = JobCategory::new(2);
-
+    AdministrativeAndOffice,
     /// An advertising and marketing job, such as Marketing Manager.
-    pub const ADVERTISING_AND_MARKETING: JobCategory = JobCategory::new(3);
-
+    AdvertisingAndMarketing,
     /// An animal care job, such as Veterinarian.
-    pub const ANIMAL_CARE: JobCategory = JobCategory::new(4);
-
+    AnimalCare,
     /// An art, fashion, or design job, such as Designer.
-    pub const ART_FASHION_AND_DESIGN: JobCategory = JobCategory::new(5);
-
+    ArtFashionAndDesign,
     /// A business operations job, such as Business Operations Manager.
-    pub const BUSINESS_OPERATIONS: JobCategory = JobCategory::new(6);
-
+    BusinessOperations,
     /// A cleaning and facilities job, such as Custodial Staff.
-    pub const CLEANING_AND_FACILITIES: JobCategory = JobCategory::new(7);
-
+    CleaningAndFacilities,
     /// A computer and IT job, such as Systems Administrator.
-    pub const COMPUTER_AND_IT: JobCategory = JobCategory::new(8);
-
+    ComputerAndIt,
     /// A construction job, such as General Laborer.
-    pub const CONSTRUCTION: JobCategory = JobCategory::new(9);
-
+    Construction,
     /// A customer service job, such s Cashier.
-    pub const CUSTOMER_SERVICE: JobCategory = JobCategory::new(10);
-
+    CustomerService,
     /// An education job, such as School Teacher.
-    pub const EDUCATION: JobCategory = JobCategory::new(11);
-
+    Education,
     /// An entertainment and travel job, such as Flight Attendant.
-    pub const ENTERTAINMENT_AND_TRAVEL: JobCategory = JobCategory::new(12);
-
+    EntertainmentAndTravel,
     /// A farming or outdoor job, such as Park Ranger.
-    pub const FARMING_AND_OUTDOORS: JobCategory = JobCategory::new(13);
-
+    FarmingAndOutdoors,
     /// A healthcare job, such as Registered Nurse.
-    pub const HEALTHCARE: JobCategory = JobCategory::new(14);
-
+    Healthcare,
     /// A human resources job, such as Human Resources Director.
-    pub const HUMAN_RESOURCES: JobCategory = JobCategory::new(15);
-
+    HumanResources,
     /// An installation, maintenance, or repair job, such as Electrician.
-    pub const INSTALLATION_MAINTENANCE_AND_REPAIR: JobCategory = JobCategory::new(16);
-
+    InstallationMaintenanceAndRepair,
     /// A legal job, such as Law Clerk.
-    pub const LEGAL: JobCategory = JobCategory::new(17);
-
+    Legal,
     /// A management job, often used in conjunction with another category,
     /// such as Store Manager.
-    pub const MANAGEMENT: JobCategory = JobCategory::new(18);
-
+    Management,
     /// A manufacturing or warehouse job, such as Assembly Technician.
-    pub const MANUFACTURING_AND_WAREHOUSE: JobCategory = JobCategory::new(19);
-
+    ManufacturingAndWarehouse,
     /// A media, communications, or writing job, such as Media Relations.
-    pub const MEDIA_COMMUNICATIONS_AND_WRITING: JobCategory = JobCategory::new(20);
-
+    MediaCommunicationsAndWriting,
     /// An oil, gas or mining job, such as Offshore Driller.
-    pub const OIL_GAS_AND_MINING: JobCategory = JobCategory::new(21);
-
+    OilGasAndMining,
     /// A personal care and services job, such as Hair Stylist.
-    pub const PERSONAL_CARE_AND_SERVICES: JobCategory = JobCategory::new(22);
-
+    PersonalCareAndServices,
     /// A protective services job, such as Security Guard.
-    pub const PROTECTIVE_SERVICES: JobCategory = JobCategory::new(23);
-
+    ProtectiveServices,
     /// A real estate job, such as Buyer's Agent.
-    pub const REAL_ESTATE: JobCategory = JobCategory::new(24);
-
+    RealEstate,
     /// A restaurant and hospitality job, such as Restaurant Server.
-    pub const RESTAURANT_AND_HOSPITALITY: JobCategory = JobCategory::new(25);
-
+    RestaurantAndHospitality,
     /// A sales and/or retail job, such Sales Associate.
-    pub const SALES_AND_RETAIL: JobCategory = JobCategory::new(26);
-
+    SalesAndRetail,
     /// A science and engineering job, such as Lab Technician.
-    pub const SCIENCE_AND_ENGINEERING: JobCategory = JobCategory::new(27);
-
+    ScienceAndEngineering,
     /// A social services or non-profit job, such as Case Worker.
-    pub const SOCIAL_SERVICES_AND_NON_PROFIT: JobCategory = JobCategory::new(28);
-
+    SocialServicesAndNonProfit,
     /// A sports, fitness, or recreation job, such as Personal Trainer.
-    pub const SPORTS_FITNESS_AND_RECREATION: JobCategory = JobCategory::new(29);
-
+    SportsFitnessAndRecreation,
     /// A transportation or logistics job, such as Truck Driver.
-    pub const TRANSPORTATION_AND_LOGISTICS: JobCategory = JobCategory::new(30);
+    TransportationAndLogistics,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [JobCategory::value] or
+    /// [JobCategory::name].
+    UnknownValue(job_category::UnknownValue),
+}
 
-    /// Creates a new JobCategory instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod job_category {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl JobCategory {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::AccountingAndFinance => std::option::Option::Some(1),
+            Self::AdministrativeAndOffice => std::option::Option::Some(2),
+            Self::AdvertisingAndMarketing => std::option::Option::Some(3),
+            Self::AnimalCare => std::option::Option::Some(4),
+            Self::ArtFashionAndDesign => std::option::Option::Some(5),
+            Self::BusinessOperations => std::option::Option::Some(6),
+            Self::CleaningAndFacilities => std::option::Option::Some(7),
+            Self::ComputerAndIt => std::option::Option::Some(8),
+            Self::Construction => std::option::Option::Some(9),
+            Self::CustomerService => std::option::Option::Some(10),
+            Self::Education => std::option::Option::Some(11),
+            Self::EntertainmentAndTravel => std::option::Option::Some(12),
+            Self::FarmingAndOutdoors => std::option::Option::Some(13),
+            Self::Healthcare => std::option::Option::Some(14),
+            Self::HumanResources => std::option::Option::Some(15),
+            Self::InstallationMaintenanceAndRepair => std::option::Option::Some(16),
+            Self::Legal => std::option::Option::Some(17),
+            Self::Management => std::option::Option::Some(18),
+            Self::ManufacturingAndWarehouse => std::option::Option::Some(19),
+            Self::MediaCommunicationsAndWriting => std::option::Option::Some(20),
+            Self::OilGasAndMining => std::option::Option::Some(21),
+            Self::PersonalCareAndServices => std::option::Option::Some(22),
+            Self::ProtectiveServices => std::option::Option::Some(23),
+            Self::RealEstate => std::option::Option::Some(24),
+            Self::RestaurantAndHospitality => std::option::Option::Some(25),
+            Self::SalesAndRetail => std::option::Option::Some(26),
+            Self::ScienceAndEngineering => std::option::Option::Some(27),
+            Self::SocialServicesAndNonProfit => std::option::Option::Some(28),
+            Self::SportsFitnessAndRecreation => std::option::Option::Some(29),
+            Self::TransportationAndLogistics => std::option::Option::Some(30),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("JOB_CATEGORY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACCOUNTING_AND_FINANCE"),
-            2 => std::borrow::Cow::Borrowed("ADMINISTRATIVE_AND_OFFICE"),
-            3 => std::borrow::Cow::Borrowed("ADVERTISING_AND_MARKETING"),
-            4 => std::borrow::Cow::Borrowed("ANIMAL_CARE"),
-            5 => std::borrow::Cow::Borrowed("ART_FASHION_AND_DESIGN"),
-            6 => std::borrow::Cow::Borrowed("BUSINESS_OPERATIONS"),
-            7 => std::borrow::Cow::Borrowed("CLEANING_AND_FACILITIES"),
-            8 => std::borrow::Cow::Borrowed("COMPUTER_AND_IT"),
-            9 => std::borrow::Cow::Borrowed("CONSTRUCTION"),
-            10 => std::borrow::Cow::Borrowed("CUSTOMER_SERVICE"),
-            11 => std::borrow::Cow::Borrowed("EDUCATION"),
-            12 => std::borrow::Cow::Borrowed("ENTERTAINMENT_AND_TRAVEL"),
-            13 => std::borrow::Cow::Borrowed("FARMING_AND_OUTDOORS"),
-            14 => std::borrow::Cow::Borrowed("HEALTHCARE"),
-            15 => std::borrow::Cow::Borrowed("HUMAN_RESOURCES"),
-            16 => std::borrow::Cow::Borrowed("INSTALLATION_MAINTENANCE_AND_REPAIR"),
-            17 => std::borrow::Cow::Borrowed("LEGAL"),
-            18 => std::borrow::Cow::Borrowed("MANAGEMENT"),
-            19 => std::borrow::Cow::Borrowed("MANUFACTURING_AND_WAREHOUSE"),
-            20 => std::borrow::Cow::Borrowed("MEDIA_COMMUNICATIONS_AND_WRITING"),
-            21 => std::borrow::Cow::Borrowed("OIL_GAS_AND_MINING"),
-            22 => std::borrow::Cow::Borrowed("PERSONAL_CARE_AND_SERVICES"),
-            23 => std::borrow::Cow::Borrowed("PROTECTIVE_SERVICES"),
-            24 => std::borrow::Cow::Borrowed("REAL_ESTATE"),
-            25 => std::borrow::Cow::Borrowed("RESTAURANT_AND_HOSPITALITY"),
-            26 => std::borrow::Cow::Borrowed("SALES_AND_RETAIL"),
-            27 => std::borrow::Cow::Borrowed("SCIENCE_AND_ENGINEERING"),
-            28 => std::borrow::Cow::Borrowed("SOCIAL_SERVICES_AND_NON_PROFIT"),
-            29 => std::borrow::Cow::Borrowed("SPORTS_FITNESS_AND_RECREATION"),
-            30 => std::borrow::Cow::Borrowed("TRANSPORTATION_AND_LOGISTICS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("JOB_CATEGORY_UNSPECIFIED"),
+            Self::AccountingAndFinance => std::option::Option::Some("ACCOUNTING_AND_FINANCE"),
+            Self::AdministrativeAndOffice => std::option::Option::Some("ADMINISTRATIVE_AND_OFFICE"),
+            Self::AdvertisingAndMarketing => std::option::Option::Some("ADVERTISING_AND_MARKETING"),
+            Self::AnimalCare => std::option::Option::Some("ANIMAL_CARE"),
+            Self::ArtFashionAndDesign => std::option::Option::Some("ART_FASHION_AND_DESIGN"),
+            Self::BusinessOperations => std::option::Option::Some("BUSINESS_OPERATIONS"),
+            Self::CleaningAndFacilities => std::option::Option::Some("CLEANING_AND_FACILITIES"),
+            Self::ComputerAndIt => std::option::Option::Some("COMPUTER_AND_IT"),
+            Self::Construction => std::option::Option::Some("CONSTRUCTION"),
+            Self::CustomerService => std::option::Option::Some("CUSTOMER_SERVICE"),
+            Self::Education => std::option::Option::Some("EDUCATION"),
+            Self::EntertainmentAndTravel => std::option::Option::Some("ENTERTAINMENT_AND_TRAVEL"),
+            Self::FarmingAndOutdoors => std::option::Option::Some("FARMING_AND_OUTDOORS"),
+            Self::Healthcare => std::option::Option::Some("HEALTHCARE"),
+            Self::HumanResources => std::option::Option::Some("HUMAN_RESOURCES"),
+            Self::InstallationMaintenanceAndRepair => {
+                std::option::Option::Some("INSTALLATION_MAINTENANCE_AND_REPAIR")
+            }
+            Self::Legal => std::option::Option::Some("LEGAL"),
+            Self::Management => std::option::Option::Some("MANAGEMENT"),
+            Self::ManufacturingAndWarehouse => {
+                std::option::Option::Some("MANUFACTURING_AND_WAREHOUSE")
+            }
+            Self::MediaCommunicationsAndWriting => {
+                std::option::Option::Some("MEDIA_COMMUNICATIONS_AND_WRITING")
+            }
+            Self::OilGasAndMining => std::option::Option::Some("OIL_GAS_AND_MINING"),
+            Self::PersonalCareAndServices => {
+                std::option::Option::Some("PERSONAL_CARE_AND_SERVICES")
+            }
+            Self::ProtectiveServices => std::option::Option::Some("PROTECTIVE_SERVICES"),
+            Self::RealEstate => std::option::Option::Some("REAL_ESTATE"),
+            Self::RestaurantAndHospitality => {
+                std::option::Option::Some("RESTAURANT_AND_HOSPITALITY")
+            }
+            Self::SalesAndRetail => std::option::Option::Some("SALES_AND_RETAIL"),
+            Self::ScienceAndEngineering => std::option::Option::Some("SCIENCE_AND_ENGINEERING"),
+            Self::SocialServicesAndNonProfit => {
+                std::option::Option::Some("SOCIAL_SERVICES_AND_NON_PROFIT")
+            }
+            Self::SportsFitnessAndRecreation => {
+                std::option::Option::Some("SPORTS_FITNESS_AND_RECREATION")
+            }
+            Self::TransportationAndLogistics => {
+                std::option::Option::Some("TRANSPORTATION_AND_LOGISTICS")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "JOB_CATEGORY_UNSPECIFIED" => std::option::Option::Some(Self::JOB_CATEGORY_UNSPECIFIED),
-            "ACCOUNTING_AND_FINANCE" => std::option::Option::Some(Self::ACCOUNTING_AND_FINANCE),
-            "ADMINISTRATIVE_AND_OFFICE" => {
-                std::option::Option::Some(Self::ADMINISTRATIVE_AND_OFFICE)
-            }
-            "ADVERTISING_AND_MARKETING" => {
-                std::option::Option::Some(Self::ADVERTISING_AND_MARKETING)
-            }
-            "ANIMAL_CARE" => std::option::Option::Some(Self::ANIMAL_CARE),
-            "ART_FASHION_AND_DESIGN" => std::option::Option::Some(Self::ART_FASHION_AND_DESIGN),
-            "BUSINESS_OPERATIONS" => std::option::Option::Some(Self::BUSINESS_OPERATIONS),
-            "CLEANING_AND_FACILITIES" => std::option::Option::Some(Self::CLEANING_AND_FACILITIES),
-            "COMPUTER_AND_IT" => std::option::Option::Some(Self::COMPUTER_AND_IT),
-            "CONSTRUCTION" => std::option::Option::Some(Self::CONSTRUCTION),
-            "CUSTOMER_SERVICE" => std::option::Option::Some(Self::CUSTOMER_SERVICE),
-            "EDUCATION" => std::option::Option::Some(Self::EDUCATION),
-            "ENTERTAINMENT_AND_TRAVEL" => std::option::Option::Some(Self::ENTERTAINMENT_AND_TRAVEL),
-            "FARMING_AND_OUTDOORS" => std::option::Option::Some(Self::FARMING_AND_OUTDOORS),
-            "HEALTHCARE" => std::option::Option::Some(Self::HEALTHCARE),
-            "HUMAN_RESOURCES" => std::option::Option::Some(Self::HUMAN_RESOURCES),
-            "INSTALLATION_MAINTENANCE_AND_REPAIR" => {
-                std::option::Option::Some(Self::INSTALLATION_MAINTENANCE_AND_REPAIR)
-            }
-            "LEGAL" => std::option::Option::Some(Self::LEGAL),
-            "MANAGEMENT" => std::option::Option::Some(Self::MANAGEMENT),
-            "MANUFACTURING_AND_WAREHOUSE" => {
-                std::option::Option::Some(Self::MANUFACTURING_AND_WAREHOUSE)
-            }
-            "MEDIA_COMMUNICATIONS_AND_WRITING" => {
-                std::option::Option::Some(Self::MEDIA_COMMUNICATIONS_AND_WRITING)
-            }
-            "OIL_GAS_AND_MINING" => std::option::Option::Some(Self::OIL_GAS_AND_MINING),
-            "PERSONAL_CARE_AND_SERVICES" => {
-                std::option::Option::Some(Self::PERSONAL_CARE_AND_SERVICES)
-            }
-            "PROTECTIVE_SERVICES" => std::option::Option::Some(Self::PROTECTIVE_SERVICES),
-            "REAL_ESTATE" => std::option::Option::Some(Self::REAL_ESTATE),
-            "RESTAURANT_AND_HOSPITALITY" => {
-                std::option::Option::Some(Self::RESTAURANT_AND_HOSPITALITY)
-            }
-            "SALES_AND_RETAIL" => std::option::Option::Some(Self::SALES_AND_RETAIL),
-            "SCIENCE_AND_ENGINEERING" => std::option::Option::Some(Self::SCIENCE_AND_ENGINEERING),
-            "SOCIAL_SERVICES_AND_NON_PROFIT" => {
-                std::option::Option::Some(Self::SOCIAL_SERVICES_AND_NON_PROFIT)
-            }
-            "SPORTS_FITNESS_AND_RECREATION" => {
-                std::option::Option::Some(Self::SPORTS_FITNESS_AND_RECREATION)
-            }
-            "TRANSPORTATION_AND_LOGISTICS" => {
-                std::option::Option::Some(Self::TRANSPORTATION_AND_LOGISTICS)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for JobCategory {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for JobCategory {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for JobCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for JobCategory {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::AccountingAndFinance,
+            2 => Self::AdministrativeAndOffice,
+            3 => Self::AdvertisingAndMarketing,
+            4 => Self::AnimalCare,
+            5 => Self::ArtFashionAndDesign,
+            6 => Self::BusinessOperations,
+            7 => Self::CleaningAndFacilities,
+            8 => Self::ComputerAndIt,
+            9 => Self::Construction,
+            10 => Self::CustomerService,
+            11 => Self::Education,
+            12 => Self::EntertainmentAndTravel,
+            13 => Self::FarmingAndOutdoors,
+            14 => Self::Healthcare,
+            15 => Self::HumanResources,
+            16 => Self::InstallationMaintenanceAndRepair,
+            17 => Self::Legal,
+            18 => Self::Management,
+            19 => Self::ManufacturingAndWarehouse,
+            20 => Self::MediaCommunicationsAndWriting,
+            21 => Self::OilGasAndMining,
+            22 => Self::PersonalCareAndServices,
+            23 => Self::ProtectiveServices,
+            24 => Self::RealEstate,
+            25 => Self::RestaurantAndHospitality,
+            26 => Self::SalesAndRetail,
+            27 => Self::ScienceAndEngineering,
+            28 => Self::SocialServicesAndNonProfit,
+            29 => Self::SportsFitnessAndRecreation,
+            30 => Self::TransportationAndLogistics,
+            _ => Self::UnknownValue(job_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for JobCategory {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "JOB_CATEGORY_UNSPECIFIED" => Self::Unspecified,
+            "ACCOUNTING_AND_FINANCE" => Self::AccountingAndFinance,
+            "ADMINISTRATIVE_AND_OFFICE" => Self::AdministrativeAndOffice,
+            "ADVERTISING_AND_MARKETING" => Self::AdvertisingAndMarketing,
+            "ANIMAL_CARE" => Self::AnimalCare,
+            "ART_FASHION_AND_DESIGN" => Self::ArtFashionAndDesign,
+            "BUSINESS_OPERATIONS" => Self::BusinessOperations,
+            "CLEANING_AND_FACILITIES" => Self::CleaningAndFacilities,
+            "COMPUTER_AND_IT" => Self::ComputerAndIt,
+            "CONSTRUCTION" => Self::Construction,
+            "CUSTOMER_SERVICE" => Self::CustomerService,
+            "EDUCATION" => Self::Education,
+            "ENTERTAINMENT_AND_TRAVEL" => Self::EntertainmentAndTravel,
+            "FARMING_AND_OUTDOORS" => Self::FarmingAndOutdoors,
+            "HEALTHCARE" => Self::Healthcare,
+            "HUMAN_RESOURCES" => Self::HumanResources,
+            "INSTALLATION_MAINTENANCE_AND_REPAIR" => Self::InstallationMaintenanceAndRepair,
+            "LEGAL" => Self::Legal,
+            "MANAGEMENT" => Self::Management,
+            "MANUFACTURING_AND_WAREHOUSE" => Self::ManufacturingAndWarehouse,
+            "MEDIA_COMMUNICATIONS_AND_WRITING" => Self::MediaCommunicationsAndWriting,
+            "OIL_GAS_AND_MINING" => Self::OilGasAndMining,
+            "PERSONAL_CARE_AND_SERVICES" => Self::PersonalCareAndServices,
+            "PROTECTIVE_SERVICES" => Self::ProtectiveServices,
+            "REAL_ESTATE" => Self::RealEstate,
+            "RESTAURANT_AND_HOSPITALITY" => Self::RestaurantAndHospitality,
+            "SALES_AND_RETAIL" => Self::SalesAndRetail,
+            "SCIENCE_AND_ENGINEERING" => Self::ScienceAndEngineering,
+            "SOCIAL_SERVICES_AND_NON_PROFIT" => Self::SocialServicesAndNonProfit,
+            "SPORTS_FITNESS_AND_RECREATION" => Self::SportsFitnessAndRecreation,
+            "TRANSPORTATION_AND_LOGISTICS" => Self::TransportationAndLogistics,
+            _ => Self::UnknownValue(job_category::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for JobCategory {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::AccountingAndFinance => serializer.serialize_i32(1),
+            Self::AdministrativeAndOffice => serializer.serialize_i32(2),
+            Self::AdvertisingAndMarketing => serializer.serialize_i32(3),
+            Self::AnimalCare => serializer.serialize_i32(4),
+            Self::ArtFashionAndDesign => serializer.serialize_i32(5),
+            Self::BusinessOperations => serializer.serialize_i32(6),
+            Self::CleaningAndFacilities => serializer.serialize_i32(7),
+            Self::ComputerAndIt => serializer.serialize_i32(8),
+            Self::Construction => serializer.serialize_i32(9),
+            Self::CustomerService => serializer.serialize_i32(10),
+            Self::Education => serializer.serialize_i32(11),
+            Self::EntertainmentAndTravel => serializer.serialize_i32(12),
+            Self::FarmingAndOutdoors => serializer.serialize_i32(13),
+            Self::Healthcare => serializer.serialize_i32(14),
+            Self::HumanResources => serializer.serialize_i32(15),
+            Self::InstallationMaintenanceAndRepair => serializer.serialize_i32(16),
+            Self::Legal => serializer.serialize_i32(17),
+            Self::Management => serializer.serialize_i32(18),
+            Self::ManufacturingAndWarehouse => serializer.serialize_i32(19),
+            Self::MediaCommunicationsAndWriting => serializer.serialize_i32(20),
+            Self::OilGasAndMining => serializer.serialize_i32(21),
+            Self::PersonalCareAndServices => serializer.serialize_i32(22),
+            Self::ProtectiveServices => serializer.serialize_i32(23),
+            Self::RealEstate => serializer.serialize_i32(24),
+            Self::RestaurantAndHospitality => serializer.serialize_i32(25),
+            Self::SalesAndRetail => serializer.serialize_i32(26),
+            Self::ScienceAndEngineering => serializer.serialize_i32(27),
+            Self::SocialServicesAndNonProfit => serializer.serialize_i32(28),
+            Self::SportsFitnessAndRecreation => serializer.serialize_i32(29),
+            Self::TransportationAndLogistics => serializer.serialize_i32(30),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for JobCategory {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobCategory>::new(
+            ".google.cloud.talent.v4.JobCategory",
+        ))
     }
 }
 
 /// An enum that represents the job posting region. In most cases, job postings
 /// don't need to specify a region. If a region is given, jobs are
 /// eligible for searches in the specified region.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PostingRegion(i32);
-
-impl PostingRegion {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PostingRegion {
     /// If the region is unspecified, the job is only returned if it
     /// matches the [LocationFilter][google.cloud.talent.v4.LocationFilter].
     ///
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
-    pub const POSTING_REGION_UNSPECIFIED: PostingRegion = PostingRegion::new(0);
-
+    Unspecified,
     /// In addition to exact location matching, job posting is returned when the
     /// [LocationFilter][google.cloud.talent.v4.LocationFilter] in the search query
     /// is in the same administrative area as the returned job posting. For
@@ -8186,8 +9708,7 @@ impl PostingRegion {
     /// JP prefecture.
     ///
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
-    pub const ADMINISTRATIVE_AREA: PostingRegion = PostingRegion::new(1);
-
+    AdministrativeArea,
     /// In addition to exact location matching, job is returned when
     /// [LocationFilter][google.cloud.talent.v4.LocationFilter] in search query is
     /// in the same country as this job. For example, if a `NATION_WIDE` job is
@@ -8196,264 +9717,513 @@ impl PostingRegion {
     /// View'.
     ///
     /// [google.cloud.talent.v4.LocationFilter]: crate::model::LocationFilter
-    pub const NATION: PostingRegion = PostingRegion::new(2);
-
+    Nation,
     /// Job allows employees to work remotely (telecommute).
     /// If locations are provided with this value, the job is
     /// considered as having a location, but telecommuting is allowed.
-    pub const TELECOMMUTE: PostingRegion = PostingRegion::new(3);
+    Telecommute,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PostingRegion::value] or
+    /// [PostingRegion::name].
+    UnknownValue(posting_region::UnknownValue),
+}
 
-    /// Creates a new PostingRegion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod posting_region {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl PostingRegion {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::AdministrativeArea => std::option::Option::Some(1),
+            Self::Nation => std::option::Option::Some(2),
+            Self::Telecommute => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("POSTING_REGION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ADMINISTRATIVE_AREA"),
-            2 => std::borrow::Cow::Borrowed("NATION"),
-            3 => std::borrow::Cow::Borrowed("TELECOMMUTE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("POSTING_REGION_UNSPECIFIED"),
+            Self::AdministrativeArea => std::option::Option::Some("ADMINISTRATIVE_AREA"),
+            Self::Nation => std::option::Option::Some("NATION"),
+            Self::Telecommute => std::option::Option::Some("TELECOMMUTE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "POSTING_REGION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::POSTING_REGION_UNSPECIFIED)
-            }
-            "ADMINISTRATIVE_AREA" => std::option::Option::Some(Self::ADMINISTRATIVE_AREA),
-            "NATION" => std::option::Option::Some(Self::NATION),
-            "TELECOMMUTE" => std::option::Option::Some(Self::TELECOMMUTE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PostingRegion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PostingRegion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PostingRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PostingRegion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::AdministrativeArea,
+            2 => Self::Nation,
+            3 => Self::Telecommute,
+            _ => Self::UnknownValue(posting_region::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PostingRegion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "POSTING_REGION_UNSPECIFIED" => Self::Unspecified,
+            "ADMINISTRATIVE_AREA" => Self::AdministrativeArea,
+            "NATION" => Self::Nation,
+            "TELECOMMUTE" => Self::Telecommute,
+            _ => Self::UnknownValue(posting_region::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PostingRegion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::AdministrativeArea => serializer.serialize_i32(1),
+            Self::Nation => serializer.serialize_i32(2),
+            Self::Telecommute => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PostingRegion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PostingRegion>::new(
+            ".google.cloud.talent.v4.PostingRegion",
+        ))
     }
 }
 
 /// Deprecated. All resources are only visible to the owner.
 ///
 /// An enum that represents who has view access to the resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Visibility(i32);
-
-impl Visibility {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Visibility {
     /// Default value.
-    pub const VISIBILITY_UNSPECIFIED: Visibility = Visibility::new(0);
-
+    Unspecified,
     /// The resource is only visible to the GCP account who owns it.
-    pub const ACCOUNT_ONLY: Visibility = Visibility::new(1);
-
+    AccountOnly,
     /// The resource is visible to the owner and may be visible to other
     /// applications and processes at Google.
-    pub const SHARED_WITH_GOOGLE: Visibility = Visibility::new(2);
-
+    SharedWithGoogle,
     /// The resource is visible to the owner and may be visible to all other API
     /// clients.
-    pub const SHARED_WITH_PUBLIC: Visibility = Visibility::new(3);
+    SharedWithPublic,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Visibility::value] or
+    /// [Visibility::name].
+    UnknownValue(visibility::UnknownValue),
+}
 
-    /// Creates a new Visibility instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod visibility {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl Visibility {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::AccountOnly => std::option::Option::Some(1),
+            Self::SharedWithGoogle => std::option::Option::Some(2),
+            Self::SharedWithPublic => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VISIBILITY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACCOUNT_ONLY"),
-            2 => std::borrow::Cow::Borrowed("SHARED_WITH_GOOGLE"),
-            3 => std::borrow::Cow::Borrowed("SHARED_WITH_PUBLIC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VISIBILITY_UNSPECIFIED"),
+            Self::AccountOnly => std::option::Option::Some("ACCOUNT_ONLY"),
+            Self::SharedWithGoogle => std::option::Option::Some("SHARED_WITH_GOOGLE"),
+            Self::SharedWithPublic => std::option::Option::Some("SHARED_WITH_PUBLIC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VISIBILITY_UNSPECIFIED" => std::option::Option::Some(Self::VISIBILITY_UNSPECIFIED),
-            "ACCOUNT_ONLY" => std::option::Option::Some(Self::ACCOUNT_ONLY),
-            "SHARED_WITH_GOOGLE" => std::option::Option::Some(Self::SHARED_WITH_GOOGLE),
-            "SHARED_WITH_PUBLIC" => std::option::Option::Some(Self::SHARED_WITH_PUBLIC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Visibility {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Visibility {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Visibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Visibility {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::AccountOnly,
+            2 => Self::SharedWithGoogle,
+            3 => Self::SharedWithPublic,
+            _ => Self::UnknownValue(visibility::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Visibility {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VISIBILITY_UNSPECIFIED" => Self::Unspecified,
+            "ACCOUNT_ONLY" => Self::AccountOnly,
+            "SHARED_WITH_GOOGLE" => Self::SharedWithGoogle,
+            "SHARED_WITH_PUBLIC" => Self::SharedWithPublic,
+            _ => Self::UnknownValue(visibility::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Visibility {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::AccountOnly => serializer.serialize_i32(1),
+            Self::SharedWithGoogle => serializer.serialize_i32(2),
+            Self::SharedWithPublic => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Visibility {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Visibility>::new(
+            ".google.cloud.talent.v4.Visibility",
+        ))
     }
 }
 
 /// Option for HTML content sanitization on user input fields, for example, job
 /// description. By setting this option, user can determine whether and how
 /// sanitization is performed on these fields.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HtmlSanitization(i32);
-
-impl HtmlSanitization {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HtmlSanitization {
     /// Default value.
-    pub const HTML_SANITIZATION_UNSPECIFIED: HtmlSanitization = HtmlSanitization::new(0);
-
+    Unspecified,
     /// Disables sanitization on HTML input.
-    pub const HTML_SANITIZATION_DISABLED: HtmlSanitization = HtmlSanitization::new(1);
-
+    Disabled,
     /// Sanitizes HTML input, only accepts bold, italic, ordered list, and
     /// unordered list markup tags.
-    pub const SIMPLE_FORMATTING_ONLY: HtmlSanitization = HtmlSanitization::new(2);
+    SimpleFormattingOnly,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HtmlSanitization::value] or
+    /// [HtmlSanitization::name].
+    UnknownValue(html_sanitization::UnknownValue),
+}
 
-    /// Creates a new HtmlSanitization instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod html_sanitization {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl HtmlSanitization {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Disabled => std::option::Option::Some(1),
+            Self::SimpleFormattingOnly => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HTML_SANITIZATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HTML_SANITIZATION_DISABLED"),
-            2 => std::borrow::Cow::Borrowed("SIMPLE_FORMATTING_ONLY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HTML_SANITIZATION_UNSPECIFIED"),
+            Self::Disabled => std::option::Option::Some("HTML_SANITIZATION_DISABLED"),
+            Self::SimpleFormattingOnly => std::option::Option::Some("SIMPLE_FORMATTING_ONLY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HTML_SANITIZATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::HTML_SANITIZATION_UNSPECIFIED)
-            }
-            "HTML_SANITIZATION_DISABLED" => {
-                std::option::Option::Some(Self::HTML_SANITIZATION_DISABLED)
-            }
-            "SIMPLE_FORMATTING_ONLY" => std::option::Option::Some(Self::SIMPLE_FORMATTING_ONLY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HtmlSanitization {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HtmlSanitization {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HtmlSanitization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HtmlSanitization {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Disabled,
+            2 => Self::SimpleFormattingOnly,
+            _ => Self::UnknownValue(html_sanitization::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HtmlSanitization {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HTML_SANITIZATION_UNSPECIFIED" => Self::Unspecified,
+            "HTML_SANITIZATION_DISABLED" => Self::Disabled,
+            "SIMPLE_FORMATTING_ONLY" => Self::SimpleFormattingOnly,
+            _ => Self::UnknownValue(html_sanitization::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HtmlSanitization {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Disabled => serializer.serialize_i32(1),
+            Self::SimpleFormattingOnly => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HtmlSanitization {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HtmlSanitization>::new(
+            ".google.cloud.talent.v4.HtmlSanitization",
+        ))
     }
 }
 
 /// Method for commute. Walking, biking and wheelchair accessible transit is
 /// still in the Preview stage.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CommuteMethod(i32);
-
-impl CommuteMethod {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CommuteMethod {
     /// Commute method isn't specified.
-    pub const COMMUTE_METHOD_UNSPECIFIED: CommuteMethod = CommuteMethod::new(0);
-
+    Unspecified,
     /// Commute time is calculated based on driving time.
-    pub const DRIVING: CommuteMethod = CommuteMethod::new(1);
-
+    Driving,
     /// Commute time is calculated based on public transit including bus, metro,
     /// subway, and so on.
-    pub const TRANSIT: CommuteMethod = CommuteMethod::new(2);
-
+    Transit,
     /// Commute time is calculated based on walking time.
-    pub const WALKING: CommuteMethod = CommuteMethod::new(3);
-
+    Walking,
     /// Commute time is calculated based on biking time.
-    pub const CYCLING: CommuteMethod = CommuteMethod::new(4);
-
+    Cycling,
     /// Commute time is calculated based on public transit that is wheelchair
     /// accessible.
-    pub const TRANSIT_ACCESSIBLE: CommuteMethod = CommuteMethod::new(5);
+    TransitAccessible,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CommuteMethod::value] or
+    /// [CommuteMethod::name].
+    UnknownValue(commute_method::UnknownValue),
+}
 
-    /// Creates a new CommuteMethod instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod commute_method {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl CommuteMethod {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Driving => std::option::Option::Some(1),
+            Self::Transit => std::option::Option::Some(2),
+            Self::Walking => std::option::Option::Some(3),
+            Self::Cycling => std::option::Option::Some(4),
+            Self::TransitAccessible => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMMUTE_METHOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DRIVING"),
-            2 => std::borrow::Cow::Borrowed("TRANSIT"),
-            3 => std::borrow::Cow::Borrowed("WALKING"),
-            4 => std::borrow::Cow::Borrowed("CYCLING"),
-            5 => std::borrow::Cow::Borrowed("TRANSIT_ACCESSIBLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMMUTE_METHOD_UNSPECIFIED"),
+            Self::Driving => std::option::Option::Some("DRIVING"),
+            Self::Transit => std::option::Option::Some("TRANSIT"),
+            Self::Walking => std::option::Option::Some("WALKING"),
+            Self::Cycling => std::option::Option::Some("CYCLING"),
+            Self::TransitAccessible => std::option::Option::Some("TRANSIT_ACCESSIBLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMMUTE_METHOD_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMMUTE_METHOD_UNSPECIFIED)
-            }
-            "DRIVING" => std::option::Option::Some(Self::DRIVING),
-            "TRANSIT" => std::option::Option::Some(Self::TRANSIT),
-            "WALKING" => std::option::Option::Some(Self::WALKING),
-            "CYCLING" => std::option::Option::Some(Self::CYCLING),
-            "TRANSIT_ACCESSIBLE" => std::option::Option::Some(Self::TRANSIT_ACCESSIBLE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CommuteMethod {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CommuteMethod {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CommuteMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CommuteMethod {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Driving,
+            2 => Self::Transit,
+            3 => Self::Walking,
+            4 => Self::Cycling,
+            5 => Self::TransitAccessible,
+            _ => Self::UnknownValue(commute_method::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CommuteMethod {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMMUTE_METHOD_UNSPECIFIED" => Self::Unspecified,
+            "DRIVING" => Self::Driving,
+            "TRANSIT" => Self::Transit,
+            "WALKING" => Self::Walking,
+            "CYCLING" => Self::Cycling,
+            "TRANSIT_ACCESSIBLE" => Self::TransitAccessible,
+            _ => Self::UnknownValue(commute_method::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CommuteMethod {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Driving => serializer.serialize_i32(1),
+            Self::Transit => serializer.serialize_i32(2),
+            Self::Walking => serializer.serialize_i32(3),
+            Self::Cycling => serializer.serialize_i32(4),
+            Self::TransitAccessible => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CommuteMethod {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommuteMethod>::new(
+            ".google.cloud.talent.v4.CommuteMethod",
+        ))
     }
 }
 
@@ -8464,13 +10234,11 @@ impl std::default::Default for CommuteMethod {
 ///
 /// [google.cloud.talent.v4.ListJobsResponse.jobs]: crate::model::ListJobsResponse::jobs
 /// [google.cloud.talent.v4.SearchJobsResponse.MatchingJob.job]: crate::model::search_jobs_response::MatchingJob::job
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct JobView(i32);
-
-impl JobView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum JobView {
     /// Default value.
-    pub const JOB_VIEW_UNSPECIFIED: JobView = JobView::new(0);
-
+    Unspecified,
     /// A ID only view of job, with following attributes:
     /// [Job.name][google.cloud.talent.v4.Job.name],
     /// [Job.requisition_id][google.cloud.talent.v4.Job.requisition_id],
@@ -8479,8 +10247,7 @@ impl JobView {
     /// [google.cloud.talent.v4.Job.language_code]: crate::model::Job::language_code
     /// [google.cloud.talent.v4.Job.name]: crate::model::Job::name
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
-    pub const JOB_VIEW_ID_ONLY: JobView = JobView::new(1);
-
+    IdOnly,
     /// A minimal view of the job, with the following attributes:
     /// [Job.name][google.cloud.talent.v4.Job.name],
     /// [Job.requisition_id][google.cloud.talent.v4.Job.requisition_id],
@@ -8495,8 +10262,7 @@ impl JobView {
     /// [google.cloud.talent.v4.Job.name]: crate::model::Job::name
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
     /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
-    pub const JOB_VIEW_MINIMAL: JobView = JobView::new(2);
-
+    Minimal,
     /// A small view of the job, with the following attributes in the search
     /// results: [Job.name][google.cloud.talent.v4.Job.name],
     /// [Job.requisition_id][google.cloud.talent.v4.Job.requisition_id],
@@ -8515,54 +10281,123 @@ impl JobView {
     /// [google.cloud.talent.v4.Job.requisition_id]: crate::model::Job::requisition_id
     /// [google.cloud.talent.v4.Job.title]: crate::model::Job::title
     /// [google.cloud.talent.v4.Job.visibility]: crate::model::Job::visibility
-    pub const JOB_VIEW_SMALL: JobView = JobView::new(3);
-
+    Small,
     /// All available attributes are included in the search results.
-    pub const JOB_VIEW_FULL: JobView = JobView::new(4);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [JobView::value] or
+    /// [JobView::name].
+    UnknownValue(job_view::UnknownValue),
+}
 
-    /// Creates a new JobView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod job_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl JobView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::IdOnly => std::option::Option::Some(1),
+            Self::Minimal => std::option::Option::Some(2),
+            Self::Small => std::option::Option::Some(3),
+            Self::Full => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("JOB_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("JOB_VIEW_ID_ONLY"),
-            2 => std::borrow::Cow::Borrowed("JOB_VIEW_MINIMAL"),
-            3 => std::borrow::Cow::Borrowed("JOB_VIEW_SMALL"),
-            4 => std::borrow::Cow::Borrowed("JOB_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("JOB_VIEW_UNSPECIFIED"),
+            Self::IdOnly => std::option::Option::Some("JOB_VIEW_ID_ONLY"),
+            Self::Minimal => std::option::Option::Some("JOB_VIEW_MINIMAL"),
+            Self::Small => std::option::Option::Some("JOB_VIEW_SMALL"),
+            Self::Full => std::option::Option::Some("JOB_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "JOB_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::JOB_VIEW_UNSPECIFIED),
-            "JOB_VIEW_ID_ONLY" => std::option::Option::Some(Self::JOB_VIEW_ID_ONLY),
-            "JOB_VIEW_MINIMAL" => std::option::Option::Some(Self::JOB_VIEW_MINIMAL),
-            "JOB_VIEW_SMALL" => std::option::Option::Some(Self::JOB_VIEW_SMALL),
-            "JOB_VIEW_FULL" => std::option::Option::Some(Self::JOB_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for JobView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for JobView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for JobView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for JobView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::IdOnly,
+            2 => Self::Minimal,
+            3 => Self::Small,
+            4 => Self::Full,
+            _ => Self::UnknownValue(job_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for JobView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "JOB_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "JOB_VIEW_ID_ONLY" => Self::IdOnly,
+            "JOB_VIEW_MINIMAL" => Self::Minimal,
+            "JOB_VIEW_SMALL" => Self::Small,
+            "JOB_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(job_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for JobView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::IdOnly => serializer.serialize_i32(1),
+            Self::Minimal => serializer.serialize_i32(2),
+            Self::Small => serializer.serialize_i32(3),
+            Self::Full => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for JobView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobView>::new(
+            ".google.cloud.talent.v4.JobView",
+        ))
     }
 }

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -229,8 +229,8 @@ impl super::stub::Completion for Completion {
             .fold(builder, |builder, p| builder.query(&[("languageCodes", p)]));
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("company", &req.company)]);
-        let builder = builder.query(&[("scope", &req.scope.value())]);
-        let builder = builder.query(&[("type", &req.r#type.value())]);
+        let builder = builder.query(&[("scope", &req.scope)]);
+        let builder = builder.query(&[("type", &req.r#type)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -510,7 +510,7 @@ impl super::stub::JobService for JobService {
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
-        let builder = builder.query(&[("jobView", &req.job_view.value())]);
+        let builder = builder.query(&[("jobView", &req.job_view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/tasks/v2/src/client.rs
+++ b/src/generated/cloud/tasks/v2/src/client.rs
@@ -222,7 +222,7 @@ impl CloudTasks {
     /// [PAUSED][google.cloud.tasks.v2.Queue.State.PAUSED].
     ///
     /// [google.cloud.tasks.v2.CloudTasks.ResumeQueue]: crate::client::CloudTasks::resume_queue
-    /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::state::PAUSED
+    /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
     /// [google.cloud.tasks.v2.Queue.state]: crate::model::Queue::state
     pub fn pause_queue(
         &self,
@@ -246,9 +246,9 @@ impl CloudTasks {
     /// [Managing Cloud Tasks Scaling
     /// Risks](https://cloud.google.com/tasks/docs/manage-cloud-task-scaling).
     ///
-    /// [google.cloud.tasks.v2.Queue.State.DISABLED]: crate::model::queue::state::DISABLED
-    /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::state::PAUSED
-    /// [google.cloud.tasks.v2.Queue.State.RUNNING]: crate::model::queue::state::RUNNING
+    /// [google.cloud.tasks.v2.Queue.State.DISABLED]: crate::model::queue::State::Disabled
+    /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
+    /// [google.cloud.tasks.v2.Queue.State.RUNNING]: crate::model::queue::State::Running
     /// [google.cloud.tasks.v2.Queue.state]: crate::model::Queue::state
     pub fn resume_queue(
         &self,
@@ -326,7 +326,7 @@ impl CloudTasks {
     /// time.
     ///
     /// [google.cloud.tasks.v2.ListTasksRequest.response_view]: crate::model::ListTasksRequest::response_view
-    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::view::BASIC
+    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::View::Basic
     pub fn list_tasks(
         &self,
         parent: impl Into<std::string::String>,
@@ -394,7 +394,7 @@ impl CloudTasks {
     /// task that has already succeeded or permanently failed.
     ///
     /// [google.cloud.tasks.v2.CloudTasks.RunTask]: crate::client::CloudTasks::run_task
-    /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::state::PAUSED
+    /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
     /// [google.cloud.tasks.v2.RateLimits]: crate::model::RateLimits
     /// [google.cloud.tasks.v2.RetryConfig]: crate::model::RetryConfig
     /// [google.cloud.tasks.v2.Task.schedule_time]: crate::model::Task::schedule_time

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -532,8 +532,8 @@ pub struct ListTasksRequest {
     /// permission on the [Task][google.cloud.tasks.v2.Task] resource.
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
-    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::view::BASIC
-    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::view::FULL
+    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::View::Basic
+    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::View::Full
     pub response_view: crate::model::task::View,
 
     /// Maximum page size.
@@ -708,8 +708,8 @@ pub struct GetTaskRequest {
     /// permission on the [Task][google.cloud.tasks.v2.Task] resource.
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
-    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::view::BASIC
-    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::view::FULL
+    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::View::Basic
+    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::View::Full
     pub response_view: crate::model::task::View,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -813,8 +813,8 @@ pub struct CreateTaskRequest {
     /// permission on the [Task][google.cloud.tasks.v2.Task] resource.
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
-    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::view::BASIC
-    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::view::FULL
+    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::View::Basic
+    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::View::Full
     pub response_view: crate::model::task::View,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -921,8 +921,8 @@ pub struct RunTaskRequest {
     /// permission on the [Task][google.cloud.tasks.v2.Task] resource.
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
-    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::view::BASIC
-    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::view::FULL
+    /// [google.cloud.tasks.v2.Task.View.BASIC]: crate::model::task::View::Basic
+    /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::View::Full
     pub response_view: crate::model::task::View,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1178,13 +1178,11 @@ pub mod queue {
     use super::*;
 
     /// State of the queue.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The queue is running. Tasks can be dispatched.
         ///
         /// If the queue was created using Cloud Tasks and the queue has
@@ -1193,13 +1191,11 @@ pub mod queue {
         /// calls may return [NOT_FOUND][google.rpc.Code.NOT_FOUND] and
         /// tasks may not be dispatched for a few minutes until the queue
         /// has been re-activated.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// Tasks are paused by the user. If the queue is paused then Cloud
         /// Tasks will stop delivering tasks from it, but more tasks can
         /// still be added to it by the user.
-        pub const PAUSED: State = State::new(2);
-
+        Paused,
         /// The queue is disabled.
         ///
         /// A queue becomes `DISABLED` when
@@ -1216,50 +1212,117 @@ pub mod queue {
         /// [DeleteQueue][google.cloud.tasks.v2.CloudTasks.DeleteQueue].
         ///
         /// [google.cloud.tasks.v2.CloudTasks.DeleteQueue]: crate::client::CloudTasks::delete_queue
-        pub const DISABLED: State = State::new(3);
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Disabled => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Paused,
+                3 => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "PAUSED" => Self::Paused,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Disabled => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.tasks.v2.Queue.State",
+            ))
         }
     }
 }
@@ -2649,13 +2712,11 @@ pub mod task {
     /// contains.
     ///
     /// [google.cloud.tasks.v2.Task]: crate::model::Task
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct View(i32);
-
-    impl View {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum View {
         /// Unspecified. Defaults to BASIC.
-        pub const VIEW_UNSPECIFIED: View = View::new(0);
-
+        Unspecified,
         /// The basic view omits fields which can be large or can contain
         /// sensitive data.
         ///
@@ -2667,8 +2728,7 @@ pub mod task {
         /// choose to store in it.
         ///
         /// [google.cloud.tasks.v2.AppEngineHttpRequest.body]: crate::model::AppEngineHttpRequest::body
-        pub const BASIC: View = View::new(1);
-
+        Basic,
         /// All information is returned.
         ///
         /// Authorization for [FULL][google.cloud.tasks.v2.Task.View.FULL] requires
@@ -2676,49 +2736,113 @@ pub mod task {
         /// permission on the [Queue][google.cloud.tasks.v2.Queue] resource.
         ///
         /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
-        /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::view::FULL
-        pub const FULL: View = View::new(2);
+        /// [google.cloud.tasks.v2.Task.View.FULL]: crate::model::task::View::Full
+        Full,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [View::value] or
+        /// [View::name].
+        UnknownValue(view::UnknownValue),
+    }
 
-        /// Creates a new View instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl View {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Basic => std::option::Option::Some(1),
+                Self::Full => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VIEW_UNSPECIFIED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for View {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for View {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for View {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for View {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Basic,
+                2 => Self::Full,
+                _ => Self::UnknownValue(view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for View {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VIEW_UNSPECIFIED" => Self::Unspecified,
+                "BASIC" => Self::Basic,
+                "FULL" => Self::Full,
+                _ => Self::UnknownValue(view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for View {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Basic => serializer.serialize_i32(1),
+                Self::Full => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for View {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<View>::new(
+                ".google.cloud.tasks.v2.Task.View",
+            ))
         }
     }
 
@@ -2828,83 +2952,154 @@ impl wkt::message::Message for Attempt {
 }
 
 /// The HTTP method used to deliver the task.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct HttpMethod(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum HttpMethod {
+    /// HTTP method unspecified
+    Unspecified,
+    /// HTTP POST
+    Post,
+    /// HTTP GET
+    Get,
+    /// HTTP HEAD
+    Head,
+    /// HTTP PUT
+    Put,
+    /// HTTP DELETE
+    Delete,
+    /// HTTP PATCH
+    Patch,
+    /// HTTP OPTIONS
+    Options,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [HttpMethod::value] or
+    /// [HttpMethod::name].
+    UnknownValue(http_method::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod http_method {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl HttpMethod {
-    /// HTTP method unspecified
-    pub const HTTP_METHOD_UNSPECIFIED: HttpMethod = HttpMethod::new(0);
-
-    /// HTTP POST
-    pub const POST: HttpMethod = HttpMethod::new(1);
-
-    /// HTTP GET
-    pub const GET: HttpMethod = HttpMethod::new(2);
-
-    /// HTTP HEAD
-    pub const HEAD: HttpMethod = HttpMethod::new(3);
-
-    /// HTTP PUT
-    pub const PUT: HttpMethod = HttpMethod::new(4);
-
-    /// HTTP DELETE
-    pub const DELETE: HttpMethod = HttpMethod::new(5);
-
-    /// HTTP PATCH
-    pub const PATCH: HttpMethod = HttpMethod::new(6);
-
-    /// HTTP OPTIONS
-    pub const OPTIONS: HttpMethod = HttpMethod::new(7);
-
-    /// Creates a new HttpMethod instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Post => std::option::Option::Some(1),
+            Self::Get => std::option::Option::Some(2),
+            Self::Head => std::option::Option::Some(3),
+            Self::Put => std::option::Option::Some(4),
+            Self::Delete => std::option::Option::Some(5),
+            Self::Patch => std::option::Option::Some(6),
+            Self::Options => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("HTTP_METHOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("POST"),
-            2 => std::borrow::Cow::Borrowed("GET"),
-            3 => std::borrow::Cow::Borrowed("HEAD"),
-            4 => std::borrow::Cow::Borrowed("PUT"),
-            5 => std::borrow::Cow::Borrowed("DELETE"),
-            6 => std::borrow::Cow::Borrowed("PATCH"),
-            7 => std::borrow::Cow::Borrowed("OPTIONS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("HTTP_METHOD_UNSPECIFIED"),
+            Self::Post => std::option::Option::Some("POST"),
+            Self::Get => std::option::Option::Some("GET"),
+            Self::Head => std::option::Option::Some("HEAD"),
+            Self::Put => std::option::Option::Some("PUT"),
+            Self::Delete => std::option::Option::Some("DELETE"),
+            Self::Patch => std::option::Option::Some("PATCH"),
+            Self::Options => std::option::Option::Some("OPTIONS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "HTTP_METHOD_UNSPECIFIED" => std::option::Option::Some(Self::HTTP_METHOD_UNSPECIFIED),
-            "POST" => std::option::Option::Some(Self::POST),
-            "GET" => std::option::Option::Some(Self::GET),
-            "HEAD" => std::option::Option::Some(Self::HEAD),
-            "PUT" => std::option::Option::Some(Self::PUT),
-            "DELETE" => std::option::Option::Some(Self::DELETE),
-            "PATCH" => std::option::Option::Some(Self::PATCH),
-            "OPTIONS" => std::option::Option::Some(Self::OPTIONS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for HttpMethod {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for HttpMethod {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for HttpMethod {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Post,
+            2 => Self::Get,
+            3 => Self::Head,
+            4 => Self::Put,
+            5 => Self::Delete,
+            6 => Self::Patch,
+            7 => Self::Options,
+            _ => Self::UnknownValue(http_method::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for HttpMethod {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "HTTP_METHOD_UNSPECIFIED" => Self::Unspecified,
+            "POST" => Self::Post,
+            "GET" => Self::Get,
+            "HEAD" => Self::Head,
+            "PUT" => Self::Put,
+            "DELETE" => Self::Delete,
+            "PATCH" => Self::Patch,
+            "OPTIONS" => Self::Options,
+            _ => Self::UnknownValue(http_method::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for HttpMethod {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Post => serializer.serialize_i32(1),
+            Self::Get => serializer.serialize_i32(2),
+            Self::Head => serializer.serialize_i32(3),
+            Self::Put => serializer.serialize_i32(4),
+            Self::Delete => serializer.serialize_i32(5),
+            Self::Patch => serializer.serialize_i32(6),
+            Self::Options => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for HttpMethod {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<HttpMethod>::new(
+            ".google.cloud.tasks.v2.HttpMethod",
+        ))
     }
 }

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -278,7 +278,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("responseView", &req.response_view.value())]);
+        let builder = builder.query(&[("responseView", &req.response_view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -300,7 +300,7 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("responseView", &req.response_view.value())]);
+        let builder = builder.query(&[("responseView", &req.response_view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -152,70 +152,135 @@ pub mod orchestration_cluster {
     use super::*;
 
     /// Possible states that the Orchestration Cluster can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// OrchestrationCluster is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// OrchestrationCluster has been created and is ready for use.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// OrchestrationCluster is being deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// OrchestrationCluster encountered an error and is in an indeterministic
         /// state. User can still initiate a delete operation on this state.
-        pub const FAILED: State = State::new(4);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.telcoautomation.v1.OrchestrationCluster.State",
+            ))
         }
     }
 }
@@ -352,131 +417,254 @@ pub mod edge_slm {
     use super::*;
 
     /// Possible states of the resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// EdgeSlm is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// EdgeSlm has been created and is ready for use.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// EdgeSlm is being deleted.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// EdgeSlm encountered an error and is in an indeterministic
         /// state. User can still initiate a delete operation on this state.
-        pub const FAILED: State = State::new(4);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.telcoautomation.v1.EdgeSlm.State",
+            ))
         }
     }
 
     /// Workload clusters supported by TNA. New values will be added to the enum
     /// list as TNA adds supports for new workload clusters in future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct WorkloadClusterType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum WorkloadClusterType {
+        /// Unspecified workload cluster.
+        Unspecified,
+        /// Workload cluster is a GDCE cluster.
+        Gdce,
+        /// Workload cluster is a GKE cluster.
+        Gke,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [WorkloadClusterType::value] or
+        /// [WorkloadClusterType::name].
+        UnknownValue(workload_cluster_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod workload_cluster_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl WorkloadClusterType {
-        /// Unspecified workload cluster.
-        pub const WORKLOAD_CLUSTER_TYPE_UNSPECIFIED: WorkloadClusterType =
-            WorkloadClusterType::new(0);
-
-        /// Workload cluster is a GDCE cluster.
-        pub const GDCE: WorkloadClusterType = WorkloadClusterType::new(1);
-
-        /// Workload cluster is a GKE cluster.
-        pub const GKE: WorkloadClusterType = WorkloadClusterType::new(2);
-
-        /// Creates a new WorkloadClusterType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gdce => std::option::Option::Some(1),
+                Self::Gke => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("WORKLOAD_CLUSTER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GDCE"),
-                2 => std::borrow::Cow::Borrowed("GKE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("WORKLOAD_CLUSTER_TYPE_UNSPECIFIED"),
+                Self::Gdce => std::option::Option::Some("GDCE"),
+                Self::Gke => std::option::Option::Some("GKE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "WORKLOAD_CLUSTER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::WORKLOAD_CLUSTER_TYPE_UNSPECIFIED)
-                }
-                "GDCE" => std::option::Option::Some(Self::GDCE),
-                "GKE" => std::option::Option::Some(Self::GKE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for WorkloadClusterType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for WorkloadClusterType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for WorkloadClusterType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for WorkloadClusterType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Gdce,
+                2 => Self::Gke,
+                _ => Self::UnknownValue(workload_cluster_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for WorkloadClusterType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "WORKLOAD_CLUSTER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GDCE" => Self::Gdce,
+                "GKE" => Self::Gke,
+                _ => Self::UnknownValue(workload_cluster_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for WorkloadClusterType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gdce => serializer.serialize_i32(1),
+                Self::Gke => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for WorkloadClusterType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<WorkloadClusterType>::new(
+                ".google.cloud.telcoautomation.v1.EdgeSlm.WorkloadClusterType",
+            ))
         }
     }
 }
@@ -694,72 +882,133 @@ pub mod blueprint {
 
     /// Approval state indicates the state of a Blueprint in its approval
     /// lifecycle.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApprovalState(i32);
-
-    impl ApprovalState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ApprovalState {
         /// Unspecified state.
-        pub const APPROVAL_STATE_UNSPECIFIED: ApprovalState = ApprovalState::new(0);
-
+        Unspecified,
         /// A blueprint starts in DRAFT state once it is created. All edits are made
         /// to the blueprint in DRAFT state.
-        pub const DRAFT: ApprovalState = ApprovalState::new(1);
-
+        Draft,
         /// When the edits are ready for review, blueprint can be proposed and moves
         /// to PROPOSED state. Edits cannot be made to a blueprint in PROPOSED state.
-        pub const PROPOSED: ApprovalState = ApprovalState::new(2);
-
+        Proposed,
         /// When a proposed blueprint is approved, it moves to APPROVED state. A new
         /// revision is committed. The latest committed revision can be used to
         /// create a deployment on Orchestration or Workload Cluster. Edits to an
         /// APPROVED blueprint changes its state back to DRAFT. The last committed
         /// revision of a blueprint represents its latest APPROVED state.
-        pub const APPROVED: ApprovalState = ApprovalState::new(3);
+        Approved,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ApprovalState::value] or
+        /// [ApprovalState::name].
+        UnknownValue(approval_state::UnknownValue),
+    }
 
-        /// Creates a new ApprovalState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod approval_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ApprovalState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Proposed => std::option::Option::Some(2),
+                Self::Approved => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("APPROVAL_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("PROPOSED"),
-                3 => std::borrow::Cow::Borrowed("APPROVED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("APPROVAL_STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Proposed => std::option::Option::Some("PROPOSED"),
+                Self::Approved => std::option::Option::Some("APPROVED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "APPROVAL_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::APPROVAL_STATE_UNSPECIFIED)
-                }
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "PROPOSED" => std::option::Option::Some(Self::PROPOSED),
-                "APPROVED" => std::option::Option::Some(Self::APPROVED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ApprovalState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ApprovalState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ApprovalState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ApprovalState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Proposed,
+                3 => Self::Approved,
+                _ => Self::UnknownValue(approval_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ApprovalState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "APPROVAL_STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "PROPOSED" => Self::Proposed,
+                "APPROVED" => Self::Approved,
+                _ => Self::UnknownValue(approval_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ApprovalState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Proposed => serializer.serialize_i32(2),
+                Self::Approved => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ApprovalState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ApprovalState>::new(
+                ".google.cloud.telcoautomation.v1.Blueprint.ApprovalState",
+            ))
         }
     }
 }
@@ -1077,73 +1326,136 @@ pub mod deployment {
     use super::*;
 
     /// State defines which state the current deployment is in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// A deployment starts in DRAFT state. All edits are made in DRAFT state. A
         /// deployment opened for editing after applying will be in draft state,
         /// while its prevision revision will be its current applied version.
-        pub const DRAFT: State = State::new(1);
-
+        Draft,
         /// This state means that the contents (YAML files containing kubernetes
         /// resources) of the deployment have been applied to an Orchestration or
         /// Workload Cluster. A revision is created when a deployment is applied.
         /// This revision will represent the latest view of what is applied on the
         /// cluster until the deployment is modified and applied again, which will
         /// create a new revision.
-        pub const APPLIED: State = State::new(2);
-
+        Applied,
         /// A deployment in DELETING state has been marked for deletion. Its
         /// deletion status can be queried using `ComputeDeploymentStatus` API. No
         /// updates are allowed to a deployment in DELETING state.
-        pub const DELETING: State = State::new(3);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Applied => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("APPLIED"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Applied => std::option::Option::Some("APPLIED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "APPLIED" => std::option::Option::Some(Self::APPLIED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Applied,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "APPLIED" => Self::Applied,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Applied => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.telcoautomation.v1.Deployment.State",
+            ))
         }
     }
 }
@@ -1231,61 +1543,122 @@ pub mod hydrated_deployment {
     use super::*;
 
     /// State defines which state the current hydrated deployment is in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// A hydrated deployment starts in DRAFT state. All edits are made in DRAFT
         /// state.
-        pub const DRAFT: State = State::new(1);
-
+        Draft,
         /// When the edit is applied, the hydrated deployment moves to APPLIED
         /// state. No changes can be made once a hydrated deployment is applied.
-        pub const APPLIED: State = State::new(2);
+        Applied,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Draft => std::option::Option::Some(1),
+                Self::Applied => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DRAFT"),
-                2 => std::borrow::Cow::Borrowed("APPLIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Draft => std::option::Option::Some("DRAFT"),
+                Self::Applied => std::option::Option::Some("APPLIED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "DRAFT" => std::option::Option::Some(Self::DRAFT),
-                "APPLIED" => std::option::Option::Some(Self::APPLIED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Draft,
+                2 => Self::Applied,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "DRAFT" => Self::Draft,
+                "APPLIED" => Self::Applied,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Draft => serializer.serialize_i32(1),
+                Self::Applied => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.telcoautomation.v1.HydratedDeployment.State",
+            ))
         }
     }
 }
@@ -4862,346 +5235,657 @@ impl wkt::message::Message for WorkloadStatus {
 }
 
 /// BlueprintView defines the type of view of the blueprint.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BlueprintView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BlueprintView {
+    /// Unspecified enum value.
+    Unspecified,
+    /// View which only contains metadata.
+    Basic,
+    /// View which contains metadata and files it encapsulates.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BlueprintView::value] or
+    /// [BlueprintView::name].
+    UnknownValue(blueprint_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod blueprint_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl BlueprintView {
-    /// Unspecified enum value.
-    pub const BLUEPRINT_VIEW_UNSPECIFIED: BlueprintView = BlueprintView::new(0);
-
-    /// View which only contains metadata.
-    pub const BLUEPRINT_VIEW_BASIC: BlueprintView = BlueprintView::new(1);
-
-    /// View which contains metadata and files it encapsulates.
-    pub const BLUEPRINT_VIEW_FULL: BlueprintView = BlueprintView::new(2);
-
-    /// Creates a new BlueprintView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BLUEPRINT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BLUEPRINT_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("BLUEPRINT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BLUEPRINT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BLUEPRINT_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("BLUEPRINT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BLUEPRINT_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::BLUEPRINT_VIEW_UNSPECIFIED)
-            }
-            "BLUEPRINT_VIEW_BASIC" => std::option::Option::Some(Self::BLUEPRINT_VIEW_BASIC),
-            "BLUEPRINT_VIEW_FULL" => std::option::Option::Some(Self::BLUEPRINT_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BlueprintView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BlueprintView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BlueprintView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BlueprintView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(blueprint_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BlueprintView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BLUEPRINT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BLUEPRINT_VIEW_BASIC" => Self::Basic,
+            "BLUEPRINT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(blueprint_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BlueprintView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BlueprintView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BlueprintView>::new(
+            ".google.cloud.telcoautomation.v1.BlueprintView",
+        ))
     }
 }
 
 /// DeploymentView defines the type of view of the deployment.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentView(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DeploymentView {
+    /// Unspecified enum value.
+    Unspecified,
+    /// View which only contains metadata.
+    Basic,
+    /// View which contains metadata and files it encapsulates.
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DeploymentView::value] or
+    /// [DeploymentView::name].
+    UnknownValue(deployment_view::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod deployment_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DeploymentView {
-    /// Unspecified enum value.
-    pub const DEPLOYMENT_VIEW_UNSPECIFIED: DeploymentView = DeploymentView::new(0);
-
-    /// View which only contains metadata.
-    pub const DEPLOYMENT_VIEW_BASIC: DeploymentView = DeploymentView::new(1);
-
-    /// View which contains metadata and files it encapsulates.
-    pub const DEPLOYMENT_VIEW_FULL: DeploymentView = DeploymentView::new(2);
-
-    /// Creates a new DeploymentView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DEPLOYMENT_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("DEPLOYMENT_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DEPLOYMENT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("DEPLOYMENT_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("DEPLOYMENT_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DEPLOYMENT_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DEPLOYMENT_VIEW_UNSPECIFIED)
-            }
-            "DEPLOYMENT_VIEW_BASIC" => std::option::Option::Some(Self::DEPLOYMENT_VIEW_BASIC),
-            "DEPLOYMENT_VIEW_FULL" => std::option::Option::Some(Self::DEPLOYMENT_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DeploymentView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DeploymentView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DeploymentView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(deployment_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DeploymentView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DEPLOYMENT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "DEPLOYMENT_VIEW_BASIC" => Self::Basic,
+            "DEPLOYMENT_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(deployment_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DeploymentView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DeploymentView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeploymentView>::new(
+            ".google.cloud.telcoautomation.v1.DeploymentView",
+        ))
     }
 }
 
 /// Represent type of CR.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ResourceType {
+    /// Unspecified resource type.
+    Unspecified,
+    /// User specified NF Deploy CR.
+    NfDeployResource,
+    /// CRs that are part of a blueprint.
+    DeploymentResource,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ResourceType::value] or
+    /// [ResourceType::name].
+    UnknownValue(resource_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod resource_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ResourceType {
-    /// Unspecified resource type.
-    pub const RESOURCE_TYPE_UNSPECIFIED: ResourceType = ResourceType::new(0);
-
-    /// User specified NF Deploy CR.
-    pub const NF_DEPLOY_RESOURCE: ResourceType = ResourceType::new(1);
-
-    /// CRs that are part of a blueprint.
-    pub const DEPLOYMENT_RESOURCE: ResourceType = ResourceType::new(2);
-
-    /// Creates a new ResourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NfDeployResource => std::option::Option::Some(1),
+            Self::DeploymentResource => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NF_DEPLOY_RESOURCE"),
-            2 => std::borrow::Cow::Borrowed("DEPLOYMENT_RESOURCE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RESOURCE_TYPE_UNSPECIFIED"),
+            Self::NfDeployResource => std::option::Option::Some("NF_DEPLOY_RESOURCE"),
+            Self::DeploymentResource => std::option::Option::Some("DEPLOYMENT_RESOURCE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESOURCE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
-            }
-            "NF_DEPLOY_RESOURCE" => std::option::Option::Some(Self::NF_DEPLOY_RESOURCE),
-            "DEPLOYMENT_RESOURCE" => std::option::Option::Some(Self::DEPLOYMENT_RESOURCE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ResourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ResourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NfDeployResource,
+            2 => Self::DeploymentResource,
+            _ => Self::UnknownValue(resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ResourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "NF_DEPLOY_RESOURCE" => Self::NfDeployResource,
+            "DEPLOYMENT_RESOURCE" => Self::DeploymentResource,
+            _ => Self::UnknownValue(resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ResourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NfDeployResource => serializer.serialize_i32(1),
+            Self::DeploymentResource => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ResourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceType>::new(
+            ".google.cloud.telcoautomation.v1.ResourceType",
+        ))
     }
 }
 
 /// Status of an entity (resource, deployment).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Status(i32);
-
-impl Status {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Status {
     /// Unknown state.
-    pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+    Unspecified,
     /// Under progress.
-    pub const STATUS_IN_PROGRESS: Status = Status::new(1);
-
+    InProgress,
     /// Running and ready to serve traffic.
-    pub const STATUS_ACTIVE: Status = Status::new(2);
-
+    Active,
     /// Failed or stalled.
-    pub const STATUS_FAILED: Status = Status::new(3);
-
+    Failed,
     /// Delete in progress.
-    pub const STATUS_DELETING: Status = Status::new(4);
-
+    Deleting,
     /// Deleted deployment.
-    pub const STATUS_DELETED: Status = Status::new(5);
-
+    Deleted,
     /// NFDeploy specific status. Peering in progress.
-    pub const STATUS_PEERING: Status = Status::new(10);
-
+    Peering,
     /// K8s objects such as NetworkAttachmentDefinition don't have a defined
     /// status.
-    pub const STATUS_NOT_APPLICABLE: Status = Status::new(11);
+    NotApplicable,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Status::value] or
+    /// [Status::name].
+    UnknownValue(status::UnknownValue),
+}
 
-    /// Creates a new Status instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl Status {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::InProgress => std::option::Option::Some(1),
+            Self::Active => std::option::Option::Some(2),
+            Self::Failed => std::option::Option::Some(3),
+            Self::Deleting => std::option::Option::Some(4),
+            Self::Deleted => std::option::Option::Some(5),
+            Self::Peering => std::option::Option::Some(10),
+            Self::NotApplicable => std::option::Option::Some(11),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("STATUS_IN_PROGRESS"),
-            2 => std::borrow::Cow::Borrowed("STATUS_ACTIVE"),
-            3 => std::borrow::Cow::Borrowed("STATUS_FAILED"),
-            4 => std::borrow::Cow::Borrowed("STATUS_DELETING"),
-            5 => std::borrow::Cow::Borrowed("STATUS_DELETED"),
-            10 => std::borrow::Cow::Borrowed("STATUS_PEERING"),
-            11 => std::borrow::Cow::Borrowed("STATUS_NOT_APPLICABLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+            Self::InProgress => std::option::Option::Some("STATUS_IN_PROGRESS"),
+            Self::Active => std::option::Option::Some("STATUS_ACTIVE"),
+            Self::Failed => std::option::Option::Some("STATUS_FAILED"),
+            Self::Deleting => std::option::Option::Some("STATUS_DELETING"),
+            Self::Deleted => std::option::Option::Some("STATUS_DELETED"),
+            Self::Peering => std::option::Option::Some("STATUS_PEERING"),
+            Self::NotApplicable => std::option::Option::Some("STATUS_NOT_APPLICABLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-            "STATUS_IN_PROGRESS" => std::option::Option::Some(Self::STATUS_IN_PROGRESS),
-            "STATUS_ACTIVE" => std::option::Option::Some(Self::STATUS_ACTIVE),
-            "STATUS_FAILED" => std::option::Option::Some(Self::STATUS_FAILED),
-            "STATUS_DELETING" => std::option::Option::Some(Self::STATUS_DELETING),
-            "STATUS_DELETED" => std::option::Option::Some(Self::STATUS_DELETED),
-            "STATUS_PEERING" => std::option::Option::Some(Self::STATUS_PEERING),
-            "STATUS_NOT_APPLICABLE" => std::option::Option::Some(Self::STATUS_NOT_APPLICABLE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Status {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Status {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Status {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::InProgress,
+            2 => Self::Active,
+            3 => Self::Failed,
+            4 => Self::Deleting,
+            5 => Self::Deleted,
+            10 => Self::Peering,
+            11 => Self::NotApplicable,
+            _ => Self::UnknownValue(status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Status {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATUS_UNSPECIFIED" => Self::Unspecified,
+            "STATUS_IN_PROGRESS" => Self::InProgress,
+            "STATUS_ACTIVE" => Self::Active,
+            "STATUS_FAILED" => Self::Failed,
+            "STATUS_DELETING" => Self::Deleting,
+            "STATUS_DELETED" => Self::Deleted,
+            "STATUS_PEERING" => Self::Peering,
+            "STATUS_NOT_APPLICABLE" => Self::NotApplicable,
+            _ => Self::UnknownValue(status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Status {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::InProgress => serializer.serialize_i32(1),
+            Self::Active => serializer.serialize_i32(2),
+            Self::Failed => serializer.serialize_i32(3),
+            Self::Deleting => serializer.serialize_i32(4),
+            Self::Deleted => serializer.serialize_i32(5),
+            Self::Peering => serializer.serialize_i32(10),
+            Self::NotApplicable => serializer.serialize_i32(11),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Status {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+            ".google.cloud.telcoautomation.v1.Status",
+        ))
     }
 }
 
 /// DeploymentLevel of a blueprint signifies where the blueprint will be
 /// applied.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeploymentLevel(i32);
-
-impl DeploymentLevel {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DeploymentLevel {
     /// Default unspecified deployment level.
-    pub const DEPLOYMENT_LEVEL_UNSPECIFIED: DeploymentLevel = DeploymentLevel::new(0);
-
+    Unspecified,
     /// Blueprints at HYDRATION level cannot be used to create a Deployment
     /// (A user cannot manually initate deployment of these blueprints on
     /// orchestration or workload cluster).
     /// These blueprints stay in a user's private catalog and are configured and
     /// deployed by TNA automation.
-    pub const HYDRATION: DeploymentLevel = DeploymentLevel::new(1);
-
+    Hydration,
     /// Blueprints at SINGLE_DEPLOYMENT level can be
     /// a) Modified in private catalog.
     /// b) Used to create a deployment on orchestration cluster by the user, once
     /// approved.
-    pub const SINGLE_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new(2);
-
+    SingleDeployment,
     /// Blueprints at MULTI_DEPLOYMENT level can be
     /// a) Modified in private catalog.
     /// b) Used to create a deployment on orchestration cluster which will create
     /// further hydrated deployments.
-    pub const MULTI_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new(3);
-
+    MultiDeployment,
     /// Blueprints at WORKLOAD_CLUSTER_DEPLOYMENT level can be
     /// a) Modified in private catalog.
     /// b) Used to create a deployment on workload cluster by the user, once
     /// approved.
-    pub const WORKLOAD_CLUSTER_DEPLOYMENT: DeploymentLevel = DeploymentLevel::new(4);
+    WorkloadClusterDeployment,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DeploymentLevel::value] or
+    /// [DeploymentLevel::name].
+    UnknownValue(deployment_level::UnknownValue),
+}
 
-    /// Creates a new DeploymentLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod deployment_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DeploymentLevel {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Hydration => std::option::Option::Some(1),
+            Self::SingleDeployment => std::option::Option::Some(2),
+            Self::MultiDeployment => std::option::Option::Some(3),
+            Self::WorkloadClusterDeployment => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DEPLOYMENT_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("HYDRATION"),
-            2 => std::borrow::Cow::Borrowed("SINGLE_DEPLOYMENT"),
-            3 => std::borrow::Cow::Borrowed("MULTI_DEPLOYMENT"),
-            4 => std::borrow::Cow::Borrowed("WORKLOAD_CLUSTER_DEPLOYMENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DEPLOYMENT_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DEPLOYMENT_LEVEL_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DEPLOYMENT_LEVEL_UNSPECIFIED"),
+            Self::Hydration => std::option::Option::Some("HYDRATION"),
+            Self::SingleDeployment => std::option::Option::Some("SINGLE_DEPLOYMENT"),
+            Self::MultiDeployment => std::option::Option::Some("MULTI_DEPLOYMENT"),
+            Self::WorkloadClusterDeployment => {
+                std::option::Option::Some("WORKLOAD_CLUSTER_DEPLOYMENT")
             }
-            "HYDRATION" => std::option::Option::Some(Self::HYDRATION),
-            "SINGLE_DEPLOYMENT" => std::option::Option::Some(Self::SINGLE_DEPLOYMENT),
-            "MULTI_DEPLOYMENT" => std::option::Option::Some(Self::MULTI_DEPLOYMENT),
-            "WORKLOAD_CLUSTER_DEPLOYMENT" => {
-                std::option::Option::Some(Self::WORKLOAD_CLUSTER_DEPLOYMENT)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for DeploymentLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DeploymentLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DeploymentLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DeploymentLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Hydration,
+            2 => Self::SingleDeployment,
+            3 => Self::MultiDeployment,
+            4 => Self::WorkloadClusterDeployment,
+            _ => Self::UnknownValue(deployment_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DeploymentLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DEPLOYMENT_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "HYDRATION" => Self::Hydration,
+            "SINGLE_DEPLOYMENT" => Self::SingleDeployment,
+            "MULTI_DEPLOYMENT" => Self::MultiDeployment,
+            "WORKLOAD_CLUSTER_DEPLOYMENT" => Self::WorkloadClusterDeployment,
+            _ => Self::UnknownValue(deployment_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DeploymentLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Hydration => serializer.serialize_i32(1),
+            Self::SingleDeployment => serializer.serialize_i32(2),
+            Self::MultiDeployment => serializer.serialize_i32(3),
+            Self::WorkloadClusterDeployment => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DeploymentLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeploymentLevel>::new(
+            ".google.cloud.telcoautomation.v1.DeploymentLevel",
+        ))
     }
 }

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -286,7 +286,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -596,7 +596,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -370,65 +370,122 @@ pub mod custom_pronunciation_params {
     use super::*;
 
     /// The phonetic encoding of the phrase.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PhoneticEncoding(i32);
-
-    impl PhoneticEncoding {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PhoneticEncoding {
         /// Not specified.
-        pub const PHONETIC_ENCODING_UNSPECIFIED: PhoneticEncoding = PhoneticEncoding::new(0);
-
+        Unspecified,
         /// IPA, such as apple -> ˈæpəl.
         /// <https://en.wikipedia.org/wiki/International_Phonetic_Alphabet>
-        pub const PHONETIC_ENCODING_IPA: PhoneticEncoding = PhoneticEncoding::new(1);
-
+        Ipa,
         /// X-SAMPA, such as apple -> "{p@l".
         /// <https://en.wikipedia.org/wiki/X-SAMPA>
-        pub const PHONETIC_ENCODING_X_SAMPA: PhoneticEncoding = PhoneticEncoding::new(2);
+        XSampa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PhoneticEncoding::value] or
+        /// [PhoneticEncoding::name].
+        UnknownValue(phonetic_encoding::UnknownValue),
+    }
 
-        /// Creates a new PhoneticEncoding instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod phonetic_encoding {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PhoneticEncoding {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ipa => std::option::Option::Some(1),
+                Self::XSampa => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PHONETIC_ENCODING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PHONETIC_ENCODING_IPA"),
-                2 => std::borrow::Cow::Borrowed("PHONETIC_ENCODING_X_SAMPA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PHONETIC_ENCODING_UNSPECIFIED"),
+                Self::Ipa => std::option::Option::Some("PHONETIC_ENCODING_IPA"),
+                Self::XSampa => std::option::Option::Some("PHONETIC_ENCODING_X_SAMPA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PHONETIC_ENCODING_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PHONETIC_ENCODING_UNSPECIFIED)
-                }
-                "PHONETIC_ENCODING_IPA" => std::option::Option::Some(Self::PHONETIC_ENCODING_IPA),
-                "PHONETIC_ENCODING_X_SAMPA" => {
-                    std::option::Option::Some(Self::PHONETIC_ENCODING_X_SAMPA)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PhoneticEncoding {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PhoneticEncoding {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PhoneticEncoding {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PhoneticEncoding {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ipa,
+                2 => Self::XSampa,
+                _ => Self::UnknownValue(phonetic_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PhoneticEncoding {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PHONETIC_ENCODING_UNSPECIFIED" => Self::Unspecified,
+                "PHONETIC_ENCODING_IPA" => Self::Ipa,
+                "PHONETIC_ENCODING_X_SAMPA" => Self::XSampa,
+                _ => Self::UnknownValue(phonetic_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PhoneticEncoding {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ipa => serializer.serialize_i32(1),
+                Self::XSampa => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PhoneticEncoding {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PhoneticEncoding>::new(
+                ".google.cloud.texttospeech.v1.CustomPronunciationParams.PhoneticEncoding",
+            ))
         }
     }
 }
@@ -992,64 +1049,123 @@ pub mod custom_voice_params {
 
     /// Deprecated. The usage of the synthesized audio. Usage does not affect
     /// billing.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReportedUsage(i32);
-
-    impl ReportedUsage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReportedUsage {
         /// Request with reported usage unspecified will be rejected.
-        pub const REPORTED_USAGE_UNSPECIFIED: ReportedUsage = ReportedUsage::new(0);
-
+        Unspecified,
         /// For scenarios where the synthesized audio is not downloadable and can
         /// only be used once. For example, real-time request in IVR system.
-        pub const REALTIME: ReportedUsage = ReportedUsage::new(1);
-
+        Realtime,
         /// For scenarios where the synthesized audio is downloadable and can be
         /// reused. For example, the synthesized audio is downloaded, stored in
         /// customer service system and played repeatedly.
-        pub const OFFLINE: ReportedUsage = ReportedUsage::new(2);
+        Offline,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReportedUsage::value] or
+        /// [ReportedUsage::name].
+        UnknownValue(reported_usage::UnknownValue),
+    }
 
-        /// Creates a new ReportedUsage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reported_usage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ReportedUsage {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Realtime => std::option::Option::Some(1),
+                Self::Offline => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REPORTED_USAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REALTIME"),
-                2 => std::borrow::Cow::Borrowed("OFFLINE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REPORTED_USAGE_UNSPECIFIED"),
+                Self::Realtime => std::option::Option::Some("REALTIME"),
+                Self::Offline => std::option::Option::Some("OFFLINE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REPORTED_USAGE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REPORTED_USAGE_UNSPECIFIED)
-                }
-                "REALTIME" => std::option::Option::Some(Self::REALTIME),
-                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReportedUsage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReportedUsage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReportedUsage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReportedUsage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Realtime,
+                2 => Self::Offline,
+                _ => Self::UnknownValue(reported_usage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReportedUsage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REPORTED_USAGE_UNSPECIFIED" => Self::Unspecified,
+                "REALTIME" => Self::Realtime,
+                "OFFLINE" => Self::Offline,
+                _ => Self::UnknownValue(reported_usage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReportedUsage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Realtime => serializer.serialize_i32(1),
+                Self::Offline => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReportedUsage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReportedUsage>::new(
+                ".google.cloud.texttospeech.v1.CustomVoiceParams.ReportedUsage",
+            ))
         }
     }
 }
@@ -1682,158 +1798,286 @@ impl wkt::message::Message for SynthesizeLongAudioMetadata {
 
 /// Gender of the voice as described in
 /// [SSML voice element](https://www.w3.org/TR/speech-synthesis11/#edef_voice).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct SsmlVoiceGender(i32);
-
-impl SsmlVoiceGender {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum SsmlVoiceGender {
     /// An unspecified gender.
     /// In VoiceSelectionParams, this means that the client doesn't care which
     /// gender the selected voice will have. In the Voice field of
     /// ListVoicesResponse, this may mean that the voice doesn't fit any of the
     /// other categories in this enum, or that the gender of the voice isn't known.
-    pub const SSML_VOICE_GENDER_UNSPECIFIED: SsmlVoiceGender = SsmlVoiceGender::new(0);
-
+    Unspecified,
     /// A male voice.
-    pub const MALE: SsmlVoiceGender = SsmlVoiceGender::new(1);
-
+    Male,
     /// A female voice.
-    pub const FEMALE: SsmlVoiceGender = SsmlVoiceGender::new(2);
-
+    Female,
     /// A gender-neutral voice. This voice is not yet supported.
-    pub const NEUTRAL: SsmlVoiceGender = SsmlVoiceGender::new(3);
+    Neutral,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [SsmlVoiceGender::value] or
+    /// [SsmlVoiceGender::name].
+    UnknownValue(ssml_voice_gender::UnknownValue),
+}
 
-    /// Creates a new SsmlVoiceGender instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod ssml_voice_gender {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl SsmlVoiceGender {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Male => std::option::Option::Some(1),
+            Self::Female => std::option::Option::Some(2),
+            Self::Neutral => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SSML_VOICE_GENDER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MALE"),
-            2 => std::borrow::Cow::Borrowed("FEMALE"),
-            3 => std::borrow::Cow::Borrowed("NEUTRAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SSML_VOICE_GENDER_UNSPECIFIED"),
+            Self::Male => std::option::Option::Some("MALE"),
+            Self::Female => std::option::Option::Some("FEMALE"),
+            Self::Neutral => std::option::Option::Some("NEUTRAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SSML_VOICE_GENDER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SSML_VOICE_GENDER_UNSPECIFIED)
-            }
-            "MALE" => std::option::Option::Some(Self::MALE),
-            "FEMALE" => std::option::Option::Some(Self::FEMALE),
-            "NEUTRAL" => std::option::Option::Some(Self::NEUTRAL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for SsmlVoiceGender {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for SsmlVoiceGender {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for SsmlVoiceGender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for SsmlVoiceGender {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Male,
+            2 => Self::Female,
+            3 => Self::Neutral,
+            _ => Self::UnknownValue(ssml_voice_gender::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for SsmlVoiceGender {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SSML_VOICE_GENDER_UNSPECIFIED" => Self::Unspecified,
+            "MALE" => Self::Male,
+            "FEMALE" => Self::Female,
+            "NEUTRAL" => Self::Neutral,
+            _ => Self::UnknownValue(ssml_voice_gender::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for SsmlVoiceGender {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Male => serializer.serialize_i32(1),
+            Self::Female => serializer.serialize_i32(2),
+            Self::Neutral => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for SsmlVoiceGender {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<SsmlVoiceGender>::new(
+            ".google.cloud.texttospeech.v1.SsmlVoiceGender",
+        ))
     }
 }
 
 /// Configuration to set up audio encoder. The encoding determines the output
 /// audio format that we'd like.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AudioEncoding(i32);
-
-impl AudioEncoding {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AudioEncoding {
     /// Not specified. Will return result
     /// [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
-    pub const AUDIO_ENCODING_UNSPECIFIED: AudioEncoding = AudioEncoding::new(0);
-
+    Unspecified,
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Audio content returned as LINEAR16 also contains a WAV header.
-    pub const LINEAR16: AudioEncoding = AudioEncoding::new(1);
-
+    Linear16,
     /// MP3 audio at 32kbps.
-    pub const MP3: AudioEncoding = AudioEncoding::new(2);
-
+    Mp3,
     /// Opus encoded audio wrapped in an ogg container. The result is a
     /// file which can be played natively on Android, and in browsers (at least
     /// Chrome and Firefox). The quality of the encoding is considerably higher
     /// than MP3 while using approximately the same bitrate.
-    pub const OGG_OPUS: AudioEncoding = AudioEncoding::new(3);
-
+    OggOpus,
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
     /// Audio content returned as MULAW also contains a WAV header.
-    pub const MULAW: AudioEncoding = AudioEncoding::new(5);
-
+    Mulaw,
     /// 8-bit samples that compand 14-bit audio samples using G.711 PCMU/A-law.
     /// Audio content returned as ALAW also contains a WAV header.
-    pub const ALAW: AudioEncoding = AudioEncoding::new(6);
-
+    Alaw,
     /// Uncompressed 16-bit signed little-endian samples (Linear PCM).
     /// Note that as opposed to LINEAR16, audio won't be wrapped in a WAV (or
     /// any other) header.
-    pub const PCM: AudioEncoding = AudioEncoding::new(7);
+    Pcm,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AudioEncoding::value] or
+    /// [AudioEncoding::name].
+    UnknownValue(audio_encoding::UnknownValue),
+}
 
-    /// Creates a new AudioEncoding instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod audio_encoding {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AudioEncoding {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linear16 => std::option::Option::Some(1),
+            Self::Mp3 => std::option::Option::Some(2),
+            Self::OggOpus => std::option::Option::Some(3),
+            Self::Mulaw => std::option::Option::Some(5),
+            Self::Alaw => std::option::Option::Some(6),
+            Self::Pcm => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AUDIO_ENCODING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LINEAR16"),
-            2 => std::borrow::Cow::Borrowed("MP3"),
-            3 => std::borrow::Cow::Borrowed("OGG_OPUS"),
-            5 => std::borrow::Cow::Borrowed("MULAW"),
-            6 => std::borrow::Cow::Borrowed("ALAW"),
-            7 => std::borrow::Cow::Borrowed("PCM"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AUDIO_ENCODING_UNSPECIFIED"),
+            Self::Linear16 => std::option::Option::Some("LINEAR16"),
+            Self::Mp3 => std::option::Option::Some("MP3"),
+            Self::OggOpus => std::option::Option::Some("OGG_OPUS"),
+            Self::Mulaw => std::option::Option::Some("MULAW"),
+            Self::Alaw => std::option::Option::Some("ALAW"),
+            Self::Pcm => std::option::Option::Some("PCM"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AUDIO_ENCODING_UNSPECIFIED" => {
-                std::option::Option::Some(Self::AUDIO_ENCODING_UNSPECIFIED)
-            }
-            "LINEAR16" => std::option::Option::Some(Self::LINEAR16),
-            "MP3" => std::option::Option::Some(Self::MP3),
-            "OGG_OPUS" => std::option::Option::Some(Self::OGG_OPUS),
-            "MULAW" => std::option::Option::Some(Self::MULAW),
-            "ALAW" => std::option::Option::Some(Self::ALAW),
-            "PCM" => std::option::Option::Some(Self::PCM),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AudioEncoding {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AudioEncoding {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AudioEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AudioEncoding {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linear16,
+            2 => Self::Mp3,
+            3 => Self::OggOpus,
+            5 => Self::Mulaw,
+            6 => Self::Alaw,
+            7 => Self::Pcm,
+            _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AudioEncoding {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AUDIO_ENCODING_UNSPECIFIED" => Self::Unspecified,
+            "LINEAR16" => Self::Linear16,
+            "MP3" => Self::Mp3,
+            "OGG_OPUS" => Self::OggOpus,
+            "MULAW" => Self::Mulaw,
+            "ALAW" => Self::Alaw,
+            "PCM" => Self::Pcm,
+            _ => Self::UnknownValue(audio_encoding::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AudioEncoding {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linear16 => serializer.serialize_i32(1),
+            Self::Mp3 => serializer.serialize_i32(2),
+            Self::OggOpus => serializer.serialize_i32(3),
+            Self::Mulaw => serializer.serialize_i32(5),
+            Self::Alaw => serializer.serialize_i32(6),
+            Self::Pcm => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AudioEncoding {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AudioEncoding>::new(
+            ".google.cloud.texttospeech.v1.AudioEncoding",
+        ))
     }
 }

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -268,85 +268,156 @@ pub mod data_set {
     use super::*;
 
     /// DataSet state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified / undefined state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Dataset is unknown to the system; we have never seen this dataset before
         /// or we have seen this dataset but have fully GC-ed it.
-        pub const UNKNOWN: State = State::new(1);
-
+        Unknown,
         /// Dataset processing is pending.
-        pub const PENDING: State = State::new(2);
-
+        Pending,
         /// Dataset is loading.
-        pub const LOADING: State = State::new(3);
-
+        Loading,
         /// Dataset is loaded and can be queried.
-        pub const LOADED: State = State::new(4);
-
+        Loaded,
         /// Dataset is unloading.
-        pub const UNLOADING: State = State::new(5);
-
+        Unloading,
         /// Dataset is unloaded and is removed from the system.
-        pub const UNLOADED: State = State::new(6);
-
+        Unloaded,
         /// Dataset processing failed.
-        pub const FAILED: State = State::new(7);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unknown => std::option::Option::Some(1),
+                Self::Pending => std::option::Option::Some(2),
+                Self::Loading => std::option::Option::Some(3),
+                Self::Loaded => std::option::Option::Some(4),
+                Self::Unloading => std::option::Option::Some(5),
+                Self::Unloaded => std::option::Option::Some(6),
+                Self::Failed => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                2 => std::borrow::Cow::Borrowed("PENDING"),
-                3 => std::borrow::Cow::Borrowed("LOADING"),
-                4 => std::borrow::Cow::Borrowed("LOADED"),
-                5 => std::borrow::Cow::Borrowed("UNLOADING"),
-                6 => std::borrow::Cow::Borrowed("UNLOADED"),
-                7 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Loading => std::option::Option::Some("LOADING"),
+                Self::Loaded => std::option::Option::Some("LOADED"),
+                Self::Unloading => std::option::Option::Some("UNLOADING"),
+                Self::Unloaded => std::option::Option::Some("UNLOADED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "LOADING" => std::option::Option::Some(Self::LOADING),
-                "LOADED" => std::option::Option::Some(Self::LOADED),
-                "UNLOADING" => std::option::Option::Some(Self::UNLOADING),
-                "UNLOADED" => std::option::Option::Some(Self::UNLOADED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unknown,
+                2 => Self::Pending,
+                3 => Self::Loading,
+                4 => Self::Loaded,
+                5 => Self::Unloading,
+                6 => Self::Unloaded,
+                7 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN" => Self::Unknown,
+                "PENDING" => Self::Pending,
+                "LOADING" => Self::Loading,
+                "LOADED" => Self::Loaded,
+                "UNLOADING" => Self::Unloading,
+                "UNLOADED" => Self::Unloaded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unknown => serializer.serialize_i32(1),
+                Self::Pending => serializer.serialize_i32(2),
+                Self::Loading => serializer.serialize_i32(3),
+                Self::Loaded => serializer.serialize_i32(4),
+                Self::Unloading => serializer.serialize_i32(5),
+                Self::Unloaded => serializer.serialize_i32(6),
+                Self::Failed => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.timeseriesinsights.v1.DataSet.State",
+            ))
         }
     }
 }
@@ -1137,74 +1208,141 @@ pub mod forecast_params {
     use super::*;
 
     /// A time period of a fixed interval.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Period(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Period {
+        /// Unknown or simply not given.
+        Unspecified,
+        /// 1 hour
+        Hourly,
+        /// 24 hours
+        Daily,
+        /// 7 days
+        Weekly,
+        /// 30 days
+        Monthly,
+        /// 365 days
+        Yearly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Period::value] or
+        /// [Period::name].
+        UnknownValue(period::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod period {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Period {
-        /// Unknown or simply not given.
-        pub const PERIOD_UNSPECIFIED: Period = Period::new(0);
-
-        /// 1 hour
-        pub const HOURLY: Period = Period::new(5);
-
-        /// 24 hours
-        pub const DAILY: Period = Period::new(1);
-
-        /// 7 days
-        pub const WEEKLY: Period = Period::new(2);
-
-        /// 30 days
-        pub const MONTHLY: Period = Period::new(3);
-
-        /// 365 days
-        pub const YEARLY: Period = Period::new(4);
-
-        /// Creates a new Period instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hourly => std::option::Option::Some(5),
+                Self::Daily => std::option::Option::Some(1),
+                Self::Weekly => std::option::Option::Some(2),
+                Self::Monthly => std::option::Option::Some(3),
+                Self::Yearly => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERIOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DAILY"),
-                2 => std::borrow::Cow::Borrowed("WEEKLY"),
-                3 => std::borrow::Cow::Borrowed("MONTHLY"),
-                4 => std::borrow::Cow::Borrowed("YEARLY"),
-                5 => std::borrow::Cow::Borrowed("HOURLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PERIOD_UNSPECIFIED"),
+                Self::Hourly => std::option::Option::Some("HOURLY"),
+                Self::Daily => std::option::Option::Some("DAILY"),
+                Self::Weekly => std::option::Option::Some("WEEKLY"),
+                Self::Monthly => std::option::Option::Some("MONTHLY"),
+                Self::Yearly => std::option::Option::Some("YEARLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERIOD_UNSPECIFIED" => std::option::Option::Some(Self::PERIOD_UNSPECIFIED),
-                "HOURLY" => std::option::Option::Some(Self::HOURLY),
-                "DAILY" => std::option::Option::Some(Self::DAILY),
-                "WEEKLY" => std::option::Option::Some(Self::WEEKLY),
-                "MONTHLY" => std::option::Option::Some(Self::MONTHLY),
-                "YEARLY" => std::option::Option::Some(Self::YEARLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Period {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Period {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Period {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Period {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Daily,
+                2 => Self::Weekly,
+                3 => Self::Monthly,
+                4 => Self::Yearly,
+                5 => Self::Hourly,
+                _ => Self::UnknownValue(period::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Period {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERIOD_UNSPECIFIED" => Self::Unspecified,
+                "HOURLY" => Self::Hourly,
+                "DAILY" => Self::Daily,
+                "WEEKLY" => Self::Weekly,
+                "MONTHLY" => Self::Monthly,
+                "YEARLY" => Self::Yearly,
+                _ => Self::UnknownValue(period::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Period {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hourly => serializer.serialize_i32(5),
+                Self::Daily => serializer.serialize_i32(1),
+                Self::Weekly => serializer.serialize_i32(2),
+                Self::Monthly => serializer.serialize_i32(3),
+                Self::Yearly => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Period {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Period>::new(
+                ".google.cloud.timeseriesinsights.v1.ForecastParams.Period",
+            ))
         }
     }
 }
@@ -1813,67 +1951,126 @@ pub mod timeseries_params {
     /// [metric][google.cloud.timeseriesinsights.v1.TimeseriesParams.metric].
     ///
     /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AggregationMethod(i32);
-
-    impl AggregationMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AggregationMethod {
         /// Unspecified.
-        pub const AGGREGATION_METHOD_UNSPECIFIED: AggregationMethod = AggregationMethod::new(0);
-
+        Unspecified,
         /// Aggregate multiple events by summing up the values found in the
         /// [metric][google.cloud.timeseriesinsights.v1.TimeseriesParams.metric] dimension.
         ///
         /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
-        pub const SUM: AggregationMethod = AggregationMethod::new(1);
-
+        Sum,
         /// Aggregate multiple events by averaging out the values found in the
         /// [metric][google.cloud.timeseriesinsights.v1.TimeseriesParams.metric] dimension.
         ///
         /// [google.cloud.timeseriesinsights.v1.TimeseriesParams.metric]: crate::model::TimeseriesParams::metric
-        pub const AVERAGE: AggregationMethod = AggregationMethod::new(2);
+        Average,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AggregationMethod::value] or
+        /// [AggregationMethod::name].
+        UnknownValue(aggregation_method::UnknownValue),
+    }
 
-        /// Creates a new AggregationMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod aggregation_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AggregationMethod {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Sum => std::option::Option::Some(1),
+                Self::Average => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AGGREGATION_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUM"),
-                2 => std::borrow::Cow::Borrowed("AVERAGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AGGREGATION_METHOD_UNSPECIFIED"),
+                Self::Sum => std::option::Option::Some("SUM"),
+                Self::Average => std::option::Option::Some("AVERAGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AGGREGATION_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AGGREGATION_METHOD_UNSPECIFIED)
-                }
-                "SUM" => std::option::Option::Some(Self::SUM),
-                "AVERAGE" => std::option::Option::Some(Self::AVERAGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AggregationMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AggregationMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AggregationMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AggregationMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Sum,
+                2 => Self::Average,
+                _ => Self::UnknownValue(aggregation_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AggregationMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AGGREGATION_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "SUM" => Self::Sum,
+                "AVERAGE" => Self::Average,
+                _ => Self::UnknownValue(aggregation_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AggregationMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Sum => serializer.serialize_i32(1),
+                Self::Average => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AggregationMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AggregationMethod>::new(
+                ".google.cloud.timeseriesinsights.v1.TimeseriesParams.AggregationMethod",
+            ))
         }
     }
 }

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -227,61 +227,122 @@ pub mod attached_disk {
     use super::*;
 
     /// The different mode of the attached disk.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DiskMode(i32);
-
-    impl DiskMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DiskMode {
         /// The disk mode is not known/set.
-        pub const DISK_MODE_UNSPECIFIED: DiskMode = DiskMode::new(0);
-
+        Unspecified,
         /// Attaches the disk in read-write mode. Only one TPU node can attach a disk
         /// in read-write mode at a time.
-        pub const READ_WRITE: DiskMode = DiskMode::new(1);
-
+        ReadWrite,
         /// Attaches the disk in read-only mode. Multiple TPU nodes can attach
         /// a disk in read-only mode at a time.
-        pub const READ_ONLY: DiskMode = DiskMode::new(2);
+        ReadOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DiskMode::value] or
+        /// [DiskMode::name].
+        UnknownValue(disk_mode::UnknownValue),
+    }
 
-        /// Creates a new DiskMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod disk_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DiskMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ReadWrite => std::option::Option::Some(1),
+                Self::ReadOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISK_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                2 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISK_MODE_UNSPECIFIED"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISK_MODE_UNSPECIFIED" => std::option::Option::Some(Self::DISK_MODE_UNSPECIFIED),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DiskMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DiskMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DiskMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DiskMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ReadWrite,
+                2 => Self::ReadOnly,
+                _ => Self::UnknownValue(disk_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DiskMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISK_MODE_UNSPECIFIED" => Self::Unspecified,
+                "READ_WRITE" => Self::ReadWrite,
+                "READ_ONLY" => Self::ReadOnly,
+                _ => Self::UnknownValue(disk_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DiskMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ReadWrite => serializer.serialize_i32(1),
+                Self::ReadOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DiskMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DiskMode>::new(
+                ".google.cloud.tpu.v2.AttachedDisk.DiskMode",
+            ))
         }
     }
 }
@@ -925,264 +986,479 @@ pub mod node {
     use super::*;
 
     /// Represents the different states of a TPU node during its lifecycle.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// TPU node state is not known/set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// TPU node is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// TPU node has been created.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// TPU node is restarting.
-        pub const RESTARTING: State = State::new(3);
-
+        Restarting,
         /// TPU node is undergoing reimaging.
-        pub const REIMAGING: State = State::new(4);
-
+        Reimaging,
         /// TPU node is being deleted.
-        pub const DELETING: State = State::new(5);
-
+        Deleting,
         /// TPU node is being repaired and may be unusable. Details can be
         /// found in the 'help_description' field.
-        pub const REPAIRING: State = State::new(6);
-
+        Repairing,
         /// TPU node is stopped.
-        pub const STOPPED: State = State::new(8);
-
+        Stopped,
         /// TPU node is currently stopping.
-        pub const STOPPING: State = State::new(9);
-
+        Stopping,
         /// TPU node is currently starting.
-        pub const STARTING: State = State::new(10);
-
+        Starting,
         /// TPU node has been preempted. Only applies to Preemptible TPU Nodes.
-        pub const PREEMPTED: State = State::new(11);
-
+        Preempted,
         /// TPU node has been terminated due to maintenance or has reached the end of
         /// its life cycle (for preemptible nodes).
-        pub const TERMINATED: State = State::new(12);
-
+        Terminated,
         /// TPU node is currently hiding.
-        pub const HIDING: State = State::new(13);
-
+        Hiding,
         /// TPU node has been hidden.
-        pub const HIDDEN: State = State::new(14);
-
+        Hidden,
         /// TPU node is currently unhiding.
-        pub const UNHIDING: State = State::new(15);
-
+        Unhiding,
         /// TPU node has unknown state after a failed repair.
-        pub const UNKNOWN: State = State::new(16);
+        Unknown,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Restarting => std::option::Option::Some(3),
+                Self::Reimaging => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Repairing => std::option::Option::Some(6),
+                Self::Stopped => std::option::Option::Some(8),
+                Self::Stopping => std::option::Option::Some(9),
+                Self::Starting => std::option::Option::Some(10),
+                Self::Preempted => std::option::Option::Some(11),
+                Self::Terminated => std::option::Option::Some(12),
+                Self::Hiding => std::option::Option::Some(13),
+                Self::Hidden => std::option::Option::Some(14),
+                Self::Unhiding => std::option::Option::Some(15),
+                Self::Unknown => std::option::Option::Some(16),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("RESTARTING"),
-                4 => std::borrow::Cow::Borrowed("REIMAGING"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("REPAIRING"),
-                8 => std::borrow::Cow::Borrowed("STOPPED"),
-                9 => std::borrow::Cow::Borrowed("STOPPING"),
-                10 => std::borrow::Cow::Borrowed("STARTING"),
-                11 => std::borrow::Cow::Borrowed("PREEMPTED"),
-                12 => std::borrow::Cow::Borrowed("TERMINATED"),
-                13 => std::borrow::Cow::Borrowed("HIDING"),
-                14 => std::borrow::Cow::Borrowed("HIDDEN"),
-                15 => std::borrow::Cow::Borrowed("UNHIDING"),
-                16 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Restarting => std::option::Option::Some("RESTARTING"),
+                Self::Reimaging => std::option::Option::Some("REIMAGING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Preempted => std::option::Option::Some("PREEMPTED"),
+                Self::Terminated => std::option::Option::Some("TERMINATED"),
+                Self::Hiding => std::option::Option::Some("HIDING"),
+                Self::Hidden => std::option::Option::Some("HIDDEN"),
+                Self::Unhiding => std::option::Option::Some("UNHIDING"),
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "RESTARTING" => std::option::Option::Some(Self::RESTARTING),
-                "REIMAGING" => std::option::Option::Some(Self::REIMAGING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "PREEMPTED" => std::option::Option::Some(Self::PREEMPTED),
-                "TERMINATED" => std::option::Option::Some(Self::TERMINATED),
-                "HIDING" => std::option::Option::Some(Self::HIDING),
-                "HIDDEN" => std::option::Option::Some(Self::HIDDEN),
-                "UNHIDING" => std::option::Option::Some(Self::UNHIDING),
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Restarting,
+                4 => Self::Reimaging,
+                5 => Self::Deleting,
+                6 => Self::Repairing,
+                8 => Self::Stopped,
+                9 => Self::Stopping,
+                10 => Self::Starting,
+                11 => Self::Preempted,
+                12 => Self::Terminated,
+                13 => Self::Hiding,
+                14 => Self::Hidden,
+                15 => Self::Unhiding,
+                16 => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "RESTARTING" => Self::Restarting,
+                "REIMAGING" => Self::Reimaging,
+                "DELETING" => Self::Deleting,
+                "REPAIRING" => Self::Repairing,
+                "STOPPED" => Self::Stopped,
+                "STOPPING" => Self::Stopping,
+                "STARTING" => Self::Starting,
+                "PREEMPTED" => Self::Preempted,
+                "TERMINATED" => Self::Terminated,
+                "HIDING" => Self::Hiding,
+                "HIDDEN" => Self::Hidden,
+                "UNHIDING" => Self::Unhiding,
+                "UNKNOWN" => Self::Unknown,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Restarting => serializer.serialize_i32(3),
+                Self::Reimaging => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Repairing => serializer.serialize_i32(6),
+                Self::Stopped => serializer.serialize_i32(8),
+                Self::Stopping => serializer.serialize_i32(9),
+                Self::Starting => serializer.serialize_i32(10),
+                Self::Preempted => serializer.serialize_i32(11),
+                Self::Terminated => serializer.serialize_i32(12),
+                Self::Hiding => serializer.serialize_i32(13),
+                Self::Hidden => serializer.serialize_i32(14),
+                Self::Unhiding => serializer.serialize_i32(15),
+                Self::Unknown => serializer.serialize_i32(16),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.tpu.v2.Node.State",
+            ))
         }
     }
 
     /// Health defines the status of a TPU node as reported by
     /// Health Monitor.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Health(i32);
-
-    impl Health {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Health {
         /// Health status is unknown: not initialized or failed to retrieve.
-        pub const HEALTH_UNSPECIFIED: Health = Health::new(0);
-
+        Unspecified,
         /// The resource is healthy.
-        pub const HEALTHY: Health = Health::new(1);
-
+        Healthy,
         /// The resource is unresponsive.
-        pub const TIMEOUT: Health = Health::new(3);
-
+        Timeout,
         /// The in-guest ML stack is unhealthy.
-        pub const UNHEALTHY_TENSORFLOW: Health = Health::new(4);
-
+        UnhealthyTensorflow,
         /// The node is under maintenance/priority boost caused rescheduling and
         /// will resume running once rescheduled.
-        pub const UNHEALTHY_MAINTENANCE: Health = Health::new(5);
+        UnhealthyMaintenance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Health::value] or
+        /// [Health::name].
+        UnknownValue(health::UnknownValue),
+    }
 
-        /// Creates a new Health instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod health {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Health {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Healthy => std::option::Option::Some(1),
+                Self::Timeout => std::option::Option::Some(3),
+                Self::UnhealthyTensorflow => std::option::Option::Some(4),
+                Self::UnhealthyMaintenance => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HEALTH_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HEALTHY"),
-                3 => std::borrow::Cow::Borrowed("TIMEOUT"),
-                4 => std::borrow::Cow::Borrowed("UNHEALTHY_TENSORFLOW"),
-                5 => std::borrow::Cow::Borrowed("UNHEALTHY_MAINTENANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HEALTH_UNSPECIFIED"),
+                Self::Healthy => std::option::Option::Some("HEALTHY"),
+                Self::Timeout => std::option::Option::Some("TIMEOUT"),
+                Self::UnhealthyTensorflow => std::option::Option::Some("UNHEALTHY_TENSORFLOW"),
+                Self::UnhealthyMaintenance => std::option::Option::Some("UNHEALTHY_MAINTENANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HEALTH_UNSPECIFIED" => std::option::Option::Some(Self::HEALTH_UNSPECIFIED),
-                "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
-                "TIMEOUT" => std::option::Option::Some(Self::TIMEOUT),
-                "UNHEALTHY_TENSORFLOW" => std::option::Option::Some(Self::UNHEALTHY_TENSORFLOW),
-                "UNHEALTHY_MAINTENANCE" => std::option::Option::Some(Self::UNHEALTHY_MAINTENANCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Health {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Health {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Health {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Health {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Healthy,
+                3 => Self::Timeout,
+                4 => Self::UnhealthyTensorflow,
+                5 => Self::UnhealthyMaintenance,
+                _ => Self::UnknownValue(health::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Health {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HEALTH_UNSPECIFIED" => Self::Unspecified,
+                "HEALTHY" => Self::Healthy,
+                "TIMEOUT" => Self::Timeout,
+                "UNHEALTHY_TENSORFLOW" => Self::UnhealthyTensorflow,
+                "UNHEALTHY_MAINTENANCE" => Self::UnhealthyMaintenance,
+                _ => Self::UnknownValue(health::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Health {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Healthy => serializer.serialize_i32(1),
+                Self::Timeout => serializer.serialize_i32(3),
+                Self::UnhealthyTensorflow => serializer.serialize_i32(4),
+                Self::UnhealthyMaintenance => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Health {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Health>::new(
+                ".google.cloud.tpu.v2.Node.Health",
+            ))
         }
     }
 
     /// TPU API Version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiVersion(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ApiVersion {
+        /// API version is unknown.
+        Unspecified,
+        /// TPU API V1Alpha1 version.
+        V1Alpha1,
+        /// TPU API V1 version.
+        V1,
+        /// TPU API V2Alpha1 version.
+        V2Alpha1,
+        /// TPU API V2 version.
+        V2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ApiVersion::value] or
+        /// [ApiVersion::name].
+        UnknownValue(api_version::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod api_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ApiVersion {
-        /// API version is unknown.
-        pub const API_VERSION_UNSPECIFIED: ApiVersion = ApiVersion::new(0);
-
-        /// TPU API V1Alpha1 version.
-        pub const V1_ALPHA1: ApiVersion = ApiVersion::new(1);
-
-        /// TPU API V1 version.
-        pub const V1: ApiVersion = ApiVersion::new(2);
-
-        /// TPU API V2Alpha1 version.
-        pub const V2_ALPHA1: ApiVersion = ApiVersion::new(3);
-
-        /// TPU API V2 version.
-        pub const V2: ApiVersion = ApiVersion::new(4);
-
-        /// Creates a new ApiVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V1Alpha1 => std::option::Option::Some(1),
+                Self::V1 => std::option::Option::Some(2),
+                Self::V2Alpha1 => std::option::Option::Some(3),
+                Self::V2 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("API_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("V1_ALPHA1"),
-                2 => std::borrow::Cow::Borrowed("V1"),
-                3 => std::borrow::Cow::Borrowed("V2_ALPHA1"),
-                4 => std::borrow::Cow::Borrowed("V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("API_VERSION_UNSPECIFIED"),
+                Self::V1Alpha1 => std::option::Option::Some("V1_ALPHA1"),
+                Self::V1 => std::option::Option::Some("V1"),
+                Self::V2Alpha1 => std::option::Option::Some("V2_ALPHA1"),
+                Self::V2 => std::option::Option::Some("V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "API_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::API_VERSION_UNSPECIFIED)
-                }
-                "V1_ALPHA1" => std::option::Option::Some(Self::V1_ALPHA1),
-                "V1" => std::option::Option::Some(Self::V1),
-                "V2_ALPHA1" => std::option::Option::Some(Self::V2_ALPHA1),
-                "V2" => std::option::Option::Some(Self::V2),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ApiVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ApiVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ApiVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::V1Alpha1,
+                2 => Self::V1,
+                3 => Self::V2Alpha1,
+                4 => Self::V2,
+                _ => Self::UnknownValue(api_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ApiVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "API_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "V1_ALPHA1" => Self::V1Alpha1,
+                "V1" => Self::V1,
+                "V2_ALPHA1" => Self::V2Alpha1,
+                "V2" => Self::V2,
+                _ => Self::UnknownValue(api_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ApiVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V1Alpha1 => serializer.serialize_i32(1),
+                Self::V1 => serializer.serialize_i32(2),
+                Self::V2Alpha1 => serializer.serialize_i32(3),
+                Self::V2 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ApiVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ApiVersion>::new(
+                ".google.cloud.tpu.v2.Node.ApiVersion",
+            ))
         }
     }
 }
@@ -2478,48 +2754,38 @@ pub mod queued_resource_state {
     }
 
     /// Output only state of the request
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State of the QueuedResource request is not known/set.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The QueuedResource request has been received. We're still working on
         /// determining if we will be able to honor this request.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The QueuedResource request has passed initial validation/admission
         /// control and has been persisted in the queue.
-        pub const ACCEPTED: State = State::new(2);
-
+        Accepted,
         /// The QueuedResource request has been selected. The
         /// associated resources are currently being provisioned (or very soon
         /// will begin provisioning).
-        pub const PROVISIONING: State = State::new(3);
-
+        Provisioning,
         /// The request could not be completed. This may be due to some
         /// late-discovered problem with the request itself, or due to
         /// unavailability of resources within the constraints of the request
         /// (e.g., the 'valid until' start timing constraint expired).
-        pub const FAILED: State = State::new(4);
-
+        Failed,
         /// The QueuedResource is being deleted.
-        pub const DELETING: State = State::new(5);
-
+        Deleting,
         /// The resources specified in the QueuedResource request have been
         /// provisioned and are ready for use by the end-user/consumer.
-        pub const ACTIVE: State = State::new(6);
-
+        Active,
         /// The resources specified in the QueuedResource request are being
         /// deleted. This may have been initiated by the user, or
         /// the Cloud TPU service. Inspect the state data for more details.
-        pub const SUSPENDING: State = State::new(7);
-
+        Suspending,
         /// The resources specified in the QueuedResource request have been
         /// deleted.
-        pub const SUSPENDED: State = State::new(8);
-
+        Suspended,
         /// The QueuedResource request has passed initial validation and has been
         /// persisted in the queue. It will remain in this state until there are
         /// sufficient free resources to begin provisioning your request. Wait times
@@ -2529,121 +2795,265 @@ pub mod queued_resource_state {
         /// reservation. To put a limit on how long you are willing to wait, use
         /// [timing
         /// constraints](https://cloud.google.com/tpu/docs/queued-resources#request_a_queued_resource_before_a_specified_time).
-        pub const WAITING_FOR_RESOURCES: State = State::new(9);
+        WaitingForResources,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Accepted => std::option::Option::Some(2),
+                Self::Provisioning => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Deleting => std::option::Option::Some(5),
+                Self::Active => std::option::Option::Some(6),
+                Self::Suspending => std::option::Option::Some(7),
+                Self::Suspended => std::option::Option::Some(8),
+                Self::WaitingForResources => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACCEPTED"),
-                3 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("DELETING"),
-                6 => std::borrow::Cow::Borrowed("ACTIVE"),
-                7 => std::borrow::Cow::Borrowed("SUSPENDING"),
-                8 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                9 => std::borrow::Cow::Borrowed("WAITING_FOR_RESOURCES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Accepted => std::option::Option::Some("ACCEPTED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Suspending => std::option::Option::Some("SUSPENDING"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::WaitingForResources => std::option::Option::Some("WAITING_FOR_RESOURCES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACCEPTED" => std::option::Option::Some(Self::ACCEPTED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "WAITING_FOR_RESOURCES" => std::option::Option::Some(Self::WAITING_FOR_RESOURCES),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Accepted,
+                3 => Self::Provisioning,
+                4 => Self::Failed,
+                5 => Self::Deleting,
+                6 => Self::Active,
+                7 => Self::Suspending,
+                8 => Self::Suspended,
+                9 => Self::WaitingForResources,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACCEPTED" => Self::Accepted,
+                "PROVISIONING" => Self::Provisioning,
+                "FAILED" => Self::Failed,
+                "DELETING" => Self::Deleting,
+                "ACTIVE" => Self::Active,
+                "SUSPENDING" => Self::Suspending,
+                "SUSPENDED" => Self::Suspended,
+                "WAITING_FOR_RESOURCES" => Self::WaitingForResources,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Accepted => serializer.serialize_i32(2),
+                Self::Provisioning => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Deleting => serializer.serialize_i32(5),
+                Self::Active => serializer.serialize_i32(6),
+                Self::Suspending => serializer.serialize_i32(7),
+                Self::Suspended => serializer.serialize_i32(8),
+                Self::WaitingForResources => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.tpu.v2.QueuedResourceState.State",
+            ))
         }
     }
 
     /// The initiator of the QueuedResource's SUSPENDING/SUSPENDED state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StateInitiator(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StateInitiator {
+        /// The state initiator is unspecified.
+        Unspecified,
+        /// The current QueuedResource state was initiated by the user.
+        User,
+        /// The current QueuedResource state was initiated by the service.
+        Service,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StateInitiator::value] or
+        /// [StateInitiator::name].
+        UnknownValue(state_initiator::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state_initiator {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StateInitiator {
-        /// The state initiator is unspecified.
-        pub const STATE_INITIATOR_UNSPECIFIED: StateInitiator = StateInitiator::new(0);
-
-        /// The current QueuedResource state was initiated by the user.
-        pub const USER: StateInitiator = StateInitiator::new(1);
-
-        /// The current QueuedResource state was initiated by the service.
-        pub const SERVICE: StateInitiator = StateInitiator::new(2);
-
-        /// Creates a new StateInitiator instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::User => std::option::Option::Some(1),
+                Self::Service => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_INITIATOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER"),
-                2 => std::borrow::Cow::Borrowed("SERVICE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_INITIATOR_UNSPECIFIED"),
+                Self::User => std::option::Option::Some("USER"),
+                Self::Service => std::option::Option::Some("SERVICE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_INITIATOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STATE_INITIATOR_UNSPECIFIED)
-                }
-                "USER" => std::option::Option::Some(Self::USER),
-                "SERVICE" => std::option::Option::Some(Self::SERVICE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StateInitiator {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StateInitiator {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StateInitiator {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StateInitiator {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::User,
+                2 => Self::Service,
+                _ => Self::UnknownValue(state_initiator::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StateInitiator {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_INITIATOR_UNSPECIFIED" => Self::Unspecified,
+                "USER" => Self::User,
+                "SERVICE" => Self::Service,
+                _ => Self::UnknownValue(state_initiator::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StateInitiator {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::User => serializer.serialize_i32(1),
+                Self::Service => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StateInitiator {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StateInitiator>::new(
+                ".google.cloud.tpu.v2.QueuedResourceState.StateInitiator",
+            ))
         }
     }
 
@@ -4143,82 +4553,149 @@ pub mod symptom {
 
     /// SymptomType represents the different types of Symptoms that a TPU can be
     /// at.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SymptomType(i32);
-
-    impl SymptomType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SymptomType {
         /// Unspecified symptom.
-        pub const SYMPTOM_TYPE_UNSPECIFIED: SymptomType = SymptomType::new(0);
-
+        Unspecified,
         /// TPU VM memory is low.
-        pub const LOW_MEMORY: SymptomType = SymptomType::new(1);
-
+        LowMemory,
         /// TPU runtime is out of memory.
-        pub const OUT_OF_MEMORY: SymptomType = SymptomType::new(2);
-
+        OutOfMemory,
         /// TPU runtime execution has timed out.
-        pub const EXECUTE_TIMED_OUT: SymptomType = SymptomType::new(3);
-
+        ExecuteTimedOut,
         /// TPU runtime fails to construct a mesh that recognizes each TPU device's
         /// neighbors.
-        pub const MESH_BUILD_FAIL: SymptomType = SymptomType::new(4);
-
+        MeshBuildFail,
         /// TPU HBM is out of memory.
-        pub const HBM_OUT_OF_MEMORY: SymptomType = SymptomType::new(5);
-
+        HbmOutOfMemory,
         /// Abusive behaviors have been identified on the current project.
-        pub const PROJECT_ABUSE: SymptomType = SymptomType::new(6);
+        ProjectAbuse,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SymptomType::value] or
+        /// [SymptomType::name].
+        UnknownValue(symptom_type::UnknownValue),
+    }
 
-        /// Creates a new SymptomType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod symptom_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SymptomType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LowMemory => std::option::Option::Some(1),
+                Self::OutOfMemory => std::option::Option::Some(2),
+                Self::ExecuteTimedOut => std::option::Option::Some(3),
+                Self::MeshBuildFail => std::option::Option::Some(4),
+                Self::HbmOutOfMemory => std::option::Option::Some(5),
+                Self::ProjectAbuse => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SYMPTOM_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOW_MEMORY"),
-                2 => std::borrow::Cow::Borrowed("OUT_OF_MEMORY"),
-                3 => std::borrow::Cow::Borrowed("EXECUTE_TIMED_OUT"),
-                4 => std::borrow::Cow::Borrowed("MESH_BUILD_FAIL"),
-                5 => std::borrow::Cow::Borrowed("HBM_OUT_OF_MEMORY"),
-                6 => std::borrow::Cow::Borrowed("PROJECT_ABUSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SYMPTOM_TYPE_UNSPECIFIED"),
+                Self::LowMemory => std::option::Option::Some("LOW_MEMORY"),
+                Self::OutOfMemory => std::option::Option::Some("OUT_OF_MEMORY"),
+                Self::ExecuteTimedOut => std::option::Option::Some("EXECUTE_TIMED_OUT"),
+                Self::MeshBuildFail => std::option::Option::Some("MESH_BUILD_FAIL"),
+                Self::HbmOutOfMemory => std::option::Option::Some("HBM_OUT_OF_MEMORY"),
+                Self::ProjectAbuse => std::option::Option::Some("PROJECT_ABUSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SYMPTOM_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SYMPTOM_TYPE_UNSPECIFIED)
-                }
-                "LOW_MEMORY" => std::option::Option::Some(Self::LOW_MEMORY),
-                "OUT_OF_MEMORY" => std::option::Option::Some(Self::OUT_OF_MEMORY),
-                "EXECUTE_TIMED_OUT" => std::option::Option::Some(Self::EXECUTE_TIMED_OUT),
-                "MESH_BUILD_FAIL" => std::option::Option::Some(Self::MESH_BUILD_FAIL),
-                "HBM_OUT_OF_MEMORY" => std::option::Option::Some(Self::HBM_OUT_OF_MEMORY),
-                "PROJECT_ABUSE" => std::option::Option::Some(Self::PROJECT_ABUSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SymptomType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SymptomType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SymptomType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SymptomType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LowMemory,
+                2 => Self::OutOfMemory,
+                3 => Self::ExecuteTimedOut,
+                4 => Self::MeshBuildFail,
+                5 => Self::HbmOutOfMemory,
+                6 => Self::ProjectAbuse,
+                _ => Self::UnknownValue(symptom_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SymptomType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SYMPTOM_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LOW_MEMORY" => Self::LowMemory,
+                "OUT_OF_MEMORY" => Self::OutOfMemory,
+                "EXECUTE_TIMED_OUT" => Self::ExecuteTimedOut,
+                "MESH_BUILD_FAIL" => Self::MeshBuildFail,
+                "HBM_OUT_OF_MEMORY" => Self::HbmOutOfMemory,
+                "PROJECT_ABUSE" => Self::ProjectAbuse,
+                _ => Self::UnknownValue(symptom_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SymptomType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LowMemory => serializer.serialize_i32(1),
+                Self::OutOfMemory => serializer.serialize_i32(2),
+                Self::ExecuteTimedOut => serializer.serialize_i32(3),
+                Self::MeshBuildFail => serializer.serialize_i32(4),
+                Self::HbmOutOfMemory => serializer.serialize_i32(5),
+                Self::ProjectAbuse => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SymptomType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SymptomType>::new(
+                ".google.cloud.tpu.v2.Symptom.SymptomType",
+            ))
         }
     }
 }
@@ -4374,79 +4851,148 @@ pub mod accelerator_config {
     use super::*;
 
     /// TPU type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified version.
+        Unspecified,
+        /// TPU v2.
+        V2,
+        /// TPU v3.
+        V3,
+        /// TPU v4.
+        V4,
+        /// TPU v5lite pod.
+        V5LitePod,
+        /// TPU v5p.
+        V5P,
+        /// TPU v6e.
+        V6E,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified version.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// TPU v2.
-        pub const V2: Type = Type::new(2);
-
-        /// TPU v3.
-        pub const V3: Type = Type::new(4);
-
-        /// TPU v4.
-        pub const V4: Type = Type::new(7);
-
-        /// TPU v5lite pod.
-        pub const V5LITE_POD: Type = Type::new(9);
-
-        /// TPU v5p.
-        pub const V5P: Type = Type::new(10);
-
-        /// TPU v6e.
-        pub const V6E: Type = Type::new(11);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V2 => std::option::Option::Some(2),
+                Self::V3 => std::option::Option::Some(4),
+                Self::V4 => std::option::Option::Some(7),
+                Self::V5LitePod => std::option::Option::Some(9),
+                Self::V5P => std::option::Option::Some(10),
+                Self::V6E => std::option::Option::Some(11),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("V2"),
-                4 => std::borrow::Cow::Borrowed("V3"),
-                7 => std::borrow::Cow::Borrowed("V4"),
-                9 => std::borrow::Cow::Borrowed("V5LITE_POD"),
-                10 => std::borrow::Cow::Borrowed("V5P"),
-                11 => std::borrow::Cow::Borrowed("V6E"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::V2 => std::option::Option::Some("V2"),
+                Self::V3 => std::option::Option::Some("V3"),
+                Self::V4 => std::option::Option::Some("V4"),
+                Self::V5LitePod => std::option::Option::Some("V5LITE_POD"),
+                Self::V5P => std::option::Option::Some("V5P"),
+                Self::V6E => std::option::Option::Some("V6E"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "V2" => std::option::Option::Some(Self::V2),
-                "V3" => std::option::Option::Some(Self::V3),
-                "V4" => std::option::Option::Some(Self::V4),
-                "V5LITE_POD" => std::option::Option::Some(Self::V5LITE_POD),
-                "V5P" => std::option::Option::Some(Self::V5P),
-                "V6E" => std::option::Option::Some(Self::V6E),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::V2,
+                4 => Self::V3,
+                7 => Self::V4,
+                9 => Self::V5LitePod,
+                10 => Self::V5P,
+                11 => Self::V6E,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "V2" => Self::V2,
+                "V3" => Self::V3,
+                "V4" => Self::V4,
+                "V5LITE_POD" => Self::V5LitePod,
+                "V5P" => Self::V5P,
+                "V6E" => Self::V6E,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V2 => serializer.serialize_i32(2),
+                Self::V3 => serializer.serialize_i32(4),
+                Self::V4 => serializer.serialize_i32(7),
+                Self::V5LitePod => serializer.serialize_i32(9),
+                Self::V5P => serializer.serialize_i32(10),
+                Self::V6E => serializer.serialize_i32(11),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.tpu.v2.AcceleratorConfig.Type",
+            ))
         }
     }
 }

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -5865,78 +5865,145 @@ pub mod batch_translate_metadata {
     use super::*;
 
     /// State of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is being processed.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The batch is processed, and at least one item was successfully
         /// processed.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// The batch is done and no item was successfully processed.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new(4);
-
+        Cancelling,
         /// The batch is done after the user has called the
         /// longrunning.Operations.CancelOperation. Any records processed before the
         /// cancel command are output as specified in the request.
-        pub const CANCELLED: State = State::new(5);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.translation.v3.BatchTranslateMetadata.State",
+            ))
         }
     }
 }
@@ -7049,75 +7116,142 @@ pub mod create_glossary_metadata {
     use super::*;
 
     /// Enumerates the possible states that the creation request can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is being processed.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The glossary was successfully created.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// Failed to create the glossary.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new(4);
-
+        Cancelling,
         /// The glossary creation request was successfully canceled.
-        pub const CANCELLED: State = State::new(5);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.translation.v3.CreateGlossaryMetadata.State",
+            ))
         }
     }
 }
@@ -7193,75 +7327,142 @@ pub mod update_glossary_metadata {
     use super::*;
 
     /// Enumerates the possible states that the update request can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is being processed.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The glossary was successfully updated.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// Failed to update the glossary.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new(4);
-
+        Cancelling,
         /// The glossary update request was successfully canceled.
-        pub const CANCELLED: State = State::new(5);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.translation.v3.UpdateGlossaryMetadata.State",
+            ))
         }
     }
 }
@@ -7333,75 +7534,142 @@ pub mod delete_glossary_metadata {
     use super::*;
 
     /// Enumerates the possible states that the creation request can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is being processed.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The glossary was successfully deleted.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// Failed to delete the glossary.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new(4);
-
+        Cancelling,
         /// The glossary deletion request was successfully canceled.
-        pub const CANCELLED: State = State::new(5);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.translation.v3.DeleteGlossaryMetadata.State",
+            ))
         }
     }
 }
@@ -8232,77 +8500,144 @@ pub mod batch_translate_document_metadata {
     use super::*;
 
     /// State of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is being processed.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The batch is processed, and at least one item was successfully processed.
-        pub const SUCCEEDED: State = State::new(2);
-
+        Succeeded,
         /// The batch is done and no item was successfully processed.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// Request is in the process of being canceled after caller invoked
         /// longrunning.Operations.CancelOperation on the request id.
-        pub const CANCELLING: State = State::new(4);
-
+        Cancelling,
         /// The batch is done after the user has called the
         /// longrunning.Operations.CancelOperation. Any records processed before the
         /// cancel command are output as specified in the request.
-        pub const CANCELLED: State = State::new(5);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelling => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLING"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelling,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLING" => Self::Cancelling,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelling => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.translation.v3.BatchTranslateDocumentMetadata.State",
+            ))
         }
     }
 }
@@ -8368,82 +8703,141 @@ impl wkt::message::Message for TranslateTextGlossaryConfig {
 }
 
 /// Possible states of long running operations.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationState(i32);
-
-impl OperationState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperationState {
     /// Invalid.
-    pub const OPERATION_STATE_UNSPECIFIED: OperationState = OperationState::new(0);
-
+    Unspecified,
     /// Request is being processed.
-    pub const OPERATION_STATE_RUNNING: OperationState = OperationState::new(1);
-
+    Running,
     /// The operation was successful.
-    pub const OPERATION_STATE_SUCCEEDED: OperationState = OperationState::new(2);
-
+    Succeeded,
     /// Failed to process operation.
-    pub const OPERATION_STATE_FAILED: OperationState = OperationState::new(3);
-
+    Failed,
     /// Request is in the process of being canceled after caller invoked
     /// longrunning.Operations.CancelOperation on the request id.
-    pub const OPERATION_STATE_CANCELLING: OperationState = OperationState::new(4);
-
+    Cancelling,
     /// The operation request was successfully canceled.
-    pub const OPERATION_STATE_CANCELLED: OperationState = OperationState::new(5);
+    Cancelled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperationState::value] or
+    /// [OperationState::name].
+    UnknownValue(operation_state::UnknownValue),
+}
 
-    /// Creates a new OperationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod operation_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl OperationState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Running => std::option::Option::Some(1),
+            Self::Succeeded => std::option::Option::Some(2),
+            Self::Failed => std::option::Option::Some(3),
+            Self::Cancelling => std::option::Option::Some(4),
+            Self::Cancelled => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OPERATION_STATE_RUNNING"),
-            2 => std::borrow::Cow::Borrowed("OPERATION_STATE_SUCCEEDED"),
-            3 => std::borrow::Cow::Borrowed("OPERATION_STATE_FAILED"),
-            4 => std::borrow::Cow::Borrowed("OPERATION_STATE_CANCELLING"),
-            5 => std::borrow::Cow::Borrowed("OPERATION_STATE_CANCELLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OPERATION_STATE_UNSPECIFIED"),
+            Self::Running => std::option::Option::Some("OPERATION_STATE_RUNNING"),
+            Self::Succeeded => std::option::Option::Some("OPERATION_STATE_SUCCEEDED"),
+            Self::Failed => std::option::Option::Some("OPERATION_STATE_FAILED"),
+            Self::Cancelling => std::option::Option::Some("OPERATION_STATE_CANCELLING"),
+            Self::Cancelled => std::option::Option::Some("OPERATION_STATE_CANCELLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_UNSPECIFIED)
-            }
-            "OPERATION_STATE_RUNNING" => std::option::Option::Some(Self::OPERATION_STATE_RUNNING),
-            "OPERATION_STATE_SUCCEEDED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_SUCCEEDED)
-            }
-            "OPERATION_STATE_FAILED" => std::option::Option::Some(Self::OPERATION_STATE_FAILED),
-            "OPERATION_STATE_CANCELLING" => {
-                std::option::Option::Some(Self::OPERATION_STATE_CANCELLING)
-            }
-            "OPERATION_STATE_CANCELLED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_CANCELLED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Running,
+            2 => Self::Succeeded,
+            3 => Self::Failed,
+            4 => Self::Cancelling,
+            5 => Self::Cancelled,
+            _ => Self::UnknownValue(operation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "OPERATION_STATE_RUNNING" => Self::Running,
+            "OPERATION_STATE_SUCCEEDED" => Self::Succeeded,
+            "OPERATION_STATE_FAILED" => Self::Failed,
+            "OPERATION_STATE_CANCELLING" => Self::Cancelling,
+            "OPERATION_STATE_CANCELLED" => Self::Cancelled,
+            _ => Self::UnknownValue(operation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Running => serializer.serialize_i32(1),
+            Self::Succeeded => serializer.serialize_i32(2),
+            Self::Failed => serializer.serialize_i32(3),
+            Self::Cancelling => serializer.serialize_i32(4),
+            Self::Cancelled => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationState>::new(
+            ".google.cloud.translation.v3.OperationState",
+        ))
     }
 }

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -434,61 +434,120 @@ pub mod manifest {
     use super::*;
 
     /// The manifest type can be either `HLS` or `DASH`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ManifestType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ManifestType {
+        /// The manifest type is not specified.
+        Unspecified,
+        /// Create an `HLS` manifest. The corresponding file extension is `.m3u8`.
+        Hls,
+        /// Create a `DASH` manifest. The corresponding file extension is `.mpd`.
+        Dash,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ManifestType::value] or
+        /// [ManifestType::name].
+        UnknownValue(manifest_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod manifest_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ManifestType {
-        /// The manifest type is not specified.
-        pub const MANIFEST_TYPE_UNSPECIFIED: ManifestType = ManifestType::new(0);
-
-        /// Create an `HLS` manifest. The corresponding file extension is `.m3u8`.
-        pub const HLS: ManifestType = ManifestType::new(1);
-
-        /// Create a `DASH` manifest. The corresponding file extension is `.mpd`.
-        pub const DASH: ManifestType = ManifestType::new(2);
-
-        /// Creates a new ManifestType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hls => std::option::Option::Some(1),
+                Self::Dash => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MANIFEST_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HLS"),
-                2 => std::borrow::Cow::Borrowed("DASH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MANIFEST_TYPE_UNSPECIFIED"),
+                Self::Hls => std::option::Option::Some("HLS"),
+                Self::Dash => std::option::Option::Some("DASH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MANIFEST_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MANIFEST_TYPE_UNSPECIFIED)
-                }
-                "HLS" => std::option::Option::Some(Self::HLS),
-                "DASH" => std::option::Option::Some(Self::DASH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ManifestType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ManifestType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ManifestType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ManifestType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hls,
+                2 => Self::Dash,
+                _ => Self::UnknownValue(manifest_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ManifestType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MANIFEST_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "HLS" => Self::Hls,
+                "DASH" => Self::Dash,
+                _ => Self::UnknownValue(manifest_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ManifestType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hls => serializer.serialize_i32(1),
+                Self::Dash => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ManifestType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ManifestType>::new(
+                ".google.cloud.video.livestream.v1.Manifest.ManifestType",
+            ))
         }
     }
 }
@@ -1664,61 +1723,120 @@ pub mod timecode_config {
     use super::*;
 
     /// The source of timecode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimecodeSource(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimecodeSource {
+        /// The timecode source is not specified.
+        Unspecified,
+        /// Use input media timestamp.
+        MediaTimestamp,
+        /// Use input embedded timecode e.g. picture timing SEI message.
+        EmbeddedTimecode,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimecodeSource::value] or
+        /// [TimecodeSource::name].
+        UnknownValue(timecode_source::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod timecode_source {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TimecodeSource {
-        /// The timecode source is not specified.
-        pub const TIMECODE_SOURCE_UNSPECIFIED: TimecodeSource = TimecodeSource::new(0);
-
-        /// Use input media timestamp.
-        pub const MEDIA_TIMESTAMP: TimecodeSource = TimecodeSource::new(1);
-
-        /// Use input embedded timecode e.g. picture timing SEI message.
-        pub const EMBEDDED_TIMECODE: TimecodeSource = TimecodeSource::new(2);
-
-        /// Creates a new TimecodeSource instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MediaTimestamp => std::option::Option::Some(1),
+                Self::EmbeddedTimecode => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIMECODE_SOURCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MEDIA_TIMESTAMP"),
-                2 => std::borrow::Cow::Borrowed("EMBEDDED_TIMECODE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIMECODE_SOURCE_UNSPECIFIED"),
+                Self::MediaTimestamp => std::option::Option::Some("MEDIA_TIMESTAMP"),
+                Self::EmbeddedTimecode => std::option::Option::Some("EMBEDDED_TIMECODE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIMECODE_SOURCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TIMECODE_SOURCE_UNSPECIFIED)
-                }
-                "MEDIA_TIMESTAMP" => std::option::Option::Some(Self::MEDIA_TIMESTAMP),
-                "EMBEDDED_TIMECODE" => std::option::Option::Some(Self::EMBEDDED_TIMECODE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TimecodeSource {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimecodeSource {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimecodeSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimecodeSource {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::MediaTimestamp,
+                2 => Self::EmbeddedTimecode,
+                _ => Self::UnknownValue(timecode_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimecodeSource {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIMECODE_SOURCE_UNSPECIFIED" => Self::Unspecified,
+                "MEDIA_TIMESTAMP" => Self::MediaTimestamp,
+                "EMBEDDED_TIMECODE" => Self::EmbeddedTimecode,
+                _ => Self::UnknownValue(timecode_source::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimecodeSource {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MediaTimestamp => serializer.serialize_i32(1),
+                Self::EmbeddedTimecode => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimecodeSource {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimecodeSource>::new(
+                ".google.cloud.video.livestream.v1.TimecodeConfig.TimecodeSource",
+            ))
         }
     }
 
@@ -1944,121 +2062,245 @@ pub mod input {
     }
 
     /// The type of the input.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Input type is not specified.
+        Unspecified,
+        /// Input will take an rtmp input stream.
+        RtmpPush,
+        /// Input will take an srt (Secure Reliable Transport) input stream.
+        SrtPush,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Input type is not specified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Input will take an rtmp input stream.
-        pub const RTMP_PUSH: Type = Type::new(1);
-
-        /// Input will take an srt (Secure Reliable Transport) input stream.
-        pub const SRT_PUSH: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RtmpPush => std::option::Option::Some(1),
+                Self::SrtPush => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RTMP_PUSH"),
-                2 => std::borrow::Cow::Borrowed("SRT_PUSH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::RtmpPush => std::option::Option::Some("RTMP_PUSH"),
+                Self::SrtPush => std::option::Option::Some("SRT_PUSH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "RTMP_PUSH" => std::option::Option::Some(Self::RTMP_PUSH),
-                "SRT_PUSH" => std::option::Option::Some(Self::SRT_PUSH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RtmpPush,
+                2 => Self::SrtPush,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "RTMP_PUSH" => Self::RtmpPush,
+                "SRT_PUSH" => Self::SrtPush,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RtmpPush => serializer.serialize_i32(1),
+                Self::SrtPush => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.video.livestream.v1.Input.Type",
+            ))
         }
     }
 
     /// Tier of the input specification.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Tier(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Tier {
+        /// Tier is not specified.
+        Unspecified,
+        /// Resolution < 1280x720. Bitrate <= 6 Mbps. FPS <= 60.
+        Sd,
+        /// Resolution <= 1920x1080. Bitrate <= 25 Mbps. FPS <= 60.
+        Hd,
+        /// Resolution <= 4096x2160. Not supported yet.
+        Uhd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Tier::value] or
+        /// [Tier::name].
+        UnknownValue(tier::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Tier {
-        /// Tier is not specified.
-        pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
-        /// Resolution < 1280x720. Bitrate <= 6 Mbps. FPS <= 60.
-        pub const SD: Tier = Tier::new(1);
-
-        /// Resolution <= 1920x1080. Bitrate <= 25 Mbps. FPS <= 60.
-        pub const HD: Tier = Tier::new(2);
-
-        /// Resolution <= 4096x2160. Not supported yet.
-        pub const UHD: Tier = Tier::new(3);
-
-        /// Creates a new Tier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Sd => std::option::Option::Some(1),
+                Self::Hd => std::option::Option::Some(2),
+                Self::Uhd => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SD"),
-                2 => std::borrow::Cow::Borrowed("HD"),
-                3 => std::borrow::Cow::Borrowed("UHD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                Self::Sd => std::option::Option::Some("SD"),
+                Self::Hd => std::option::Option::Some("HD"),
+                Self::Uhd => std::option::Option::Some("UHD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                "SD" => std::option::Option::Some(Self::SD),
-                "HD" => std::option::Option::Some(Self::HD),
-                "UHD" => std::option::Option::Some(Self::UHD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Tier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Tier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Tier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Tier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Sd,
+                2 => Self::Hd,
+                3 => Self::Uhd,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Tier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIER_UNSPECIFIED" => Self::Unspecified,
+                "SD" => Self::Sd,
+                "HD" => Self::Hd,
+                "UHD" => Self::Uhd,
+                _ => Self::UnknownValue(tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Tier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Sd => serializer.serialize_i32(1),
+                Self::Hd => serializer.serialize_i32(2),
+                Self::Uhd => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Tier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                ".google.cloud.video.livestream.v1.Input.Tier",
+            ))
         }
     }
 }
@@ -2137,7 +2379,7 @@ pub struct Channel {
     /// is
     /// [STREAMING_ERROR][google.cloud.video.livestream.v1.Channel.StreamingState.STREAMING_ERROR].
     ///
-    /// [google.cloud.video.livestream.v1.Channel.StreamingState.STREAMING_ERROR]: crate::model::channel::streaming_state::STREAMING_ERROR
+    /// [google.cloud.video.livestream.v1.Channel.StreamingState.STREAMING_ERROR]: crate::model::channel::StreamingState::StreamingError
     /// [google.cloud.video.livestream.v1.Channel.streaming_state]: crate::model::Channel::streaming_state
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub streaming_error: std::option::Option<rpc::model::Status>,
@@ -2414,91 +2656,160 @@ pub mod channel {
     }
 
     /// State of streaming operation that the channel is running.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StreamingState(i32);
-
-    impl StreamingState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StreamingState {
         /// Streaming state is not specified.
-        pub const STREAMING_STATE_UNSPECIFIED: StreamingState = StreamingState::new(0);
-
+        Unspecified,
         /// Channel is getting the input stream, generating the live streams to the
         /// specified output location.
-        pub const STREAMING: StreamingState = StreamingState::new(1);
-
+        Streaming,
         /// Channel is waiting for the input stream through the input.
-        pub const AWAITING_INPUT: StreamingState = StreamingState::new(2);
-
+        AwaitingInput,
         /// Channel is running, but has trouble publishing the live streams onto the
         /// specified output location (for example, the specified Cloud Storage
         /// bucket is not writable).
-        pub const STREAMING_ERROR: StreamingState = StreamingState::new(4);
-
+        StreamingError,
         /// Channel is generating live streams with no input stream. Live streams are
         /// filled out with black screen, while input stream is missing.
         /// Not supported yet.
-        pub const STREAMING_NO_INPUT: StreamingState = StreamingState::new(5);
-
+        StreamingNoInput,
         /// Channel is stopped, finishing live streams.
-        pub const STOPPED: StreamingState = StreamingState::new(6);
-
+        Stopped,
         /// Channel is starting.
-        pub const STARTING: StreamingState = StreamingState::new(7);
-
+        Starting,
         /// Channel is stopping.
-        pub const STOPPING: StreamingState = StreamingState::new(8);
+        Stopping,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StreamingState::value] or
+        /// [StreamingState::name].
+        UnknownValue(streaming_state::UnknownValue),
+    }
 
-        /// Creates a new StreamingState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod streaming_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl StreamingState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Streaming => std::option::Option::Some(1),
+                Self::AwaitingInput => std::option::Option::Some(2),
+                Self::StreamingError => std::option::Option::Some(4),
+                Self::StreamingNoInput => std::option::Option::Some(5),
+                Self::Stopped => std::option::Option::Some(6),
+                Self::Starting => std::option::Option::Some(7),
+                Self::Stopping => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STREAMING_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STREAMING"),
-                2 => std::borrow::Cow::Borrowed("AWAITING_INPUT"),
-                4 => std::borrow::Cow::Borrowed("STREAMING_ERROR"),
-                5 => std::borrow::Cow::Borrowed("STREAMING_NO_INPUT"),
-                6 => std::borrow::Cow::Borrowed("STOPPED"),
-                7 => std::borrow::Cow::Borrowed("STARTING"),
-                8 => std::borrow::Cow::Borrowed("STOPPING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STREAMING_STATE_UNSPECIFIED"),
+                Self::Streaming => std::option::Option::Some("STREAMING"),
+                Self::AwaitingInput => std::option::Option::Some("AWAITING_INPUT"),
+                Self::StreamingError => std::option::Option::Some("STREAMING_ERROR"),
+                Self::StreamingNoInput => std::option::Option::Some("STREAMING_NO_INPUT"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::Starting => std::option::Option::Some("STARTING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STREAMING_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STREAMING_STATE_UNSPECIFIED)
-                }
-                "STREAMING" => std::option::Option::Some(Self::STREAMING),
-                "AWAITING_INPUT" => std::option::Option::Some(Self::AWAITING_INPUT),
-                "STREAMING_ERROR" => std::option::Option::Some(Self::STREAMING_ERROR),
-                "STREAMING_NO_INPUT" => std::option::Option::Some(Self::STREAMING_NO_INPUT),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                "STARTING" => std::option::Option::Some(Self::STARTING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StreamingState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StreamingState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StreamingState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StreamingState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Streaming,
+                2 => Self::AwaitingInput,
+                4 => Self::StreamingError,
+                5 => Self::StreamingNoInput,
+                6 => Self::Stopped,
+                7 => Self::Starting,
+                8 => Self::Stopping,
+                _ => Self::UnknownValue(streaming_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StreamingState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STREAMING_STATE_UNSPECIFIED" => Self::Unspecified,
+                "STREAMING" => Self::Streaming,
+                "AWAITING_INPUT" => Self::AwaitingInput,
+                "STREAMING_ERROR" => Self::StreamingError,
+                "STREAMING_NO_INPUT" => Self::StreamingNoInput,
+                "STOPPED" => Self::Stopped,
+                "STARTING" => Self::Starting,
+                "STOPPING" => Self::Stopping,
+                _ => Self::UnknownValue(streaming_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StreamingState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Streaming => serializer.serialize_i32(1),
+                Self::AwaitingInput => serializer.serialize_i32(2),
+                Self::StreamingError => serializer.serialize_i32(4),
+                Self::StreamingNoInput => serializer.serialize_i32(5),
+                Self::Stopped => serializer.serialize_i32(6),
+                Self::Starting => serializer.serialize_i32(7),
+                Self::Stopping => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StreamingState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StreamingState>::new(
+                ".google.cloud.video.livestream.v1.Channel.StreamingState",
+            ))
         }
     }
 }
@@ -2712,21 +3023,18 @@ pub mod input_config {
     use super::*;
 
     /// Input switch mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InputSwitchMode(i32);
-
-    impl InputSwitchMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InputSwitchMode {
         /// The input switch mode is not specified.
-        pub const INPUT_SWITCH_MODE_UNSPECIFIED: InputSwitchMode = InputSwitchMode::new(0);
-
+        Unspecified,
         /// Automatic failover is enabled. The primary input stream is always
         /// preferred over its backup input streams configured using the
         /// [AutomaticFailover][google.cloud.video.livestream.v1.InputAttachment.AutomaticFailover]
         /// field.
         ///
         /// [google.cloud.video.livestream.v1.InputAttachment.AutomaticFailover]: crate::model::input_attachment::AutomaticFailover
-        pub const FAILOVER_PREFER_PRIMARY: InputSwitchMode = InputSwitchMode::new(1);
-
+        FailoverPreferPrimary,
         /// Automatic failover is disabled. You must use the
         /// [inputSwitch][google.cloud.video.livestream.v1.Event.input_switch] event
         /// to switch the active input source for the channel to stream from. When
@@ -2736,52 +3044,112 @@ pub mod input_config {
         ///
         /// [google.cloud.video.livestream.v1.Event.input_switch]: crate::model::Event::task
         /// [google.cloud.video.livestream.v1.InputAttachment.AutomaticFailover]: crate::model::input_attachment::AutomaticFailover
-        pub const MANUAL: InputSwitchMode = InputSwitchMode::new(3);
+        Manual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InputSwitchMode::value] or
+        /// [InputSwitchMode::name].
+        UnknownValue(input_switch_mode::UnknownValue),
+    }
 
-        /// Creates a new InputSwitchMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod input_switch_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl InputSwitchMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FailoverPreferPrimary => std::option::Option::Some(1),
+                Self::Manual => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INPUT_SWITCH_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FAILOVER_PREFER_PRIMARY"),
-                3 => std::borrow::Cow::Borrowed("MANUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INPUT_SWITCH_MODE_UNSPECIFIED"),
+                Self::FailoverPreferPrimary => std::option::Option::Some("FAILOVER_PREFER_PRIMARY"),
+                Self::Manual => std::option::Option::Some("MANUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INPUT_SWITCH_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INPUT_SWITCH_MODE_UNSPECIFIED)
-                }
-                "FAILOVER_PREFER_PRIMARY" => {
-                    std::option::Option::Some(Self::FAILOVER_PREFER_PRIMARY)
-                }
-                "MANUAL" => std::option::Option::Some(Self::MANUAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InputSwitchMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InputSwitchMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InputSwitchMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InputSwitchMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FailoverPreferPrimary,
+                3 => Self::Manual,
+                _ => Self::UnknownValue(input_switch_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InputSwitchMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INPUT_SWITCH_MODE_UNSPECIFIED" => Self::Unspecified,
+                "FAILOVER_PREFER_PRIMARY" => Self::FailoverPreferPrimary,
+                "MANUAL" => Self::Manual,
+                _ => Self::UnknownValue(input_switch_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InputSwitchMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FailoverPreferPrimary => serializer.serialize_i32(1),
+                Self::Manual => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InputSwitchMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InputSwitchMode>::new(
+                ".google.cloud.video.livestream.v1.InputConfig.InputSwitchMode",
+            ))
         }
     }
 }
@@ -2836,76 +3204,141 @@ pub mod log_config {
     /// See
     /// [LogSeverity](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity)
     /// for more information.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogSeverity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogSeverity {
+        /// Log severity is not specified. This is the same as log severity is OFF.
+        Unspecified,
+        /// Log is turned off.
+        Off,
+        /// Log with severity higher than or equal to DEBUG are logged.
+        Debug,
+        /// Logs with severity higher than or equal to INFO are logged.
+        Info,
+        /// Logs with severity higher than or equal to WARNING are logged.
+        Warning,
+        /// Logs with severity higher than or equal to ERROR are logged.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogSeverity::value] or
+        /// [LogSeverity::name].
+        UnknownValue(log_severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod log_severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LogSeverity {
-        /// Log severity is not specified. This is the same as log severity is OFF.
-        pub const LOG_SEVERITY_UNSPECIFIED: LogSeverity = LogSeverity::new(0);
-
-        /// Log is turned off.
-        pub const OFF: LogSeverity = LogSeverity::new(1);
-
-        /// Log with severity higher than or equal to DEBUG are logged.
-        pub const DEBUG: LogSeverity = LogSeverity::new(100);
-
-        /// Logs with severity higher than or equal to INFO are logged.
-        pub const INFO: LogSeverity = LogSeverity::new(200);
-
-        /// Logs with severity higher than or equal to WARNING are logged.
-        pub const WARNING: LogSeverity = LogSeverity::new(400);
-
-        /// Logs with severity higher than or equal to ERROR are logged.
-        pub const ERROR: LogSeverity = LogSeverity::new(500);
-
-        /// Creates a new LogSeverity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Off => std::option::Option::Some(1),
+                Self::Debug => std::option::Option::Some(100),
+                Self::Info => std::option::Option::Some(200),
+                Self::Warning => std::option::Option::Some(400),
+                Self::Error => std::option::Option::Some(500),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OFF"),
-                100 => std::borrow::Cow::Borrowed("DEBUG"),
-                200 => std::borrow::Cow::Borrowed("INFO"),
-                400 => std::borrow::Cow::Borrowed("WARNING"),
-                500 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_SEVERITY_UNSPECIFIED"),
+                Self::Off => std::option::Option::Some("OFF"),
+                Self::Debug => std::option::Option::Some("DEBUG"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_SEVERITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOG_SEVERITY_UNSPECIFIED)
-                }
-                "OFF" => std::option::Option::Some(Self::OFF),
-                "DEBUG" => std::option::Option::Some(Self::DEBUG),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LogSeverity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LogSeverity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LogSeverity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LogSeverity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Off,
+                100 => Self::Debug,
+                200 => Self::Info,
+                400 => Self::Warning,
+                500 => Self::Error,
+                _ => Self::UnknownValue(log_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LogSeverity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "OFF" => Self::Off,
+                "DEBUG" => Self::Debug,
+                "INFO" => Self::Info,
+                "WARNING" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(log_severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LogSeverity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Off => serializer.serialize_i32(1),
+                Self::Debug => serializer.serialize_i32(100),
+                Self::Info => serializer.serialize_i32(200),
+                Self::Warning => serializer.serialize_i32(400),
+                Self::Error => serializer.serialize_i32(500),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LogSeverity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogSeverity>::new(
+                ".google.cloud.video.livestream.v1.LogConfig.LogSeverity",
+            ))
         }
     }
 }
@@ -3867,79 +4300,148 @@ pub mod event {
     }
 
     /// State of the event
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Event state is not specified.
+        Unspecified,
+        /// Event is scheduled but not executed yet.
+        Scheduled,
+        /// Event is being executed.
+        Running,
+        /// Event has been successfully executed.
+        Succeeded,
+        /// Event fails to be executed.
+        Failed,
+        /// Event has been created but not scheduled yet.
+        Pending,
+        /// Event was stopped before running for its full duration.
+        Stopped,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Event state is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Event is scheduled but not executed yet.
-        pub const SCHEDULED: State = State::new(1);
-
-        /// Event is being executed.
-        pub const RUNNING: State = State::new(2);
-
-        /// Event has been successfully executed.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// Event fails to be executed.
-        pub const FAILED: State = State::new(4);
-
-        /// Event has been created but not scheduled yet.
-        pub const PENDING: State = State::new(5);
-
-        /// Event was stopped before running for its full duration.
-        pub const STOPPED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Scheduled => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Pending => std::option::Option::Some(5),
+                Self::Stopped => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCHEDULED"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("PENDING"),
-                6 => std::borrow::Cow::Borrowed("STOPPED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Scheduled => std::option::Option::Some("SCHEDULED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Stopped => std::option::Option::Some("STOPPED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "SCHEDULED" => std::option::Option::Some(Self::SCHEDULED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "STOPPED" => std::option::Option::Some(Self::STOPPED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Scheduled,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                5 => Self::Pending,
+                6 => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "SCHEDULED" => Self::Scheduled,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "PENDING" => Self::Pending,
+                "STOPPED" => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Scheduled => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Pending => serializer.serialize_i32(5),
+                Self::Stopped => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.video.livestream.v1.Event.State",
+            ))
         }
     }
 
@@ -4320,72 +4822,137 @@ pub mod clip {
     }
 
     /// State of clipping operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The operation is pending to be picked up by the server.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The server admitted this create clip request, and
         /// outputs are under processing.
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// Outputs are available in the specified Cloud Storage bucket. For
         /// additional information, see the `outputs` field.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The operation has failed. For additional information, see the `error`
         /// field.
-        pub const FAILED: State = State::new(4);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Creating,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "CREATING" => Self::Creating,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.video.livestream.v1.Clip.State",
+            ))
         }
     }
 }
@@ -4651,69 +5218,134 @@ pub mod asset {
     }
 
     /// State of the asset resource.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is not specified.
+        Unspecified,
+        /// The asset is being created.
+        Creating,
+        /// The asset is ready for use.
+        Active,
+        /// The asset is being deleted.
+        Deleting,
+        /// The asset has an error.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The asset is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The asset is ready for use.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The asset is being deleted.
-        pub const DELETING: State = State::new(3);
-
-        /// The asset has an error.
-        pub const ERROR: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.video.livestream.v1.Asset.State",
+            ))
         }
     }
 

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -725,66 +725,127 @@ pub mod companion_ads {
     use super::*;
 
     /// Indicates how many of the companions should be displayed with the ad.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DisplayRequirement(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DisplayRequirement {
+        /// Required companions are not specified. The default is ALL.
+        Unspecified,
+        /// All companions are required to be displayed.
+        All,
+        /// At least one of companions needs to be displayed.
+        Any,
+        /// All companions are optional for display.
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DisplayRequirement::value] or
+        /// [DisplayRequirement::name].
+        UnknownValue(display_requirement::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod display_requirement {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DisplayRequirement {
-        /// Required companions are not specified. The default is ALL.
-        pub const DISPLAY_REQUIREMENT_UNSPECIFIED: DisplayRequirement = DisplayRequirement::new(0);
-
-        /// All companions are required to be displayed.
-        pub const ALL: DisplayRequirement = DisplayRequirement::new(1);
-
-        /// At least one of companions needs to be displayed.
-        pub const ANY: DisplayRequirement = DisplayRequirement::new(2);
-
-        /// All companions are optional for display.
-        pub const NONE: DisplayRequirement = DisplayRequirement::new(3);
-
-        /// Creates a new DisplayRequirement instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::All => std::option::Option::Some(1),
+                Self::Any => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DISPLAY_REQUIREMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL"),
-                2 => std::borrow::Cow::Borrowed("ANY"),
-                3 => std::borrow::Cow::Borrowed("NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DISPLAY_REQUIREMENT_UNSPECIFIED"),
+                Self::All => std::option::Option::Some("ALL"),
+                Self::Any => std::option::Option::Some("ANY"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DISPLAY_REQUIREMENT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DISPLAY_REQUIREMENT_UNSPECIFIED)
-                }
-                "ALL" => std::option::Option::Some(Self::ALL),
-                "ANY" => std::option::Option::Some(Self::ANY),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DisplayRequirement {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DisplayRequirement {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DisplayRequirement {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DisplayRequirement {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::All,
+                2 => Self::Any,
+                3 => Self::None,
+                _ => Self::UnknownValue(display_requirement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DisplayRequirement {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DISPLAY_REQUIREMENT_UNSPECIFIED" => Self::Unspecified,
+                "ALL" => Self::All,
+                "ANY" => Self::Any,
+                "NONE" => Self::None,
+                _ => Self::UnknownValue(display_requirement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DisplayRequirement {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::All => serializer.serialize_i32(1),
+                Self::Any => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DisplayRequirement {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DisplayRequirement>::new(
+                ".google.cloud.video.stitcher.v1.CompanionAds.DisplayRequirement",
+            ))
         }
     }
 }
@@ -1216,169 +1277,274 @@ pub mod event {
     use super::*;
 
     /// Describes the event that occurred.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// The event type is unspecified.
+        Unspecified,
+        /// First frame of creative ad viewed.
+        CreativeView,
+        /// Creative ad started.
+        Start,
+        /// Start of an ad break.
+        BreakStart,
+        /// End of an ad break.
+        BreakEnd,
+        /// Impression.
+        Impression,
+        /// First quartile progress.
+        FirstQuartile,
+        /// Midpoint progress.
+        Midpoint,
+        /// Third quartile progress.
+        ThirdQuartile,
+        /// Ad progress completed.
+        Complete,
+        /// Specific progress event with an offset.
+        Progress,
+        /// Player muted.
+        Mute,
+        /// Player unmuted.
+        Unmute,
+        /// Player paused.
+        Pause,
+        /// Click event.
+        Click,
+        /// Click-through event.
+        ClickThrough,
+        /// Player rewinding.
+        Rewind,
+        /// Player resumed.
+        Resume,
+        /// Error event.
+        Error,
+        /// Ad expanded to a larger size.
+        Expand,
+        /// Ad collapsed to a smaller size.
+        Collapse,
+        /// Non-linear ad closed.
+        Close,
+        /// Linear ad closed.
+        CloseLinear,
+        /// Ad skipped.
+        Skip,
+        /// Accept invitation event.
+        AcceptInvitation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// The event type is unspecified.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// First frame of creative ad viewed.
-        pub const CREATIVE_VIEW: EventType = EventType::new(1);
-
-        /// Creative ad started.
-        pub const START: EventType = EventType::new(2);
-
-        /// Start of an ad break.
-        pub const BREAK_START: EventType = EventType::new(3);
-
-        /// End of an ad break.
-        pub const BREAK_END: EventType = EventType::new(4);
-
-        /// Impression.
-        pub const IMPRESSION: EventType = EventType::new(5);
-
-        /// First quartile progress.
-        pub const FIRST_QUARTILE: EventType = EventType::new(6);
-
-        /// Midpoint progress.
-        pub const MIDPOINT: EventType = EventType::new(7);
-
-        /// Third quartile progress.
-        pub const THIRD_QUARTILE: EventType = EventType::new(8);
-
-        /// Ad progress completed.
-        pub const COMPLETE: EventType = EventType::new(9);
-
-        /// Specific progress event with an offset.
-        pub const PROGRESS: EventType = EventType::new(10);
-
-        /// Player muted.
-        pub const MUTE: EventType = EventType::new(11);
-
-        /// Player unmuted.
-        pub const UNMUTE: EventType = EventType::new(12);
-
-        /// Player paused.
-        pub const PAUSE: EventType = EventType::new(13);
-
-        /// Click event.
-        pub const CLICK: EventType = EventType::new(14);
-
-        /// Click-through event.
-        pub const CLICK_THROUGH: EventType = EventType::new(15);
-
-        /// Player rewinding.
-        pub const REWIND: EventType = EventType::new(16);
-
-        /// Player resumed.
-        pub const RESUME: EventType = EventType::new(17);
-
-        /// Error event.
-        pub const ERROR: EventType = EventType::new(18);
-
-        /// Ad expanded to a larger size.
-        pub const EXPAND: EventType = EventType::new(21);
-
-        /// Ad collapsed to a smaller size.
-        pub const COLLAPSE: EventType = EventType::new(22);
-
-        /// Non-linear ad closed.
-        pub const CLOSE: EventType = EventType::new(24);
-
-        /// Linear ad closed.
-        pub const CLOSE_LINEAR: EventType = EventType::new(25);
-
-        /// Ad skipped.
-        pub const SKIP: EventType = EventType::new(26);
-
-        /// Accept invitation event.
-        pub const ACCEPT_INVITATION: EventType = EventType::new(27);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CreativeView => std::option::Option::Some(1),
+                Self::Start => std::option::Option::Some(2),
+                Self::BreakStart => std::option::Option::Some(3),
+                Self::BreakEnd => std::option::Option::Some(4),
+                Self::Impression => std::option::Option::Some(5),
+                Self::FirstQuartile => std::option::Option::Some(6),
+                Self::Midpoint => std::option::Option::Some(7),
+                Self::ThirdQuartile => std::option::Option::Some(8),
+                Self::Complete => std::option::Option::Some(9),
+                Self::Progress => std::option::Option::Some(10),
+                Self::Mute => std::option::Option::Some(11),
+                Self::Unmute => std::option::Option::Some(12),
+                Self::Pause => std::option::Option::Some(13),
+                Self::Click => std::option::Option::Some(14),
+                Self::ClickThrough => std::option::Option::Some(15),
+                Self::Rewind => std::option::Option::Some(16),
+                Self::Resume => std::option::Option::Some(17),
+                Self::Error => std::option::Option::Some(18),
+                Self::Expand => std::option::Option::Some(21),
+                Self::Collapse => std::option::Option::Some(22),
+                Self::Close => std::option::Option::Some(24),
+                Self::CloseLinear => std::option::Option::Some(25),
+                Self::Skip => std::option::Option::Some(26),
+                Self::AcceptInvitation => std::option::Option::Some(27),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATIVE_VIEW"),
-                2 => std::borrow::Cow::Borrowed("START"),
-                3 => std::borrow::Cow::Borrowed("BREAK_START"),
-                4 => std::borrow::Cow::Borrowed("BREAK_END"),
-                5 => std::borrow::Cow::Borrowed("IMPRESSION"),
-                6 => std::borrow::Cow::Borrowed("FIRST_QUARTILE"),
-                7 => std::borrow::Cow::Borrowed("MIDPOINT"),
-                8 => std::borrow::Cow::Borrowed("THIRD_QUARTILE"),
-                9 => std::borrow::Cow::Borrowed("COMPLETE"),
-                10 => std::borrow::Cow::Borrowed("PROGRESS"),
-                11 => std::borrow::Cow::Borrowed("MUTE"),
-                12 => std::borrow::Cow::Borrowed("UNMUTE"),
-                13 => std::borrow::Cow::Borrowed("PAUSE"),
-                14 => std::borrow::Cow::Borrowed("CLICK"),
-                15 => std::borrow::Cow::Borrowed("CLICK_THROUGH"),
-                16 => std::borrow::Cow::Borrowed("REWIND"),
-                17 => std::borrow::Cow::Borrowed("RESUME"),
-                18 => std::borrow::Cow::Borrowed("ERROR"),
-                21 => std::borrow::Cow::Borrowed("EXPAND"),
-                22 => std::borrow::Cow::Borrowed("COLLAPSE"),
-                24 => std::borrow::Cow::Borrowed("CLOSE"),
-                25 => std::borrow::Cow::Borrowed("CLOSE_LINEAR"),
-                26 => std::borrow::Cow::Borrowed("SKIP"),
-                27 => std::borrow::Cow::Borrowed("ACCEPT_INVITATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::CreativeView => std::option::Option::Some("CREATIVE_VIEW"),
+                Self::Start => std::option::Option::Some("START"),
+                Self::BreakStart => std::option::Option::Some("BREAK_START"),
+                Self::BreakEnd => std::option::Option::Some("BREAK_END"),
+                Self::Impression => std::option::Option::Some("IMPRESSION"),
+                Self::FirstQuartile => std::option::Option::Some("FIRST_QUARTILE"),
+                Self::Midpoint => std::option::Option::Some("MIDPOINT"),
+                Self::ThirdQuartile => std::option::Option::Some("THIRD_QUARTILE"),
+                Self::Complete => std::option::Option::Some("COMPLETE"),
+                Self::Progress => std::option::Option::Some("PROGRESS"),
+                Self::Mute => std::option::Option::Some("MUTE"),
+                Self::Unmute => std::option::Option::Some("UNMUTE"),
+                Self::Pause => std::option::Option::Some("PAUSE"),
+                Self::Click => std::option::Option::Some("CLICK"),
+                Self::ClickThrough => std::option::Option::Some("CLICK_THROUGH"),
+                Self::Rewind => std::option::Option::Some("REWIND"),
+                Self::Resume => std::option::Option::Some("RESUME"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Expand => std::option::Option::Some("EXPAND"),
+                Self::Collapse => std::option::Option::Some("COLLAPSE"),
+                Self::Close => std::option::Option::Some("CLOSE"),
+                Self::CloseLinear => std::option::Option::Some("CLOSE_LINEAR"),
+                Self::Skip => std::option::Option::Some("SKIP"),
+                Self::AcceptInvitation => std::option::Option::Some("ACCEPT_INVITATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "CREATIVE_VIEW" => std::option::Option::Some(Self::CREATIVE_VIEW),
-                "START" => std::option::Option::Some(Self::START),
-                "BREAK_START" => std::option::Option::Some(Self::BREAK_START),
-                "BREAK_END" => std::option::Option::Some(Self::BREAK_END),
-                "IMPRESSION" => std::option::Option::Some(Self::IMPRESSION),
-                "FIRST_QUARTILE" => std::option::Option::Some(Self::FIRST_QUARTILE),
-                "MIDPOINT" => std::option::Option::Some(Self::MIDPOINT),
-                "THIRD_QUARTILE" => std::option::Option::Some(Self::THIRD_QUARTILE),
-                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                "PROGRESS" => std::option::Option::Some(Self::PROGRESS),
-                "MUTE" => std::option::Option::Some(Self::MUTE),
-                "UNMUTE" => std::option::Option::Some(Self::UNMUTE),
-                "PAUSE" => std::option::Option::Some(Self::PAUSE),
-                "CLICK" => std::option::Option::Some(Self::CLICK),
-                "CLICK_THROUGH" => std::option::Option::Some(Self::CLICK_THROUGH),
-                "REWIND" => std::option::Option::Some(Self::REWIND),
-                "RESUME" => std::option::Option::Some(Self::RESUME),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "EXPAND" => std::option::Option::Some(Self::EXPAND),
-                "COLLAPSE" => std::option::Option::Some(Self::COLLAPSE),
-                "CLOSE" => std::option::Option::Some(Self::CLOSE),
-                "CLOSE_LINEAR" => std::option::Option::Some(Self::CLOSE_LINEAR),
-                "SKIP" => std::option::Option::Some(Self::SKIP),
-                "ACCEPT_INVITATION" => std::option::Option::Some(Self::ACCEPT_INVITATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CreativeView,
+                2 => Self::Start,
+                3 => Self::BreakStart,
+                4 => Self::BreakEnd,
+                5 => Self::Impression,
+                6 => Self::FirstQuartile,
+                7 => Self::Midpoint,
+                8 => Self::ThirdQuartile,
+                9 => Self::Complete,
+                10 => Self::Progress,
+                11 => Self::Mute,
+                12 => Self::Unmute,
+                13 => Self::Pause,
+                14 => Self::Click,
+                15 => Self::ClickThrough,
+                16 => Self::Rewind,
+                17 => Self::Resume,
+                18 => Self::Error,
+                21 => Self::Expand,
+                22 => Self::Collapse,
+                24 => Self::Close,
+                25 => Self::CloseLinear,
+                26 => Self::Skip,
+                27 => Self::AcceptInvitation,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATIVE_VIEW" => Self::CreativeView,
+                "START" => Self::Start,
+                "BREAK_START" => Self::BreakStart,
+                "BREAK_END" => Self::BreakEnd,
+                "IMPRESSION" => Self::Impression,
+                "FIRST_QUARTILE" => Self::FirstQuartile,
+                "MIDPOINT" => Self::Midpoint,
+                "THIRD_QUARTILE" => Self::ThirdQuartile,
+                "COMPLETE" => Self::Complete,
+                "PROGRESS" => Self::Progress,
+                "MUTE" => Self::Mute,
+                "UNMUTE" => Self::Unmute,
+                "PAUSE" => Self::Pause,
+                "CLICK" => Self::Click,
+                "CLICK_THROUGH" => Self::ClickThrough,
+                "REWIND" => Self::Rewind,
+                "RESUME" => Self::Resume,
+                "ERROR" => Self::Error,
+                "EXPAND" => Self::Expand,
+                "COLLAPSE" => Self::Collapse,
+                "CLOSE" => Self::Close,
+                "CLOSE_LINEAR" => Self::CloseLinear,
+                "SKIP" => Self::Skip,
+                "ACCEPT_INVITATION" => Self::AcceptInvitation,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CreativeView => serializer.serialize_i32(1),
+                Self::Start => serializer.serialize_i32(2),
+                Self::BreakStart => serializer.serialize_i32(3),
+                Self::BreakEnd => serializer.serialize_i32(4),
+                Self::Impression => serializer.serialize_i32(5),
+                Self::FirstQuartile => serializer.serialize_i32(6),
+                Self::Midpoint => serializer.serialize_i32(7),
+                Self::ThirdQuartile => serializer.serialize_i32(8),
+                Self::Complete => serializer.serialize_i32(9),
+                Self::Progress => serializer.serialize_i32(10),
+                Self::Mute => serializer.serialize_i32(11),
+                Self::Unmute => serializer.serialize_i32(12),
+                Self::Pause => serializer.serialize_i32(13),
+                Self::Click => serializer.serialize_i32(14),
+                Self::ClickThrough => serializer.serialize_i32(15),
+                Self::Rewind => serializer.serialize_i32(16),
+                Self::Resume => serializer.serialize_i32(17),
+                Self::Error => serializer.serialize_i32(18),
+                Self::Expand => serializer.serialize_i32(21),
+                Self::Collapse => serializer.serialize_i32(22),
+                Self::Close => serializer.serialize_i32(24),
+                Self::CloseLinear => serializer.serialize_i32(25),
+                Self::Skip => serializer.serialize_i32(26),
+                Self::AcceptInvitation => serializer.serialize_i32(27),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.cloud.video.stitcher.v1.Event.EventType",
+            ))
         }
     }
 }
@@ -1636,125 +1802,247 @@ pub mod live_config {
     use super::*;
 
     /// State of the live config.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is not specified.
+        Unspecified,
+        /// Live config is being created.
+        Creating,
+        /// Live config is ready for use.
+        Ready,
+        /// Live config is queued up for deletion.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Live config is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// Live config is ready for use.
-        pub const READY: State = State::new(2);
-
-        /// Live config is queued up for deletion.
-        pub const DELETING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.video.stitcher.v1.LiveConfig.State",
+            ))
         }
     }
 
     /// Defines the ad stitching behavior in case the ad duration does not align
     /// exactly with the ad break boundaries. If not specified, the default is
     /// `CUT_CURRENT`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StitchingPolicy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StitchingPolicy {
+        /// Stitching policy is not specified.
+        Unspecified,
+        /// Cuts an ad short and returns to content in the middle of the ad.
+        CutCurrent,
+        /// Finishes stitching the current ad before returning to content.
+        CompleteAd,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StitchingPolicy::value] or
+        /// [StitchingPolicy::name].
+        UnknownValue(stitching_policy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod stitching_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl StitchingPolicy {
-        /// Stitching policy is not specified.
-        pub const STITCHING_POLICY_UNSPECIFIED: StitchingPolicy = StitchingPolicy::new(0);
-
-        /// Cuts an ad short and returns to content in the middle of the ad.
-        pub const CUT_CURRENT: StitchingPolicy = StitchingPolicy::new(1);
-
-        /// Finishes stitching the current ad before returning to content.
-        pub const COMPLETE_AD: StitchingPolicy = StitchingPolicy::new(2);
-
-        /// Creates a new StitchingPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CutCurrent => std::option::Option::Some(1),
+                Self::CompleteAd => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STITCHING_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CUT_CURRENT"),
-                2 => std::borrow::Cow::Borrowed("COMPLETE_AD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STITCHING_POLICY_UNSPECIFIED"),
+                Self::CutCurrent => std::option::Option::Some("CUT_CURRENT"),
+                Self::CompleteAd => std::option::Option::Some("COMPLETE_AD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STITCHING_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STITCHING_POLICY_UNSPECIFIED)
-                }
-                "CUT_CURRENT" => std::option::Option::Some(Self::CUT_CURRENT),
-                "COMPLETE_AD" => std::option::Option::Some(Self::COMPLETE_AD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for StitchingPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StitchingPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StitchingPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StitchingPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CutCurrent,
+                2 => Self::CompleteAd,
+                _ => Self::UnknownValue(stitching_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StitchingPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STITCHING_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "CUT_CURRENT" => Self::CutCurrent,
+                "COMPLETE_AD" => Self::CompleteAd,
+                _ => Self::UnknownValue(stitching_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StitchingPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CutCurrent => serializer.serialize_i32(1),
+                Self::CompleteAd => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StitchingPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StitchingPolicy>::new(
+                ".google.cloud.video.stitcher.v1.LiveConfig.StitchingPolicy",
+            ))
         }
     }
 }
@@ -2574,61 +2862,120 @@ pub mod manifest_options {
     use super::*;
 
     /// Defines the ordering policy during manifest generation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OrderPolicy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OrderPolicy {
+        /// Ordering policy is not specified.
+        Unspecified,
+        /// Order by ascending.
+        Ascending,
+        /// Order by descending.
+        Descending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OrderPolicy::value] or
+        /// [OrderPolicy::name].
+        UnknownValue(order_policy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod order_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OrderPolicy {
-        /// Ordering policy is not specified.
-        pub const ORDER_POLICY_UNSPECIFIED: OrderPolicy = OrderPolicy::new(0);
-
-        /// Order by ascending.
-        pub const ASCENDING: OrderPolicy = OrderPolicy::new(1);
-
-        /// Order by descending.
-        pub const DESCENDING: OrderPolicy = OrderPolicy::new(2);
-
-        /// Creates a new OrderPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ascending => std::option::Option::Some(1),
+                Self::Descending => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ORDER_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ASCENDING"),
-                2 => std::borrow::Cow::Borrowed("DESCENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ORDER_POLICY_UNSPECIFIED"),
+                Self::Ascending => std::option::Option::Some("ASCENDING"),
+                Self::Descending => std::option::Option::Some("DESCENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ORDER_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ORDER_POLICY_UNSPECIFIED)
-                }
-                "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
-                "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OrderPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OrderPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OrderPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OrderPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ascending,
+                2 => Self::Descending,
+                _ => Self::UnknownValue(order_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OrderPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ORDER_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "ASCENDING" => Self::Ascending,
+                "DESCENDING" => Self::Descending,
+                _ => Self::UnknownValue(order_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OrderPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ascending => serializer.serialize_i32(1),
+                Self::Descending => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OrderPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OrderPolicy>::new(
+                ".google.cloud.video.stitcher.v1.ManifestOptions.OrderPolicy",
+            ))
         }
     }
 }
@@ -5060,64 +5407,127 @@ pub mod vod_config {
     use super::*;
 
     /// State of the VOD config.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State is not specified.
+        Unspecified,
+        /// VOD config is being created.
+        Creating,
+        /// VOD config is ready for use.
+        Ready,
+        /// VOD config is queued up for deletion.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State is not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// VOD config is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// VOD config is ready for use.
-        pub const READY: State = State::new(2);
-
-        /// VOD config is queued up for deletion.
-        pub const DELETING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.video.stitcher.v1.VodConfig.State",
+            ))
         }
     }
 }
@@ -5155,60 +5565,121 @@ impl wkt::message::Message for GamVodConfig {
 }
 
 /// Determines the ad tracking policy.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct AdTracking(i32);
-
-impl AdTracking {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AdTracking {
     /// The ad tracking policy is not specified.
-    pub const AD_TRACKING_UNSPECIFIED: AdTracking = AdTracking::new(0);
-
+    Unspecified,
     /// Client-side ad tracking is specified. The client player is expected to
     /// trigger playback and activity events itself.
-    pub const CLIENT: AdTracking = AdTracking::new(1);
-
+    Client,
     /// The Video Stitcher API will trigger playback events on behalf of
     /// the client player.
-    pub const SERVER: AdTracking = AdTracking::new(2);
+    Server,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [AdTracking::value] or
+    /// [AdTracking::name].
+    UnknownValue(ad_tracking::UnknownValue),
+}
 
-    /// Creates a new AdTracking instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod ad_tracking {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl AdTracking {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Client => std::option::Option::Some(1),
+            Self::Server => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("AD_TRACKING_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CLIENT"),
-            2 => std::borrow::Cow::Borrowed("SERVER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("AD_TRACKING_UNSPECIFIED"),
+            Self::Client => std::option::Option::Some("CLIENT"),
+            Self::Server => std::option::Option::Some("SERVER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "AD_TRACKING_UNSPECIFIED" => std::option::Option::Some(Self::AD_TRACKING_UNSPECIFIED),
-            "CLIENT" => std::option::Option::Some(Self::CLIENT),
-            "SERVER" => std::option::Option::Some(Self::SERVER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for AdTracking {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for AdTracking {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for AdTracking {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for AdTracking {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Client,
+            2 => Self::Server,
+            _ => Self::UnknownValue(ad_tracking::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for AdTracking {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "AD_TRACKING_UNSPECIFIED" => Self::Unspecified,
+            "CLIENT" => Self::Client,
+            "SERVER" => Self::Server,
+            _ => Self::UnknownValue(ad_tracking::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for AdTracking {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Client => serializer.serialize_i32(1),
+            Self::Server => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for AdTracking {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<AdTracking>::new(
+            ".google.cloud.video.stitcher.v1.AdTracking",
+        ))
     }
 }

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -299,196 +299,374 @@ pub mod job {
     use super::*;
 
     /// The current state of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProcessingState(i32);
-
-    impl ProcessingState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProcessingState {
         /// The processing state is not specified.
-        pub const PROCESSING_STATE_UNSPECIFIED: ProcessingState = ProcessingState::new(0);
-
+        Unspecified,
         /// The job is enqueued and will be picked up for processing soon.
-        pub const PENDING: ProcessingState = ProcessingState::new(1);
-
+        Pending,
         /// The job is being processed.
-        pub const RUNNING: ProcessingState = ProcessingState::new(2);
-
+        Running,
         /// The job has been completed successfully.
-        pub const SUCCEEDED: ProcessingState = ProcessingState::new(3);
-
+        Succeeded,
         /// The job has failed. For additional information, see `failure_reason` and
         /// `failure_details`
-        pub const FAILED: ProcessingState = ProcessingState::new(4);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProcessingState::value] or
+        /// [ProcessingState::name].
+        UnknownValue(processing_state::UnknownValue),
+    }
 
-        /// Creates a new ProcessingState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod processing_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ProcessingState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROCESSING_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROCESSING_STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROCESSING_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROCESSING_STATE_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ProcessingState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProcessingState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProcessingState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProcessingState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Succeeded,
+                4 => Self::Failed,
+                _ => Self::UnknownValue(processing_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProcessingState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROCESSING_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(processing_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProcessingState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProcessingState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProcessingState>::new(
+                ".google.cloud.video.transcoder.v1.Job.ProcessingState",
+            ))
         }
     }
 
     /// The processing mode of the job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProcessingMode(i32);
-
-    impl ProcessingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProcessingMode {
         /// The job processing mode is not specified.
-        pub const PROCESSING_MODE_UNSPECIFIED: ProcessingMode = ProcessingMode::new(0);
-
+        Unspecified,
         /// The job processing mode is interactive mode.
         /// Interactive job will either be ran or rejected if quota does not allow
         /// for it.
-        pub const PROCESSING_MODE_INTERACTIVE: ProcessingMode = ProcessingMode::new(1);
-
+        Interactive,
         /// The job processing mode is batch mode.
         /// Batch mode allows queuing of jobs.
-        pub const PROCESSING_MODE_BATCH: ProcessingMode = ProcessingMode::new(2);
+        Batch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProcessingMode::value] or
+        /// [ProcessingMode::name].
+        UnknownValue(processing_mode::UnknownValue),
+    }
 
-        /// Creates a new ProcessingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod processing_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ProcessingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Interactive => std::option::Option::Some(1),
+                Self::Batch => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROCESSING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROCESSING_MODE_INTERACTIVE"),
-                2 => std::borrow::Cow::Borrowed("PROCESSING_MODE_BATCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROCESSING_MODE_UNSPECIFIED"),
+                Self::Interactive => std::option::Option::Some("PROCESSING_MODE_INTERACTIVE"),
+                Self::Batch => std::option::Option::Some("PROCESSING_MODE_BATCH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROCESSING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROCESSING_MODE_UNSPECIFIED)
-                }
-                "PROCESSING_MODE_INTERACTIVE" => {
-                    std::option::Option::Some(Self::PROCESSING_MODE_INTERACTIVE)
-                }
-                "PROCESSING_MODE_BATCH" => std::option::Option::Some(Self::PROCESSING_MODE_BATCH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ProcessingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProcessingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProcessingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProcessingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Interactive,
+                2 => Self::Batch,
+                _ => Self::UnknownValue(processing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProcessingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROCESSING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "PROCESSING_MODE_INTERACTIVE" => Self::Interactive,
+                "PROCESSING_MODE_BATCH" => Self::Batch,
+                _ => Self::UnknownValue(processing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProcessingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Interactive => serializer.serialize_i32(1),
+                Self::Batch => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProcessingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProcessingMode>::new(
+                ".google.cloud.video.transcoder.v1.Job.ProcessingMode",
+            ))
         }
     }
 
     /// The optimization strategy of the job. The default is `AUTODETECT`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptimizationStrategy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OptimizationStrategy {
+        /// The optimization strategy is not specified.
+        Unspecified,
+        /// Prioritize job processing speed.
+        Autodetect,
+        /// Disable all optimizations.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OptimizationStrategy::value] or
+        /// [OptimizationStrategy::name].
+        UnknownValue(optimization_strategy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod optimization_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OptimizationStrategy {
-        /// The optimization strategy is not specified.
-        pub const OPTIMIZATION_STRATEGY_UNSPECIFIED: OptimizationStrategy =
-            OptimizationStrategy::new(0);
-
-        /// Prioritize job processing speed.
-        pub const AUTODETECT: OptimizationStrategy = OptimizationStrategy::new(1);
-
-        /// Disable all optimizations.
-        pub const DISABLED: OptimizationStrategy = OptimizationStrategy::new(2);
-
-        /// Creates a new OptimizationStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Autodetect => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPTIMIZATION_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTODETECT"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPTIMIZATION_STRATEGY_UNSPECIFIED"),
+                Self::Autodetect => std::option::Option::Some("AUTODETECT"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPTIMIZATION_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OPTIMIZATION_STRATEGY_UNSPECIFIED)
-                }
-                "AUTODETECT" => std::option::Option::Some(Self::AUTODETECT),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OptimizationStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OptimizationStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OptimizationStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OptimizationStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Autodetect,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(optimization_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OptimizationStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPTIMIZATION_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "AUTODETECT" => Self::Autodetect,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(optimization_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OptimizationStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Autodetect => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OptimizationStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OptimizationStrategy>::new(
+                ".google.cloud.video.transcoder.v1.Job.OptimizationStrategy",
+            ))
         }
     }
 
@@ -1401,125 +1579,245 @@ pub mod manifest {
         use super::*;
 
         /// The segment reference scheme for a `DASH` manifest.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SegmentReferenceScheme(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SegmentReferenceScheme {
+            /// The segment reference scheme is not specified.
+            Unspecified,
+            /// Lists the URLs of media files for each segment.
+            SegmentList,
+            /// Lists each segment from a template with $Number$ variable.
+            SegmentTemplateNumber,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SegmentReferenceScheme::value] or
+            /// [SegmentReferenceScheme::name].
+            UnknownValue(segment_reference_scheme::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod segment_reference_scheme {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SegmentReferenceScheme {
-            /// The segment reference scheme is not specified.
-            pub const SEGMENT_REFERENCE_SCHEME_UNSPECIFIED: SegmentReferenceScheme =
-                SegmentReferenceScheme::new(0);
-
-            /// Lists the URLs of media files for each segment.
-            pub const SEGMENT_LIST: SegmentReferenceScheme = SegmentReferenceScheme::new(1);
-
-            /// Lists each segment from a template with $Number$ variable.
-            pub const SEGMENT_TEMPLATE_NUMBER: SegmentReferenceScheme =
-                SegmentReferenceScheme::new(2);
-
-            /// Creates a new SegmentReferenceScheme instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::SegmentList => std::option::Option::Some(1),
+                    Self::SegmentTemplateNumber => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SEGMENT_REFERENCE_SCHEME_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SEGMENT_LIST"),
-                    2 => std::borrow::Cow::Borrowed("SEGMENT_TEMPLATE_NUMBER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SEGMENT_REFERENCE_SCHEME_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SEGMENT_REFERENCE_SCHEME_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("SEGMENT_REFERENCE_SCHEME_UNSPECIFIED")
                     }
-                    "SEGMENT_LIST" => std::option::Option::Some(Self::SEGMENT_LIST),
-                    "SEGMENT_TEMPLATE_NUMBER" => {
-                        std::option::Option::Some(Self::SEGMENT_TEMPLATE_NUMBER)
+                    Self::SegmentList => std::option::Option::Some("SEGMENT_LIST"),
+                    Self::SegmentTemplateNumber => {
+                        std::option::Option::Some("SEGMENT_TEMPLATE_NUMBER")
                     }
-                    _ => std::option::Option::None,
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for SegmentReferenceScheme {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SegmentReferenceScheme {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SegmentReferenceScheme {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SegmentReferenceScheme {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::SegmentList,
+                    2 => Self::SegmentTemplateNumber,
+                    _ => Self::UnknownValue(segment_reference_scheme::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SegmentReferenceScheme {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SEGMENT_REFERENCE_SCHEME_UNSPECIFIED" => Self::Unspecified,
+                    "SEGMENT_LIST" => Self::SegmentList,
+                    "SEGMENT_TEMPLATE_NUMBER" => Self::SegmentTemplateNumber,
+                    _ => Self::UnknownValue(segment_reference_scheme::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SegmentReferenceScheme {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::SegmentList => serializer.serialize_i32(1),
+                    Self::SegmentTemplateNumber => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SegmentReferenceScheme {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SegmentReferenceScheme>::new(
+                    ".google.cloud.video.transcoder.v1.Manifest.DashConfig.SegmentReferenceScheme"))
             }
         }
     }
 
     /// The manifest type, which corresponds to the adaptive streaming format used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ManifestType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ManifestType {
+        /// The manifest type is not specified.
+        Unspecified,
+        /// Create an HLS manifest. The corresponding file extension is `.m3u8`.
+        Hls,
+        /// Create an MPEG-DASH manifest. The corresponding file extension is `.mpd`.
+        Dash,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ManifestType::value] or
+        /// [ManifestType::name].
+        UnknownValue(manifest_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod manifest_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ManifestType {
-        /// The manifest type is not specified.
-        pub const MANIFEST_TYPE_UNSPECIFIED: ManifestType = ManifestType::new(0);
-
-        /// Create an HLS manifest. The corresponding file extension is `.m3u8`.
-        pub const HLS: ManifestType = ManifestType::new(1);
-
-        /// Create an MPEG-DASH manifest. The corresponding file extension is `.mpd`.
-        pub const DASH: ManifestType = ManifestType::new(2);
-
-        /// Creates a new ManifestType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hls => std::option::Option::Some(1),
+                Self::Dash => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MANIFEST_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HLS"),
-                2 => std::borrow::Cow::Borrowed("DASH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MANIFEST_TYPE_UNSPECIFIED"),
+                Self::Hls => std::option::Option::Some("HLS"),
+                Self::Dash => std::option::Option::Some("DASH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MANIFEST_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::MANIFEST_TYPE_UNSPECIFIED)
-                }
-                "HLS" => std::option::Option::Some(Self::HLS),
-                "DASH" => std::option::Option::Some(Self::DASH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ManifestType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ManifestType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ManifestType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ManifestType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hls,
+                2 => Self::Dash,
+                _ => Self::UnknownValue(manifest_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ManifestType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MANIFEST_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "HLS" => Self::Hls,
+                "DASH" => Self::Dash,
+                _ => Self::UnknownValue(manifest_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ManifestType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hls => serializer.serialize_i32(1),
+                Self::Dash => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ManifestType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ManifestType>::new(
+                ".google.cloud.video.transcoder.v1.Manifest.ManifestType",
+            ))
         }
     }
 
@@ -2308,59 +2606,120 @@ pub mod overlay {
     }
 
     /// Fade type for the overlay: `FADE_IN` or `FADE_OUT`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FadeType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FadeType {
+        /// The fade type is not specified.
+        Unspecified,
+        /// Fade the overlay object into view.
+        FadeIn,
+        /// Fade the overlay object out of view.
+        FadeOut,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FadeType::value] or
+        /// [FadeType::name].
+        UnknownValue(fade_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod fade_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FadeType {
-        /// The fade type is not specified.
-        pub const FADE_TYPE_UNSPECIFIED: FadeType = FadeType::new(0);
-
-        /// Fade the overlay object into view.
-        pub const FADE_IN: FadeType = FadeType::new(1);
-
-        /// Fade the overlay object out of view.
-        pub const FADE_OUT: FadeType = FadeType::new(2);
-
-        /// Creates a new FadeType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FadeIn => std::option::Option::Some(1),
+                Self::FadeOut => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FADE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FADE_IN"),
-                2 => std::borrow::Cow::Borrowed("FADE_OUT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FADE_TYPE_UNSPECIFIED"),
+                Self::FadeIn => std::option::Option::Some("FADE_IN"),
+                Self::FadeOut => std::option::Option::Some("FADE_OUT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FADE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FADE_TYPE_UNSPECIFIED),
-                "FADE_IN" => std::option::Option::Some(Self::FADE_IN),
-                "FADE_OUT" => std::option::Option::Some(Self::FADE_OUT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FadeType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FadeType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FadeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FadeType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FadeIn,
+                2 => Self::FadeOut,
+                _ => Self::UnknownValue(fade_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FadeType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FADE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FADE_IN" => Self::FadeIn,
+                "FADE_OUT" => Self::FadeOut,
+                _ => Self::UnknownValue(fade_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FadeType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FadeIn => serializer.serialize_i32(1),
+                Self::FadeOut => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FadeType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FadeType>::new(
+                ".google.cloud.video.transcoder.v1.Overlay.FadeType",
+            ))
         }
     }
 }

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -3056,231 +3056,434 @@ impl wkt::message::Message for LogoRecognitionAnnotation {
 }
 
 /// Video annotation feature.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Feature(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Feature {
+    /// Unspecified.
+    Unspecified,
+    /// Label detection. Detect objects, such as dog or flower.
+    LabelDetection,
+    /// Shot change detection.
+    ShotChangeDetection,
+    /// Explicit content detection.
+    ExplicitContentDetection,
+    /// Human face detection.
+    FaceDetection,
+    /// Speech transcription.
+    SpeechTranscription,
+    /// OCR text detection and tracking.
+    TextDetection,
+    /// Object detection and tracking.
+    ObjectTracking,
+    /// Logo detection, tracking, and recognition.
+    LogoRecognition,
+    /// Person detection.
+    PersonDetection,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Feature::value] or
+    /// [Feature::name].
+    UnknownValue(feature::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod feature {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Feature {
-    /// Unspecified.
-    pub const FEATURE_UNSPECIFIED: Feature = Feature::new(0);
-
-    /// Label detection. Detect objects, such as dog or flower.
-    pub const LABEL_DETECTION: Feature = Feature::new(1);
-
-    /// Shot change detection.
-    pub const SHOT_CHANGE_DETECTION: Feature = Feature::new(2);
-
-    /// Explicit content detection.
-    pub const EXPLICIT_CONTENT_DETECTION: Feature = Feature::new(3);
-
-    /// Human face detection.
-    pub const FACE_DETECTION: Feature = Feature::new(4);
-
-    /// Speech transcription.
-    pub const SPEECH_TRANSCRIPTION: Feature = Feature::new(6);
-
-    /// OCR text detection and tracking.
-    pub const TEXT_DETECTION: Feature = Feature::new(7);
-
-    /// Object detection and tracking.
-    pub const OBJECT_TRACKING: Feature = Feature::new(9);
-
-    /// Logo detection, tracking, and recognition.
-    pub const LOGO_RECOGNITION: Feature = Feature::new(12);
-
-    /// Person detection.
-    pub const PERSON_DETECTION: Feature = Feature::new(14);
-
-    /// Creates a new Feature instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::LabelDetection => std::option::Option::Some(1),
+            Self::ShotChangeDetection => std::option::Option::Some(2),
+            Self::ExplicitContentDetection => std::option::Option::Some(3),
+            Self::FaceDetection => std::option::Option::Some(4),
+            Self::SpeechTranscription => std::option::Option::Some(6),
+            Self::TextDetection => std::option::Option::Some(7),
+            Self::ObjectTracking => std::option::Option::Some(9),
+            Self::LogoRecognition => std::option::Option::Some(12),
+            Self::PersonDetection => std::option::Option::Some(14),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FEATURE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LABEL_DETECTION"),
-            2 => std::borrow::Cow::Borrowed("SHOT_CHANGE_DETECTION"),
-            3 => std::borrow::Cow::Borrowed("EXPLICIT_CONTENT_DETECTION"),
-            4 => std::borrow::Cow::Borrowed("FACE_DETECTION"),
-            6 => std::borrow::Cow::Borrowed("SPEECH_TRANSCRIPTION"),
-            7 => std::borrow::Cow::Borrowed("TEXT_DETECTION"),
-            9 => std::borrow::Cow::Borrowed("OBJECT_TRACKING"),
-            12 => std::borrow::Cow::Borrowed("LOGO_RECOGNITION"),
-            14 => std::borrow::Cow::Borrowed("PERSON_DETECTION"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FEATURE_UNSPECIFIED" => std::option::Option::Some(Self::FEATURE_UNSPECIFIED),
-            "LABEL_DETECTION" => std::option::Option::Some(Self::LABEL_DETECTION),
-            "SHOT_CHANGE_DETECTION" => std::option::Option::Some(Self::SHOT_CHANGE_DETECTION),
-            "EXPLICIT_CONTENT_DETECTION" => {
-                std::option::Option::Some(Self::EXPLICIT_CONTENT_DETECTION)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FEATURE_UNSPECIFIED"),
+            Self::LabelDetection => std::option::Option::Some("LABEL_DETECTION"),
+            Self::ShotChangeDetection => std::option::Option::Some("SHOT_CHANGE_DETECTION"),
+            Self::ExplicitContentDetection => {
+                std::option::Option::Some("EXPLICIT_CONTENT_DETECTION")
             }
-            "FACE_DETECTION" => std::option::Option::Some(Self::FACE_DETECTION),
-            "SPEECH_TRANSCRIPTION" => std::option::Option::Some(Self::SPEECH_TRANSCRIPTION),
-            "TEXT_DETECTION" => std::option::Option::Some(Self::TEXT_DETECTION),
-            "OBJECT_TRACKING" => std::option::Option::Some(Self::OBJECT_TRACKING),
-            "LOGO_RECOGNITION" => std::option::Option::Some(Self::LOGO_RECOGNITION),
-            "PERSON_DETECTION" => std::option::Option::Some(Self::PERSON_DETECTION),
-            _ => std::option::Option::None,
+            Self::FaceDetection => std::option::Option::Some("FACE_DETECTION"),
+            Self::SpeechTranscription => std::option::Option::Some("SPEECH_TRANSCRIPTION"),
+            Self::TextDetection => std::option::Option::Some("TEXT_DETECTION"),
+            Self::ObjectTracking => std::option::Option::Some("OBJECT_TRACKING"),
+            Self::LogoRecognition => std::option::Option::Some("LOGO_RECOGNITION"),
+            Self::PersonDetection => std::option::Option::Some("PERSON_DETECTION"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for Feature {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Feature {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Feature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Feature {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::LabelDetection,
+            2 => Self::ShotChangeDetection,
+            3 => Self::ExplicitContentDetection,
+            4 => Self::FaceDetection,
+            6 => Self::SpeechTranscription,
+            7 => Self::TextDetection,
+            9 => Self::ObjectTracking,
+            12 => Self::LogoRecognition,
+            14 => Self::PersonDetection,
+            _ => Self::UnknownValue(feature::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Feature {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FEATURE_UNSPECIFIED" => Self::Unspecified,
+            "LABEL_DETECTION" => Self::LabelDetection,
+            "SHOT_CHANGE_DETECTION" => Self::ShotChangeDetection,
+            "EXPLICIT_CONTENT_DETECTION" => Self::ExplicitContentDetection,
+            "FACE_DETECTION" => Self::FaceDetection,
+            "SPEECH_TRANSCRIPTION" => Self::SpeechTranscription,
+            "TEXT_DETECTION" => Self::TextDetection,
+            "OBJECT_TRACKING" => Self::ObjectTracking,
+            "LOGO_RECOGNITION" => Self::LogoRecognition,
+            "PERSON_DETECTION" => Self::PersonDetection,
+            _ => Self::UnknownValue(feature::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Feature {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::LabelDetection => serializer.serialize_i32(1),
+            Self::ShotChangeDetection => serializer.serialize_i32(2),
+            Self::ExplicitContentDetection => serializer.serialize_i32(3),
+            Self::FaceDetection => serializer.serialize_i32(4),
+            Self::SpeechTranscription => serializer.serialize_i32(6),
+            Self::TextDetection => serializer.serialize_i32(7),
+            Self::ObjectTracking => serializer.serialize_i32(9),
+            Self::LogoRecognition => serializer.serialize_i32(12),
+            Self::PersonDetection => serializer.serialize_i32(14),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Feature {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Feature>::new(
+            ".google.cloud.videointelligence.v1.Feature",
+        ))
     }
 }
 
 /// Label detection mode.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LabelDetectionMode(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LabelDetectionMode {
+    /// Unspecified.
+    Unspecified,
+    /// Detect shot-level labels.
+    ShotMode,
+    /// Detect frame-level labels.
+    FrameMode,
+    /// Detect both shot-level and frame-level labels.
+    ShotAndFrameMode,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LabelDetectionMode::value] or
+    /// [LabelDetectionMode::name].
+    UnknownValue(label_detection_mode::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod label_detection_mode {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl LabelDetectionMode {
-    /// Unspecified.
-    pub const LABEL_DETECTION_MODE_UNSPECIFIED: LabelDetectionMode = LabelDetectionMode::new(0);
-
-    /// Detect shot-level labels.
-    pub const SHOT_MODE: LabelDetectionMode = LabelDetectionMode::new(1);
-
-    /// Detect frame-level labels.
-    pub const FRAME_MODE: LabelDetectionMode = LabelDetectionMode::new(2);
-
-    /// Detect both shot-level and frame-level labels.
-    pub const SHOT_AND_FRAME_MODE: LabelDetectionMode = LabelDetectionMode::new(3);
-
-    /// Creates a new LabelDetectionMode instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ShotMode => std::option::Option::Some(1),
+            Self::FrameMode => std::option::Option::Some(2),
+            Self::ShotAndFrameMode => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LABEL_DETECTION_MODE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SHOT_MODE"),
-            2 => std::borrow::Cow::Borrowed("FRAME_MODE"),
-            3 => std::borrow::Cow::Borrowed("SHOT_AND_FRAME_MODE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LABEL_DETECTION_MODE_UNSPECIFIED"),
+            Self::ShotMode => std::option::Option::Some("SHOT_MODE"),
+            Self::FrameMode => std::option::Option::Some("FRAME_MODE"),
+            Self::ShotAndFrameMode => std::option::Option::Some("SHOT_AND_FRAME_MODE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LABEL_DETECTION_MODE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LABEL_DETECTION_MODE_UNSPECIFIED)
-            }
-            "SHOT_MODE" => std::option::Option::Some(Self::SHOT_MODE),
-            "FRAME_MODE" => std::option::Option::Some(Self::FRAME_MODE),
-            "SHOT_AND_FRAME_MODE" => std::option::Option::Some(Self::SHOT_AND_FRAME_MODE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LabelDetectionMode {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LabelDetectionMode {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LabelDetectionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LabelDetectionMode {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ShotMode,
+            2 => Self::FrameMode,
+            3 => Self::ShotAndFrameMode,
+            _ => Self::UnknownValue(label_detection_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LabelDetectionMode {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LABEL_DETECTION_MODE_UNSPECIFIED" => Self::Unspecified,
+            "SHOT_MODE" => Self::ShotMode,
+            "FRAME_MODE" => Self::FrameMode,
+            "SHOT_AND_FRAME_MODE" => Self::ShotAndFrameMode,
+            _ => Self::UnknownValue(label_detection_mode::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LabelDetectionMode {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ShotMode => serializer.serialize_i32(1),
+            Self::FrameMode => serializer.serialize_i32(2),
+            Self::ShotAndFrameMode => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LabelDetectionMode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LabelDetectionMode>::new(
+            ".google.cloud.videointelligence.v1.LabelDetectionMode",
+        ))
     }
 }
 
 /// Bucketized representation of likelihood.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Likelihood(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Likelihood {
+    /// Unspecified likelihood.
+    Unspecified,
+    /// Very unlikely.
+    VeryUnlikely,
+    /// Unlikely.
+    Unlikely,
+    /// Possible.
+    Possible,
+    /// Likely.
+    Likely,
+    /// Very likely.
+    VeryLikely,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Likelihood::value] or
+    /// [Likelihood::name].
+    UnknownValue(likelihood::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod likelihood {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Likelihood {
-    /// Unspecified likelihood.
-    pub const LIKELIHOOD_UNSPECIFIED: Likelihood = Likelihood::new(0);
-
-    /// Very unlikely.
-    pub const VERY_UNLIKELY: Likelihood = Likelihood::new(1);
-
-    /// Unlikely.
-    pub const UNLIKELY: Likelihood = Likelihood::new(2);
-
-    /// Possible.
-    pub const POSSIBLE: Likelihood = Likelihood::new(3);
-
-    /// Likely.
-    pub const LIKELY: Likelihood = Likelihood::new(4);
-
-    /// Very likely.
-    pub const VERY_LIKELY: Likelihood = Likelihood::new(5);
-
-    /// Creates a new Likelihood instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::VeryUnlikely => std::option::Option::Some(1),
+            Self::Unlikely => std::option::Option::Some(2),
+            Self::Possible => std::option::Option::Some(3),
+            Self::Likely => std::option::Option::Some(4),
+            Self::VeryLikely => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LIKELIHOOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
-            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
-            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
-            4 => std::borrow::Cow::Borrowed("LIKELY"),
-            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LIKELIHOOD_UNSPECIFIED"),
+            Self::VeryUnlikely => std::option::Option::Some("VERY_UNLIKELY"),
+            Self::Unlikely => std::option::Option::Some("UNLIKELY"),
+            Self::Possible => std::option::Option::Some("POSSIBLE"),
+            Self::Likely => std::option::Option::Some("LIKELY"),
+            Self::VeryLikely => std::option::Option::Some("VERY_LIKELY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LIKELIHOOD_UNSPECIFIED" => std::option::Option::Some(Self::LIKELIHOOD_UNSPECIFIED),
-            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
-            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
-            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
-            "LIKELY" => std::option::Option::Some(Self::LIKELY),
-            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Likelihood {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Likelihood {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Likelihood {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Likelihood {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::VeryUnlikely,
+            2 => Self::Unlikely,
+            3 => Self::Possible,
+            4 => Self::Likely,
+            5 => Self::VeryLikely,
+            _ => Self::UnknownValue(likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Likelihood {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LIKELIHOOD_UNSPECIFIED" => Self::Unspecified,
+            "VERY_UNLIKELY" => Self::VeryUnlikely,
+            "UNLIKELY" => Self::Unlikely,
+            "POSSIBLE" => Self::Possible,
+            "LIKELY" => Self::Likely,
+            "VERY_LIKELY" => Self::VeryLikely,
+            _ => Self::UnknownValue(likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Likelihood {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::VeryUnlikely => serializer.serialize_i32(1),
+            Self::Unlikely => serializer.serialize_i32(2),
+            Self::Possible => serializer.serialize_i32(3),
+            Self::Likely => serializer.serialize_i32(4),
+            Self::VeryLikely => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Likelihood {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Likelihood>::new(
+            ".google.cloud.videointelligence.v1.Likelihood",
+        ))
     }
 }

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -291,116 +291,195 @@ pub mod feature {
     use super::*;
 
     /// Type of Google Cloud Vision API feature to be extracted.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Unspecified feature type.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Run face detection.
-        pub const FACE_DETECTION: Type = Type::new(1);
-
+        FaceDetection,
         /// Run landmark detection.
-        pub const LANDMARK_DETECTION: Type = Type::new(2);
-
+        LandmarkDetection,
         /// Run logo detection.
-        pub const LOGO_DETECTION: Type = Type::new(3);
-
+        LogoDetection,
         /// Run label detection.
-        pub const LABEL_DETECTION: Type = Type::new(4);
-
+        LabelDetection,
         /// Run text detection / optical character recognition (OCR). Text detection
         /// is optimized for areas of text within a larger image; if the image is
         /// a document, use `DOCUMENT_TEXT_DETECTION` instead.
-        pub const TEXT_DETECTION: Type = Type::new(5);
-
+        TextDetection,
         /// Run dense text document OCR. Takes precedence when both
         /// `DOCUMENT_TEXT_DETECTION` and `TEXT_DETECTION` are present.
-        pub const DOCUMENT_TEXT_DETECTION: Type = Type::new(11);
-
+        DocumentTextDetection,
         /// Run Safe Search to detect potentially unsafe
         /// or undesirable content.
-        pub const SAFE_SEARCH_DETECTION: Type = Type::new(6);
-
+        SafeSearchDetection,
         /// Compute a set of image properties, such as the
         /// image's dominant colors.
-        pub const IMAGE_PROPERTIES: Type = Type::new(7);
-
+        ImageProperties,
         /// Run crop hints.
-        pub const CROP_HINTS: Type = Type::new(9);
-
+        CropHints,
         /// Run web detection.
-        pub const WEB_DETECTION: Type = Type::new(10);
-
+        WebDetection,
         /// Run Product Search.
-        pub const PRODUCT_SEARCH: Type = Type::new(12);
-
+        ProductSearch,
         /// Run localizer for object detection.
-        pub const OBJECT_LOCALIZATION: Type = Type::new(19);
+        ObjectLocalization,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FaceDetection => std::option::Option::Some(1),
+                Self::LandmarkDetection => std::option::Option::Some(2),
+                Self::LogoDetection => std::option::Option::Some(3),
+                Self::LabelDetection => std::option::Option::Some(4),
+                Self::TextDetection => std::option::Option::Some(5),
+                Self::DocumentTextDetection => std::option::Option::Some(11),
+                Self::SafeSearchDetection => std::option::Option::Some(6),
+                Self::ImageProperties => std::option::Option::Some(7),
+                Self::CropHints => std::option::Option::Some(9),
+                Self::WebDetection => std::option::Option::Some(10),
+                Self::ProductSearch => std::option::Option::Some(12),
+                Self::ObjectLocalization => std::option::Option::Some(19),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FACE_DETECTION"),
-                2 => std::borrow::Cow::Borrowed("LANDMARK_DETECTION"),
-                3 => std::borrow::Cow::Borrowed("LOGO_DETECTION"),
-                4 => std::borrow::Cow::Borrowed("LABEL_DETECTION"),
-                5 => std::borrow::Cow::Borrowed("TEXT_DETECTION"),
-                6 => std::borrow::Cow::Borrowed("SAFE_SEARCH_DETECTION"),
-                7 => std::borrow::Cow::Borrowed("IMAGE_PROPERTIES"),
-                9 => std::borrow::Cow::Borrowed("CROP_HINTS"),
-                10 => std::borrow::Cow::Borrowed("WEB_DETECTION"),
-                11 => std::borrow::Cow::Borrowed("DOCUMENT_TEXT_DETECTION"),
-                12 => std::borrow::Cow::Borrowed("PRODUCT_SEARCH"),
-                19 => std::borrow::Cow::Borrowed("OBJECT_LOCALIZATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::FaceDetection => std::option::Option::Some("FACE_DETECTION"),
+                Self::LandmarkDetection => std::option::Option::Some("LANDMARK_DETECTION"),
+                Self::LogoDetection => std::option::Option::Some("LOGO_DETECTION"),
+                Self::LabelDetection => std::option::Option::Some("LABEL_DETECTION"),
+                Self::TextDetection => std::option::Option::Some("TEXT_DETECTION"),
+                Self::DocumentTextDetection => std::option::Option::Some("DOCUMENT_TEXT_DETECTION"),
+                Self::SafeSearchDetection => std::option::Option::Some("SAFE_SEARCH_DETECTION"),
+                Self::ImageProperties => std::option::Option::Some("IMAGE_PROPERTIES"),
+                Self::CropHints => std::option::Option::Some("CROP_HINTS"),
+                Self::WebDetection => std::option::Option::Some("WEB_DETECTION"),
+                Self::ProductSearch => std::option::Option::Some("PRODUCT_SEARCH"),
+                Self::ObjectLocalization => std::option::Option::Some("OBJECT_LOCALIZATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "FACE_DETECTION" => std::option::Option::Some(Self::FACE_DETECTION),
-                "LANDMARK_DETECTION" => std::option::Option::Some(Self::LANDMARK_DETECTION),
-                "LOGO_DETECTION" => std::option::Option::Some(Self::LOGO_DETECTION),
-                "LABEL_DETECTION" => std::option::Option::Some(Self::LABEL_DETECTION),
-                "TEXT_DETECTION" => std::option::Option::Some(Self::TEXT_DETECTION),
-                "DOCUMENT_TEXT_DETECTION" => {
-                    std::option::Option::Some(Self::DOCUMENT_TEXT_DETECTION)
-                }
-                "SAFE_SEARCH_DETECTION" => std::option::Option::Some(Self::SAFE_SEARCH_DETECTION),
-                "IMAGE_PROPERTIES" => std::option::Option::Some(Self::IMAGE_PROPERTIES),
-                "CROP_HINTS" => std::option::Option::Some(Self::CROP_HINTS),
-                "WEB_DETECTION" => std::option::Option::Some(Self::WEB_DETECTION),
-                "PRODUCT_SEARCH" => std::option::Option::Some(Self::PRODUCT_SEARCH),
-                "OBJECT_LOCALIZATION" => std::option::Option::Some(Self::OBJECT_LOCALIZATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FaceDetection,
+                2 => Self::LandmarkDetection,
+                3 => Self::LogoDetection,
+                4 => Self::LabelDetection,
+                5 => Self::TextDetection,
+                6 => Self::SafeSearchDetection,
+                7 => Self::ImageProperties,
+                9 => Self::CropHints,
+                10 => Self::WebDetection,
+                11 => Self::DocumentTextDetection,
+                12 => Self::ProductSearch,
+                19 => Self::ObjectLocalization,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FACE_DETECTION" => Self::FaceDetection,
+                "LANDMARK_DETECTION" => Self::LandmarkDetection,
+                "LOGO_DETECTION" => Self::LogoDetection,
+                "LABEL_DETECTION" => Self::LabelDetection,
+                "TEXT_DETECTION" => Self::TextDetection,
+                "DOCUMENT_TEXT_DETECTION" => Self::DocumentTextDetection,
+                "SAFE_SEARCH_DETECTION" => Self::SafeSearchDetection,
+                "IMAGE_PROPERTIES" => Self::ImageProperties,
+                "CROP_HINTS" => Self::CropHints,
+                "WEB_DETECTION" => Self::WebDetection,
+                "PRODUCT_SEARCH" => Self::ProductSearch,
+                "OBJECT_LOCALIZATION" => Self::ObjectLocalization,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FaceDetection => serializer.serialize_i32(1),
+                Self::LandmarkDetection => serializer.serialize_i32(2),
+                Self::LogoDetection => serializer.serialize_i32(3),
+                Self::LabelDetection => serializer.serialize_i32(4),
+                Self::TextDetection => serializer.serialize_i32(5),
+                Self::DocumentTextDetection => serializer.serialize_i32(11),
+                Self::SafeSearchDetection => serializer.serialize_i32(6),
+                Self::ImageProperties => serializer.serialize_i32(7),
+                Self::CropHints => serializer.serialize_i32(9),
+                Self::WebDetection => serializer.serialize_i32(10),
+                Self::ProductSearch => serializer.serialize_i32(12),
+                Self::ObjectLocalization => serializer.serialize_i32(19),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.vision.v1.Feature.Type",
+            ))
         }
     }
 }
@@ -801,255 +880,375 @@ pub mod face_annotation {
         /// Left and right are defined from the vantage of the viewer of the image
         /// without considering mirror projections typical of photos. So, `LEFT_EYE`,
         /// typically, is the person's right eye.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// Unknown face landmark detected. Should not be filled.
+            UnknownLandmark,
+            /// Left eye.
+            LeftEye,
+            /// Right eye.
+            RightEye,
+            /// Left of left eyebrow.
+            LeftOfLeftEyebrow,
+            /// Right of left eyebrow.
+            RightOfLeftEyebrow,
+            /// Left of right eyebrow.
+            LeftOfRightEyebrow,
+            /// Right of right eyebrow.
+            RightOfRightEyebrow,
+            /// Midpoint between eyes.
+            MidpointBetweenEyes,
+            /// Nose tip.
+            NoseTip,
+            /// Upper lip.
+            UpperLip,
+            /// Lower lip.
+            LowerLip,
+            /// Mouth left.
+            MouthLeft,
+            /// Mouth right.
+            MouthRight,
+            /// Mouth center.
+            MouthCenter,
+            /// Nose, bottom right.
+            NoseBottomRight,
+            /// Nose, bottom left.
+            NoseBottomLeft,
+            /// Nose, bottom center.
+            NoseBottomCenter,
+            /// Left eye, top boundary.
+            LeftEyeTopBoundary,
+            /// Left eye, right corner.
+            LeftEyeRightCorner,
+            /// Left eye, bottom boundary.
+            LeftEyeBottomBoundary,
+            /// Left eye, left corner.
+            LeftEyeLeftCorner,
+            /// Right eye, top boundary.
+            RightEyeTopBoundary,
+            /// Right eye, right corner.
+            RightEyeRightCorner,
+            /// Right eye, bottom boundary.
+            RightEyeBottomBoundary,
+            /// Right eye, left corner.
+            RightEyeLeftCorner,
+            /// Left eyebrow, upper midpoint.
+            LeftEyebrowUpperMidpoint,
+            /// Right eyebrow, upper midpoint.
+            RightEyebrowUpperMidpoint,
+            /// Left ear tragion.
+            LeftEarTragion,
+            /// Right ear tragion.
+            RightEarTragion,
+            /// Left eye pupil.
+            LeftEyePupil,
+            /// Right eye pupil.
+            RightEyePupil,
+            /// Forehead glabella.
+            ForeheadGlabella,
+            /// Chin gnathion.
+            ChinGnathion,
+            /// Chin left gonion.
+            ChinLeftGonion,
+            /// Chin right gonion.
+            ChinRightGonion,
+            /// Left cheek center.
+            LeftCheekCenter,
+            /// Right cheek center.
+            RightCheekCenter,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// Unknown face landmark detected. Should not be filled.
-            pub const UNKNOWN_LANDMARK: Type = Type::new(0);
-
-            /// Left eye.
-            pub const LEFT_EYE: Type = Type::new(1);
-
-            /// Right eye.
-            pub const RIGHT_EYE: Type = Type::new(2);
-
-            /// Left of left eyebrow.
-            pub const LEFT_OF_LEFT_EYEBROW: Type = Type::new(3);
-
-            /// Right of left eyebrow.
-            pub const RIGHT_OF_LEFT_EYEBROW: Type = Type::new(4);
-
-            /// Left of right eyebrow.
-            pub const LEFT_OF_RIGHT_EYEBROW: Type = Type::new(5);
-
-            /// Right of right eyebrow.
-            pub const RIGHT_OF_RIGHT_EYEBROW: Type = Type::new(6);
-
-            /// Midpoint between eyes.
-            pub const MIDPOINT_BETWEEN_EYES: Type = Type::new(7);
-
-            /// Nose tip.
-            pub const NOSE_TIP: Type = Type::new(8);
-
-            /// Upper lip.
-            pub const UPPER_LIP: Type = Type::new(9);
-
-            /// Lower lip.
-            pub const LOWER_LIP: Type = Type::new(10);
-
-            /// Mouth left.
-            pub const MOUTH_LEFT: Type = Type::new(11);
-
-            /// Mouth right.
-            pub const MOUTH_RIGHT: Type = Type::new(12);
-
-            /// Mouth center.
-            pub const MOUTH_CENTER: Type = Type::new(13);
-
-            /// Nose, bottom right.
-            pub const NOSE_BOTTOM_RIGHT: Type = Type::new(14);
-
-            /// Nose, bottom left.
-            pub const NOSE_BOTTOM_LEFT: Type = Type::new(15);
-
-            /// Nose, bottom center.
-            pub const NOSE_BOTTOM_CENTER: Type = Type::new(16);
-
-            /// Left eye, top boundary.
-            pub const LEFT_EYE_TOP_BOUNDARY: Type = Type::new(17);
-
-            /// Left eye, right corner.
-            pub const LEFT_EYE_RIGHT_CORNER: Type = Type::new(18);
-
-            /// Left eye, bottom boundary.
-            pub const LEFT_EYE_BOTTOM_BOUNDARY: Type = Type::new(19);
-
-            /// Left eye, left corner.
-            pub const LEFT_EYE_LEFT_CORNER: Type = Type::new(20);
-
-            /// Right eye, top boundary.
-            pub const RIGHT_EYE_TOP_BOUNDARY: Type = Type::new(21);
-
-            /// Right eye, right corner.
-            pub const RIGHT_EYE_RIGHT_CORNER: Type = Type::new(22);
-
-            /// Right eye, bottom boundary.
-            pub const RIGHT_EYE_BOTTOM_BOUNDARY: Type = Type::new(23);
-
-            /// Right eye, left corner.
-            pub const RIGHT_EYE_LEFT_CORNER: Type = Type::new(24);
-
-            /// Left eyebrow, upper midpoint.
-            pub const LEFT_EYEBROW_UPPER_MIDPOINT: Type = Type::new(25);
-
-            /// Right eyebrow, upper midpoint.
-            pub const RIGHT_EYEBROW_UPPER_MIDPOINT: Type = Type::new(26);
-
-            /// Left ear tragion.
-            pub const LEFT_EAR_TRAGION: Type = Type::new(27);
-
-            /// Right ear tragion.
-            pub const RIGHT_EAR_TRAGION: Type = Type::new(28);
-
-            /// Left eye pupil.
-            pub const LEFT_EYE_PUPIL: Type = Type::new(29);
-
-            /// Right eye pupil.
-            pub const RIGHT_EYE_PUPIL: Type = Type::new(30);
-
-            /// Forehead glabella.
-            pub const FOREHEAD_GLABELLA: Type = Type::new(31);
-
-            /// Chin gnathion.
-            pub const CHIN_GNATHION: Type = Type::new(32);
-
-            /// Chin left gonion.
-            pub const CHIN_LEFT_GONION: Type = Type::new(33);
-
-            /// Chin right gonion.
-            pub const CHIN_RIGHT_GONION: Type = Type::new(34);
-
-            /// Left cheek center.
-            pub const LEFT_CHEEK_CENTER: Type = Type::new(35);
-
-            /// Right cheek center.
-            pub const RIGHT_CHEEK_CENTER: Type = Type::new(36);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::UnknownLandmark => std::option::Option::Some(0),
+                    Self::LeftEye => std::option::Option::Some(1),
+                    Self::RightEye => std::option::Option::Some(2),
+                    Self::LeftOfLeftEyebrow => std::option::Option::Some(3),
+                    Self::RightOfLeftEyebrow => std::option::Option::Some(4),
+                    Self::LeftOfRightEyebrow => std::option::Option::Some(5),
+                    Self::RightOfRightEyebrow => std::option::Option::Some(6),
+                    Self::MidpointBetweenEyes => std::option::Option::Some(7),
+                    Self::NoseTip => std::option::Option::Some(8),
+                    Self::UpperLip => std::option::Option::Some(9),
+                    Self::LowerLip => std::option::Option::Some(10),
+                    Self::MouthLeft => std::option::Option::Some(11),
+                    Self::MouthRight => std::option::Option::Some(12),
+                    Self::MouthCenter => std::option::Option::Some(13),
+                    Self::NoseBottomRight => std::option::Option::Some(14),
+                    Self::NoseBottomLeft => std::option::Option::Some(15),
+                    Self::NoseBottomCenter => std::option::Option::Some(16),
+                    Self::LeftEyeTopBoundary => std::option::Option::Some(17),
+                    Self::LeftEyeRightCorner => std::option::Option::Some(18),
+                    Self::LeftEyeBottomBoundary => std::option::Option::Some(19),
+                    Self::LeftEyeLeftCorner => std::option::Option::Some(20),
+                    Self::RightEyeTopBoundary => std::option::Option::Some(21),
+                    Self::RightEyeRightCorner => std::option::Option::Some(22),
+                    Self::RightEyeBottomBoundary => std::option::Option::Some(23),
+                    Self::RightEyeLeftCorner => std::option::Option::Some(24),
+                    Self::LeftEyebrowUpperMidpoint => std::option::Option::Some(25),
+                    Self::RightEyebrowUpperMidpoint => std::option::Option::Some(26),
+                    Self::LeftEarTragion => std::option::Option::Some(27),
+                    Self::RightEarTragion => std::option::Option::Some(28),
+                    Self::LeftEyePupil => std::option::Option::Some(29),
+                    Self::RightEyePupil => std::option::Option::Some(30),
+                    Self::ForeheadGlabella => std::option::Option::Some(31),
+                    Self::ChinGnathion => std::option::Option::Some(32),
+                    Self::ChinLeftGonion => std::option::Option::Some(33),
+                    Self::ChinRightGonion => std::option::Option::Some(34),
+                    Self::LeftCheekCenter => std::option::Option::Some(35),
+                    Self::RightCheekCenter => std::option::Option::Some(36),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNKNOWN_LANDMARK"),
-                    1 => std::borrow::Cow::Borrowed("LEFT_EYE"),
-                    2 => std::borrow::Cow::Borrowed("RIGHT_EYE"),
-                    3 => std::borrow::Cow::Borrowed("LEFT_OF_LEFT_EYEBROW"),
-                    4 => std::borrow::Cow::Borrowed("RIGHT_OF_LEFT_EYEBROW"),
-                    5 => std::borrow::Cow::Borrowed("LEFT_OF_RIGHT_EYEBROW"),
-                    6 => std::borrow::Cow::Borrowed("RIGHT_OF_RIGHT_EYEBROW"),
-                    7 => std::borrow::Cow::Borrowed("MIDPOINT_BETWEEN_EYES"),
-                    8 => std::borrow::Cow::Borrowed("NOSE_TIP"),
-                    9 => std::borrow::Cow::Borrowed("UPPER_LIP"),
-                    10 => std::borrow::Cow::Borrowed("LOWER_LIP"),
-                    11 => std::borrow::Cow::Borrowed("MOUTH_LEFT"),
-                    12 => std::borrow::Cow::Borrowed("MOUTH_RIGHT"),
-                    13 => std::borrow::Cow::Borrowed("MOUTH_CENTER"),
-                    14 => std::borrow::Cow::Borrowed("NOSE_BOTTOM_RIGHT"),
-                    15 => std::borrow::Cow::Borrowed("NOSE_BOTTOM_LEFT"),
-                    16 => std::borrow::Cow::Borrowed("NOSE_BOTTOM_CENTER"),
-                    17 => std::borrow::Cow::Borrowed("LEFT_EYE_TOP_BOUNDARY"),
-                    18 => std::borrow::Cow::Borrowed("LEFT_EYE_RIGHT_CORNER"),
-                    19 => std::borrow::Cow::Borrowed("LEFT_EYE_BOTTOM_BOUNDARY"),
-                    20 => std::borrow::Cow::Borrowed("LEFT_EYE_LEFT_CORNER"),
-                    21 => std::borrow::Cow::Borrowed("RIGHT_EYE_TOP_BOUNDARY"),
-                    22 => std::borrow::Cow::Borrowed("RIGHT_EYE_RIGHT_CORNER"),
-                    23 => std::borrow::Cow::Borrowed("RIGHT_EYE_BOTTOM_BOUNDARY"),
-                    24 => std::borrow::Cow::Borrowed("RIGHT_EYE_LEFT_CORNER"),
-                    25 => std::borrow::Cow::Borrowed("LEFT_EYEBROW_UPPER_MIDPOINT"),
-                    26 => std::borrow::Cow::Borrowed("RIGHT_EYEBROW_UPPER_MIDPOINT"),
-                    27 => std::borrow::Cow::Borrowed("LEFT_EAR_TRAGION"),
-                    28 => std::borrow::Cow::Borrowed("RIGHT_EAR_TRAGION"),
-                    29 => std::borrow::Cow::Borrowed("LEFT_EYE_PUPIL"),
-                    30 => std::borrow::Cow::Borrowed("RIGHT_EYE_PUPIL"),
-                    31 => std::borrow::Cow::Borrowed("FOREHEAD_GLABELLA"),
-                    32 => std::borrow::Cow::Borrowed("CHIN_GNATHION"),
-                    33 => std::borrow::Cow::Borrowed("CHIN_LEFT_GONION"),
-                    34 => std::borrow::Cow::Borrowed("CHIN_RIGHT_GONION"),
-                    35 => std::borrow::Cow::Borrowed("LEFT_CHEEK_CENTER"),
-                    36 => std::borrow::Cow::Borrowed("RIGHT_CHEEK_CENTER"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::UnknownLandmark => std::option::Option::Some("UNKNOWN_LANDMARK"),
+                    Self::LeftEye => std::option::Option::Some("LEFT_EYE"),
+                    Self::RightEye => std::option::Option::Some("RIGHT_EYE"),
+                    Self::LeftOfLeftEyebrow => std::option::Option::Some("LEFT_OF_LEFT_EYEBROW"),
+                    Self::RightOfLeftEyebrow => std::option::Option::Some("RIGHT_OF_LEFT_EYEBROW"),
+                    Self::LeftOfRightEyebrow => std::option::Option::Some("LEFT_OF_RIGHT_EYEBROW"),
+                    Self::RightOfRightEyebrow => {
+                        std::option::Option::Some("RIGHT_OF_RIGHT_EYEBROW")
+                    }
+                    Self::MidpointBetweenEyes => std::option::Option::Some("MIDPOINT_BETWEEN_EYES"),
+                    Self::NoseTip => std::option::Option::Some("NOSE_TIP"),
+                    Self::UpperLip => std::option::Option::Some("UPPER_LIP"),
+                    Self::LowerLip => std::option::Option::Some("LOWER_LIP"),
+                    Self::MouthLeft => std::option::Option::Some("MOUTH_LEFT"),
+                    Self::MouthRight => std::option::Option::Some("MOUTH_RIGHT"),
+                    Self::MouthCenter => std::option::Option::Some("MOUTH_CENTER"),
+                    Self::NoseBottomRight => std::option::Option::Some("NOSE_BOTTOM_RIGHT"),
+                    Self::NoseBottomLeft => std::option::Option::Some("NOSE_BOTTOM_LEFT"),
+                    Self::NoseBottomCenter => std::option::Option::Some("NOSE_BOTTOM_CENTER"),
+                    Self::LeftEyeTopBoundary => std::option::Option::Some("LEFT_EYE_TOP_BOUNDARY"),
+                    Self::LeftEyeRightCorner => std::option::Option::Some("LEFT_EYE_RIGHT_CORNER"),
+                    Self::LeftEyeBottomBoundary => {
+                        std::option::Option::Some("LEFT_EYE_BOTTOM_BOUNDARY")
+                    }
+                    Self::LeftEyeLeftCorner => std::option::Option::Some("LEFT_EYE_LEFT_CORNER"),
+                    Self::RightEyeTopBoundary => {
+                        std::option::Option::Some("RIGHT_EYE_TOP_BOUNDARY")
+                    }
+                    Self::RightEyeRightCorner => {
+                        std::option::Option::Some("RIGHT_EYE_RIGHT_CORNER")
+                    }
+                    Self::RightEyeBottomBoundary => {
+                        std::option::Option::Some("RIGHT_EYE_BOTTOM_BOUNDARY")
+                    }
+                    Self::RightEyeLeftCorner => std::option::Option::Some("RIGHT_EYE_LEFT_CORNER"),
+                    Self::LeftEyebrowUpperMidpoint => {
+                        std::option::Option::Some("LEFT_EYEBROW_UPPER_MIDPOINT")
+                    }
+                    Self::RightEyebrowUpperMidpoint => {
+                        std::option::Option::Some("RIGHT_EYEBROW_UPPER_MIDPOINT")
+                    }
+                    Self::LeftEarTragion => std::option::Option::Some("LEFT_EAR_TRAGION"),
+                    Self::RightEarTragion => std::option::Option::Some("RIGHT_EAR_TRAGION"),
+                    Self::LeftEyePupil => std::option::Option::Some("LEFT_EYE_PUPIL"),
+                    Self::RightEyePupil => std::option::Option::Some("RIGHT_EYE_PUPIL"),
+                    Self::ForeheadGlabella => std::option::Option::Some("FOREHEAD_GLABELLA"),
+                    Self::ChinGnathion => std::option::Option::Some("CHIN_GNATHION"),
+                    Self::ChinLeftGonion => std::option::Option::Some("CHIN_LEFT_GONION"),
+                    Self::ChinRightGonion => std::option::Option::Some("CHIN_RIGHT_GONION"),
+                    Self::LeftCheekCenter => std::option::Option::Some("LEFT_CHEEK_CENTER"),
+                    Self::RightCheekCenter => std::option::Option::Some("RIGHT_CHEEK_CENTER"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNKNOWN_LANDMARK" => std::option::Option::Some(Self::UNKNOWN_LANDMARK),
-                    "LEFT_EYE" => std::option::Option::Some(Self::LEFT_EYE),
-                    "RIGHT_EYE" => std::option::Option::Some(Self::RIGHT_EYE),
-                    "LEFT_OF_LEFT_EYEBROW" => std::option::Option::Some(Self::LEFT_OF_LEFT_EYEBROW),
-                    "RIGHT_OF_LEFT_EYEBROW" => {
-                        std::option::Option::Some(Self::RIGHT_OF_LEFT_EYEBROW)
-                    }
-                    "LEFT_OF_RIGHT_EYEBROW" => {
-                        std::option::Option::Some(Self::LEFT_OF_RIGHT_EYEBROW)
-                    }
-                    "RIGHT_OF_RIGHT_EYEBROW" => {
-                        std::option::Option::Some(Self::RIGHT_OF_RIGHT_EYEBROW)
-                    }
-                    "MIDPOINT_BETWEEN_EYES" => {
-                        std::option::Option::Some(Self::MIDPOINT_BETWEEN_EYES)
-                    }
-                    "NOSE_TIP" => std::option::Option::Some(Self::NOSE_TIP),
-                    "UPPER_LIP" => std::option::Option::Some(Self::UPPER_LIP),
-                    "LOWER_LIP" => std::option::Option::Some(Self::LOWER_LIP),
-                    "MOUTH_LEFT" => std::option::Option::Some(Self::MOUTH_LEFT),
-                    "MOUTH_RIGHT" => std::option::Option::Some(Self::MOUTH_RIGHT),
-                    "MOUTH_CENTER" => std::option::Option::Some(Self::MOUTH_CENTER),
-                    "NOSE_BOTTOM_RIGHT" => std::option::Option::Some(Self::NOSE_BOTTOM_RIGHT),
-                    "NOSE_BOTTOM_LEFT" => std::option::Option::Some(Self::NOSE_BOTTOM_LEFT),
-                    "NOSE_BOTTOM_CENTER" => std::option::Option::Some(Self::NOSE_BOTTOM_CENTER),
-                    "LEFT_EYE_TOP_BOUNDARY" => {
-                        std::option::Option::Some(Self::LEFT_EYE_TOP_BOUNDARY)
-                    }
-                    "LEFT_EYE_RIGHT_CORNER" => {
-                        std::option::Option::Some(Self::LEFT_EYE_RIGHT_CORNER)
-                    }
-                    "LEFT_EYE_BOTTOM_BOUNDARY" => {
-                        std::option::Option::Some(Self::LEFT_EYE_BOTTOM_BOUNDARY)
-                    }
-                    "LEFT_EYE_LEFT_CORNER" => std::option::Option::Some(Self::LEFT_EYE_LEFT_CORNER),
-                    "RIGHT_EYE_TOP_BOUNDARY" => {
-                        std::option::Option::Some(Self::RIGHT_EYE_TOP_BOUNDARY)
-                    }
-                    "RIGHT_EYE_RIGHT_CORNER" => {
-                        std::option::Option::Some(Self::RIGHT_EYE_RIGHT_CORNER)
-                    }
-                    "RIGHT_EYE_BOTTOM_BOUNDARY" => {
-                        std::option::Option::Some(Self::RIGHT_EYE_BOTTOM_BOUNDARY)
-                    }
-                    "RIGHT_EYE_LEFT_CORNER" => {
-                        std::option::Option::Some(Self::RIGHT_EYE_LEFT_CORNER)
-                    }
-                    "LEFT_EYEBROW_UPPER_MIDPOINT" => {
-                        std::option::Option::Some(Self::LEFT_EYEBROW_UPPER_MIDPOINT)
-                    }
-                    "RIGHT_EYEBROW_UPPER_MIDPOINT" => {
-                        std::option::Option::Some(Self::RIGHT_EYEBROW_UPPER_MIDPOINT)
-                    }
-                    "LEFT_EAR_TRAGION" => std::option::Option::Some(Self::LEFT_EAR_TRAGION),
-                    "RIGHT_EAR_TRAGION" => std::option::Option::Some(Self::RIGHT_EAR_TRAGION),
-                    "LEFT_EYE_PUPIL" => std::option::Option::Some(Self::LEFT_EYE_PUPIL),
-                    "RIGHT_EYE_PUPIL" => std::option::Option::Some(Self::RIGHT_EYE_PUPIL),
-                    "FOREHEAD_GLABELLA" => std::option::Option::Some(Self::FOREHEAD_GLABELLA),
-                    "CHIN_GNATHION" => std::option::Option::Some(Self::CHIN_GNATHION),
-                    "CHIN_LEFT_GONION" => std::option::Option::Some(Self::CHIN_LEFT_GONION),
-                    "CHIN_RIGHT_GONION" => std::option::Option::Some(Self::CHIN_RIGHT_GONION),
-                    "LEFT_CHEEK_CENTER" => std::option::Option::Some(Self::LEFT_CHEEK_CENTER),
-                    "RIGHT_CHEEK_CENTER" => std::option::Option::Some(Self::RIGHT_CHEEK_CENTER),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::UnknownLandmark,
+                    1 => Self::LeftEye,
+                    2 => Self::RightEye,
+                    3 => Self::LeftOfLeftEyebrow,
+                    4 => Self::RightOfLeftEyebrow,
+                    5 => Self::LeftOfRightEyebrow,
+                    6 => Self::RightOfRightEyebrow,
+                    7 => Self::MidpointBetweenEyes,
+                    8 => Self::NoseTip,
+                    9 => Self::UpperLip,
+                    10 => Self::LowerLip,
+                    11 => Self::MouthLeft,
+                    12 => Self::MouthRight,
+                    13 => Self::MouthCenter,
+                    14 => Self::NoseBottomRight,
+                    15 => Self::NoseBottomLeft,
+                    16 => Self::NoseBottomCenter,
+                    17 => Self::LeftEyeTopBoundary,
+                    18 => Self::LeftEyeRightCorner,
+                    19 => Self::LeftEyeBottomBoundary,
+                    20 => Self::LeftEyeLeftCorner,
+                    21 => Self::RightEyeTopBoundary,
+                    22 => Self::RightEyeRightCorner,
+                    23 => Self::RightEyeBottomBoundary,
+                    24 => Self::RightEyeLeftCorner,
+                    25 => Self::LeftEyebrowUpperMidpoint,
+                    26 => Self::RightEyebrowUpperMidpoint,
+                    27 => Self::LeftEarTragion,
+                    28 => Self::RightEarTragion,
+                    29 => Self::LeftEyePupil,
+                    30 => Self::RightEyePupil,
+                    31 => Self::ForeheadGlabella,
+                    32 => Self::ChinGnathion,
+                    33 => Self::ChinLeftGonion,
+                    34 => Self::ChinRightGonion,
+                    35 => Self::LeftCheekCenter,
+                    36 => Self::RightCheekCenter,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNKNOWN_LANDMARK" => Self::UnknownLandmark,
+                    "LEFT_EYE" => Self::LeftEye,
+                    "RIGHT_EYE" => Self::RightEye,
+                    "LEFT_OF_LEFT_EYEBROW" => Self::LeftOfLeftEyebrow,
+                    "RIGHT_OF_LEFT_EYEBROW" => Self::RightOfLeftEyebrow,
+                    "LEFT_OF_RIGHT_EYEBROW" => Self::LeftOfRightEyebrow,
+                    "RIGHT_OF_RIGHT_EYEBROW" => Self::RightOfRightEyebrow,
+                    "MIDPOINT_BETWEEN_EYES" => Self::MidpointBetweenEyes,
+                    "NOSE_TIP" => Self::NoseTip,
+                    "UPPER_LIP" => Self::UpperLip,
+                    "LOWER_LIP" => Self::LowerLip,
+                    "MOUTH_LEFT" => Self::MouthLeft,
+                    "MOUTH_RIGHT" => Self::MouthRight,
+                    "MOUTH_CENTER" => Self::MouthCenter,
+                    "NOSE_BOTTOM_RIGHT" => Self::NoseBottomRight,
+                    "NOSE_BOTTOM_LEFT" => Self::NoseBottomLeft,
+                    "NOSE_BOTTOM_CENTER" => Self::NoseBottomCenter,
+                    "LEFT_EYE_TOP_BOUNDARY" => Self::LeftEyeTopBoundary,
+                    "LEFT_EYE_RIGHT_CORNER" => Self::LeftEyeRightCorner,
+                    "LEFT_EYE_BOTTOM_BOUNDARY" => Self::LeftEyeBottomBoundary,
+                    "LEFT_EYE_LEFT_CORNER" => Self::LeftEyeLeftCorner,
+                    "RIGHT_EYE_TOP_BOUNDARY" => Self::RightEyeTopBoundary,
+                    "RIGHT_EYE_RIGHT_CORNER" => Self::RightEyeRightCorner,
+                    "RIGHT_EYE_BOTTOM_BOUNDARY" => Self::RightEyeBottomBoundary,
+                    "RIGHT_EYE_LEFT_CORNER" => Self::RightEyeLeftCorner,
+                    "LEFT_EYEBROW_UPPER_MIDPOINT" => Self::LeftEyebrowUpperMidpoint,
+                    "RIGHT_EYEBROW_UPPER_MIDPOINT" => Self::RightEyebrowUpperMidpoint,
+                    "LEFT_EAR_TRAGION" => Self::LeftEarTragion,
+                    "RIGHT_EAR_TRAGION" => Self::RightEarTragion,
+                    "LEFT_EYE_PUPIL" => Self::LeftEyePupil,
+                    "RIGHT_EYE_PUPIL" => Self::RightEyePupil,
+                    "FOREHEAD_GLABELLA" => Self::ForeheadGlabella,
+                    "CHIN_GNATHION" => Self::ChinGnathion,
+                    "CHIN_LEFT_GONION" => Self::ChinLeftGonion,
+                    "CHIN_RIGHT_GONION" => Self::ChinRightGonion,
+                    "LEFT_CHEEK_CENTER" => Self::LeftCheekCenter,
+                    "RIGHT_CHEEK_CENTER" => Self::RightCheekCenter,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::UnknownLandmark => serializer.serialize_i32(0),
+                    Self::LeftEye => serializer.serialize_i32(1),
+                    Self::RightEye => serializer.serialize_i32(2),
+                    Self::LeftOfLeftEyebrow => serializer.serialize_i32(3),
+                    Self::RightOfLeftEyebrow => serializer.serialize_i32(4),
+                    Self::LeftOfRightEyebrow => serializer.serialize_i32(5),
+                    Self::RightOfRightEyebrow => serializer.serialize_i32(6),
+                    Self::MidpointBetweenEyes => serializer.serialize_i32(7),
+                    Self::NoseTip => serializer.serialize_i32(8),
+                    Self::UpperLip => serializer.serialize_i32(9),
+                    Self::LowerLip => serializer.serialize_i32(10),
+                    Self::MouthLeft => serializer.serialize_i32(11),
+                    Self::MouthRight => serializer.serialize_i32(12),
+                    Self::MouthCenter => serializer.serialize_i32(13),
+                    Self::NoseBottomRight => serializer.serialize_i32(14),
+                    Self::NoseBottomLeft => serializer.serialize_i32(15),
+                    Self::NoseBottomCenter => serializer.serialize_i32(16),
+                    Self::LeftEyeTopBoundary => serializer.serialize_i32(17),
+                    Self::LeftEyeRightCorner => serializer.serialize_i32(18),
+                    Self::LeftEyeBottomBoundary => serializer.serialize_i32(19),
+                    Self::LeftEyeLeftCorner => serializer.serialize_i32(20),
+                    Self::RightEyeTopBoundary => serializer.serialize_i32(21),
+                    Self::RightEyeRightCorner => serializer.serialize_i32(22),
+                    Self::RightEyeBottomBoundary => serializer.serialize_i32(23),
+                    Self::RightEyeLeftCorner => serializer.serialize_i32(24),
+                    Self::LeftEyebrowUpperMidpoint => serializer.serialize_i32(25),
+                    Self::RightEyebrowUpperMidpoint => serializer.serialize_i32(26),
+                    Self::LeftEarTragion => serializer.serialize_i32(27),
+                    Self::RightEarTragion => serializer.serialize_i32(28),
+                    Self::LeftEyePupil => serializer.serialize_i32(29),
+                    Self::RightEyePupil => serializer.serialize_i32(30),
+                    Self::ForeheadGlabella => serializer.serialize_i32(31),
+                    Self::ChinGnathion => serializer.serialize_i32(32),
+                    Self::ChinLeftGonion => serializer.serialize_i32(33),
+                    Self::ChinRightGonion => serializer.serialize_i32(34),
+                    Self::LeftCheekCenter => serializer.serialize_i32(35),
+                    Self::RightCheekCenter => serializer.serialize_i32(36),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.vision.v1.FaceAnnotation.Landmark.Type",
+                ))
             }
         }
     }
@@ -3365,69 +3564,134 @@ pub mod operation_metadata {
     use super::*;
 
     /// Batch operation states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Invalid.
+        Unspecified,
+        /// Request is received.
+        Created,
+        /// Request is actively being processed.
+        Running,
+        /// The batch processing is done.
+        Done,
+        /// The batch processing was cancelled.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Request is received.
-        pub const CREATED: State = State::new(1);
-
-        /// Request is actively being processed.
-        pub const RUNNING: State = State::new(2);
-
-        /// The batch processing is done.
-        pub const DONE: State = State::new(3);
-
-        /// The batch processing was cancelled.
-        pub const CANCELLED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Created => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATED"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Created,
+                2 => Self::Running,
+                3 => Self::Done,
+                4 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATED" => Self::Created,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Created => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vision.v1.OperationMetadata.State",
+            ))
         }
     }
 }
@@ -5563,72 +5827,137 @@ pub mod batch_operation_metadata {
     use super::*;
 
     /// Enumerates the possible states that the batch request can be in.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is actively being processed.
-        pub const PROCESSING: State = State::new(1);
-
+        Processing,
         /// The request is done and at least one item has been successfully
         /// processed.
-        pub const SUCCESSFUL: State = State::new(2);
-
+        Successful,
         /// The request is done and no item has been successfully processed.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// The request is done after the longrunning.Operations.CancelOperation has
         /// been called by the user.  Any records that were processed before the
         /// cancel command are output as specified in the request.
-        pub const CANCELLED: State = State::new(4);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Processing => std::option::Option::Some(1),
+                Self::Successful => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROCESSING"),
-                2 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Processing => std::option::Option::Some("PROCESSING"),
+                Self::Successful => std::option::Option::Some("SUCCESSFUL"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
-                "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Processing,
+                2 => Self::Successful,
+                3 => Self::Failed,
+                4 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PROCESSING" => Self::Processing,
+                "SUCCESSFUL" => Self::Successful,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Processing => serializer.serialize_i32(1),
+                Self::Successful => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vision.v1.BatchOperationMetadata.State",
+            ))
         }
     }
 }
@@ -5966,75 +6295,145 @@ pub mod text_annotation {
         use super::*;
 
         /// Enum to denote the type of break found. New line, space etc.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct BreakType(i32);
-
-        impl BreakType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum BreakType {
             /// Unknown break label type.
-            pub const UNKNOWN: BreakType = BreakType::new(0);
-
+            Unknown,
             /// Regular space.
-            pub const SPACE: BreakType = BreakType::new(1);
-
+            Space,
             /// Sure space (very wide).
-            pub const SURE_SPACE: BreakType = BreakType::new(2);
-
+            SureSpace,
             /// Line-wrapping break.
-            pub const EOL_SURE_SPACE: BreakType = BreakType::new(3);
-
+            EolSureSpace,
             /// End-line hyphen that is not present in text; does not co-occur with
             /// `SPACE`, `LEADER_SPACE`, or `LINE_BREAK`.
-            pub const HYPHEN: BreakType = BreakType::new(4);
-
+            Hyphen,
             /// Line break that ends a paragraph.
-            pub const LINE_BREAK: BreakType = BreakType::new(5);
+            LineBreak,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [BreakType::value] or
+            /// [BreakType::name].
+            UnknownValue(break_type::UnknownValue),
+        }
 
-            /// Creates a new BreakType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod break_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl BreakType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unknown => std::option::Option::Some(0),
+                    Self::Space => std::option::Option::Some(1),
+                    Self::SureSpace => std::option::Option::Some(2),
+                    Self::EolSureSpace => std::option::Option::Some(3),
+                    Self::Hyphen => std::option::Option::Some(4),
+                    Self::LineBreak => std::option::Option::Some(5),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                    1 => std::borrow::Cow::Borrowed("SPACE"),
-                    2 => std::borrow::Cow::Borrowed("SURE_SPACE"),
-                    3 => std::borrow::Cow::Borrowed("EOL_SURE_SPACE"),
-                    4 => std::borrow::Cow::Borrowed("HYPHEN"),
-                    5 => std::borrow::Cow::Borrowed("LINE_BREAK"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                    Self::Space => std::option::Option::Some("SPACE"),
+                    Self::SureSpace => std::option::Option::Some("SURE_SPACE"),
+                    Self::EolSureSpace => std::option::Option::Some("EOL_SURE_SPACE"),
+                    Self::Hyphen => std::option::Option::Some("HYPHEN"),
+                    Self::LineBreak => std::option::Option::Some("LINE_BREAK"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                    "SPACE" => std::option::Option::Some(Self::SPACE),
-                    "SURE_SPACE" => std::option::Option::Some(Self::SURE_SPACE),
-                    "EOL_SURE_SPACE" => std::option::Option::Some(Self::EOL_SURE_SPACE),
-                    "HYPHEN" => std::option::Option::Some(Self::HYPHEN),
-                    "LINE_BREAK" => std::option::Option::Some(Self::LINE_BREAK),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for BreakType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for BreakType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for BreakType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for BreakType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unknown,
+                    1 => Self::Space,
+                    2 => Self::SureSpace,
+                    3 => Self::EolSureSpace,
+                    4 => Self::Hyphen,
+                    5 => Self::LineBreak,
+                    _ => Self::UnknownValue(break_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for BreakType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "UNKNOWN" => Self::Unknown,
+                    "SPACE" => Self::Space,
+                    "SURE_SPACE" => Self::SureSpace,
+                    "EOL_SURE_SPACE" => Self::EolSureSpace,
+                    "HYPHEN" => Self::Hyphen,
+                    "LINE_BREAK" => Self::LineBreak,
+                    _ => Self::UnknownValue(break_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for BreakType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unknown => serializer.serialize_i32(0),
+                    Self::Space => serializer.serialize_i32(1),
+                    Self::SureSpace => serializer.serialize_i32(2),
+                    Self::EolSureSpace => serializer.serialize_i32(3),
+                    Self::Hyphen => serializer.serialize_i32(4),
+                    Self::LineBreak => serializer.serialize_i32(5),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for BreakType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<BreakType>::new(
+                    ".google.cloud.vision.v1.TextAnnotation.DetectedBreak.BreakType",
+                ))
             }
         }
     }
@@ -6295,74 +6694,141 @@ pub mod block {
     use super::*;
 
     /// Type of a block (text, image etc) as identified by OCR.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BlockType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BlockType {
+        /// Unknown block type.
+        Unknown,
+        /// Regular text block.
+        Text,
+        /// Table block.
+        Table,
+        /// Image block.
+        Picture,
+        /// Horizontal/vertical line box.
+        Ruler,
+        /// Barcode block.
+        Barcode,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BlockType::value] or
+        /// [BlockType::name].
+        UnknownValue(block_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod block_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BlockType {
-        /// Unknown block type.
-        pub const UNKNOWN: BlockType = BlockType::new(0);
-
-        /// Regular text block.
-        pub const TEXT: BlockType = BlockType::new(1);
-
-        /// Table block.
-        pub const TABLE: BlockType = BlockType::new(2);
-
-        /// Image block.
-        pub const PICTURE: BlockType = BlockType::new(3);
-
-        /// Horizontal/vertical line box.
-        pub const RULER: BlockType = BlockType::new(4);
-
-        /// Barcode block.
-        pub const BARCODE: BlockType = BlockType::new(5);
-
-        /// Creates a new BlockType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Text => std::option::Option::Some(1),
+                Self::Table => std::option::Option::Some(2),
+                Self::Picture => std::option::Option::Some(3),
+                Self::Ruler => std::option::Option::Some(4),
+                Self::Barcode => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("TEXT"),
-                2 => std::borrow::Cow::Borrowed("TABLE"),
-                3 => std::borrow::Cow::Borrowed("PICTURE"),
-                4 => std::borrow::Cow::Borrowed("RULER"),
-                5 => std::borrow::Cow::Borrowed("BARCODE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Text => std::option::Option::Some("TEXT"),
+                Self::Table => std::option::Option::Some("TABLE"),
+                Self::Picture => std::option::Option::Some("PICTURE"),
+                Self::Ruler => std::option::Option::Some("RULER"),
+                Self::Barcode => std::option::Option::Some("BARCODE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "TEXT" => std::option::Option::Some(Self::TEXT),
-                "TABLE" => std::option::Option::Some(Self::TABLE),
-                "PICTURE" => std::option::Option::Some(Self::PICTURE),
-                "RULER" => std::option::Option::Some(Self::RULER),
-                "BARCODE" => std::option::Option::Some(Self::BARCODE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BlockType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BlockType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BlockType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BlockType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Text,
+                2 => Self::Table,
+                3 => Self::Picture,
+                4 => Self::Ruler,
+                5 => Self::Barcode,
+                _ => Self::UnknownValue(block_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BlockType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "TEXT" => Self::Text,
+                "TABLE" => Self::Table,
+                "PICTURE" => Self::Picture,
+                "RULER" => Self::Ruler,
+                "BARCODE" => Self::Barcode,
+                _ => Self::UnknownValue(block_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BlockType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Text => serializer.serialize_i32(1),
+                Self::Table => serializer.serialize_i32(2),
+                Self::Picture => serializer.serialize_i32(3),
+                Self::Ruler => serializer.serialize_i32(4),
+                Self::Barcode => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BlockType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BlockType>::new(
+                ".google.cloud.vision.v1.Block.BlockType",
+            ))
         }
     }
 }
@@ -6991,73 +7457,140 @@ pub mod web_detection {
 
 /// A bucketized representation of likelihood, which is intended to give clients
 /// highly stable results across model upgrades.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Likelihood(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Likelihood {
+    /// Unknown likelihood.
+    Unknown,
+    /// It is very unlikely.
+    VeryUnlikely,
+    /// It is unlikely.
+    Unlikely,
+    /// It is possible.
+    Possible,
+    /// It is likely.
+    Likely,
+    /// It is very likely.
+    VeryLikely,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Likelihood::value] or
+    /// [Likelihood::name].
+    UnknownValue(likelihood::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod likelihood {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Likelihood {
-    /// Unknown likelihood.
-    pub const UNKNOWN: Likelihood = Likelihood::new(0);
-
-    /// It is very unlikely.
-    pub const VERY_UNLIKELY: Likelihood = Likelihood::new(1);
-
-    /// It is unlikely.
-    pub const UNLIKELY: Likelihood = Likelihood::new(2);
-
-    /// It is possible.
-    pub const POSSIBLE: Likelihood = Likelihood::new(3);
-
-    /// It is likely.
-    pub const LIKELY: Likelihood = Likelihood::new(4);
-
-    /// It is very likely.
-    pub const VERY_LIKELY: Likelihood = Likelihood::new(5);
-
-    /// Creates a new Likelihood instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unknown => std::option::Option::Some(0),
+            Self::VeryUnlikely => std::option::Option::Some(1),
+            Self::Unlikely => std::option::Option::Some(2),
+            Self::Possible => std::option::Option::Some(3),
+            Self::Likely => std::option::Option::Some(4),
+            Self::VeryLikely => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
-            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
-            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
-            4 => std::borrow::Cow::Borrowed("LIKELY"),
-            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unknown => std::option::Option::Some("UNKNOWN"),
+            Self::VeryUnlikely => std::option::Option::Some("VERY_UNLIKELY"),
+            Self::Unlikely => std::option::Option::Some("UNLIKELY"),
+            Self::Possible => std::option::Option::Some("POSSIBLE"),
+            Self::Likely => std::option::Option::Some("LIKELY"),
+            Self::VeryLikely => std::option::Option::Some("VERY_LIKELY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
-            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
-            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
-            "LIKELY" => std::option::Option::Some(Self::LIKELY),
-            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Likelihood {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Likelihood {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Likelihood {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Likelihood {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unknown,
+            1 => Self::VeryUnlikely,
+            2 => Self::Unlikely,
+            3 => Self::Possible,
+            4 => Self::Likely,
+            5 => Self::VeryLikely,
+            _ => Self::UnknownValue(likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Likelihood {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UNKNOWN" => Self::Unknown,
+            "VERY_UNLIKELY" => Self::VeryUnlikely,
+            "UNLIKELY" => Self::Unlikely,
+            "POSSIBLE" => Self::Possible,
+            "LIKELY" => Self::Likely,
+            "VERY_LIKELY" => Self::VeryLikely,
+            _ => Self::UnknownValue(likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Likelihood {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unknown => serializer.serialize_i32(0),
+            Self::VeryUnlikely => serializer.serialize_i32(1),
+            Self::Unlikely => serializer.serialize_i32(2),
+            Self::Possible => serializer.serialize_i32(3),
+            Self::Likely => serializer.serialize_i32(4),
+            Self::VeryLikely => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Likelihood {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Likelihood>::new(
+            ".google.cloud.vision.v1.Likelihood",
+        ))
     }
 }

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -174,70 +174,135 @@ pub mod replication_cycle {
     use super::*;
 
     /// Possible states of a replication cycle.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unknown. This is used for API compatibility only and is not
         /// used by the system.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The replication cycle is running.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The replication cycle is paused.
-        pub const PAUSED: State = State::new(2);
-
+        Paused,
         /// The replication cycle finished with errors.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// The replication cycle finished successfully.
-        pub const SUCCEEDED: State = State::new(4);
+        Succeeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Paused,
+                3 => Self::Failed,
+                4 => Self::Succeeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "PAUSED" => Self::Paused,
+                "FAILED" => Self::Failed,
+                "SUCCEEDED" => Self::Succeeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.ReplicationCycle.State",
+            ))
         }
     }
 }
@@ -920,110 +985,189 @@ pub mod migrating_vm {
     use super::*;
 
     /// The possible values of the state/health of source VM.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state was not sampled by the health checks yet.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The VM in the source is being verified.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The source VM was verified, and it's ready to start replication.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// Migration is going through the first sync cycle.
-        pub const FIRST_SYNC: State = State::new(3);
-
+        FirstSync,
         /// The replication is active, and it's running or scheduled to run.
-        pub const ACTIVE: State = State::new(4);
-
+        Active,
         /// The source VM is being turned off, and a final replication is currently
         /// running.
-        pub const CUTTING_OVER: State = State::new(7);
-
+        CuttingOver,
         /// The source VM was stopped and replicated. The replication is currently
         /// paused.
-        pub const CUTOVER: State = State::new(8);
-
+        Cutover,
         /// A cutover job is active and replication cycle is running the final sync.
-        pub const FINAL_SYNC: State = State::new(9);
-
+        FinalSync,
         /// The replication was paused by the user and no cycles are scheduled to
         /// run.
-        pub const PAUSED: State = State::new(10);
-
+        Paused,
         /// The migrating VM is being finalized and migration resources are being
         /// removed.
-        pub const FINALIZING: State = State::new(11);
-
+        Finalizing,
         /// The replication process is done. The migrating VM is finalized and no
         /// longer consumes billable resources.
-        pub const FINALIZED: State = State::new(12);
-
+        Finalized,
         /// The replication process encountered an unrecoverable error and was
         /// aborted.
-        pub const ERROR: State = State::new(13);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::FirstSync => std::option::Option::Some(3),
+                Self::Active => std::option::Option::Some(4),
+                Self::CuttingOver => std::option::Option::Some(7),
+                Self::Cutover => std::option::Option::Some(8),
+                Self::FinalSync => std::option::Option::Some(9),
+                Self::Paused => std::option::Option::Some(10),
+                Self::Finalizing => std::option::Option::Some(11),
+                Self::Finalized => std::option::Option::Some(12),
+                Self::Error => std::option::Option::Some(13),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("FIRST_SYNC"),
-                4 => std::borrow::Cow::Borrowed("ACTIVE"),
-                7 => std::borrow::Cow::Borrowed("CUTTING_OVER"),
-                8 => std::borrow::Cow::Borrowed("CUTOVER"),
-                9 => std::borrow::Cow::Borrowed("FINAL_SYNC"),
-                10 => std::borrow::Cow::Borrowed("PAUSED"),
-                11 => std::borrow::Cow::Borrowed("FINALIZING"),
-                12 => std::borrow::Cow::Borrowed("FINALIZED"),
-                13 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::FirstSync => std::option::Option::Some("FIRST_SYNC"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::CuttingOver => std::option::Option::Some("CUTTING_OVER"),
+                Self::Cutover => std::option::Option::Some("CUTOVER"),
+                Self::FinalSync => std::option::Option::Some("FINAL_SYNC"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Finalizing => std::option::Option::Some("FINALIZING"),
+                Self::Finalized => std::option::Option::Some("FINALIZED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "FIRST_SYNC" => std::option::Option::Some(Self::FIRST_SYNC),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CUTTING_OVER" => std::option::Option::Some(Self::CUTTING_OVER),
-                "CUTOVER" => std::option::Option::Some(Self::CUTOVER),
-                "FINAL_SYNC" => std::option::Option::Some(Self::FINAL_SYNC),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
-                "FINALIZED" => std::option::Option::Some(Self::FINALIZED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Ready,
+                3 => Self::FirstSync,
+                4 => Self::Active,
+                7 => Self::CuttingOver,
+                8 => Self::Cutover,
+                9 => Self::FinalSync,
+                10 => Self::Paused,
+                11 => Self::Finalizing,
+                12 => Self::Finalized,
+                13 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "READY" => Self::Ready,
+                "FIRST_SYNC" => Self::FirstSync,
+                "ACTIVE" => Self::Active,
+                "CUTTING_OVER" => Self::CuttingOver,
+                "CUTOVER" => Self::Cutover,
+                "FINAL_SYNC" => Self::FinalSync,
+                "PAUSED" => Self::Paused,
+                "FINALIZING" => Self::Finalizing,
+                "FINALIZED" => Self::Finalized,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::FirstSync => serializer.serialize_i32(3),
+                Self::Active => serializer.serialize_i32(4),
+                Self::CuttingOver => serializer.serialize_i32(7),
+                Self::Cutover => serializer.serialize_i32(8),
+                Self::FinalSync => serializer.serialize_i32(9),
+                Self::Paused => serializer.serialize_i32(10),
+                Self::Finalizing => serializer.serialize_i32(11),
+                Self::Finalized => serializer.serialize_i32(12),
+                Self::Error => serializer.serialize_i32(13),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.MigratingVm.State",
+            ))
         }
     }
 
@@ -1227,85 +1371,156 @@ pub mod clone_job {
     use super::*;
 
     /// Possible states of the clone job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unknown. This is used for API compatibility only and is not
         /// used by the system.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The clone job has not yet started.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The clone job is active and running.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The clone job finished with errors.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// The clone job finished successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
+        Succeeded,
         /// The clone job was cancelled.
-        pub const CANCELLED: State = State::new(5);
-
+        Cancelled,
         /// The clone job is being cancelled.
-        pub const CANCELLING: State = State::new(6);
-
+        Cancelling,
         /// OS adaptation is running as part of the clone job to generate license.
-        pub const ADAPTING_OS: State = State::new(7);
+        AdaptingOs,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::Cancelling => std::option::Option::Some(6),
+                Self::AdaptingOs => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                6 => std::borrow::Cow::Borrowed("CANCELLING"),
-                7 => std::borrow::Cow::Borrowed("ADAPTING_OS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::AdaptingOs => std::option::Option::Some("ADAPTING_OS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "ADAPTING_OS" => std::option::Option::Some(Self::ADAPTING_OS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Active,
+                3 => Self::Failed,
+                4 => Self::Succeeded,
+                5 => Self::Cancelled,
+                6 => Self::Cancelling,
+                7 => Self::AdaptingOs,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "ACTIVE" => Self::Active,
+                "FAILED" => Self::Failed,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELLED" => Self::Cancelled,
+                "CANCELLING" => Self::Cancelling,
+                "ADAPTING_OS" => Self::AdaptingOs,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::Cancelling => serializer.serialize_i32(6),
+                Self::AdaptingOs => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.CloneJob.State",
+            ))
         }
     }
 
@@ -1745,85 +1960,156 @@ pub mod cutover_job {
     use super::*;
 
     /// Possible states of the cutover job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unknown. This is used for API compatibility only and is not
         /// used by the system.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The cutover job has not yet started.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The cutover job finished with errors.
-        pub const FAILED: State = State::new(2);
-
+        Failed,
         /// The cutover job finished successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
+        Succeeded,
         /// The cutover job was cancelled.
-        pub const CANCELLED: State = State::new(4);
-
+        Cancelled,
         /// The cutover job is being cancelled.
-        pub const CANCELLING: State = State::new(5);
-
+        Cancelling,
         /// The cutover job is active and running.
-        pub const ACTIVE: State = State::new(6);
-
+        Active,
         /// OS adaptation is running as part of the cutover job to generate license.
-        pub const ADAPTING_OS: State = State::new(7);
+        AdaptingOs,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::Cancelling => std::option::Option::Some(5),
+                Self::Active => std::option::Option::Some(6),
+                Self::AdaptingOs => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLING"),
-                6 => std::borrow::Cow::Borrowed("ACTIVE"),
-                7 => std::borrow::Cow::Borrowed("ADAPTING_OS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::AdaptingOs => std::option::Option::Some("ADAPTING_OS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "ADAPTING_OS" => std::option::Option::Some(Self::ADAPTING_OS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Failed,
+                3 => Self::Succeeded,
+                4 => Self::Cancelled,
+                5 => Self::Cancelling,
+                6 => Self::Active,
+                7 => Self::AdaptingOs,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "FAILED" => Self::Failed,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELLED" => Self::Cancelled,
+                "CANCELLING" => Self::Cancelling,
+                "ACTIVE" => Self::Active,
+                "ADAPTING_OS" => Self::AdaptingOs,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::Cancelling => serializer.serialize_i32(5),
+                Self::Active => serializer.serialize_i32(6),
+                Self::AdaptingOs => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.CutoverJob.State",
+            ))
         }
     }
 
@@ -2921,67 +3207,130 @@ pub mod aws_source_details {
     }
 
     /// The possible values of the state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unknown. This is used for API compatibility only and is not
         /// used by the system.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The state was not sampled by the health checks yet.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The source is available but might not be usable yet due to invalid
         /// credentials or another reason.
         /// The error message will contain further details.
-        pub const FAILED: State = State::new(2);
-
+        Failed,
         /// The source exists and its credentials were verified.
-        pub const ACTIVE: State = State::new(3);
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Active => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Failed,
+                3 => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "FAILED" => Self::Failed,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Active => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.AwsSourceDetails.State",
+            ))
         }
     }
 
@@ -3207,72 +3556,137 @@ pub mod datacenter_connector {
     use super::*;
 
     /// The possible values of the state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unknown. This is used for API compatibility only and is not
         /// used by the system.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The state was not sampled by the health checks yet.
-        pub const PENDING: State = State::new(1);
-
+        Pending,
         /// The source was sampled by health checks and is not available.
-        pub const OFFLINE: State = State::new(2);
-
+        Offline,
         /// The source is available but might not be usable yet due to unvalidated
         /// credentials or another reason. The credentials referred to are the ones
         /// to the Source. The error message will contain further details.
-        pub const FAILED: State = State::new(3);
-
+        Failed,
         /// The source exists and its credentials were verified.
-        pub const ACTIVE: State = State::new(4);
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Offline => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Active => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("OFFLINE"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Offline => std::option::Option::Some("OFFLINE"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "OFFLINE" => std::option::Option::Some(Self::OFFLINE),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Offline,
+                3 => Self::Failed,
+                4 => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "OFFLINE" => Self::Offline,
+                "FAILED" => Self::Failed,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Offline => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Active => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.DatacenterConnector.State",
+            ))
         }
     }
 }
@@ -3366,64 +3780,127 @@ pub mod upgrade_status {
     use super::*;
 
     /// The possible values of the state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state was not sampled by the health checks yet.
+        Unspecified,
+        /// The upgrade has started.
+        Running,
+        /// The upgrade failed.
+        Failed,
+        /// The upgrade finished successfully.
+        Succeeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state was not sampled by the health checks yet.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The upgrade has started.
-        pub const RUNNING: State = State::new(1);
-
-        /// The upgrade failed.
-        pub const FAILED: State = State::new(2);
-
-        /// The upgrade finished successfully.
-        pub const SUCCEEDED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Succeeded => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Failed,
+                3 => Self::Succeeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "FAILED" => Self::Failed,
+                "SUCCEEDED" => Self::Succeeded,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Succeeded => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.UpgradeStatus.State",
+            ))
         }
     }
 }
@@ -4150,125 +4627,245 @@ pub mod vmware_vm_details {
     use super::*;
 
     /// Possible values for the power state of the VM.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PowerState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PowerState {
+        /// Power state is not specified.
+        Unspecified,
+        /// The VM is turned ON.
+        On,
+        /// The VM is turned OFF.
+        Off,
+        /// The VM is suspended. This is similar to hibernation or sleep mode.
+        Suspended,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PowerState::value] or
+        /// [PowerState::name].
+        UnknownValue(power_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod power_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PowerState {
-        /// Power state is not specified.
-        pub const POWER_STATE_UNSPECIFIED: PowerState = PowerState::new(0);
-
-        /// The VM is turned ON.
-        pub const ON: PowerState = PowerState::new(1);
-
-        /// The VM is turned OFF.
-        pub const OFF: PowerState = PowerState::new(2);
-
-        /// The VM is suspended. This is similar to hibernation or sleep mode.
-        pub const SUSPENDED: PowerState = PowerState::new(3);
-
-        /// Creates a new PowerState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::On => std::option::Option::Some(1),
+                Self::Off => std::option::Option::Some(2),
+                Self::Suspended => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POWER_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON"),
-                2 => std::borrow::Cow::Borrowed("OFF"),
-                3 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POWER_STATE_UNSPECIFIED"),
+                Self::On => std::option::Option::Some("ON"),
+                Self::Off => std::option::Option::Some("OFF"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POWER_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POWER_STATE_UNSPECIFIED)
-                }
-                "ON" => std::option::Option::Some(Self::ON),
-                "OFF" => std::option::Option::Some(Self::OFF),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PowerState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PowerState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PowerState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PowerState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::On,
+                2 => Self::Off,
+                3 => Self::Suspended,
+                _ => Self::UnknownValue(power_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PowerState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POWER_STATE_UNSPECIFIED" => Self::Unspecified,
+                "ON" => Self::On,
+                "OFF" => Self::Off,
+                "SUSPENDED" => Self::Suspended,
+                _ => Self::UnknownValue(power_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PowerState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::On => serializer.serialize_i32(1),
+                Self::Off => serializer.serialize_i32(2),
+                Self::Suspended => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PowerState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PowerState>::new(
+                ".google.cloud.vmmigration.v1.VmwareVmDetails.PowerState",
+            ))
         }
     }
 
     /// Possible values for vm boot option.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BootOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BootOption {
+        /// The boot option is unknown.
+        Unspecified,
+        /// The boot option is EFI.
+        Efi,
+        /// The boot option is BIOS.
+        Bios,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BootOption::value] or
+        /// [BootOption::name].
+        UnknownValue(boot_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod boot_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BootOption {
-        /// The boot option is unknown.
-        pub const BOOT_OPTION_UNSPECIFIED: BootOption = BootOption::new(0);
-
-        /// The boot option is EFI.
-        pub const EFI: BootOption = BootOption::new(1);
-
-        /// The boot option is BIOS.
-        pub const BIOS: BootOption = BootOption::new(2);
-
-        /// Creates a new BootOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Efi => std::option::Option::Some(1),
+                Self::Bios => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BOOT_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EFI"),
-                2 => std::borrow::Cow::Borrowed("BIOS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BOOT_OPTION_UNSPECIFIED"),
+                Self::Efi => std::option::Option::Some("EFI"),
+                Self::Bios => std::option::Option::Some("BIOS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BOOT_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BOOT_OPTION_UNSPECIFIED)
-                }
-                "EFI" => std::option::Option::Some(Self::EFI),
-                "BIOS" => std::option::Option::Some(Self::BIOS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BootOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BootOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BootOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BootOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Efi,
+                2 => Self::Bios,
+                _ => Self::UnknownValue(boot_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BootOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BOOT_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "EFI" => Self::Efi,
+                "BIOS" => Self::Bios,
+                _ => Self::UnknownValue(boot_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BootOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Efi => serializer.serialize_i32(1),
+                Self::Bios => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BootOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BootOption>::new(
+                ".google.cloud.vmmigration.v1.VmwareVmDetails.BootOption",
+            ))
         }
     }
 }
@@ -4506,260 +5103,505 @@ pub mod aws_vm_details {
     use super::*;
 
     /// Possible values for the power state of the VM.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PowerState(i32);
-
-    impl PowerState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PowerState {
         /// Power state is not specified.
-        pub const POWER_STATE_UNSPECIFIED: PowerState = PowerState::new(0);
-
+        Unspecified,
         /// The VM is turned on.
-        pub const ON: PowerState = PowerState::new(1);
-
+        On,
         /// The VM is turned off.
-        pub const OFF: PowerState = PowerState::new(2);
-
+        Off,
         /// The VM is suspended. This is similar to hibernation or sleep
         /// mode.
-        pub const SUSPENDED: PowerState = PowerState::new(3);
-
+        Suspended,
         /// The VM is starting.
-        pub const PENDING: PowerState = PowerState::new(4);
+        Pending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PowerState::value] or
+        /// [PowerState::name].
+        UnknownValue(power_state::UnknownValue),
+    }
 
-        /// Creates a new PowerState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod power_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PowerState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::On => std::option::Option::Some(1),
+                Self::Off => std::option::Option::Some(2),
+                Self::Suspended => std::option::Option::Some(3),
+                Self::Pending => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POWER_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ON"),
-                2 => std::borrow::Cow::Borrowed("OFF"),
-                3 => std::borrow::Cow::Borrowed("SUSPENDED"),
-                4 => std::borrow::Cow::Borrowed("PENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POWER_STATE_UNSPECIFIED"),
+                Self::On => std::option::Option::Some("ON"),
+                Self::Off => std::option::Option::Some("OFF"),
+                Self::Suspended => std::option::Option::Some("SUSPENDED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POWER_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POWER_STATE_UNSPECIFIED)
-                }
-                "ON" => std::option::Option::Some(Self::ON),
-                "OFF" => std::option::Option::Some(Self::OFF),
-                "SUSPENDED" => std::option::Option::Some(Self::SUSPENDED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PowerState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PowerState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PowerState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PowerState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::On,
+                2 => Self::Off,
+                3 => Self::Suspended,
+                4 => Self::Pending,
+                _ => Self::UnknownValue(power_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PowerState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POWER_STATE_UNSPECIFIED" => Self::Unspecified,
+                "ON" => Self::On,
+                "OFF" => Self::Off,
+                "SUSPENDED" => Self::Suspended,
+                "PENDING" => Self::Pending,
+                _ => Self::UnknownValue(power_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PowerState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::On => serializer.serialize_i32(1),
+                Self::Off => serializer.serialize_i32(2),
+                Self::Suspended => serializer.serialize_i32(3),
+                Self::Pending => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PowerState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PowerState>::new(
+                ".google.cloud.vmmigration.v1.AwsVmDetails.PowerState",
+            ))
         }
     }
 
     /// The possible values for the vm boot option.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BootOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BootOption {
+        /// The boot option is unknown.
+        Unspecified,
+        /// The boot option is UEFI.
+        Efi,
+        /// The boot option is LEGACY-BIOS.
+        Bios,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BootOption::value] or
+        /// [BootOption::name].
+        UnknownValue(boot_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod boot_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BootOption {
-        /// The boot option is unknown.
-        pub const BOOT_OPTION_UNSPECIFIED: BootOption = BootOption::new(0);
-
-        /// The boot option is UEFI.
-        pub const EFI: BootOption = BootOption::new(1);
-
-        /// The boot option is LEGACY-BIOS.
-        pub const BIOS: BootOption = BootOption::new(2);
-
-        /// Creates a new BootOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Efi => std::option::Option::Some(1),
+                Self::Bios => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BOOT_OPTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EFI"),
-                2 => std::borrow::Cow::Borrowed("BIOS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BOOT_OPTION_UNSPECIFIED"),
+                Self::Efi => std::option::Option::Some("EFI"),
+                Self::Bios => std::option::Option::Some("BIOS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BOOT_OPTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::BOOT_OPTION_UNSPECIFIED)
-                }
-                "EFI" => std::option::Option::Some(Self::EFI),
-                "BIOS" => std::option::Option::Some(Self::BIOS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BootOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BootOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BootOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BootOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Efi,
+                2 => Self::Bios,
+                _ => Self::UnknownValue(boot_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BootOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BOOT_OPTION_UNSPECIFIED" => Self::Unspecified,
+                "EFI" => Self::Efi,
+                "BIOS" => Self::Bios,
+                _ => Self::UnknownValue(boot_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BootOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Efi => serializer.serialize_i32(1),
+                Self::Bios => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BootOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BootOption>::new(
+                ".google.cloud.vmmigration.v1.AwsVmDetails.BootOption",
+            ))
         }
     }
 
     /// Possible values for the virtualization types of the VM.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VmVirtualizationType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VmVirtualizationType {
+        /// The virtualization type is unknown.
+        Unspecified,
+        /// The virtualziation type is HVM.
+        Hvm,
+        /// The virtualziation type is PARAVIRTUAL.
+        Paravirtual,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VmVirtualizationType::value] or
+        /// [VmVirtualizationType::name].
+        UnknownValue(vm_virtualization_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod vm_virtualization_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VmVirtualizationType {
-        /// The virtualization type is unknown.
-        pub const VM_VIRTUALIZATION_TYPE_UNSPECIFIED: VmVirtualizationType =
-            VmVirtualizationType::new(0);
-
-        /// The virtualziation type is HVM.
-        pub const HVM: VmVirtualizationType = VmVirtualizationType::new(1);
-
-        /// The virtualziation type is PARAVIRTUAL.
-        pub const PARAVIRTUAL: VmVirtualizationType = VmVirtualizationType::new(2);
-
-        /// Creates a new VmVirtualizationType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Hvm => std::option::Option::Some(1),
+                Self::Paravirtual => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VM_VIRTUALIZATION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HVM"),
-                2 => std::borrow::Cow::Borrowed("PARAVIRTUAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VM_VIRTUALIZATION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VM_VIRTUALIZATION_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("VM_VIRTUALIZATION_TYPE_UNSPECIFIED")
                 }
-                "HVM" => std::option::Option::Some(Self::HVM),
-                "PARAVIRTUAL" => std::option::Option::Some(Self::PARAVIRTUAL),
-                _ => std::option::Option::None,
+                Self::Hvm => std::option::Option::Some("HVM"),
+                Self::Paravirtual => std::option::Option::Some("PARAVIRTUAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for VmVirtualizationType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VmVirtualizationType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VmVirtualizationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VmVirtualizationType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Hvm,
+                2 => Self::Paravirtual,
+                _ => Self::UnknownValue(vm_virtualization_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VmVirtualizationType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VM_VIRTUALIZATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "HVM" => Self::Hvm,
+                "PARAVIRTUAL" => Self::Paravirtual,
+                _ => Self::UnknownValue(vm_virtualization_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VmVirtualizationType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Hvm => serializer.serialize_i32(1),
+                Self::Paravirtual => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VmVirtualizationType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VmVirtualizationType>::new(
+                ".google.cloud.vmmigration.v1.AwsVmDetails.VmVirtualizationType",
+            ))
         }
     }
 
     /// Possible values for the architectures of the VM.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VmArchitecture(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VmArchitecture {
+        /// The architecture is unknown.
+        Unspecified,
+        /// The architecture is I386.
+        I386,
+        /// The architecture is X86_64.
+        X8664,
+        /// The architecture is ARM64.
+        Arm64,
+        /// The architecture is X86_64_MAC.
+        X8664Mac,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VmArchitecture::value] or
+        /// [VmArchitecture::name].
+        UnknownValue(vm_architecture::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod vm_architecture {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VmArchitecture {
-        /// The architecture is unknown.
-        pub const VM_ARCHITECTURE_UNSPECIFIED: VmArchitecture = VmArchitecture::new(0);
-
-        /// The architecture is I386.
-        pub const I386: VmArchitecture = VmArchitecture::new(1);
-
-        /// The architecture is X86_64.
-        pub const X86_64: VmArchitecture = VmArchitecture::new(2);
-
-        /// The architecture is ARM64.
-        pub const ARM64: VmArchitecture = VmArchitecture::new(3);
-
-        /// The architecture is X86_64_MAC.
-        pub const X86_64_MAC: VmArchitecture = VmArchitecture::new(4);
-
-        /// Creates a new VmArchitecture instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::I386 => std::option::Option::Some(1),
+                Self::X8664 => std::option::Option::Some(2),
+                Self::Arm64 => std::option::Option::Some(3),
+                Self::X8664Mac => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VM_ARCHITECTURE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("I386"),
-                2 => std::borrow::Cow::Borrowed("X86_64"),
-                3 => std::borrow::Cow::Borrowed("ARM64"),
-                4 => std::borrow::Cow::Borrowed("X86_64_MAC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VM_ARCHITECTURE_UNSPECIFIED"),
+                Self::I386 => std::option::Option::Some("I386"),
+                Self::X8664 => std::option::Option::Some("X86_64"),
+                Self::Arm64 => std::option::Option::Some("ARM64"),
+                Self::X8664Mac => std::option::Option::Some("X86_64_MAC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VM_ARCHITECTURE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VM_ARCHITECTURE_UNSPECIFIED)
-                }
-                "I386" => std::option::Option::Some(Self::I386),
-                "X86_64" => std::option::Option::Some(Self::X86_64),
-                "ARM64" => std::option::Option::Some(Self::ARM64),
-                "X86_64_MAC" => std::option::Option::Some(Self::X86_64_MAC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VmArchitecture {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VmArchitecture {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VmArchitecture {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VmArchitecture {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::I386,
+                2 => Self::X8664,
+                3 => Self::Arm64,
+                4 => Self::X8664Mac,
+                _ => Self::UnknownValue(vm_architecture::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VmArchitecture {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VM_ARCHITECTURE_UNSPECIFIED" => Self::Unspecified,
+                "I386" => Self::I386,
+                "X86_64" => Self::X8664,
+                "ARM64" => Self::Arm64,
+                "X86_64_MAC" => Self::X8664Mac,
+                _ => Self::UnknownValue(vm_architecture::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VmArchitecture {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::I386 => serializer.serialize_i32(1),
+                Self::X8664 => serializer.serialize_i32(2),
+                Self::Arm64 => serializer.serialize_i32(3),
+                Self::X8664Mac => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VmArchitecture {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VmArchitecture>::new(
+                ".google.cloud.vmmigration.v1.AwsVmDetails.VmArchitecture",
+            ))
         }
     }
 }
@@ -5170,126 +6012,252 @@ pub mod utilization_report {
     use super::*;
 
     /// Utilization report state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The state is unknown. This value is not in use.
+        Unspecified,
+        /// The report is in the making.
+        Creating,
+        /// Report creation completed successfully.
+        Succeeded,
+        /// Report creation failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The state is unknown. This value is not in use.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The report is in the making.
-        pub const CREATING: State = State::new(1);
-
-        /// Report creation completed successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// Report creation failed.
-        pub const FAILED: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmmigration.v1.UtilizationReport.State",
+            ))
         }
     }
 
     /// Report time frame options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeFrame(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimeFrame {
+        /// The time frame was not specified and will default to WEEK.
+        Unspecified,
+        /// One week.
+        Week,
+        /// One month.
+        Month,
+        /// One year.
+        Year,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimeFrame::value] or
+        /// [TimeFrame::name].
+        UnknownValue(time_frame::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod time_frame {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TimeFrame {
-        /// The time frame was not specified and will default to WEEK.
-        pub const TIME_FRAME_UNSPECIFIED: TimeFrame = TimeFrame::new(0);
-
-        /// One week.
-        pub const WEEK: TimeFrame = TimeFrame::new(1);
-
-        /// One month.
-        pub const MONTH: TimeFrame = TimeFrame::new(2);
-
-        /// One year.
-        pub const YEAR: TimeFrame = TimeFrame::new(3);
-
-        /// Creates a new TimeFrame instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Week => std::option::Option::Some(1),
+                Self::Month => std::option::Option::Some(2),
+                Self::Year => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIME_FRAME_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("WEEK"),
-                2 => std::borrow::Cow::Borrowed("MONTH"),
-                3 => std::borrow::Cow::Borrowed("YEAR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIME_FRAME_UNSPECIFIED"),
+                Self::Week => std::option::Option::Some("WEEK"),
+                Self::Month => std::option::Option::Some("MONTH"),
+                Self::Year => std::option::Option::Some("YEAR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIME_FRAME_UNSPECIFIED" => std::option::Option::Some(Self::TIME_FRAME_UNSPECIFIED),
-                "WEEK" => std::option::Option::Some(Self::WEEK),
-                "MONTH" => std::option::Option::Some(Self::MONTH),
-                "YEAR" => std::option::Option::Some(Self::YEAR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TimeFrame {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeFrame {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimeFrame {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimeFrame {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Week,
+                2 => Self::Month,
+                3 => Self::Year,
+                _ => Self::UnknownValue(time_frame::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimeFrame {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIME_FRAME_UNSPECIFIED" => Self::Unspecified,
+                "WEEK" => Self::Week,
+                "MONTH" => Self::Month,
+                "YEAR" => Self::Year,
+                _ => Self::UnknownValue(time_frame::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimeFrame {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Week => serializer.serialize_i32(1),
+                Self::Month => serializer.serialize_i32(2),
+                Self::Year => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimeFrame {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimeFrame>::new(
+                ".google.cloud.vmmigration.v1.UtilizationReport.TimeFrame",
+            ))
         }
     }
 }
@@ -6890,64 +7858,127 @@ pub mod applied_license {
     use super::*;
 
     /// License types used in OS adaptation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified license for the OS.
+        Unspecified,
+        /// No license available for the OS.
+        None,
+        /// The license type is Pay As You Go license type.
+        Payg,
+        /// The license type is Bring Your Own License type.
+        Byol,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified license for the OS.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// No license available for the OS.
-        pub const NONE: Type = Type::new(1);
-
-        /// The license type is Pay As You Go license type.
-        pub const PAYG: Type = Type::new(2);
-
-        /// The license type is Bring Your Own License type.
-        pub const BYOL: Type = Type::new(3);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Payg => std::option::Option::Some(2),
+                Self::Byol => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("PAYG"),
-                3 => std::borrow::Cow::Borrowed("BYOL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Payg => std::option::Option::Some("PAYG"),
+                Self::Byol => std::option::Option::Some("BYOL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "PAYG" => std::option::Option::Some(Self::PAYG),
-                "BYOL" => std::option::Option::Some(Self::BYOL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Payg,
+                3 => Self::Byol,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "PAYG" => Self::Payg,
+                "BYOL" => Self::Byol,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Payg => serializer.serialize_i32(2),
+                Self::Byol => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.vmmigration.v1.AppliedLicense.Type",
+            ))
         }
     }
 }
@@ -7021,59 +8052,120 @@ pub mod scheduling_node_affinity {
 
     /// Possible types of node selection operators. Valid operators are IN for
     /// affinity and NOT_IN for anti-affinity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operator(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Operator {
+        /// An unknown, unexpected behavior.
+        Unspecified,
+        /// The node resource group should be in these resources affinity.
+        In,
+        /// The node resource group should not be in these resources affinity.
+        NotIn,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Operator::value] or
+        /// [Operator::name].
+        UnknownValue(operator::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod operator {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Operator {
-        /// An unknown, unexpected behavior.
-        pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
-        /// The node resource group should be in these resources affinity.
-        pub const IN: Operator = Operator::new(1);
-
-        /// The node resource group should not be in these resources affinity.
-        pub const NOT_IN: Operator = Operator::new(2);
-
-        /// Creates a new Operator instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::In => std::option::Option::Some(1),
+                Self::NotIn => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN"),
-                2 => std::borrow::Cow::Borrowed("NOT_IN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                Self::In => std::option::Option::Some("IN"),
+                Self::NotIn => std::option::Option::Some("NOT_IN"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                "IN" => std::option::Option::Some(Self::IN),
-                "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Operator {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Operator {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Operator {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Operator {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::In,
+                2 => Self::NotIn,
+                _ => Self::UnknownValue(operator::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Operator {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                "IN" => Self::In,
+                "NOT_IN" => Self::NotIn,
+                _ => Self::UnknownValue(operator::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Operator {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::In => serializer.serialize_i32(1),
+                Self::NotIn => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Operator {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                ".google.cloud.vmmigration.v1.SchedulingNodeAffinity.Operator",
+            ))
         }
     }
 }
@@ -7168,123 +8260,241 @@ pub mod compute_scheduling {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OnHostMaintenance(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OnHostMaintenance {
+        /// An unknown, unexpected behavior.
+        Unspecified,
+        /// Terminate the instance when the host machine undergoes maintenance.
+        Terminate,
+        /// Migrate the instance when the host machine undergoes maintenance.
+        Migrate,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OnHostMaintenance::value] or
+        /// [OnHostMaintenance::name].
+        UnknownValue(on_host_maintenance::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod on_host_maintenance {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OnHostMaintenance {
-        /// An unknown, unexpected behavior.
-        pub const ON_HOST_MAINTENANCE_UNSPECIFIED: OnHostMaintenance = OnHostMaintenance::new(0);
-
-        /// Terminate the instance when the host machine undergoes maintenance.
-        pub const TERMINATE: OnHostMaintenance = OnHostMaintenance::new(1);
-
-        /// Migrate the instance when the host machine undergoes maintenance.
-        pub const MIGRATE: OnHostMaintenance = OnHostMaintenance::new(2);
-
-        /// Creates a new OnHostMaintenance instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Terminate => std::option::Option::Some(1),
+                Self::Migrate => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ON_HOST_MAINTENANCE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TERMINATE"),
-                2 => std::borrow::Cow::Borrowed("MIGRATE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ON_HOST_MAINTENANCE_UNSPECIFIED"),
+                Self::Terminate => std::option::Option::Some("TERMINATE"),
+                Self::Migrate => std::option::Option::Some("MIGRATE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ON_HOST_MAINTENANCE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ON_HOST_MAINTENANCE_UNSPECIFIED)
-                }
-                "TERMINATE" => std::option::Option::Some(Self::TERMINATE),
-                "MIGRATE" => std::option::Option::Some(Self::MIGRATE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OnHostMaintenance {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OnHostMaintenance {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OnHostMaintenance {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OnHostMaintenance {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Terminate,
+                2 => Self::Migrate,
+                _ => Self::UnknownValue(on_host_maintenance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OnHostMaintenance {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ON_HOST_MAINTENANCE_UNSPECIFIED" => Self::Unspecified,
+                "TERMINATE" => Self::Terminate,
+                "MIGRATE" => Self::Migrate,
+                _ => Self::UnknownValue(on_host_maintenance::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OnHostMaintenance {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Terminate => serializer.serialize_i32(1),
+                Self::Migrate => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OnHostMaintenance {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OnHostMaintenance>::new(
+                ".google.cloud.vmmigration.v1.ComputeScheduling.OnHostMaintenance",
+            ))
         }
     }
 
     /// Defines whether the Instance should be automatically restarted whenever
     /// it is terminated by Compute Engine (not terminated by user).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RestartType(i32);
-
-    impl RestartType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RestartType {
         /// Unspecified behavior. This will use the default.
-        pub const RESTART_TYPE_UNSPECIFIED: RestartType = RestartType::new(0);
-
+        Unspecified,
         /// The Instance should be automatically restarted whenever it is
         /// terminated by Compute Engine.
-        pub const AUTOMATIC_RESTART: RestartType = RestartType::new(1);
-
+        AutomaticRestart,
         /// The Instance isn't automatically restarted whenever it is
         /// terminated by Compute Engine.
-        pub const NO_AUTOMATIC_RESTART: RestartType = RestartType::new(2);
+        NoAutomaticRestart,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RestartType::value] or
+        /// [RestartType::name].
+        UnknownValue(restart_type::UnknownValue),
+    }
 
-        /// Creates a new RestartType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod restart_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RestartType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AutomaticRestart => std::option::Option::Some(1),
+                Self::NoAutomaticRestart => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESTART_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTOMATIC_RESTART"),
-                2 => std::borrow::Cow::Borrowed("NO_AUTOMATIC_RESTART"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESTART_TYPE_UNSPECIFIED"),
+                Self::AutomaticRestart => std::option::Option::Some("AUTOMATIC_RESTART"),
+                Self::NoAutomaticRestart => std::option::Option::Some("NO_AUTOMATIC_RESTART"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESTART_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESTART_TYPE_UNSPECIFIED)
-                }
-                "AUTOMATIC_RESTART" => std::option::Option::Some(Self::AUTOMATIC_RESTART),
-                "NO_AUTOMATIC_RESTART" => std::option::Option::Some(Self::NO_AUTOMATIC_RESTART),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RestartType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RestartType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RestartType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RestartType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AutomaticRestart,
+                2 => Self::NoAutomaticRestart,
+                _ => Self::UnknownValue(restart_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RestartType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESTART_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "AUTOMATIC_RESTART" => Self::AutomaticRestart,
+                "NO_AUTOMATIC_RESTART" => Self::NoAutomaticRestart,
+                _ => Self::UnknownValue(restart_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RestartType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AutomaticRestart => serializer.serialize_i32(1),
+                Self::NoAutomaticRestart => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RestartType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestartType>::new(
+                ".google.cloud.vmmigration.v1.ComputeScheduling.RestartType",
+            ))
         }
     }
 }
@@ -9549,106 +10759,177 @@ pub mod migration_error {
     use super::*;
 
     /// Represents resource error codes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorCode(i32);
-
-    impl ErrorCode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorCode {
         /// Default value. This value is not used.
-        pub const ERROR_CODE_UNSPECIFIED: ErrorCode = ErrorCode::new(0);
-
+        Unspecified,
         /// Migrate for Compute encountered an unknown error.
-        pub const UNKNOWN_ERROR: ErrorCode = ErrorCode::new(1);
-
+        UnknownError,
         /// Migrate for Compute encountered an error while validating replication
         /// source health.
-        pub const SOURCE_VALIDATION_ERROR: ErrorCode = ErrorCode::new(2);
-
+        SourceValidationError,
         /// Migrate for Compute encountered an error during source data operation.
-        pub const SOURCE_REPLICATION_ERROR: ErrorCode = ErrorCode::new(3);
-
+        SourceReplicationError,
         /// Migrate for Compute encountered an error during target data operation.
-        pub const TARGET_REPLICATION_ERROR: ErrorCode = ErrorCode::new(4);
-
+        TargetReplicationError,
         /// Migrate for Compute encountered an error during OS adaptation.
-        pub const OS_ADAPTATION_ERROR: ErrorCode = ErrorCode::new(5);
-
+        OsAdaptationError,
         /// Migrate for Compute encountered an error in clone operation.
-        pub const CLONE_ERROR: ErrorCode = ErrorCode::new(6);
-
+        CloneError,
         /// Migrate for Compute encountered an error in cutover operation.
-        pub const CUTOVER_ERROR: ErrorCode = ErrorCode::new(7);
-
+        CutoverError,
         /// Migrate for Compute encountered an error during utilization report
         /// creation.
-        pub const UTILIZATION_REPORT_ERROR: ErrorCode = ErrorCode::new(8);
-
+        UtilizationReportError,
         /// Migrate for Compute encountered an error during appliance upgrade.
-        pub const APPLIANCE_UPGRADE_ERROR: ErrorCode = ErrorCode::new(9);
+        ApplianceUpgradeError,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorCode::value] or
+        /// [ErrorCode::name].
+        UnknownValue(error_code::UnknownValue),
+    }
 
-        /// Creates a new ErrorCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod error_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ErrorCode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UnknownError => std::option::Option::Some(1),
+                Self::SourceValidationError => std::option::Option::Some(2),
+                Self::SourceReplicationError => std::option::Option::Some(3),
+                Self::TargetReplicationError => std::option::Option::Some(4),
+                Self::OsAdaptationError => std::option::Option::Some(5),
+                Self::CloneError => std::option::Option::Some(6),
+                Self::CutoverError => std::option::Option::Some(7),
+                Self::UtilizationReportError => std::option::Option::Some(8),
+                Self::ApplianceUpgradeError => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNKNOWN_ERROR"),
-                2 => std::borrow::Cow::Borrowed("SOURCE_VALIDATION_ERROR"),
-                3 => std::borrow::Cow::Borrowed("SOURCE_REPLICATION_ERROR"),
-                4 => std::borrow::Cow::Borrowed("TARGET_REPLICATION_ERROR"),
-                5 => std::borrow::Cow::Borrowed("OS_ADAPTATION_ERROR"),
-                6 => std::borrow::Cow::Borrowed("CLONE_ERROR"),
-                7 => std::borrow::Cow::Borrowed("CUTOVER_ERROR"),
-                8 => std::borrow::Cow::Borrowed("UTILIZATION_REPORT_ERROR"),
-                9 => std::borrow::Cow::Borrowed("APPLIANCE_UPGRADE_ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ERROR_CODE_UNSPECIFIED"),
+                Self::UnknownError => std::option::Option::Some("UNKNOWN_ERROR"),
+                Self::SourceValidationError => std::option::Option::Some("SOURCE_VALIDATION_ERROR"),
+                Self::SourceReplicationError => {
+                    std::option::Option::Some("SOURCE_REPLICATION_ERROR")
+                }
+                Self::TargetReplicationError => {
+                    std::option::Option::Some("TARGET_REPLICATION_ERROR")
+                }
+                Self::OsAdaptationError => std::option::Option::Some("OS_ADAPTATION_ERROR"),
+                Self::CloneError => std::option::Option::Some("CLONE_ERROR"),
+                Self::CutoverError => std::option::Option::Some("CUTOVER_ERROR"),
+                Self::UtilizationReportError => {
+                    std::option::Option::Some("UTILIZATION_REPORT_ERROR")
+                }
+                Self::ApplianceUpgradeError => std::option::Option::Some("APPLIANCE_UPGRADE_ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_CODE_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_CODE_UNSPECIFIED),
-                "UNKNOWN_ERROR" => std::option::Option::Some(Self::UNKNOWN_ERROR),
-                "SOURCE_VALIDATION_ERROR" => {
-                    std::option::Option::Some(Self::SOURCE_VALIDATION_ERROR)
-                }
-                "SOURCE_REPLICATION_ERROR" => {
-                    std::option::Option::Some(Self::SOURCE_REPLICATION_ERROR)
-                }
-                "TARGET_REPLICATION_ERROR" => {
-                    std::option::Option::Some(Self::TARGET_REPLICATION_ERROR)
-                }
-                "OS_ADAPTATION_ERROR" => std::option::Option::Some(Self::OS_ADAPTATION_ERROR),
-                "CLONE_ERROR" => std::option::Option::Some(Self::CLONE_ERROR),
-                "CUTOVER_ERROR" => std::option::Option::Some(Self::CUTOVER_ERROR),
-                "UTILIZATION_REPORT_ERROR" => {
-                    std::option::Option::Some(Self::UTILIZATION_REPORT_ERROR)
-                }
-                "APPLIANCE_UPGRADE_ERROR" => {
-                    std::option::Option::Some(Self::APPLIANCE_UPGRADE_ERROR)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UnknownError,
+                2 => Self::SourceValidationError,
+                3 => Self::SourceReplicationError,
+                4 => Self::TargetReplicationError,
+                5 => Self::OsAdaptationError,
+                6 => Self::CloneError,
+                7 => Self::CutoverError,
+                8 => Self::UtilizationReportError,
+                9 => Self::ApplianceUpgradeError,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_CODE_UNSPECIFIED" => Self::Unspecified,
+                "UNKNOWN_ERROR" => Self::UnknownError,
+                "SOURCE_VALIDATION_ERROR" => Self::SourceValidationError,
+                "SOURCE_REPLICATION_ERROR" => Self::SourceReplicationError,
+                "TARGET_REPLICATION_ERROR" => Self::TargetReplicationError,
+                "OS_ADAPTATION_ERROR" => Self::OsAdaptationError,
+                "CLONE_ERROR" => Self::CloneError,
+                "CUTOVER_ERROR" => Self::CutoverError,
+                "UTILIZATION_REPORT_ERROR" => Self::UtilizationReportError,
+                "APPLIANCE_UPGRADE_ERROR" => Self::ApplianceUpgradeError,
+                _ => Self::UnknownValue(error_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UnknownError => serializer.serialize_i32(1),
+                Self::SourceValidationError => serializer.serialize_i32(2),
+                Self::SourceReplicationError => serializer.serialize_i32(3),
+                Self::TargetReplicationError => serializer.serialize_i32(4),
+                Self::OsAdaptationError => serializer.serialize_i32(5),
+                Self::CloneError => serializer.serialize_i32(6),
+                Self::CutoverError => serializer.serialize_i32(7),
+                Self::UtilizationReportError => serializer.serialize_i32(8),
+                Self::ApplianceUpgradeError => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorCode>::new(
+                ".google.cloud.vmmigration.v1.MigrationError.ErrorCode",
+            ))
         }
     }
 }
@@ -9704,59 +10985,120 @@ pub mod aws_source_vm_details {
     use super::*;
 
     /// Possible values for AWS VM firmware.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Firmware(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Firmware {
+        /// The firmware is unknown.
+        Unspecified,
+        /// The firmware is EFI.
+        Efi,
+        /// The firmware is BIOS.
+        Bios,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Firmware::value] or
+        /// [Firmware::name].
+        UnknownValue(firmware::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod firmware {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Firmware {
-        /// The firmware is unknown.
-        pub const FIRMWARE_UNSPECIFIED: Firmware = Firmware::new(0);
-
-        /// The firmware is EFI.
-        pub const EFI: Firmware = Firmware::new(1);
-
-        /// The firmware is BIOS.
-        pub const BIOS: Firmware = Firmware::new(2);
-
-        /// Creates a new Firmware instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Efi => std::option::Option::Some(1),
+                Self::Bios => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FIRMWARE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EFI"),
-                2 => std::borrow::Cow::Borrowed("BIOS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FIRMWARE_UNSPECIFIED"),
+                Self::Efi => std::option::Option::Some("EFI"),
+                Self::Bios => std::option::Option::Some("BIOS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FIRMWARE_UNSPECIFIED" => std::option::Option::Some(Self::FIRMWARE_UNSPECIFIED),
-                "EFI" => std::option::Option::Some(Self::EFI),
-                "BIOS" => std::option::Option::Some(Self::BIOS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Firmware {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Firmware {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Firmware {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Firmware {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Efi,
+                2 => Self::Bios,
+                _ => Self::UnknownValue(firmware::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Firmware {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FIRMWARE_UNSPECIFIED" => Self::Unspecified,
+                "EFI" => Self::Efi,
+                "BIOS" => Self::Bios,
+                _ => Self::UnknownValue(firmware::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Firmware {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Efi => serializer.serialize_i32(1),
+                Self::Bios => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Firmware {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Firmware>::new(
+                ".google.cloud.vmmigration.v1.AwsSourceVmDetails.Firmware",
+            ))
         }
     }
 }
@@ -9950,331 +11292,606 @@ impl wkt::message::Message for GetReplicationCycleRequest {
 }
 
 /// Controls the level of details of a Utilization Report.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UtilizationReportView(i32);
-
-impl UtilizationReportView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum UtilizationReportView {
     /// The default / unset value.
     /// The API will default to FULL on single report request and BASIC for
     /// multiple reports request.
-    pub const UTILIZATION_REPORT_VIEW_UNSPECIFIED: UtilizationReportView =
-        UtilizationReportView::new(0);
-
+    Unspecified,
     /// Get the report metadata, without the list of VMs and their utilization
     /// info.
-    pub const BASIC: UtilizationReportView = UtilizationReportView::new(1);
-
+    Basic,
     /// Include everything.
-    pub const FULL: UtilizationReportView = UtilizationReportView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [UtilizationReportView::value] or
+    /// [UtilizationReportView::name].
+    UnknownValue(utilization_report_view::UnknownValue),
+}
 
-    /// Creates a new UtilizationReportView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod utilization_report_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl UtilizationReportView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UTILIZATION_REPORT_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("UTILIZATION_REPORT_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UTILIZATION_REPORT_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::UTILIZATION_REPORT_VIEW_UNSPECIFIED)
-            }
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for UtilizationReportView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for UtilizationReportView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for UtilizationReportView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for UtilizationReportView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(utilization_report_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for UtilizationReportView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UTILIZATION_REPORT_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(utilization_report_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for UtilizationReportView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for UtilizationReportView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<UtilizationReportView>::new(
+            ".google.cloud.vmmigration.v1.UtilizationReportView",
+        ))
     }
 }
 
 /// Controls the level of details of a Migrating VM.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MigratingVmView(i32);
-
-impl MigratingVmView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MigratingVmView {
     /// View is unspecified. The API will fallback to the default value.
-    pub const MIGRATING_VM_VIEW_UNSPECIFIED: MigratingVmView = MigratingVmView::new(0);
-
+    Unspecified,
     /// Get the migrating VM basic details.
     /// The basic details do not include the recent clone jobs and recent cutover
     /// jobs lists.
-    pub const MIGRATING_VM_VIEW_BASIC: MigratingVmView = MigratingVmView::new(1);
-
+    Basic,
     /// Include everything.
-    pub const MIGRATING_VM_VIEW_FULL: MigratingVmView = MigratingVmView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MigratingVmView::value] or
+    /// [MigratingVmView::name].
+    UnknownValue(migrating_vm_view::UnknownValue),
+}
 
-    /// Creates a new MigratingVmView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod migrating_vm_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl MigratingVmView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MIGRATING_VM_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MIGRATING_VM_VIEW_BASIC"),
-            2 => std::borrow::Cow::Borrowed("MIGRATING_VM_VIEW_FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MIGRATING_VM_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("MIGRATING_VM_VIEW_BASIC"),
+            Self::Full => std::option::Option::Some("MIGRATING_VM_VIEW_FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MIGRATING_VM_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MIGRATING_VM_VIEW_UNSPECIFIED)
-            }
-            "MIGRATING_VM_VIEW_BASIC" => std::option::Option::Some(Self::MIGRATING_VM_VIEW_BASIC),
-            "MIGRATING_VM_VIEW_FULL" => std::option::Option::Some(Self::MIGRATING_VM_VIEW_FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MigratingVmView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MigratingVmView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MigratingVmView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MigratingVmView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(migrating_vm_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MigratingVmView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MIGRATING_VM_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "MIGRATING_VM_VIEW_BASIC" => Self::Basic,
+            "MIGRATING_VM_VIEW_FULL" => Self::Full,
+            _ => Self::UnknownValue(migrating_vm_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MigratingVmView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MigratingVmView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MigratingVmView>::new(
+            ".google.cloud.vmmigration.v1.MigratingVmView",
+        ))
     }
 }
 
 /// Types of disks supported for Compute Engine VM.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComputeEngineDiskType(i32);
-
-impl ComputeEngineDiskType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ComputeEngineDiskType {
     /// An unspecified disk type. Will be used as STANDARD.
-    pub const COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED: ComputeEngineDiskType =
-        ComputeEngineDiskType::new(0);
-
+    Unspecified,
     /// A Standard disk type.
-    pub const COMPUTE_ENGINE_DISK_TYPE_STANDARD: ComputeEngineDiskType =
-        ComputeEngineDiskType::new(1);
-
+    Standard,
     /// SSD hard disk type.
-    pub const COMPUTE_ENGINE_DISK_TYPE_SSD: ComputeEngineDiskType = ComputeEngineDiskType::new(2);
-
+    Ssd,
     /// An alternative to SSD persistent disks that balance performance and
     /// cost.
-    pub const COMPUTE_ENGINE_DISK_TYPE_BALANCED: ComputeEngineDiskType =
-        ComputeEngineDiskType::new(3);
+    Balanced,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ComputeEngineDiskType::value] or
+    /// [ComputeEngineDiskType::name].
+    UnknownValue(compute_engine_disk_type::UnknownValue),
+}
 
-    /// Creates a new ComputeEngineDiskType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod compute_engine_disk_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ComputeEngineDiskType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Standard => std::option::Option::Some(1),
+            Self::Ssd => std::option::Option::Some(2),
+            Self::Balanced => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_DISK_TYPE_STANDARD"),
-            2 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_DISK_TYPE_SSD"),
-            3 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_DISK_TYPE_BALANCED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED"),
+            Self::Standard => std::option::Option::Some("COMPUTE_ENGINE_DISK_TYPE_STANDARD"),
+            Self::Ssd => std::option::Option::Some("COMPUTE_ENGINE_DISK_TYPE_SSD"),
+            Self::Balanced => std::option::Option::Some("COMPUTE_ENGINE_DISK_TYPE_BALANCED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED)
-            }
-            "COMPUTE_ENGINE_DISK_TYPE_STANDARD" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_DISK_TYPE_STANDARD)
-            }
-            "COMPUTE_ENGINE_DISK_TYPE_SSD" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_DISK_TYPE_SSD)
-            }
-            "COMPUTE_ENGINE_DISK_TYPE_BALANCED" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_DISK_TYPE_BALANCED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ComputeEngineDiskType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ComputeEngineDiskType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ComputeEngineDiskType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ComputeEngineDiskType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Standard,
+            2 => Self::Ssd,
+            3 => Self::Balanced,
+            _ => Self::UnknownValue(compute_engine_disk_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ComputeEngineDiskType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPUTE_ENGINE_DISK_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "COMPUTE_ENGINE_DISK_TYPE_STANDARD" => Self::Standard,
+            "COMPUTE_ENGINE_DISK_TYPE_SSD" => Self::Ssd,
+            "COMPUTE_ENGINE_DISK_TYPE_BALANCED" => Self::Balanced,
+            _ => Self::UnknownValue(compute_engine_disk_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ComputeEngineDiskType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Standard => serializer.serialize_i32(1),
+            Self::Ssd => serializer.serialize_i32(2),
+            Self::Balanced => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ComputeEngineDiskType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComputeEngineDiskType>::new(
+            ".google.cloud.vmmigration.v1.ComputeEngineDiskType",
+        ))
     }
 }
 
 /// Types of licenses used in OS adaptation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComputeEngineLicenseType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ComputeEngineLicenseType {
+    /// The license type is the default for the OS.
+    Default,
+    /// The license type is Pay As You Go license type.
+    Payg,
+    /// The license type is Bring Your Own License type.
+    Byol,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ComputeEngineLicenseType::value] or
+    /// [ComputeEngineLicenseType::name].
+    UnknownValue(compute_engine_license_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod compute_engine_license_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ComputeEngineLicenseType {
-    /// The license type is the default for the OS.
-    pub const COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT: ComputeEngineLicenseType =
-        ComputeEngineLicenseType::new(0);
-
-    /// The license type is Pay As You Go license type.
-    pub const COMPUTE_ENGINE_LICENSE_TYPE_PAYG: ComputeEngineLicenseType =
-        ComputeEngineLicenseType::new(1);
-
-    /// The license type is Bring Your Own License type.
-    pub const COMPUTE_ENGINE_LICENSE_TYPE_BYOL: ComputeEngineLicenseType =
-        ComputeEngineLicenseType::new(2);
-
-    /// Creates a new ComputeEngineLicenseType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Default => std::option::Option::Some(0),
+            Self::Payg => std::option::Option::Some(1),
+            Self::Byol => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT"),
-            1 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_LICENSE_TYPE_PAYG"),
-            2 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_LICENSE_TYPE_BYOL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Default => std::option::Option::Some("COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT"),
+            Self::Payg => std::option::Option::Some("COMPUTE_ENGINE_LICENSE_TYPE_PAYG"),
+            Self::Byol => std::option::Option::Some("COMPUTE_ENGINE_LICENSE_TYPE_BYOL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT)
-            }
-            "COMPUTE_ENGINE_LICENSE_TYPE_PAYG" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_LICENSE_TYPE_PAYG)
-            }
-            "COMPUTE_ENGINE_LICENSE_TYPE_BYOL" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_LICENSE_TYPE_BYOL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ComputeEngineLicenseType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ComputeEngineLicenseType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ComputeEngineLicenseType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ComputeEngineLicenseType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Default,
+            1 => Self::Payg,
+            2 => Self::Byol,
+            _ => Self::UnknownValue(compute_engine_license_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ComputeEngineLicenseType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPUTE_ENGINE_LICENSE_TYPE_DEFAULT" => Self::Default,
+            "COMPUTE_ENGINE_LICENSE_TYPE_PAYG" => Self::Payg,
+            "COMPUTE_ENGINE_LICENSE_TYPE_BYOL" => Self::Byol,
+            _ => Self::UnknownValue(compute_engine_license_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ComputeEngineLicenseType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Default => serializer.serialize_i32(0),
+            Self::Payg => serializer.serialize_i32(1),
+            Self::Byol => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ComputeEngineLicenseType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComputeEngineLicenseType>::new(
+            ".google.cloud.vmmigration.v1.ComputeEngineLicenseType",
+        ))
     }
 }
 
 /// Possible values for vm boot option.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComputeEngineBootOption(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ComputeEngineBootOption {
+    /// The boot option is unknown.
+    Unspecified,
+    /// The boot option is EFI.
+    Efi,
+    /// The boot option is BIOS.
+    Bios,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ComputeEngineBootOption::value] or
+    /// [ComputeEngineBootOption::name].
+    UnknownValue(compute_engine_boot_option::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod compute_engine_boot_option {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ComputeEngineBootOption {
-    /// The boot option is unknown.
-    pub const COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED: ComputeEngineBootOption =
-        ComputeEngineBootOption::new(0);
-
-    /// The boot option is EFI.
-    pub const COMPUTE_ENGINE_BOOT_OPTION_EFI: ComputeEngineBootOption =
-        ComputeEngineBootOption::new(1);
-
-    /// The boot option is BIOS.
-    pub const COMPUTE_ENGINE_BOOT_OPTION_BIOS: ComputeEngineBootOption =
-        ComputeEngineBootOption::new(2);
-
-    /// Creates a new ComputeEngineBootOption instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Efi => std::option::Option::Some(1),
+            Self::Bios => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_BOOT_OPTION_EFI"),
-            2 => std::borrow::Cow::Borrowed("COMPUTE_ENGINE_BOOT_OPTION_BIOS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED")
+            }
+            Self::Efi => std::option::Option::Some("COMPUTE_ENGINE_BOOT_OPTION_EFI"),
+            Self::Bios => std::option::Option::Some("COMPUTE_ENGINE_BOOT_OPTION_BIOS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED)
-            }
-            "COMPUTE_ENGINE_BOOT_OPTION_EFI" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_BOOT_OPTION_EFI)
-            }
-            "COMPUTE_ENGINE_BOOT_OPTION_BIOS" => {
-                std::option::Option::Some(Self::COMPUTE_ENGINE_BOOT_OPTION_BIOS)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ComputeEngineBootOption {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ComputeEngineBootOption {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ComputeEngineBootOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ComputeEngineBootOption {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Efi,
+            2 => Self::Bios,
+            _ => Self::UnknownValue(compute_engine_boot_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ComputeEngineBootOption {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPUTE_ENGINE_BOOT_OPTION_UNSPECIFIED" => Self::Unspecified,
+            "COMPUTE_ENGINE_BOOT_OPTION_EFI" => Self::Efi,
+            "COMPUTE_ENGINE_BOOT_OPTION_BIOS" => Self::Bios,
+            _ => Self::UnknownValue(compute_engine_boot_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ComputeEngineBootOption {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Efi => serializer.serialize_i32(1),
+            Self::Bios => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ComputeEngineBootOption {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComputeEngineBootOption>::new(
+            ".google.cloud.vmmigration.v1.ComputeEngineBootOption",
+        ))
     }
 }

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -194,7 +194,7 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
@@ -218,7 +218,7 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -422,7 +422,7 @@ impl super::stub::VmMigration for VmMigration {
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -442,7 +442,7 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -7401,142 +7401,272 @@ pub mod private_cloud {
     }
 
     /// Enum State defines possible states of private clouds.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The private cloud is ready.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The private cloud is being created.
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// The private cloud is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The private cloud is in failed state.
-        pub const FAILED: State = State::new(5);
-
+        Failed,
         /// The private cloud is scheduled for deletion. The deletion process can be
         /// cancelled by using the corresponding undelete method.
-        pub const DELETED: State = State::new(6);
-
+        Deleted,
         /// The private cloud is irreversibly deleted and is being removed from the
         /// system.
-        pub const PURGING: State = State::new(7);
+        Purging,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Deleted => std::option::Option::Some(6),
+                Self::Purging => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("DELETED"),
-                7 => std::borrow::Cow::Borrowed("PURGING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Purging => std::option::Option::Some("PURGING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "PURGING" => std::option::Option::Some(Self::PURGING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                5 => Self::Failed,
+                6 => Self::Deleted,
+                7 => Self::Purging,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "FAILED" => Self::Failed,
+                "DELETED" => Self::Deleted,
+                "PURGING" => Self::Purging,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Deleted => serializer.serialize_i32(6),
+                Self::Purging => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.PrivateCloud.State",
+            ))
         }
     }
 
     /// Enum Type defines private cloud type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Standard private is a zonal resource, with 3+ nodes. Default type.
-        pub const STANDARD: Type = Type::new(0);
-
+        Standard,
         /// Time limited private cloud is a zonal resource, can have only 1 node and
         /// has limited life span. Will be deleted after defined period of time,
         /// can be converted into standard private cloud by expanding it up to 3
         /// or more nodes.
-        pub const TIME_LIMITED: Type = Type::new(1);
-
+        TimeLimited,
         /// Stretched private cloud is a regional resource with redundancy,
         /// with a minimum of 6 nodes, nodes count has to be even.
-        pub const STRETCHED: Type = Type::new(2);
+        Stretched,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Standard => std::option::Option::Some(0),
+                Self::TimeLimited => std::option::Option::Some(1),
+                Self::Stretched => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STANDARD"),
-                1 => std::borrow::Cow::Borrowed("TIME_LIMITED"),
-                2 => std::borrow::Cow::Borrowed("STRETCHED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::TimeLimited => std::option::Option::Some("TIME_LIMITED"),
+                Self::Stretched => std::option::Option::Some("STRETCHED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "TIME_LIMITED" => std::option::Option::Some(Self::TIME_LIMITED),
-                "STRETCHED" => std::option::Option::Some(Self::STRETCHED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Standard,
+                1 => Self::TimeLimited,
+                2 => Self::Stretched,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STANDARD" => Self::Standard,
+                "TIME_LIMITED" => Self::TimeLimited,
+                "STRETCHED" => Self::Stretched,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Standard => serializer.serialize_i32(0),
+                Self::TimeLimited => serializer.serialize_i32(1),
+                Self::Stretched => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.vmwareengine.v1.PrivateCloud.Type",
+            ))
         }
     }
 }
@@ -7689,76 +7819,143 @@ pub mod cluster {
     use super::*;
 
     /// Enum State defines possible states of private cloud clusters.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The Cluster is operational and can be used by the user.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The Cluster is being deployed.
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// Adding or removing of a node to the cluster, any other cluster specific
         /// updates.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The Cluster is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The Cluster is undergoing maintenance, for example: a failed node is
         /// getting replaced.
-        pub const REPAIRING: State = State::new(5);
+        Repairing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Repairing => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("REPAIRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Repairing => std::option::Option::Some("REPAIRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "REPAIRING" => std::option::Option::Some(Self::REPAIRING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "REPAIRING" => Self::Repairing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Repairing => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.Cluster.State",
+            ))
         }
     }
 }
@@ -7868,69 +8065,134 @@ pub mod node {
     use super::*;
 
     /// Enum State defines possible states of a node in a cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value should never be used.
+        Unspecified,
+        /// Node is operational and can be used by the user.
+        Active,
+        /// Node is being provisioned.
+        Creating,
+        /// Node is in a failed state.
+        Failed,
+        /// Node is undergoing maintenance, e.g.: during private cloud upgrade.
+        Upgrading,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Node is operational and can be used by the user.
-        pub const ACTIVE: State = State::new(1);
-
-        /// Node is being provisioned.
-        pub const CREATING: State = State::new(2);
-
-        /// Node is in a failed state.
-        pub const FAILED: State = State::new(3);
-
-        /// Node is undergoing maintenance, e.g.: during private cloud upgrade.
-        pub const UPGRADING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Upgrading => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("UPGRADING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Upgrading => std::option::Option::Some("UPGRADING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "UPGRADING" => std::option::Option::Some(Self::UPGRADING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Failed,
+                4 => Self::Upgrading,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "FAILED" => Self::Failed,
+                "UPGRADING" => Self::Upgrading,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Upgrading => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.Node.State",
+            ))
         }
     }
 }
@@ -8056,69 +8318,134 @@ pub mod external_address {
     use super::*;
 
     /// Enum State defines possible states of external addresses.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value should never be used.
+        Unspecified,
+        /// The address is ready.
+        Active,
+        /// The address is being created.
+        Creating,
+        /// The address is being updated.
+        Updating,
+        /// The address is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The address is ready.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The address is being created.
-        pub const CREATING: State = State::new(2);
-
-        /// The address is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The address is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.ExternalAddress.State",
+            ))
         }
     }
 }
@@ -8218,80 +8545,149 @@ pub mod subnet {
     use super::*;
 
     /// Defines possible states of subnets.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The subnet is ready.
-        pub const ACTIVE: State = State::new(1);
-
+        Active,
         /// The subnet is being created.
-        pub const CREATING: State = State::new(2);
-
+        Creating,
         /// The subnet is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The subnet is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// Changes requested in the last operation are being propagated.
-        pub const RECONCILING: State = State::new(5);
-
+        Reconciling,
         /// Last operation on the subnet did not succeed. Subnet's payload is
         /// reverted back to its most recent working state.
-        pub const FAILED: State = State::new(6);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Reconciling => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("RECONCILING"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Reconciling,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "RECONCILING" => Self::Reconciling,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Reconciling => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.Subnet.State",
+            ))
         }
     }
 }
@@ -8662,126 +9058,252 @@ pub mod external_access_rule {
 
     /// Action determines whether the external access rule permits or blocks
     /// traffic, subject to the other components of the rule matching the traffic.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Defaults to allow.
+        Unspecified,
+        /// Allows connections that match the other specified components.
+        Allow,
+        /// Blocks connections that match the other specified components.
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Defaults to allow.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Allows connections that match the other specified components.
-        pub const ALLOW: Action = Action::new(1);
-
-        /// Blocks connections that match the other specified components.
-        pub const DENY: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.cloud.vmwareengine.v1.ExternalAccessRule.Action",
+            ))
         }
     }
 
     /// Defines possible states of external access firewall rules.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The rule is ready.
+        Active,
+        /// The rule is being created.
+        Creating,
+        /// The rule is being updated.
+        Updating,
+        /// The rule is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The rule is ready.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The rule is being created.
-        pub const CREATING: State = State::new(2);
-
-        /// The rule is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The rule is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.ExternalAccessRule.State",
+            ))
         }
     }
 }
@@ -8911,133 +9433,259 @@ pub mod logging_server {
 
     /// Defines possible protocols used to send logs to
     /// a logging server.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Protocol(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Protocol {
+        /// Unspecified communications protocol. This is the default value.
+        Unspecified,
+        /// UDP
+        Udp,
+        /// TCP
+        Tcp,
+        /// TLS
+        Tls,
+        /// SSL
+        Ssl,
+        /// RELP
+        Relp,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Protocol::value] or
+        /// [Protocol::name].
+        UnknownValue(protocol::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Protocol {
-        /// Unspecified communications protocol. This is the default value.
-        pub const PROTOCOL_UNSPECIFIED: Protocol = Protocol::new(0);
-
-        /// UDP
-        pub const UDP: Protocol = Protocol::new(1);
-
-        /// TCP
-        pub const TCP: Protocol = Protocol::new(2);
-
-        /// TLS
-        pub const TLS: Protocol = Protocol::new(3);
-
-        /// SSL
-        pub const SSL: Protocol = Protocol::new(4);
-
-        /// RELP
-        pub const RELP: Protocol = Protocol::new(5);
-
-        /// Creates a new Protocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Udp => std::option::Option::Some(1),
+                Self::Tcp => std::option::Option::Some(2),
+                Self::Tls => std::option::Option::Some(3),
+                Self::Ssl => std::option::Option::Some(4),
+                Self::Relp => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UDP"),
-                2 => std::borrow::Cow::Borrowed("TCP"),
-                3 => std::borrow::Cow::Borrowed("TLS"),
-                4 => std::borrow::Cow::Borrowed("SSL"),
-                5 => std::borrow::Cow::Borrowed("RELP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROTOCOL_UNSPECIFIED"),
+                Self::Udp => std::option::Option::Some("UDP"),
+                Self::Tcp => std::option::Option::Some("TCP"),
+                Self::Tls => std::option::Option::Some("TLS"),
+                Self::Ssl => std::option::Option::Some("SSL"),
+                Self::Relp => std::option::Option::Some("RELP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROTOCOL_UNSPECIFIED" => std::option::Option::Some(Self::PROTOCOL_UNSPECIFIED),
-                "UDP" => std::option::Option::Some(Self::UDP),
-                "TCP" => std::option::Option::Some(Self::TCP),
-                "TLS" => std::option::Option::Some(Self::TLS),
-                "SSL" => std::option::Option::Some(Self::SSL),
-                "RELP" => std::option::Option::Some(Self::RELP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Protocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Protocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Protocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Protocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Udp,
+                2 => Self::Tcp,
+                3 => Self::Tls,
+                4 => Self::Ssl,
+                5 => Self::Relp,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Protocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "UDP" => Self::Udp,
+                "TCP" => Self::Tcp,
+                "TLS" => Self::Tls,
+                "SSL" => Self::Ssl,
+                "RELP" => Self::Relp,
+                _ => Self::UnknownValue(protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Protocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Udp => serializer.serialize_i32(1),
+                Self::Tcp => serializer.serialize_i32(2),
+                Self::Tls => serializer.serialize_i32(3),
+                Self::Ssl => serializer.serialize_i32(4),
+                Self::Relp => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Protocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Protocol>::new(
+                ".google.cloud.vmwareengine.v1.LoggingServer.Protocol",
+            ))
         }
     }
 
     /// Defines possible types of component that produces logs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SourceType {
+        /// The default value. This value should never be used.
+        Unspecified,
+        /// Logs produced by ESXI hosts
+        Esxi,
+        /// Logs produced by vCenter server
+        Vcsa,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SourceType::value] or
+        /// [SourceType::name].
+        UnknownValue(source_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod source_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SourceType {
-        /// The default value. This value should never be used.
-        pub const SOURCE_TYPE_UNSPECIFIED: SourceType = SourceType::new(0);
-
-        /// Logs produced by ESXI hosts
-        pub const ESXI: SourceType = SourceType::new(1);
-
-        /// Logs produced by vCenter server
-        pub const VCSA: SourceType = SourceType::new(2);
-
-        /// Creates a new SourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Esxi => std::option::Option::Some(1),
+                Self::Vcsa => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ESXI"),
-                2 => std::borrow::Cow::Borrowed("VCSA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SOURCE_TYPE_UNSPECIFIED"),
+                Self::Esxi => std::option::Option::Some("ESXI"),
+                Self::Vcsa => std::option::Option::Some("VCSA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SOURCE_TYPE_UNSPECIFIED)
-                }
-                "ESXI" => std::option::Option::Some(Self::ESXI),
-                "VCSA" => std::option::Option::Some(Self::VCSA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Esxi,
+                2 => Self::Vcsa,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ESXI" => Self::Esxi,
+                "VCSA" => Self::Vcsa,
+                _ => Self::UnknownValue(source_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Esxi => serializer.serialize_i32(1),
+                Self::Vcsa => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceType>::new(
+                ".google.cloud.vmwareengine.v1.LoggingServer.SourceType",
+            ))
         }
     }
 }
@@ -9202,112 +9850,232 @@ pub mod node_type {
     use super::*;
 
     /// Enum Kind defines possible types of a NodeType.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kind {
+        /// The default value. This value should never be used.
+        Unspecified,
+        /// Standard HCI node.
+        Standard,
+        /// Storage only Node.
+        StorageOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kind::value] or
+        /// [Kind::name].
+        UnknownValue(kind::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Kind {
-        /// The default value. This value should never be used.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
-
-        /// Standard HCI node.
-        pub const STANDARD: Kind = Kind::new(1);
-
-        /// Storage only Node.
-        pub const STORAGE_ONLY: Kind = Kind::new(2);
-
-        /// Creates a new Kind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::StorageOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("STORAGE_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KIND_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::StorageOnly => std::option::Option::Some("STORAGE_ONLY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "STORAGE_ONLY" => std::option::Option::Some(Self::STORAGE_ONLY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::StorageOnly,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KIND_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "STORAGE_ONLY" => Self::StorageOnly,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::StorageOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                ".google.cloud.vmwareengine.v1.NodeType.Kind",
+            ))
         }
     }
 
     /// Capability of a node type.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Capability(i32);
-
-    impl Capability {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Capability {
         /// The default value. This value is used if the capability is omitted or
         /// unknown.
-        pub const CAPABILITY_UNSPECIFIED: Capability = Capability::new(0);
-
+        Unspecified,
         /// This node type supports stretch clusters.
-        pub const STRETCHED_CLUSTERS: Capability = Capability::new(1);
+        StretchedClusters,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Capability::value] or
+        /// [Capability::name].
+        UnknownValue(capability::UnknownValue),
+    }
 
-        /// Creates a new Capability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod capability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Capability {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StretchedClusters => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CAPABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STRETCHED_CLUSTERS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CAPABILITY_UNSPECIFIED"),
+                Self::StretchedClusters => std::option::Option::Some("STRETCHED_CLUSTERS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CAPABILITY_UNSPECIFIED" => std::option::Option::Some(Self::CAPABILITY_UNSPECIFIED),
-                "STRETCHED_CLUSTERS" => std::option::Option::Some(Self::STRETCHED_CLUSTERS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Capability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Capability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Capability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Capability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StretchedClusters,
+                _ => Self::UnknownValue(capability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Capability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CAPABILITY_UNSPECIFIED" => Self::Unspecified,
+                "STRETCHED_CLUSTERS" => Self::StretchedClusters,
+                _ => Self::UnknownValue(capability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Capability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StretchedClusters => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Capability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Capability>::new(
+                ".google.cloud.vmwareengine.v1.NodeType.Capability",
+            ))
         }
     }
 }
@@ -9451,64 +10219,127 @@ pub mod hcx_activation_key {
     use super::*;
 
     /// State of HCX activation key
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified state.
+        Unspecified,
+        /// State of a newly generated activation key.
+        Available,
+        /// State of key when it has been used to activate HCX appliance.
+        Consumed,
+        /// State of key when it is being created.
+        Creating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// State of a newly generated activation key.
-        pub const AVAILABLE: State = State::new(1);
-
-        /// State of key when it has been used to activate HCX appliance.
-        pub const CONSUMED: State = State::new(2);
-
-        /// State of key when it is being created.
-        pub const CREATING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Available => std::option::Option::Some(1),
+                Self::Consumed => std::option::Option::Some(2),
+                Self::Creating => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("CONSUMED"),
-                3 => std::borrow::Cow::Borrowed("CREATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Consumed => std::option::Option::Some("CONSUMED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "CONSUMED" => std::option::Option::Some(Self::CONSUMED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Available,
+                2 => Self::Consumed,
+                3 => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "AVAILABLE" => Self::Available,
+                "CONSUMED" => Self::Consumed,
+                "CREATING" => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Available => serializer.serialize_i32(1),
+                Self::Consumed => serializer.serialize_i32(2),
+                Self::Creating => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.HcxActivationKey.State",
+            ))
         }
     }
 }
@@ -9580,64 +10411,127 @@ pub mod hcx {
     use super::*;
 
     /// State of the appliance
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified appliance state. This is the default value.
+        Unspecified,
+        /// The appliance is operational and can be used.
+        Active,
+        /// The appliance is being deployed.
+        Creating,
+        /// The appliance is being activated.
+        Activating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified appliance state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The appliance is operational and can be used.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The appliance is being deployed.
-        pub const CREATING: State = State::new(2);
-
-        /// The appliance is being activated.
-        pub const ACTIVATING: State = State::new(3);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Activating => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("ACTIVATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Activating => std::option::Option::Some("ACTIVATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVATING" => std::option::Option::Some(Self::ACTIVATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Activating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "ACTIVATING" => Self::Activating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Activating => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.Hcx.State",
+            ))
         }
     }
 }
@@ -9709,59 +10603,120 @@ pub mod nsx {
     use super::*;
 
     /// State of the appliance
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified appliance state. This is the default value.
+        Unspecified,
+        /// The appliance is operational and can be used.
+        Active,
+        /// The appliance is being deployed.
+        Creating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified appliance state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The appliance is operational and can be used.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The appliance is being deployed.
-        pub const CREATING: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.Nsx.State",
+            ))
         }
     }
 }
@@ -9833,59 +10788,120 @@ pub mod vcenter {
     use super::*;
 
     /// State of the appliance
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified appliance state. This is the default value.
+        Unspecified,
+        /// The appliance is operational and can be used.
+        Active,
+        /// The appliance is being deployed.
+        Creating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified appliance state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The appliance is operational and can be used.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The appliance is being deployed.
-        pub const CREATING: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.Vcenter.State",
+            ))
         }
     }
 }
@@ -10537,162 +11553,294 @@ pub mod network_peering {
     use super::*;
 
     /// Possible states of a network peering.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Unspecified network peering state. This is the default value.
+        Unspecified,
+        /// The peering is not active.
+        Inactive,
+        /// The peering is active.
+        Active,
+        /// The peering is being created.
+        Creating,
+        /// The peering is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Unspecified network peering state. This is the default value.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The peering is not active.
-        pub const INACTIVE: State = State::new(1);
-
-        /// The peering is active.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The peering is being created.
-        pub const CREATING: State = State::new(3);
-
-        /// The peering is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Inactive => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Creating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INACTIVE"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("CREATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Inactive,
+                2 => Self::Active,
+                3 => Self::Creating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INACTIVE" => Self::Inactive,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Inactive => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Creating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.NetworkPeering.State",
+            ))
         }
     }
 
     /// Type or purpose of the network peering connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeerNetworkType(i32);
-
-    impl PeerNetworkType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PeerNetworkType {
         /// Unspecified
-        pub const PEER_NETWORK_TYPE_UNSPECIFIED: PeerNetworkType = PeerNetworkType::new(0);
-
+        Unspecified,
         /// Peering connection used for connecting to another VPC network established
         /// by the same user. For example, a peering connection to another VPC
         /// network in the same project or to an on-premises network.
-        pub const STANDARD: PeerNetworkType = PeerNetworkType::new(1);
-
+        Standard,
         /// Peering connection used for connecting to another VMware Engine network.
-        pub const VMWARE_ENGINE_NETWORK: PeerNetworkType = PeerNetworkType::new(2);
-
+        VmwareEngineNetwork,
         /// Peering connection used for establishing [private services
         /// access](https://cloud.google.com/vpc/docs/private-services-access).
-        pub const PRIVATE_SERVICES_ACCESS: PeerNetworkType = PeerNetworkType::new(3);
-
+        PrivateServicesAccess,
         /// Peering connection used for connecting to NetApp Cloud Volumes.
-        pub const NETAPP_CLOUD_VOLUMES: PeerNetworkType = PeerNetworkType::new(4);
-
+        NetappCloudVolumes,
         /// Peering connection used for connecting to third-party services. Most
         /// third-party services require manual setup of reverse peering on the VPC
         /// network associated with the third-party service.
-        pub const THIRD_PARTY_SERVICE: PeerNetworkType = PeerNetworkType::new(5);
-
+        ThirdPartyService,
         /// Peering connection used for connecting to Dell PowerScale Filers
-        pub const DELL_POWERSCALE: PeerNetworkType = PeerNetworkType::new(6);
-
+        DellPowerscale,
         /// Peering connection used for connecting to Google Cloud NetApp Volumes.
-        pub const GOOGLE_CLOUD_NETAPP_VOLUMES: PeerNetworkType = PeerNetworkType::new(7);
+        GoogleCloudNetappVolumes,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PeerNetworkType::value] or
+        /// [PeerNetworkType::name].
+        UnknownValue(peer_network_type::UnknownValue),
+    }
 
-        /// Creates a new PeerNetworkType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod peer_network_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PeerNetworkType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::VmwareEngineNetwork => std::option::Option::Some(2),
+                Self::PrivateServicesAccess => std::option::Option::Some(3),
+                Self::NetappCloudVolumes => std::option::Option::Some(4),
+                Self::ThirdPartyService => std::option::Option::Some(5),
+                Self::DellPowerscale => std::option::Option::Some(6),
+                Self::GoogleCloudNetappVolumes => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PEER_NETWORK_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("VMWARE_ENGINE_NETWORK"),
-                3 => std::borrow::Cow::Borrowed("PRIVATE_SERVICES_ACCESS"),
-                4 => std::borrow::Cow::Borrowed("NETAPP_CLOUD_VOLUMES"),
-                5 => std::borrow::Cow::Borrowed("THIRD_PARTY_SERVICE"),
-                6 => std::borrow::Cow::Borrowed("DELL_POWERSCALE"),
-                7 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD_NETAPP_VOLUMES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PEER_NETWORK_TYPE_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::VmwareEngineNetwork => std::option::Option::Some("VMWARE_ENGINE_NETWORK"),
+                Self::PrivateServicesAccess => std::option::Option::Some("PRIVATE_SERVICES_ACCESS"),
+                Self::NetappCloudVolumes => std::option::Option::Some("NETAPP_CLOUD_VOLUMES"),
+                Self::ThirdPartyService => std::option::Option::Some("THIRD_PARTY_SERVICE"),
+                Self::DellPowerscale => std::option::Option::Some("DELL_POWERSCALE"),
+                Self::GoogleCloudNetappVolumes => {
+                    std::option::Option::Some("GOOGLE_CLOUD_NETAPP_VOLUMES")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PEER_NETWORK_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PEER_NETWORK_TYPE_UNSPECIFIED)
-                }
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "VMWARE_ENGINE_NETWORK" => std::option::Option::Some(Self::VMWARE_ENGINE_NETWORK),
-                "PRIVATE_SERVICES_ACCESS" => {
-                    std::option::Option::Some(Self::PRIVATE_SERVICES_ACCESS)
-                }
-                "NETAPP_CLOUD_VOLUMES" => std::option::Option::Some(Self::NETAPP_CLOUD_VOLUMES),
-                "THIRD_PARTY_SERVICE" => std::option::Option::Some(Self::THIRD_PARTY_SERVICE),
-                "DELL_POWERSCALE" => std::option::Option::Some(Self::DELL_POWERSCALE),
-                "GOOGLE_CLOUD_NETAPP_VOLUMES" => {
-                    std::option::Option::Some(Self::GOOGLE_CLOUD_NETAPP_VOLUMES)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PeerNetworkType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PeerNetworkType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PeerNetworkType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PeerNetworkType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::VmwareEngineNetwork,
+                3 => Self::PrivateServicesAccess,
+                4 => Self::NetappCloudVolumes,
+                5 => Self::ThirdPartyService,
+                6 => Self::DellPowerscale,
+                7 => Self::GoogleCloudNetappVolumes,
+                _ => Self::UnknownValue(peer_network_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PeerNetworkType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PEER_NETWORK_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "VMWARE_ENGINE_NETWORK" => Self::VmwareEngineNetwork,
+                "PRIVATE_SERVICES_ACCESS" => Self::PrivateServicesAccess,
+                "NETAPP_CLOUD_VOLUMES" => Self::NetappCloudVolumes,
+                "THIRD_PARTY_SERVICE" => Self::ThirdPartyService,
+                "DELL_POWERSCALE" => Self::DellPowerscale,
+                "GOOGLE_CLOUD_NETAPP_VOLUMES" => Self::GoogleCloudNetappVolumes,
+                _ => Self::UnknownValue(peer_network_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PeerNetworkType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::VmwareEngineNetwork => serializer.serialize_i32(2),
+                Self::PrivateServicesAccess => serializer.serialize_i32(3),
+                Self::NetappCloudVolumes => serializer.serialize_i32(4),
+                Self::ThirdPartyService => serializer.serialize_i32(5),
+                Self::DellPowerscale => serializer.serialize_i32(6),
+                Self::GoogleCloudNetappVolumes => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PeerNetworkType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PeerNetworkType>::new(
+                ".google.cloud.vmwareengine.v1.NetworkPeering.PeerNetworkType",
+            ))
         }
     }
 }
@@ -10801,122 +11949,246 @@ pub mod peering_route {
     use super::*;
 
     /// The type of the peering route.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Unspecified peering route type. This is the default value.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Dynamic routes in the peer network.
-        pub const DYNAMIC_PEERING_ROUTE: Type = Type::new(1);
-
+        DynamicPeeringRoute,
         /// Static routes in the peer network.
-        pub const STATIC_PEERING_ROUTE: Type = Type::new(2);
-
+        StaticPeeringRoute,
         /// Created, updated, and removed automatically by Google Cloud when subnets
         /// are created, modified, or deleted in the peer network.
-        pub const SUBNET_PEERING_ROUTE: Type = Type::new(3);
+        SubnetPeeringRoute,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DynamicPeeringRoute => std::option::Option::Some(1),
+                Self::StaticPeeringRoute => std::option::Option::Some(2),
+                Self::SubnetPeeringRoute => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DYNAMIC_PEERING_ROUTE"),
-                2 => std::borrow::Cow::Borrowed("STATIC_PEERING_ROUTE"),
-                3 => std::borrow::Cow::Borrowed("SUBNET_PEERING_ROUTE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::DynamicPeeringRoute => std::option::Option::Some("DYNAMIC_PEERING_ROUTE"),
+                Self::StaticPeeringRoute => std::option::Option::Some("STATIC_PEERING_ROUTE"),
+                Self::SubnetPeeringRoute => std::option::Option::Some("SUBNET_PEERING_ROUTE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "DYNAMIC_PEERING_ROUTE" => std::option::Option::Some(Self::DYNAMIC_PEERING_ROUTE),
-                "STATIC_PEERING_ROUTE" => std::option::Option::Some(Self::STATIC_PEERING_ROUTE),
-                "SUBNET_PEERING_ROUTE" => std::option::Option::Some(Self::SUBNET_PEERING_ROUTE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DynamicPeeringRoute,
+                2 => Self::StaticPeeringRoute,
+                3 => Self::SubnetPeeringRoute,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DYNAMIC_PEERING_ROUTE" => Self::DynamicPeeringRoute,
+                "STATIC_PEERING_ROUTE" => Self::StaticPeeringRoute,
+                "SUBNET_PEERING_ROUTE" => Self::SubnetPeeringRoute,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DynamicPeeringRoute => serializer.serialize_i32(1),
+                Self::StaticPeeringRoute => serializer.serialize_i32(2),
+                Self::SubnetPeeringRoute => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.vmwareengine.v1.PeeringRoute.Type",
+            ))
         }
     }
 
     /// The direction of the exchanged routes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Direction {
+        /// Unspecified exchanged routes direction. This is default.
+        Unspecified,
+        /// Routes imported from the peer network.
+        Incoming,
+        /// Routes exported to the peer network.
+        Outgoing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Direction::value] or
+        /// [Direction::name].
+        UnknownValue(direction::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod direction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Direction {
-        /// Unspecified exchanged routes direction. This is default.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
-
-        /// Routes imported from the peer network.
-        pub const INCOMING: Direction = Direction::new(1);
-
-        /// Routes exported to the peer network.
-        pub const OUTGOING: Direction = Direction::new(2);
-
-        /// Creates a new Direction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incoming => std::option::Option::Some(1),
+                Self::Outgoing => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCOMING"),
-                2 => std::borrow::Cow::Borrowed("OUTGOING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIRECTION_UNSPECIFIED"),
+                Self::Incoming => std::option::Option::Some("INCOMING"),
+                Self::Outgoing => std::option::Option::Some("OUTGOING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
-                "INCOMING" => std::option::Option::Some(Self::INCOMING),
-                "OUTGOING" => std::option::Option::Some(Self::OUTGOING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Direction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Direction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Incoming,
+                2 => Self::Outgoing,
+                _ => Self::UnknownValue(direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Direction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIRECTION_UNSPECIFIED" => Self::Unspecified,
+                "INCOMING" => Self::Incoming,
+                "OUTGOING" => Self::Outgoing,
+                _ => Self::UnknownValue(direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Direction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incoming => serializer.serialize_i32(1),
+                Self::Outgoing => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Direction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Direction>::new(
+                ".google.cloud.vmwareengine.v1.PeeringRoute.Direction",
+            ))
         }
     }
 }
@@ -11149,64 +12421,130 @@ pub mod network_policy {
 
         /// Enum State defines possible states of a network policy controlled
         /// service.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
+            /// Unspecified service state. This is the default value.
+            Unspecified,
+            /// Service is not provisioned.
+            Unprovisioned,
+            /// Service is in the process of being provisioned/deprovisioned.
+            Reconciling,
+            /// Service is active.
+            Active,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl State {
-            /// Unspecified service state. This is the default value.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
-            /// Service is not provisioned.
-            pub const UNPROVISIONED: State = State::new(1);
-
-            /// Service is in the process of being provisioned/deprovisioned.
-            pub const RECONCILING: State = State::new(2);
-
-            /// Service is active.
-            pub const ACTIVE: State = State::new(3);
-
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Unprovisioned => std::option::Option::Some(1),
+                    Self::Reconciling => std::option::Option::Some(2),
+                    Self::Active => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("UNPROVISIONED"),
-                    2 => std::borrow::Cow::Borrowed("RECONCILING"),
-                    3 => std::borrow::Cow::Borrowed("ACTIVE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Unprovisioned => std::option::Option::Some("UNPROVISIONED"),
+                    Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                    Self::Active => std::option::Option::Some("ACTIVE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "UNPROVISIONED" => std::option::Option::Some(Self::UNPROVISIONED),
-                    "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Unprovisioned,
+                    2 => Self::Reconciling,
+                    3 => Self::Active,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "UNPROVISIONED" => Self::Unprovisioned,
+                    "RECONCILING" => Self::Reconciling,
+                    "ACTIVE" => Self::Active,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Unprovisioned => serializer.serialize_i32(1),
+                    Self::Reconciling => serializer.serialize_i32(2),
+                    Self::Active => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.cloud.vmwareengine.v1.NetworkPolicy.NetworkService.State",
+                ))
             }
         }
     }
@@ -11392,74 +12730,141 @@ pub mod management_dns_zone_binding {
 
     /// Enum State defines possible states of binding between the consumer VPC
     /// network and the management DNS zone.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value should never be used.
+        Unspecified,
+        /// The binding is ready.
+        Active,
+        /// The binding is being created.
+        Creating,
+        /// The binding is being updated.
+        Updating,
+        /// The binding is being deleted.
+        Deleting,
+        /// The binding has failed.
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value should never be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The binding is ready.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The binding is being created.
-        pub const CREATING: State = State::new(2);
-
-        /// The binding is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The binding is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// The binding has failed.
-        pub const FAILED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Creating,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "CREATING" => Self::Creating,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.ManagementDnsZoneBinding.State",
+            ))
         }
     }
 
@@ -11684,195 +13089,387 @@ pub mod vmware_engine_network {
 
         /// Enum Type defines possible types of a VMware Engine network controlled
         /// service.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
-
-        impl Type {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
             /// The default value. This value should never be used.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+            Unspecified,
             /// VPC network that will be peered with a consumer VPC network or the
             /// intranet VPC of another VMware Engine network. Access a private cloud
             /// through Compute Engine VMs on a peered VPC network or an on-premises
             /// resource connected to a peered consumer VPC network.
-            pub const INTRANET: Type = Type::new(1);
-
+            Intranet,
             /// VPC network used for internet access to and from a private cloud.
-            pub const INTERNET: Type = Type::new(2);
-
+            Internet,
             /// VPC network used for access to Google Cloud services like
             /// Cloud Storage.
-            pub const GOOGLE_CLOUD: Type = Type::new(3);
+            GoogleCloud,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
 
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Type {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Intranet => std::option::Option::Some(1),
+                    Self::Internet => std::option::Option::Some(2),
+                    Self::GoogleCloud => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("INTRANET"),
-                    2 => std::borrow::Cow::Borrowed("INTERNET"),
-                    3 => std::borrow::Cow::Borrowed("GOOGLE_CLOUD"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::Intranet => std::option::Option::Some("INTRANET"),
+                    Self::Internet => std::option::Option::Some("INTERNET"),
+                    Self::GoogleCloud => std::option::Option::Some("GOOGLE_CLOUD"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "INTRANET" => std::option::Option::Some(Self::INTRANET),
-                    "INTERNET" => std::option::Option::Some(Self::INTERNET),
-                    "GOOGLE_CLOUD" => std::option::Option::Some(Self::GOOGLE_CLOUD),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Intranet,
+                    2 => Self::Internet,
+                    3 => Self::GoogleCloud,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "INTRANET" => Self::Intranet,
+                    "INTERNET" => Self::Internet,
+                    "GOOGLE_CLOUD" => Self::GoogleCloud,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Intranet => serializer.serialize_i32(1),
+                    Self::Internet => serializer.serialize_i32(2),
+                    Self::GoogleCloud => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.vmwareengine.v1.VmwareEngineNetwork.VpcNetwork.Type",
+                ))
             }
         }
     }
 
     /// Enum State defines possible states of VMware Engine network.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. This value is used if the state is omitted.
+        Unspecified,
+        /// The VMware Engine network is being created.
+        Creating,
+        /// The VMware Engine network is ready.
+        Active,
+        /// The VMware Engine network is being updated.
+        Updating,
+        /// The VMware Engine network is being deleted.
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The VMware Engine network is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// The VMware Engine network is ready.
-        pub const ACTIVE: State = State::new(2);
-
-        /// The VMware Engine network is being updated.
-        pub const UPDATING: State = State::new(3);
-
-        /// The VMware Engine network is being deleted.
-        pub const DELETING: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.VmwareEngineNetwork.State",
+            ))
         }
     }
 
     /// Enum Type defines possible types of VMware Engine network.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// The default value. This value should never be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Network type used by private clouds created in projects without a network
         /// of type `STANDARD`. This network type is no longer used for new VMware
         /// Engine private cloud deployments.
-        pub const LEGACY: Type = Type::new(1);
-
+        Legacy,
         /// Standard network type used for private cloud connectivity.
-        pub const STANDARD: Type = Type::new(2);
+        Standard,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Legacy => std::option::Option::Some(1),
+                Self::Standard => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LEGACY"),
-                2 => std::borrow::Cow::Borrowed("STANDARD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Legacy => std::option::Option::Some("LEGACY"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "LEGACY" => std::option::Option::Some(Self::LEGACY),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Legacy,
+                2 => Self::Standard,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LEGACY" => Self::Legacy,
+                "STANDARD" => Self::Standard,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Legacy => serializer.serialize_i32(1),
+                Self::Standard => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.vmwareengine.v1.VmwareEngineNetwork.Type",
+            ))
         }
     }
 }
@@ -12088,268 +13685,520 @@ pub mod private_connection {
     use super::*;
 
     /// Enum State defines possible states of private connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The default value. This value is used if the state is omitted.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The private connection is being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The private connection is ready.
-        pub const ACTIVE: State = State::new(2);
-
+        Active,
         /// The private connection is being updated.
-        pub const UPDATING: State = State::new(3);
-
+        Updating,
         /// The private connection is being deleted.
-        pub const DELETING: State = State::new(4);
-
+        Deleting,
         /// The private connection is not provisioned, since no private cloud is
         /// present for which this private connection is needed.
-        pub const UNPROVISIONED: State = State::new(5);
-
+        Unprovisioned,
         /// The private connection is in failed state.
-        pub const FAILED: State = State::new(6);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Active => std::option::Option::Some(2),
+                Self::Updating => std::option::Option::Some(3),
+                Self::Deleting => std::option::Option::Some(4),
+                Self::Unprovisioned => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                3 => std::borrow::Cow::Borrowed("UPDATING"),
-                4 => std::borrow::Cow::Borrowed("DELETING"),
-                5 => std::borrow::Cow::Borrowed("UNPROVISIONED"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Unprovisioned => std::option::Option::Some("UNPROVISIONED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "UNPROVISIONED" => std::option::Option::Some(Self::UNPROVISIONED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Active,
+                3 => Self::Updating,
+                4 => Self::Deleting,
+                5 => Self::Unprovisioned,
+                6 => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "ACTIVE" => Self::Active,
+                "UPDATING" => Self::Updating,
+                "DELETING" => Self::Deleting,
+                "UNPROVISIONED" => Self::Unprovisioned,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Active => serializer.serialize_i32(2),
+                Self::Updating => serializer.serialize_i32(3),
+                Self::Deleting => serializer.serialize_i32(4),
+                Self::Unprovisioned => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vmwareengine.v1.PrivateConnection.State",
+            ))
         }
     }
 
     /// Enum Type defines possible types of private connection.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// The default value. This value should never be used.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Connection used for establishing [private services
         /// access](https://cloud.google.com/vpc/docs/private-services-access).
-        pub const PRIVATE_SERVICE_ACCESS: Type = Type::new(1);
-
+        PrivateServiceAccess,
         /// Connection used for connecting to NetApp Cloud Volumes.
-        pub const NETAPP_CLOUD_VOLUMES: Type = Type::new(2);
-
+        NetappCloudVolumes,
         /// Connection used for connecting to Dell PowerScale.
-        pub const DELL_POWERSCALE: Type = Type::new(3);
-
+        DellPowerscale,
         /// Connection used for connecting to third-party services.
-        pub const THIRD_PARTY_SERVICE: Type = Type::new(4);
+        ThirdPartyService,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PrivateServiceAccess => std::option::Option::Some(1),
+                Self::NetappCloudVolumes => std::option::Option::Some(2),
+                Self::DellPowerscale => std::option::Option::Some(3),
+                Self::ThirdPartyService => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVATE_SERVICE_ACCESS"),
-                2 => std::borrow::Cow::Borrowed("NETAPP_CLOUD_VOLUMES"),
-                3 => std::borrow::Cow::Borrowed("DELL_POWERSCALE"),
-                4 => std::borrow::Cow::Borrowed("THIRD_PARTY_SERVICE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::PrivateServiceAccess => std::option::Option::Some("PRIVATE_SERVICE_ACCESS"),
+                Self::NetappCloudVolumes => std::option::Option::Some("NETAPP_CLOUD_VOLUMES"),
+                Self::DellPowerscale => std::option::Option::Some("DELL_POWERSCALE"),
+                Self::ThirdPartyService => std::option::Option::Some("THIRD_PARTY_SERVICE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PRIVATE_SERVICE_ACCESS" => std::option::Option::Some(Self::PRIVATE_SERVICE_ACCESS),
-                "NETAPP_CLOUD_VOLUMES" => std::option::Option::Some(Self::NETAPP_CLOUD_VOLUMES),
-                "DELL_POWERSCALE" => std::option::Option::Some(Self::DELL_POWERSCALE),
-                "THIRD_PARTY_SERVICE" => std::option::Option::Some(Self::THIRD_PARTY_SERVICE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PrivateServiceAccess,
+                2 => Self::NetappCloudVolumes,
+                3 => Self::DellPowerscale,
+                4 => Self::ThirdPartyService,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PRIVATE_SERVICE_ACCESS" => Self::PrivateServiceAccess,
+                "NETAPP_CLOUD_VOLUMES" => Self::NetappCloudVolumes,
+                "DELL_POWERSCALE" => Self::DellPowerscale,
+                "THIRD_PARTY_SERVICE" => Self::ThirdPartyService,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PrivateServiceAccess => serializer.serialize_i32(1),
+                Self::NetappCloudVolumes => serializer.serialize_i32(2),
+                Self::DellPowerscale => serializer.serialize_i32(3),
+                Self::ThirdPartyService => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.cloud.vmwareengine.v1.PrivateConnection.Type",
+            ))
         }
     }
 
     /// Possible types for RoutingMode
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoutingMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoutingMode {
+        /// The default value. This value should never be used.
+        Unspecified,
+        /// Global Routing Mode
+        Global,
+        /// Regional Routing Mode
+        Regional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoutingMode::value] or
+        /// [RoutingMode::name].
+        UnknownValue(routing_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod routing_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RoutingMode {
-        /// The default value. This value should never be used.
-        pub const ROUTING_MODE_UNSPECIFIED: RoutingMode = RoutingMode::new(0);
-
-        /// Global Routing Mode
-        pub const GLOBAL: RoutingMode = RoutingMode::new(1);
-
-        /// Regional Routing Mode
-        pub const REGIONAL: RoutingMode = RoutingMode::new(2);
-
-        /// Creates a new RoutingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Global => std::option::Option::Some(1),
+                Self::Regional => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ROUTING_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GLOBAL"),
-                2 => std::borrow::Cow::Borrowed("REGIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ROUTING_MODE_UNSPECIFIED"),
+                Self::Global => std::option::Option::Some("GLOBAL"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ROUTING_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ROUTING_MODE_UNSPECIFIED)
-                }
-                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RoutingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoutingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoutingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoutingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Global,
+                2 => Self::Regional,
+                _ => Self::UnknownValue(routing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoutingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ROUTING_MODE_UNSPECIFIED" => Self::Unspecified,
+                "GLOBAL" => Self::Global,
+                "REGIONAL" => Self::Regional,
+                _ => Self::UnknownValue(routing_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoutingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Global => serializer.serialize_i32(1),
+                Self::Regional => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoutingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoutingMode>::new(
+                ".google.cloud.vmwareengine.v1.PrivateConnection.RoutingMode",
+            ))
         }
     }
 
     /// Enum PeeringState defines the possible states of peering between service
     /// network and the vpc network peered to service network
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PeeringState(i32);
-
-    impl PeeringState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PeeringState {
         /// The default value. This value is used if the peering state is omitted or
         /// unknown.
-        pub const PEERING_STATE_UNSPECIFIED: PeeringState = PeeringState::new(0);
-
+        Unspecified,
         /// The peering is in active state.
-        pub const PEERING_ACTIVE: PeeringState = PeeringState::new(1);
-
+        PeeringActive,
         /// The peering is in inactive state.
-        pub const PEERING_INACTIVE: PeeringState = PeeringState::new(2);
+        PeeringInactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PeeringState::value] or
+        /// [PeeringState::name].
+        UnknownValue(peering_state::UnknownValue),
+    }
 
-        /// Creates a new PeeringState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod peering_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PeeringState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PeeringActive => std::option::Option::Some(1),
+                Self::PeeringInactive => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PEERING_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PEERING_ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("PEERING_INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PEERING_STATE_UNSPECIFIED"),
+                Self::PeeringActive => std::option::Option::Some("PEERING_ACTIVE"),
+                Self::PeeringInactive => std::option::Option::Some("PEERING_INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PEERING_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PEERING_STATE_UNSPECIFIED)
-                }
-                "PEERING_ACTIVE" => std::option::Option::Some(Self::PEERING_ACTIVE),
-                "PEERING_INACTIVE" => std::option::Option::Some(Self::PEERING_INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PeeringState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PeeringState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PeeringState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PeeringState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PeeringActive,
+                2 => Self::PeeringInactive,
+                _ => Self::UnknownValue(peering_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PeeringState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PEERING_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PEERING_ACTIVE" => Self::PeeringActive,
+                "PEERING_INACTIVE" => Self::PeeringInactive,
+                _ => Self::UnknownValue(peering_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PeeringState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PeeringActive => serializer.serialize_i32(1),
+                Self::PeeringInactive => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PeeringState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PeeringState>::new(
+                ".google.cloud.vmwareengine.v1.PrivateConnection.PeeringState",
+            ))
         }
     }
 }
@@ -12401,55 +14250,114 @@ pub mod location_metadata {
     use super::*;
 
     /// Capability of a location.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Capability(i32);
-
-    impl Capability {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Capability {
         /// The default value. This value is used if the capability is omitted or
         /// unknown.
-        pub const CAPABILITY_UNSPECIFIED: Capability = Capability::new(0);
-
+        Unspecified,
         /// Stretch clusters are supported in this location.
-        pub const STRETCHED_CLUSTERS: Capability = Capability::new(1);
+        StretchedClusters,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Capability::value] or
+        /// [Capability::name].
+        UnknownValue(capability::UnknownValue),
+    }
 
-        /// Creates a new Capability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod capability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Capability {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StretchedClusters => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CAPABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STRETCHED_CLUSTERS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CAPABILITY_UNSPECIFIED"),
+                Self::StretchedClusters => std::option::Option::Some("STRETCHED_CLUSTERS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CAPABILITY_UNSPECIFIED" => std::option::Option::Some(Self::CAPABILITY_UNSPECIFIED),
-                "STRETCHED_CLUSTERS" => std::option::Option::Some(Self::STRETCHED_CLUSTERS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Capability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Capability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Capability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Capability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StretchedClusters,
+                _ => Self::UnknownValue(capability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Capability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CAPABILITY_UNSPECIFIED" => Self::Unspecified,
+                "STRETCHED_CLUSTERS" => Self::StretchedClusters,
+                _ => Self::UnknownValue(capability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Capability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StretchedClusters => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Capability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Capability>::new(
+                ".google.cloud.vmwareengine.v1.LocationMetadata.Capability",
+            ))
         }
     }
 }

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -231,74 +231,141 @@ pub mod connector {
     }
 
     /// State of a connector.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Invalid state.
+        Unspecified,
+        /// Connector is deployed and ready to receive traffic.
+        Ready,
+        /// An Insert operation is in progress. Transient condition.
+        Creating,
+        /// A Delete operation is in progress. Transient condition.
+        Deleting,
+        /// Connector is in a bad state, manual deletion recommended.
+        Error,
+        /// The connector is being updated.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Connector is deployed and ready to receive traffic.
-        pub const READY: State = State::new(1);
-
-        /// An Insert operation is in progress. Transient condition.
-        pub const CREATING: State = State::new(2);
-
-        /// A Delete operation is in progress. Transient condition.
-        pub const DELETING: State = State::new(3);
-
-        /// Connector is in a bad state, manual deletion recommended.
-        pub const ERROR: State = State::new(4);
-
-        /// The connector is being updated.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ready => std::option::Option::Some(1),
+                Self::Creating => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READY"),
-                2 => std::borrow::Cow::Borrowed("CREATING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "READY" => std::option::Option::Some(Self::READY),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ready,
+                2 => Self::Creating,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "READY" => Self::Ready,
+                "CREATING" => Self::Creating,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ready => serializer.serialize_i32(1),
+                Self::Creating => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.vpcaccess.v1.Connector.State",
+            ))
         }
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -324,63 +324,122 @@ pub mod compute_threat_list_diff_response {
     }
 
     /// The type of response sent to the client.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResponseType(i32);
-
-    impl ResponseType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResponseType {
         /// Unknown.
-        pub const RESPONSE_TYPE_UNSPECIFIED: ResponseType = ResponseType::new(0);
-
+        Unspecified,
         /// Partial updates are applied to the client's existing local database.
-        pub const DIFF: ResponseType = ResponseType::new(1);
-
+        Diff,
         /// Full updates resets the client's entire local database. This means
         /// that either the client had no state, was seriously out-of-date,
         /// or the client is believed to be corrupt.
-        pub const RESET: ResponseType = ResponseType::new(2);
+        Reset,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResponseType::value] or
+        /// [ResponseType::name].
+        UnknownValue(response_type::UnknownValue),
+    }
 
-        /// Creates a new ResponseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod response_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ResponseType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Diff => std::option::Option::Some(1),
+                Self::Reset => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESPONSE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIFF"),
-                2 => std::borrow::Cow::Borrowed("RESET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESPONSE_TYPE_UNSPECIFIED"),
+                Self::Diff => std::option::Option::Some("DIFF"),
+                Self::Reset => std::option::Option::Some("RESET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESPONSE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESPONSE_TYPE_UNSPECIFIED)
-                }
-                "DIFF" => std::option::Option::Some(Self::DIFF),
-                "RESET" => std::option::Option::Some(Self::RESET),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResponseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResponseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResponseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResponseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Diff,
+                2 => Self::Reset,
+                _ => Self::UnknownValue(response_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResponseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESPONSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DIFF" => Self::Diff,
+                "RESET" => Self::Reset,
+                _ => Self::UnknownValue(response_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResponseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Diff => serializer.serialize_i32(1),
+                Self::Reset => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResponseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResponseType>::new(
+                ".google.cloud.webrisk.v1.ComputeThreatListDiffResponse.ResponseType",
+            ))
         }
     }
 }
@@ -1191,66 +1250,130 @@ pub mod threat_info {
         use super::*;
 
         /// Enum representation of confidence.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ConfidenceLevel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ConfidenceLevel {
+            /// Default.
+            Unspecified,
+            /// Less than 60% confidence that the URI is unsafe.
+            Low,
+            /// Between 60% and 80% confidence that the URI is unsafe.
+            Medium,
+            /// Greater than 80% confidence that the URI is unsafe.
+            High,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ConfidenceLevel::value] or
+            /// [ConfidenceLevel::name].
+            UnknownValue(confidence_level::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod confidence_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ConfidenceLevel {
-            /// Default.
-            pub const CONFIDENCE_LEVEL_UNSPECIFIED: ConfidenceLevel = ConfidenceLevel::new(0);
-
-            /// Less than 60% confidence that the URI is unsafe.
-            pub const LOW: ConfidenceLevel = ConfidenceLevel::new(1);
-
-            /// Between 60% and 80% confidence that the URI is unsafe.
-            pub const MEDIUM: ConfidenceLevel = ConfidenceLevel::new(2);
-
-            /// Greater than 80% confidence that the URI is unsafe.
-            pub const HIGH: ConfidenceLevel = ConfidenceLevel::new(3);
-
-            /// Creates a new ConfidenceLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Low => std::option::Option::Some(1),
+                    Self::Medium => std::option::Option::Some(2),
+                    Self::High => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONFIDENCE_LEVEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("LOW"),
-                    2 => std::borrow::Cow::Borrowed("MEDIUM"),
-                    3 => std::borrow::Cow::Borrowed("HIGH"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CONFIDENCE_LEVEL_UNSPECIFIED"),
+                    Self::Low => std::option::Option::Some("LOW"),
+                    Self::Medium => std::option::Option::Some("MEDIUM"),
+                    Self::High => std::option::Option::Some("HIGH"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONFIDENCE_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONFIDENCE_LEVEL_UNSPECIFIED)
-                    }
-                    "LOW" => std::option::Option::Some(Self::LOW),
-                    "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                    "HIGH" => std::option::Option::Some(Self::HIGH),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ConfidenceLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ConfidenceLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ConfidenceLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ConfidenceLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Low,
+                    2 => Self::Medium,
+                    3 => Self::High,
+                    _ => Self::UnknownValue(confidence_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ConfidenceLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONFIDENCE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "LOW" => Self::Low,
+                    "MEDIUM" => Self::Medium,
+                    "HIGH" => Self::High,
+                    _ => Self::UnknownValue(confidence_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ConfidenceLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Low => serializer.serialize_i32(1),
+                    Self::Medium => serializer.serialize_i32(2),
+                    Self::High => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ConfidenceLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConfidenceLevel>::new(
+                    ".google.cloud.webrisk.v1.ThreatInfo.Confidence.ConfidenceLevel",
+                ))
             }
         }
 
@@ -1328,130 +1451,258 @@ pub mod threat_info {
         use super::*;
 
         /// Labels that explain how the URI was classified.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct JustificationLabel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum JustificationLabel {
+            /// Default.
+            Unspecified,
+            /// The submitter manually verified that the submission is unsafe.
+            ManualVerification,
+            /// The submitter received the submission from an end user.
+            UserReport,
+            /// The submitter received the submission from an automated system.
+            AutomatedReport,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [JustificationLabel::value] or
+            /// [JustificationLabel::name].
+            UnknownValue(justification_label::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod justification_label {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl JustificationLabel {
-            /// Default.
-            pub const JUSTIFICATION_LABEL_UNSPECIFIED: JustificationLabel =
-                JustificationLabel::new(0);
-
-            /// The submitter manually verified that the submission is unsafe.
-            pub const MANUAL_VERIFICATION: JustificationLabel = JustificationLabel::new(1);
-
-            /// The submitter received the submission from an end user.
-            pub const USER_REPORT: JustificationLabel = JustificationLabel::new(2);
-
-            /// The submitter received the submission from an automated system.
-            pub const AUTOMATED_REPORT: JustificationLabel = JustificationLabel::new(3);
-
-            /// Creates a new JustificationLabel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ManualVerification => std::option::Option::Some(1),
+                    Self::UserReport => std::option::Option::Some(2),
+                    Self::AutomatedReport => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("JUSTIFICATION_LABEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MANUAL_VERIFICATION"),
-                    2 => std::borrow::Cow::Borrowed("USER_REPORT"),
-                    3 => std::borrow::Cow::Borrowed("AUTOMATED_REPORT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "JUSTIFICATION_LABEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::JUSTIFICATION_LABEL_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("JUSTIFICATION_LABEL_UNSPECIFIED")
                     }
-                    "MANUAL_VERIFICATION" => std::option::Option::Some(Self::MANUAL_VERIFICATION),
-                    "USER_REPORT" => std::option::Option::Some(Self::USER_REPORT),
-                    "AUTOMATED_REPORT" => std::option::Option::Some(Self::AUTOMATED_REPORT),
-                    _ => std::option::Option::None,
+                    Self::ManualVerification => std::option::Option::Some("MANUAL_VERIFICATION"),
+                    Self::UserReport => std::option::Option::Some("USER_REPORT"),
+                    Self::AutomatedReport => std::option::Option::Some("AUTOMATED_REPORT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for JustificationLabel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for JustificationLabel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for JustificationLabel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for JustificationLabel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ManualVerification,
+                    2 => Self::UserReport,
+                    3 => Self::AutomatedReport,
+                    _ => Self::UnknownValue(justification_label::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for JustificationLabel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "JUSTIFICATION_LABEL_UNSPECIFIED" => Self::Unspecified,
+                    "MANUAL_VERIFICATION" => Self::ManualVerification,
+                    "USER_REPORT" => Self::UserReport,
+                    "AUTOMATED_REPORT" => Self::AutomatedReport,
+                    _ => Self::UnknownValue(justification_label::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for JustificationLabel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ManualVerification => serializer.serialize_i32(1),
+                    Self::UserReport => serializer.serialize_i32(2),
+                    Self::AutomatedReport => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for JustificationLabel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<JustificationLabel>::new(
+                    ".google.cloud.webrisk.v1.ThreatInfo.ThreatJustification.JustificationLabel",
+                ))
             }
         }
     }
 
     /// The abuse type found on the URI.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AbuseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AbuseType {
+        /// Default.
+        Unspecified,
+        /// The URI contains malware.
+        Malware,
+        /// The URI contains social engineering.
+        SocialEngineering,
+        /// The URI contains unwanted software.
+        UnwantedSoftware,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AbuseType::value] or
+        /// [AbuseType::name].
+        UnknownValue(abuse_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod abuse_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AbuseType {
-        /// Default.
-        pub const ABUSE_TYPE_UNSPECIFIED: AbuseType = AbuseType::new(0);
-
-        /// The URI contains malware.
-        pub const MALWARE: AbuseType = AbuseType::new(1);
-
-        /// The URI contains social engineering.
-        pub const SOCIAL_ENGINEERING: AbuseType = AbuseType::new(2);
-
-        /// The URI contains unwanted software.
-        pub const UNWANTED_SOFTWARE: AbuseType = AbuseType::new(3);
-
-        /// Creates a new AbuseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Malware => std::option::Option::Some(1),
+                Self::SocialEngineering => std::option::Option::Some(2),
+                Self::UnwantedSoftware => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ABUSE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MALWARE"),
-                2 => std::borrow::Cow::Borrowed("SOCIAL_ENGINEERING"),
-                3 => std::borrow::Cow::Borrowed("UNWANTED_SOFTWARE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ABUSE_TYPE_UNSPECIFIED"),
+                Self::Malware => std::option::Option::Some("MALWARE"),
+                Self::SocialEngineering => std::option::Option::Some("SOCIAL_ENGINEERING"),
+                Self::UnwantedSoftware => std::option::Option::Some("UNWANTED_SOFTWARE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ABUSE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ABUSE_TYPE_UNSPECIFIED),
-                "MALWARE" => std::option::Option::Some(Self::MALWARE),
-                "SOCIAL_ENGINEERING" => std::option::Option::Some(Self::SOCIAL_ENGINEERING),
-                "UNWANTED_SOFTWARE" => std::option::Option::Some(Self::UNWANTED_SOFTWARE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AbuseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AbuseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AbuseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AbuseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Malware,
+                2 => Self::SocialEngineering,
+                3 => Self::UnwantedSoftware,
+                _ => Self::UnknownValue(abuse_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AbuseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ABUSE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "MALWARE" => Self::Malware,
+                "SOCIAL_ENGINEERING" => Self::SocialEngineering,
+                "UNWANTED_SOFTWARE" => Self::UnwantedSoftware,
+                _ => Self::UnknownValue(abuse_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AbuseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Malware => serializer.serialize_i32(1),
+                Self::SocialEngineering => serializer.serialize_i32(2),
+                Self::UnwantedSoftware => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AbuseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AbuseType>::new(
+                ".google.cloud.webrisk.v1.ThreatInfo.AbuseType",
+            ))
         }
     }
 }
@@ -1512,69 +1763,134 @@ pub mod threat_discovery {
     use super::*;
 
     /// Platform types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Platform(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Platform {
+        /// Default.
+        Unspecified,
+        /// General Android platform.
+        Android,
+        /// General iOS platform.
+        Ios,
+        /// General macOS platform.
+        Macos,
+        /// General Windows platform.
+        Windows,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Platform::value] or
+        /// [Platform::name].
+        UnknownValue(platform::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod platform {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Platform {
-        /// Default.
-        pub const PLATFORM_UNSPECIFIED: Platform = Platform::new(0);
-
-        /// General Android platform.
-        pub const ANDROID: Platform = Platform::new(1);
-
-        /// General iOS platform.
-        pub const IOS: Platform = Platform::new(2);
-
-        /// General macOS platform.
-        pub const MACOS: Platform = Platform::new(3);
-
-        /// General Windows platform.
-        pub const WINDOWS: Platform = Platform::new(4);
-
-        /// Creates a new Platform instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Android => std::option::Option::Some(1),
+                Self::Ios => std::option::Option::Some(2),
+                Self::Macos => std::option::Option::Some(3),
+                Self::Windows => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PLATFORM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ANDROID"),
-                2 => std::borrow::Cow::Borrowed("IOS"),
-                3 => std::borrow::Cow::Borrowed("MACOS"),
-                4 => std::borrow::Cow::Borrowed("WINDOWS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PLATFORM_UNSPECIFIED"),
+                Self::Android => std::option::Option::Some("ANDROID"),
+                Self::Ios => std::option::Option::Some("IOS"),
+                Self::Macos => std::option::Option::Some("MACOS"),
+                Self::Windows => std::option::Option::Some("WINDOWS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PLATFORM_UNSPECIFIED" => std::option::Option::Some(Self::PLATFORM_UNSPECIFIED),
-                "ANDROID" => std::option::Option::Some(Self::ANDROID),
-                "IOS" => std::option::Option::Some(Self::IOS),
-                "MACOS" => std::option::Option::Some(Self::MACOS),
-                "WINDOWS" => std::option::Option::Some(Self::WINDOWS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Platform {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Platform {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Platform {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Platform {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Android,
+                2 => Self::Ios,
+                3 => Self::Macos,
+                4 => Self::Windows,
+                _ => Self::UnknownValue(platform::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Platform {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PLATFORM_UNSPECIFIED" => Self::Unspecified,
+                "ANDROID" => Self::Android,
+                "IOS" => Self::Ios,
+                "MACOS" => Self::Macos,
+                "WINDOWS" => Self::Windows,
+                _ => Self::UnknownValue(platform::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Platform {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Android => serializer.serialize_i32(1),
+                Self::Ios => serializer.serialize_i32(2),
+                Self::Macos => serializer.serialize_i32(3),
+                Self::Windows => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Platform {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Platform>::new(
+                ".google.cloud.webrisk.v1.ThreatDiscovery.Platform",
+            ))
         }
     }
 }
@@ -1765,204 +2081,395 @@ pub mod submit_uri_metadata {
     use super::*;
 
     /// Enum that represents the state of the long-running operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default unspecified state.
+        Unspecified,
+        /// The operation is currently running.
+        Running,
+        /// The operation finished with a success status.
+        Succeeded,
+        /// The operation was cancelled.
+        Cancelled,
+        /// The operation finished with a failure status.
+        Failed,
+        /// The operation was closed with no action taken.
+        Closed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default unspecified state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The operation is currently running.
-        pub const RUNNING: State = State::new(1);
-
-        /// The operation finished with a success status.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The operation was cancelled.
-        pub const CANCELLED: State = State::new(3);
-
-        /// The operation finished with a failure status.
-        pub const FAILED: State = State::new(4);
-
-        /// The operation was closed with no action taken.
-        pub const CLOSED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Closed => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("CLOSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Closed => std::option::Option::Some("CLOSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Succeeded,
+                3 => Self::Cancelled,
+                4 => Self::Failed,
+                5 => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "SUCCEEDED" => Self::Succeeded,
+                "CANCELLED" => Self::Cancelled,
+                "FAILED" => Self::Failed,
+                "CLOSED" => Self::Closed,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Closed => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.webrisk.v1.SubmitUriMetadata.State",
+            ))
         }
     }
 }
 
 /// The type of threat. This maps directly to the threat list a threat may
 /// belong to.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ThreatType(i32);
-
-impl ThreatType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ThreatType {
     /// No entries should match this threat type. This threat type is unused.
-    pub const THREAT_TYPE_UNSPECIFIED: ThreatType = ThreatType::new(0);
-
+    Unspecified,
     /// Malware targeting any platform.
-    pub const MALWARE: ThreatType = ThreatType::new(1);
-
+    Malware,
     /// Social engineering targeting any platform.
-    pub const SOCIAL_ENGINEERING: ThreatType = ThreatType::new(2);
-
+    SocialEngineering,
     /// Unwanted software targeting any platform.
-    pub const UNWANTED_SOFTWARE: ThreatType = ThreatType::new(3);
-
+    UnwantedSoftware,
     /// A list of extended coverage social engineering URIs targeting any
     /// platform.
-    pub const SOCIAL_ENGINEERING_EXTENDED_COVERAGE: ThreatType = ThreatType::new(4);
+    SocialEngineeringExtendedCoverage,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ThreatType::value] or
+    /// [ThreatType::name].
+    UnknownValue(threat_type::UnknownValue),
+}
 
-    /// Creates a new ThreatType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod threat_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ThreatType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Malware => std::option::Option::Some(1),
+            Self::SocialEngineering => std::option::Option::Some(2),
+            Self::UnwantedSoftware => std::option::Option::Some(3),
+            Self::SocialEngineeringExtendedCoverage => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("THREAT_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MALWARE"),
-            2 => std::borrow::Cow::Borrowed("SOCIAL_ENGINEERING"),
-            3 => std::borrow::Cow::Borrowed("UNWANTED_SOFTWARE"),
-            4 => std::borrow::Cow::Borrowed("SOCIAL_ENGINEERING_EXTENDED_COVERAGE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "THREAT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::THREAT_TYPE_UNSPECIFIED),
-            "MALWARE" => std::option::Option::Some(Self::MALWARE),
-            "SOCIAL_ENGINEERING" => std::option::Option::Some(Self::SOCIAL_ENGINEERING),
-            "UNWANTED_SOFTWARE" => std::option::Option::Some(Self::UNWANTED_SOFTWARE),
-            "SOCIAL_ENGINEERING_EXTENDED_COVERAGE" => {
-                std::option::Option::Some(Self::SOCIAL_ENGINEERING_EXTENDED_COVERAGE)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("THREAT_TYPE_UNSPECIFIED"),
+            Self::Malware => std::option::Option::Some("MALWARE"),
+            Self::SocialEngineering => std::option::Option::Some("SOCIAL_ENGINEERING"),
+            Self::UnwantedSoftware => std::option::Option::Some("UNWANTED_SOFTWARE"),
+            Self::SocialEngineeringExtendedCoverage => {
+                std::option::Option::Some("SOCIAL_ENGINEERING_EXTENDED_COVERAGE")
             }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ThreatType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ThreatType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ThreatType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ThreatType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Malware,
+            2 => Self::SocialEngineering,
+            3 => Self::UnwantedSoftware,
+            4 => Self::SocialEngineeringExtendedCoverage,
+            _ => Self::UnknownValue(threat_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ThreatType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "THREAT_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "MALWARE" => Self::Malware,
+            "SOCIAL_ENGINEERING" => Self::SocialEngineering,
+            "UNWANTED_SOFTWARE" => Self::UnwantedSoftware,
+            "SOCIAL_ENGINEERING_EXTENDED_COVERAGE" => Self::SocialEngineeringExtendedCoverage,
+            _ => Self::UnknownValue(threat_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ThreatType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Malware => serializer.serialize_i32(1),
+            Self::SocialEngineering => serializer.serialize_i32(2),
+            Self::UnwantedSoftware => serializer.serialize_i32(3),
+            Self::SocialEngineeringExtendedCoverage => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ThreatType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ThreatType>::new(
+            ".google.cloud.webrisk.v1.ThreatType",
+        ))
     }
 }
 
 /// The ways in which threat entry sets can be compressed.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CompressionType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CompressionType {
+    /// Unknown.
+    Unspecified,
+    /// Raw, uncompressed data.
+    Raw,
+    /// Rice-Golomb encoded data.
+    Rice,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CompressionType::value] or
+    /// [CompressionType::name].
+    UnknownValue(compression_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod compression_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CompressionType {
-    /// Unknown.
-    pub const COMPRESSION_TYPE_UNSPECIFIED: CompressionType = CompressionType::new(0);
-
-    /// Raw, uncompressed data.
-    pub const RAW: CompressionType = CompressionType::new(1);
-
-    /// Rice-Golomb encoded data.
-    pub const RICE: CompressionType = CompressionType::new(2);
-
-    /// Creates a new CompressionType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Raw => std::option::Option::Some(1),
+            Self::Rice => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPRESSION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RAW"),
-            2 => std::borrow::Cow::Borrowed("RICE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("COMPRESSION_TYPE_UNSPECIFIED"),
+            Self::Raw => std::option::Option::Some("RAW"),
+            Self::Rice => std::option::Option::Some("RICE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPRESSION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::COMPRESSION_TYPE_UNSPECIFIED)
-            }
-            "RAW" => std::option::Option::Some(Self::RAW),
-            "RICE" => std::option::Option::Some(Self::RICE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CompressionType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CompressionType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CompressionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CompressionType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Raw,
+            2 => Self::Rice,
+            _ => Self::UnknownValue(compression_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CompressionType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPRESSION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "RAW" => Self::Raw,
+            "RICE" => Self::Rice,
+            _ => Self::UnknownValue(compression_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CompressionType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Raw => serializer.serialize_i32(1),
+            Self::Rice => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CompressionType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CompressionType>::new(
+            ".google.cloud.webrisk.v1.CompressionType",
+        ))
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/transport.rs
+++ b/src/generated/cloud/webrisk/v1/src/transport.rs
@@ -57,7 +57,7 @@ impl super::stub::WebRiskService for WebRiskService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("threatType", &req.threat_type.value())]);
+        let builder = builder.query(&[("threatType", &req.threat_type)]);
         let builder = builder.query(&[("versionToken", &req.version_token)]);
         let builder = req
             .constraints
@@ -89,9 +89,10 @@ impl super::stub::WebRiskService for WebRiskService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("uri", &req.uri)]);
-        let builder = req.threat_types.iter().fold(builder, |builder, p| {
-            builder.query(&[("threatTypes", p.value())])
-        });
+        let builder = req
+            .threat_types
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("threatTypes", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -112,9 +113,10 @@ impl super::stub::WebRiskService for WebRiskService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("hashPrefix", &req.hash_prefix)]);
-        let builder = req.threat_types.iter().fold(builder, |builder, p| {
-            builder.query(&[("threatTypes", p.value())])
-        });
+        let builder = req
+            .threat_types
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("threatTypes", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -340,69 +340,134 @@ pub mod finding {
     use super::*;
 
     /// The severity level of a vulnerability.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        /// No severity specified. The default value.
+        Unspecified,
+        /// Critical severity.
+        Critical,
+        /// High severity.
+        High,
+        /// Medium severity.
+        Medium,
+        /// Low severity.
+        Low,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        /// No severity specified. The default value.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// Critical severity.
-        pub const CRITICAL: Severity = Severity::new(1);
-
-        /// High severity.
-        pub const HIGH: Severity = Severity::new(2);
-
-        /// Medium severity.
-        pub const MEDIUM: Severity = Severity::new(3);
-
-        /// Low severity.
-        pub const LOW: Severity = Severity::new(4);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Critical => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::Low => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CRITICAL"),
-                2 => std::borrow::Cow::Borrowed("HIGH"),
-                3 => std::borrow::Cow::Borrowed("MEDIUM"),
-                4 => std::borrow::Cow::Borrowed("LOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::Medium => std::option::Option::Some("MEDIUM"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Critical,
+                2 => Self::High,
+                3 => Self::Medium,
+                4 => Self::Low,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "CRITICAL" => Self::Critical,
+                "HIGH" => Self::High,
+                "MEDIUM" => Self::Medium,
+                "LOW" => Self::Low,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Critical => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::Low => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.cloud.websecurityscanner.v1.Finding.Severity",
+            ))
         }
     }
 }
@@ -769,127 +834,212 @@ pub mod xss {
     use super::*;
 
     /// Types of XSS attack vector.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(i32);
-
-    impl AttackVector {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackVector {
         /// Unknown attack vector.
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
-
+        Unspecified,
         /// The attack comes from fuzzing the browser's localStorage.
-        pub const LOCAL_STORAGE: AttackVector = AttackVector::new(1);
-
+        LocalStorage,
         /// The attack comes from fuzzing the browser's sessionStorage.
-        pub const SESSION_STORAGE: AttackVector = AttackVector::new(2);
-
+        SessionStorage,
         /// The attack comes from fuzzing the window's name property.
-        pub const WINDOW_NAME: AttackVector = AttackVector::new(3);
-
+        WindowName,
         /// The attack comes from fuzzing the referrer property.
-        pub const REFERRER: AttackVector = AttackVector::new(4);
-
+        Referrer,
         /// The attack comes from fuzzing an input element.
-        pub const FORM_INPUT: AttackVector = AttackVector::new(5);
-
+        FormInput,
         /// The attack comes from fuzzing the browser's cookies.
-        pub const COOKIE: AttackVector = AttackVector::new(6);
-
+        Cookie,
         /// The attack comes from hijacking the post messaging mechanism.
-        pub const POST_MESSAGE: AttackVector = AttackVector::new(7);
-
+        PostMessage,
         /// The attack comes from fuzzing parameters in the url.
-        pub const GET_PARAMETERS: AttackVector = AttackVector::new(8);
-
+        GetParameters,
         /// The attack comes from fuzzing the fragment in the url.
-        pub const URL_FRAGMENT: AttackVector = AttackVector::new(9);
-
+        UrlFragment,
         /// The attack comes from fuzzing the HTML comments.
-        pub const HTML_COMMENT: AttackVector = AttackVector::new(10);
-
+        HtmlComment,
         /// The attack comes from fuzzing the POST parameters.
-        pub const POST_PARAMETERS: AttackVector = AttackVector::new(11);
-
+        PostParameters,
         /// The attack comes from fuzzing the protocol.
-        pub const PROTOCOL: AttackVector = AttackVector::new(12);
-
+        Protocol,
         /// The attack comes from the server side and is stored.
-        pub const STORED_XSS: AttackVector = AttackVector::new(13);
-
+        StoredXss,
         /// The attack is a Same-Origin Method Execution attack via a GET parameter.
-        pub const SAME_ORIGIN: AttackVector = AttackVector::new(14);
-
+        SameOrigin,
         /// The attack payload is received from a third-party host via a URL that is
         /// user-controllable
-        pub const USER_CONTROLLABLE_URL: AttackVector = AttackVector::new(15);
+        UserControllableUrl,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackVector::value] or
+        /// [AttackVector::name].
+        UnknownValue(attack_vector::UnknownValue),
+    }
 
-        /// Creates a new AttackVector instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod attack_vector {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AttackVector {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LocalStorage => std::option::Option::Some(1),
+                Self::SessionStorage => std::option::Option::Some(2),
+                Self::WindowName => std::option::Option::Some(3),
+                Self::Referrer => std::option::Option::Some(4),
+                Self::FormInput => std::option::Option::Some(5),
+                Self::Cookie => std::option::Option::Some(6),
+                Self::PostMessage => std::option::Option::Some(7),
+                Self::GetParameters => std::option::Option::Some(8),
+                Self::UrlFragment => std::option::Option::Some(9),
+                Self::HtmlComment => std::option::Option::Some(10),
+                Self::PostParameters => std::option::Option::Some(11),
+                Self::Protocol => std::option::Option::Some(12),
+                Self::StoredXss => std::option::Option::Some(13),
+                Self::SameOrigin => std::option::Option::Some(14),
+                Self::UserControllableUrl => std::option::Option::Some(15),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOCAL_STORAGE"),
-                2 => std::borrow::Cow::Borrowed("SESSION_STORAGE"),
-                3 => std::borrow::Cow::Borrowed("WINDOW_NAME"),
-                4 => std::borrow::Cow::Borrowed("REFERRER"),
-                5 => std::borrow::Cow::Borrowed("FORM_INPUT"),
-                6 => std::borrow::Cow::Borrowed("COOKIE"),
-                7 => std::borrow::Cow::Borrowed("POST_MESSAGE"),
-                8 => std::borrow::Cow::Borrowed("GET_PARAMETERS"),
-                9 => std::borrow::Cow::Borrowed("URL_FRAGMENT"),
-                10 => std::borrow::Cow::Borrowed("HTML_COMMENT"),
-                11 => std::borrow::Cow::Borrowed("POST_PARAMETERS"),
-                12 => std::borrow::Cow::Borrowed("PROTOCOL"),
-                13 => std::borrow::Cow::Borrowed("STORED_XSS"),
-                14 => std::borrow::Cow::Borrowed("SAME_ORIGIN"),
-                15 => std::borrow::Cow::Borrowed("USER_CONTROLLABLE_URL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_VECTOR_UNSPECIFIED"),
+                Self::LocalStorage => std::option::Option::Some("LOCAL_STORAGE"),
+                Self::SessionStorage => std::option::Option::Some("SESSION_STORAGE"),
+                Self::WindowName => std::option::Option::Some("WINDOW_NAME"),
+                Self::Referrer => std::option::Option::Some("REFERRER"),
+                Self::FormInput => std::option::Option::Some("FORM_INPUT"),
+                Self::Cookie => std::option::Option::Some("COOKIE"),
+                Self::PostMessage => std::option::Option::Some("POST_MESSAGE"),
+                Self::GetParameters => std::option::Option::Some("GET_PARAMETERS"),
+                Self::UrlFragment => std::option::Option::Some("URL_FRAGMENT"),
+                Self::HtmlComment => std::option::Option::Some("HTML_COMMENT"),
+                Self::PostParameters => std::option::Option::Some("POST_PARAMETERS"),
+                Self::Protocol => std::option::Option::Some("PROTOCOL"),
+                Self::StoredXss => std::option::Option::Some("STORED_XSS"),
+                Self::SameOrigin => std::option::Option::Some("SAME_ORIGIN"),
+                Self::UserControllableUrl => std::option::Option::Some("USER_CONTROLLABLE_URL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_VECTOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
-                }
-                "LOCAL_STORAGE" => std::option::Option::Some(Self::LOCAL_STORAGE),
-                "SESSION_STORAGE" => std::option::Option::Some(Self::SESSION_STORAGE),
-                "WINDOW_NAME" => std::option::Option::Some(Self::WINDOW_NAME),
-                "REFERRER" => std::option::Option::Some(Self::REFERRER),
-                "FORM_INPUT" => std::option::Option::Some(Self::FORM_INPUT),
-                "COOKIE" => std::option::Option::Some(Self::COOKIE),
-                "POST_MESSAGE" => std::option::Option::Some(Self::POST_MESSAGE),
-                "GET_PARAMETERS" => std::option::Option::Some(Self::GET_PARAMETERS),
-                "URL_FRAGMENT" => std::option::Option::Some(Self::URL_FRAGMENT),
-                "HTML_COMMENT" => std::option::Option::Some(Self::HTML_COMMENT),
-                "POST_PARAMETERS" => std::option::Option::Some(Self::POST_PARAMETERS),
-                "PROTOCOL" => std::option::Option::Some(Self::PROTOCOL),
-                "STORED_XSS" => std::option::Option::Some(Self::STORED_XSS),
-                "SAME_ORIGIN" => std::option::Option::Some(Self::SAME_ORIGIN),
-                "USER_CONTROLLABLE_URL" => std::option::Option::Some(Self::USER_CONTROLLABLE_URL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackVector {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AttackVector {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LocalStorage,
+                2 => Self::SessionStorage,
+                3 => Self::WindowName,
+                4 => Self::Referrer,
+                5 => Self::FormInput,
+                6 => Self::Cookie,
+                7 => Self::PostMessage,
+                8 => Self::GetParameters,
+                9 => Self::UrlFragment,
+                10 => Self::HtmlComment,
+                11 => Self::PostParameters,
+                12 => Self::Protocol,
+                13 => Self::StoredXss,
+                14 => Self::SameOrigin,
+                15 => Self::UserControllableUrl,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackVector {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_VECTOR_UNSPECIFIED" => Self::Unspecified,
+                "LOCAL_STORAGE" => Self::LocalStorage,
+                "SESSION_STORAGE" => Self::SessionStorage,
+                "WINDOW_NAME" => Self::WindowName,
+                "REFERRER" => Self::Referrer,
+                "FORM_INPUT" => Self::FormInput,
+                "COOKIE" => Self::Cookie,
+                "POST_MESSAGE" => Self::PostMessage,
+                "GET_PARAMETERS" => Self::GetParameters,
+                "URL_FRAGMENT" => Self::UrlFragment,
+                "HTML_COMMENT" => Self::HtmlComment,
+                "POST_PARAMETERS" => Self::PostParameters,
+                "PROTOCOL" => Self::Protocol,
+                "STORED_XSS" => Self::StoredXss,
+                "SAME_ORIGIN" => Self::SameOrigin,
+                "USER_CONTROLLABLE_URL" => Self::UserControllableUrl,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackVector {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LocalStorage => serializer.serialize_i32(1),
+                Self::SessionStorage => serializer.serialize_i32(2),
+                Self::WindowName => serializer.serialize_i32(3),
+                Self::Referrer => serializer.serialize_i32(4),
+                Self::FormInput => serializer.serialize_i32(5),
+                Self::Cookie => serializer.serialize_i32(6),
+                Self::PostMessage => serializer.serialize_i32(7),
+                Self::GetParameters => serializer.serialize_i32(8),
+                Self::UrlFragment => serializer.serialize_i32(9),
+                Self::HtmlComment => serializer.serialize_i32(10),
+                Self::PostParameters => serializer.serialize_i32(11),
+                Self::Protocol => serializer.serialize_i32(12),
+                Self::StoredXss => serializer.serialize_i32(13),
+                Self::SameOrigin => serializer.serialize_i32(14),
+                Self::UserControllableUrl => serializer.serialize_i32(15),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackVector {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackVector>::new(
+                ".google.cloud.websecurityscanner.v1.Xss.AttackVector",
+            ))
         }
     }
 }
@@ -945,54 +1095,113 @@ pub mod xxe {
     use super::*;
 
     /// Locations within a request where XML was substituted.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Location(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Location {
+        /// Unknown Location.
+        Unspecified,
+        /// The XML payload replaced the complete request body.
+        CompleteRequestBody,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Location::value] or
+        /// [Location::name].
+        UnknownValue(location::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod location {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Location {
-        /// Unknown Location.
-        pub const LOCATION_UNSPECIFIED: Location = Location::new(0);
-
-        /// The XML payload replaced the complete request body.
-        pub const COMPLETE_REQUEST_BODY: Location = Location::new(1);
-
-        /// Creates a new Location instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CompleteRequestBody => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COMPLETE_REQUEST_BODY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOCATION_UNSPECIFIED"),
+                Self::CompleteRequestBody => std::option::Option::Some("COMPLETE_REQUEST_BODY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCATION_UNSPECIFIED" => std::option::Option::Some(Self::LOCATION_UNSPECIFIED),
-                "COMPLETE_REQUEST_BODY" => std::option::Option::Some(Self::COMPLETE_REQUEST_BODY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Location {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Location {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Location {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Location {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CompleteRequestBody,
+                _ => Self::UnknownValue(location::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Location {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCATION_UNSPECIFIED" => Self::Unspecified,
+                "COMPLETE_REQUEST_BODY" => Self::CompleteRequestBody,
+                _ => Self::UnknownValue(location::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Location {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CompleteRequestBody => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Location {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Location>::new(
+                ".google.cloud.websecurityscanner.v1.Xxe.Location",
+            ))
         }
     }
 }
@@ -1689,184 +1898,370 @@ pub mod scan_config {
     }
 
     /// Type of user agents used for scanning.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserAgent(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserAgent {
+        /// The user agent is unknown. Service will default to CHROME_LINUX.
+        Unspecified,
+        /// Chrome on Linux. This is the service default if unspecified.
+        ChromeLinux,
+        /// Chrome on Android.
+        ChromeAndroid,
+        /// Safari on IPhone.
+        SafariIphone,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserAgent::value] or
+        /// [UserAgent::name].
+        UnknownValue(user_agent::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod user_agent {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl UserAgent {
-        /// The user agent is unknown. Service will default to CHROME_LINUX.
-        pub const USER_AGENT_UNSPECIFIED: UserAgent = UserAgent::new(0);
-
-        /// Chrome on Linux. This is the service default if unspecified.
-        pub const CHROME_LINUX: UserAgent = UserAgent::new(1);
-
-        /// Chrome on Android.
-        pub const CHROME_ANDROID: UserAgent = UserAgent::new(2);
-
-        /// Safari on IPhone.
-        pub const SAFARI_IPHONE: UserAgent = UserAgent::new(3);
-
-        /// Creates a new UserAgent instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ChromeLinux => std::option::Option::Some(1),
+                Self::ChromeAndroid => std::option::Option::Some(2),
+                Self::SafariIphone => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_AGENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CHROME_LINUX"),
-                2 => std::borrow::Cow::Borrowed("CHROME_ANDROID"),
-                3 => std::borrow::Cow::Borrowed("SAFARI_IPHONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("USER_AGENT_UNSPECIFIED"),
+                Self::ChromeLinux => std::option::Option::Some("CHROME_LINUX"),
+                Self::ChromeAndroid => std::option::Option::Some("CHROME_ANDROID"),
+                Self::SafariIphone => std::option::Option::Some("SAFARI_IPHONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_AGENT_UNSPECIFIED" => std::option::Option::Some(Self::USER_AGENT_UNSPECIFIED),
-                "CHROME_LINUX" => std::option::Option::Some(Self::CHROME_LINUX),
-                "CHROME_ANDROID" => std::option::Option::Some(Self::CHROME_ANDROID),
-                "SAFARI_IPHONE" => std::option::Option::Some(Self::SAFARI_IPHONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UserAgent {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserAgent {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for UserAgent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserAgent {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ChromeLinux,
+                2 => Self::ChromeAndroid,
+                3 => Self::SafariIphone,
+                _ => Self::UnknownValue(user_agent::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserAgent {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_AGENT_UNSPECIFIED" => Self::Unspecified,
+                "CHROME_LINUX" => Self::ChromeLinux,
+                "CHROME_ANDROID" => Self::ChromeAndroid,
+                "SAFARI_IPHONE" => Self::SafariIphone,
+                _ => Self::UnknownValue(user_agent::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserAgent {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ChromeLinux => serializer.serialize_i32(1),
+                Self::ChromeAndroid => serializer.serialize_i32(2),
+                Self::SafariIphone => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserAgent {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserAgent>::new(
+                ".google.cloud.websecurityscanner.v1.ScanConfig.UserAgent",
+            ))
         }
     }
 
     /// Scan risk levels supported by Web Security Scanner. LOW impact
     /// scanning will minimize requests with the potential to modify data. To
     /// achieve the maximum scan coverage, NORMAL risk level is recommended.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RiskLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RiskLevel {
+        /// Use default, which is NORMAL.
+        Unspecified,
+        /// Normal scanning (Recommended)
+        Normal,
+        /// Lower impact scanning
+        Low,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RiskLevel::value] or
+        /// [RiskLevel::name].
+        UnknownValue(risk_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod risk_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RiskLevel {
-        /// Use default, which is NORMAL.
-        pub const RISK_LEVEL_UNSPECIFIED: RiskLevel = RiskLevel::new(0);
-
-        /// Normal scanning (Recommended)
-        pub const NORMAL: RiskLevel = RiskLevel::new(1);
-
-        /// Lower impact scanning
-        pub const LOW: RiskLevel = RiskLevel::new(2);
-
-        /// Creates a new RiskLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Normal => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RISK_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NORMAL"),
-                2 => std::borrow::Cow::Borrowed("LOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RISK_LEVEL_UNSPECIFIED"),
+                Self::Normal => std::option::Option::Some("NORMAL"),
+                Self::Low => std::option::Option::Some("LOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RISK_LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::RISK_LEVEL_UNSPECIFIED),
-                "NORMAL" => std::option::Option::Some(Self::NORMAL),
-                "LOW" => std::option::Option::Some(Self::LOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RiskLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RiskLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RiskLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RiskLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Normal,
+                2 => Self::Low,
+                _ => Self::UnknownValue(risk_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RiskLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RISK_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "NORMAL" => Self::Normal,
+                "LOW" => Self::Low,
+                _ => Self::UnknownValue(risk_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RiskLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Normal => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RiskLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RiskLevel>::new(
+                ".google.cloud.websecurityscanner.v1.ScanConfig.RiskLevel",
+            ))
         }
     }
 
     /// Controls export of scan configurations and results to Security
     /// Command Center.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExportToSecurityCommandCenter(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExportToSecurityCommandCenter {
+        /// Use default, which is ENABLED.
+        Unspecified,
+        /// Export results of this scan to Security Command Center.
+        Enabled,
+        /// Do not export results of this scan to Security Command Center.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExportToSecurityCommandCenter::value] or
+        /// [ExportToSecurityCommandCenter::name].
+        UnknownValue(export_to_security_command_center::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod export_to_security_command_center {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ExportToSecurityCommandCenter {
-        /// Use default, which is ENABLED.
-        pub const EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED: ExportToSecurityCommandCenter =
-            ExportToSecurityCommandCenter::new(0);
-
-        /// Export results of this scan to Security Command Center.
-        pub const ENABLED: ExportToSecurityCommandCenter = ExportToSecurityCommandCenter::new(1);
-
-        /// Do not export results of this scan to Security Command Center.
-        pub const DISABLED: ExportToSecurityCommandCenter = ExportToSecurityCommandCenter::new(2);
-
-        /// Creates a new ExportToSecurityCommandCenter instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED")
                 }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ExportToSecurityCommandCenter {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExportToSecurityCommandCenter {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExportToSecurityCommandCenter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExportToSecurityCommandCenter {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(export_to_security_command_center::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExportToSecurityCommandCenter {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXPORT_TO_SECURITY_COMMAND_CENTER_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(export_to_security_command_center::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExportToSecurityCommandCenter {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExportToSecurityCommandCenter {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<ExportToSecurityCommandCenter>::new(
+                    ".google.cloud.websecurityscanner.v1.ScanConfig.ExportToSecurityCommandCenter",
+                ),
+            )
         }
     }
 }
@@ -1929,327 +2324,476 @@ pub mod scan_config_error {
     /// Output only.
     /// Defines an error reason code.
     /// Next id: 44
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// There is no error.
-        pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+        Unspecified,
         /// There is no error.
-        pub const OK: Code = Code::new(0);
-
+        Ok,
         /// Indicates an internal server error.
         /// Please DO NOT USE THIS ERROR CODE unless the root cause is truly unknown.
-        pub const INTERNAL_ERROR: Code = Code::new(1);
-
+        InternalError,
         /// One of the seed URLs is an App Engine URL but we cannot validate the scan
         /// settings due to an App Engine API backend error.
-        pub const APPENGINE_API_BACKEND_ERROR: Code = Code::new(2);
-
+        AppengineApiBackendError,
         /// One of the seed URLs is an App Engine URL but we cannot access the
         /// App Engine API to validate scan settings.
-        pub const APPENGINE_API_NOT_ACCESSIBLE: Code = Code::new(3);
-
+        AppengineApiNotAccessible,
         /// One of the seed URLs is an App Engine URL but the Default Host of the
         /// App Engine is not set.
-        pub const APPENGINE_DEFAULT_HOST_MISSING: Code = Code::new(4);
-
+        AppengineDefaultHostMissing,
         /// Google corporate accounts can not be used for scanning.
-        pub const CANNOT_USE_GOOGLE_COM_ACCOUNT: Code = Code::new(6);
-
+        CannotUseGoogleComAccount,
         /// The account of the scan creator can not be used for scanning.
-        pub const CANNOT_USE_OWNER_ACCOUNT: Code = Code::new(7);
-
+        CannotUseOwnerAccount,
         /// This scan targets Compute Engine, but we cannot validate scan settings
         /// due to a Compute Engine API backend error.
-        pub const COMPUTE_API_BACKEND_ERROR: Code = Code::new(8);
-
+        ComputeApiBackendError,
         /// This scan targets Compute Engine, but we cannot access the Compute Engine
         /// API to validate the scan settings.
-        pub const COMPUTE_API_NOT_ACCESSIBLE: Code = Code::new(9);
-
+        ComputeApiNotAccessible,
         /// The Custom Login URL does not belong to the current project.
-        pub const CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT: Code = Code::new(10);
-
+        CustomLoginUrlDoesNotBelongToCurrentProject,
         /// The Custom Login URL is malformed (can not be parsed).
-        pub const CUSTOM_LOGIN_URL_MALFORMED: Code = Code::new(11);
-
+        CustomLoginUrlMalformed,
         /// The Custom Login URL is mapped to a non-routable IP address in DNS.
-        pub const CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS: Code = Code::new(12);
-
+        CustomLoginUrlMappedToNonRoutableAddress,
         /// The Custom Login URL is mapped to an IP address which is not reserved for
         /// the current project.
-        pub const CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS: Code = Code::new(13);
-
+        CustomLoginUrlMappedToUnreservedAddress,
         /// The Custom Login URL has a non-routable IP address.
-        pub const CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS: Code = Code::new(14);
-
+        CustomLoginUrlHasNonRoutableIpAddress,
         /// The Custom Login URL has an IP address which is not reserved for the
         /// current project.
-        pub const CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS: Code = Code::new(15);
-
+        CustomLoginUrlHasUnreservedIpAddress,
         /// Another scan with the same name (case-sensitive) already exists.
-        pub const DUPLICATE_SCAN_NAME: Code = Code::new(16);
-
+        DuplicateScanName,
         /// A field is set to an invalid value.
-        pub const INVALID_FIELD_VALUE: Code = Code::new(18);
-
+        InvalidFieldValue,
         /// There was an error trying to authenticate to the scan target.
-        pub const FAILED_TO_AUTHENTICATE_TO_TARGET: Code = Code::new(19);
-
+        FailedToAuthenticateToTarget,
         /// Finding type value is not specified in the list findings request.
-        pub const FINDING_TYPE_UNSPECIFIED: Code = Code::new(20);
-
+        FindingTypeUnspecified,
         /// Scan targets Compute Engine, yet current project was not whitelisted for
         /// Google Compute Engine Scanning Alpha access.
-        pub const FORBIDDEN_TO_SCAN_COMPUTE: Code = Code::new(21);
-
+        ForbiddenToScanCompute,
         /// User tries to update managed scan
-        pub const FORBIDDEN_UPDATE_TO_MANAGED_SCAN: Code = Code::new(43);
-
+        ForbiddenUpdateToManagedScan,
         /// The supplied filter is malformed. For example, it can not be parsed, does
         /// not have a filter type in expression, or the same filter type appears
         /// more than once.
-        pub const MALFORMED_FILTER: Code = Code::new(22);
-
+        MalformedFilter,
         /// The supplied resource name is malformed (can not be parsed).
-        pub const MALFORMED_RESOURCE_NAME: Code = Code::new(23);
-
+        MalformedResourceName,
         /// The current project is not in an active state.
-        pub const PROJECT_INACTIVE: Code = Code::new(24);
-
+        ProjectInactive,
         /// A required field is not set.
-        pub const REQUIRED_FIELD: Code = Code::new(25);
-
+        RequiredField,
         /// Project id, scanconfig id, scanrun id, or finding id are not consistent
         /// with each other in resource name.
-        pub const RESOURCE_NAME_INCONSISTENT: Code = Code::new(26);
-
+        ResourceNameInconsistent,
         /// The scan being requested to start is already running.
-        pub const SCAN_ALREADY_RUNNING: Code = Code::new(27);
-
+        ScanAlreadyRunning,
         /// The scan that was requested to be stopped is not running.
-        pub const SCAN_NOT_RUNNING: Code = Code::new(28);
-
+        ScanNotRunning,
         /// One of the seed URLs does not belong to the current project.
-        pub const SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT: Code = Code::new(29);
-
+        SeedUrlDoesNotBelongToCurrentProject,
         /// One of the seed URLs is malformed (can not be parsed).
-        pub const SEED_URL_MALFORMED: Code = Code::new(30);
-
+        SeedUrlMalformed,
         /// One of the seed URLs is mapped to a non-routable IP address in DNS.
-        pub const SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS: Code = Code::new(31);
-
+        SeedUrlMappedToNonRoutableAddress,
         /// One of the seed URLs is mapped to an IP address which is not reserved
         /// for the current project.
-        pub const SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS: Code = Code::new(32);
-
+        SeedUrlMappedToUnreservedAddress,
         /// One of the seed URLs has on-routable IP address.
-        pub const SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS: Code = Code::new(33);
-
+        SeedUrlHasNonRoutableIpAddress,
         /// One of the seed URLs has an IP address that is not reserved
         /// for the current project.
-        pub const SEED_URL_HAS_UNRESERVED_IP_ADDRESS: Code = Code::new(35);
-
+        SeedUrlHasUnreservedIpAddress,
         /// The Web Security Scanner service account is not configured under the
         /// project.
-        pub const SERVICE_ACCOUNT_NOT_CONFIGURED: Code = Code::new(36);
-
+        ServiceAccountNotConfigured,
         /// A project has reached the maximum number of scans.
-        pub const TOO_MANY_SCANS: Code = Code::new(37);
-
+        TooManyScans,
         /// Resolving the details of the current project fails.
-        pub const UNABLE_TO_RESOLVE_PROJECT_INFO: Code = Code::new(38);
-
+        UnableToResolveProjectInfo,
         /// One or more blacklist patterns were in the wrong format.
-        pub const UNSUPPORTED_BLACKLIST_PATTERN_FORMAT: Code = Code::new(39);
-
+        UnsupportedBlacklistPatternFormat,
         /// The supplied filter is not supported.
-        pub const UNSUPPORTED_FILTER: Code = Code::new(40);
-
+        UnsupportedFilter,
         /// The supplied finding type is not supported. For example, we do not
         /// provide findings of the given finding type.
-        pub const UNSUPPORTED_FINDING_TYPE: Code = Code::new(41);
-
+        UnsupportedFindingType,
         /// The URL scheme of one or more of the supplied URLs is not supported.
-        pub const UNSUPPORTED_URL_SCHEME: Code = Code::new(42);
+        UnsupportedUrlScheme,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(0),
+                Self::InternalError => std::option::Option::Some(1),
+                Self::AppengineApiBackendError => std::option::Option::Some(2),
+                Self::AppengineApiNotAccessible => std::option::Option::Some(3),
+                Self::AppengineDefaultHostMissing => std::option::Option::Some(4),
+                Self::CannotUseGoogleComAccount => std::option::Option::Some(6),
+                Self::CannotUseOwnerAccount => std::option::Option::Some(7),
+                Self::ComputeApiBackendError => std::option::Option::Some(8),
+                Self::ComputeApiNotAccessible => std::option::Option::Some(9),
+                Self::CustomLoginUrlDoesNotBelongToCurrentProject => std::option::Option::Some(10),
+                Self::CustomLoginUrlMalformed => std::option::Option::Some(11),
+                Self::CustomLoginUrlMappedToNonRoutableAddress => std::option::Option::Some(12),
+                Self::CustomLoginUrlMappedToUnreservedAddress => std::option::Option::Some(13),
+                Self::CustomLoginUrlHasNonRoutableIpAddress => std::option::Option::Some(14),
+                Self::CustomLoginUrlHasUnreservedIpAddress => std::option::Option::Some(15),
+                Self::DuplicateScanName => std::option::Option::Some(16),
+                Self::InvalidFieldValue => std::option::Option::Some(18),
+                Self::FailedToAuthenticateToTarget => std::option::Option::Some(19),
+                Self::FindingTypeUnspecified => std::option::Option::Some(20),
+                Self::ForbiddenToScanCompute => std::option::Option::Some(21),
+                Self::ForbiddenUpdateToManagedScan => std::option::Option::Some(43),
+                Self::MalformedFilter => std::option::Option::Some(22),
+                Self::MalformedResourceName => std::option::Option::Some(23),
+                Self::ProjectInactive => std::option::Option::Some(24),
+                Self::RequiredField => std::option::Option::Some(25),
+                Self::ResourceNameInconsistent => std::option::Option::Some(26),
+                Self::ScanAlreadyRunning => std::option::Option::Some(27),
+                Self::ScanNotRunning => std::option::Option::Some(28),
+                Self::SeedUrlDoesNotBelongToCurrentProject => std::option::Option::Some(29),
+                Self::SeedUrlMalformed => std::option::Option::Some(30),
+                Self::SeedUrlMappedToNonRoutableAddress => std::option::Option::Some(31),
+                Self::SeedUrlMappedToUnreservedAddress => std::option::Option::Some(32),
+                Self::SeedUrlHasNonRoutableIpAddress => std::option::Option::Some(33),
+                Self::SeedUrlHasUnreservedIpAddress => std::option::Option::Some(35),
+                Self::ServiceAccountNotConfigured => std::option::Option::Some(36),
+                Self::TooManyScans => std::option::Option::Some(37),
+                Self::UnableToResolveProjectInfo => std::option::Option::Some(38),
+                Self::UnsupportedBlacklistPatternFormat => std::option::Option::Some(39),
+                Self::UnsupportedFilter => std::option::Option::Some(40),
+                Self::UnsupportedFindingType => std::option::Option::Some(41),
+                Self::UnsupportedUrlScheme => std::option::Option::Some(42),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OK"),
-                1 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
-                2 => std::borrow::Cow::Borrowed("APPENGINE_API_BACKEND_ERROR"),
-                3 => std::borrow::Cow::Borrowed("APPENGINE_API_NOT_ACCESSIBLE"),
-                4 => std::borrow::Cow::Borrowed("APPENGINE_DEFAULT_HOST_MISSING"),
-                6 => std::borrow::Cow::Borrowed("CANNOT_USE_GOOGLE_COM_ACCOUNT"),
-                7 => std::borrow::Cow::Borrowed("CANNOT_USE_OWNER_ACCOUNT"),
-                8 => std::borrow::Cow::Borrowed("COMPUTE_API_BACKEND_ERROR"),
-                9 => std::borrow::Cow::Borrowed("COMPUTE_API_NOT_ACCESSIBLE"),
-                10 => std::borrow::Cow::Borrowed(
-                    "CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT",
-                ),
-                11 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_MALFORMED"),
-                12 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS"),
-                13 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS"),
-                14 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS"),
-                15 => std::borrow::Cow::Borrowed("CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS"),
-                16 => std::borrow::Cow::Borrowed("DUPLICATE_SCAN_NAME"),
-                18 => std::borrow::Cow::Borrowed("INVALID_FIELD_VALUE"),
-                19 => std::borrow::Cow::Borrowed("FAILED_TO_AUTHENTICATE_TO_TARGET"),
-                20 => std::borrow::Cow::Borrowed("FINDING_TYPE_UNSPECIFIED"),
-                21 => std::borrow::Cow::Borrowed("FORBIDDEN_TO_SCAN_COMPUTE"),
-                22 => std::borrow::Cow::Borrowed("MALFORMED_FILTER"),
-                23 => std::borrow::Cow::Borrowed("MALFORMED_RESOURCE_NAME"),
-                24 => std::borrow::Cow::Borrowed("PROJECT_INACTIVE"),
-                25 => std::borrow::Cow::Borrowed("REQUIRED_FIELD"),
-                26 => std::borrow::Cow::Borrowed("RESOURCE_NAME_INCONSISTENT"),
-                27 => std::borrow::Cow::Borrowed("SCAN_ALREADY_RUNNING"),
-                28 => std::borrow::Cow::Borrowed("SCAN_NOT_RUNNING"),
-                29 => std::borrow::Cow::Borrowed("SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT"),
-                30 => std::borrow::Cow::Borrowed("SEED_URL_MALFORMED"),
-                31 => std::borrow::Cow::Borrowed("SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS"),
-                32 => std::borrow::Cow::Borrowed("SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS"),
-                33 => std::borrow::Cow::Borrowed("SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS"),
-                35 => std::borrow::Cow::Borrowed("SEED_URL_HAS_UNRESERVED_IP_ADDRESS"),
-                36 => std::borrow::Cow::Borrowed("SERVICE_ACCOUNT_NOT_CONFIGURED"),
-                37 => std::borrow::Cow::Borrowed("TOO_MANY_SCANS"),
-                38 => std::borrow::Cow::Borrowed("UNABLE_TO_RESOLVE_PROJECT_INFO"),
-                39 => std::borrow::Cow::Borrowed("UNSUPPORTED_BLACKLIST_PATTERN_FORMAT"),
-                40 => std::borrow::Cow::Borrowed("UNSUPPORTED_FILTER"),
-                41 => std::borrow::Cow::Borrowed("UNSUPPORTED_FINDING_TYPE"),
-                42 => std::borrow::Cow::Borrowed("UNSUPPORTED_URL_SCHEME"),
-                43 => std::borrow::Cow::Borrowed("FORBIDDEN_UPDATE_TO_MANAGED_SCAN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::InternalError => std::option::Option::Some("INTERNAL_ERROR"),
+                Self::AppengineApiBackendError => {
+                    std::option::Option::Some("APPENGINE_API_BACKEND_ERROR")
+                }
+                Self::AppengineApiNotAccessible => {
+                    std::option::Option::Some("APPENGINE_API_NOT_ACCESSIBLE")
+                }
+                Self::AppengineDefaultHostMissing => {
+                    std::option::Option::Some("APPENGINE_DEFAULT_HOST_MISSING")
+                }
+                Self::CannotUseGoogleComAccount => {
+                    std::option::Option::Some("CANNOT_USE_GOOGLE_COM_ACCOUNT")
+                }
+                Self::CannotUseOwnerAccount => {
+                    std::option::Option::Some("CANNOT_USE_OWNER_ACCOUNT")
+                }
+                Self::ComputeApiBackendError => {
+                    std::option::Option::Some("COMPUTE_API_BACKEND_ERROR")
+                }
+                Self::ComputeApiNotAccessible => {
+                    std::option::Option::Some("COMPUTE_API_NOT_ACCESSIBLE")
+                }
+                Self::CustomLoginUrlDoesNotBelongToCurrentProject => {
+                    std::option::Option::Some("CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT")
+                }
+                Self::CustomLoginUrlMalformed => {
+                    std::option::Option::Some("CUSTOM_LOGIN_URL_MALFORMED")
+                }
+                Self::CustomLoginUrlMappedToNonRoutableAddress => {
+                    std::option::Option::Some("CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS")
+                }
+                Self::CustomLoginUrlMappedToUnreservedAddress => {
+                    std::option::Option::Some("CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS")
+                }
+                Self::CustomLoginUrlHasNonRoutableIpAddress => {
+                    std::option::Option::Some("CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS")
+                }
+                Self::CustomLoginUrlHasUnreservedIpAddress => {
+                    std::option::Option::Some("CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS")
+                }
+                Self::DuplicateScanName => std::option::Option::Some("DUPLICATE_SCAN_NAME"),
+                Self::InvalidFieldValue => std::option::Option::Some("INVALID_FIELD_VALUE"),
+                Self::FailedToAuthenticateToTarget => {
+                    std::option::Option::Some("FAILED_TO_AUTHENTICATE_TO_TARGET")
+                }
+                Self::FindingTypeUnspecified => {
+                    std::option::Option::Some("FINDING_TYPE_UNSPECIFIED")
+                }
+                Self::ForbiddenToScanCompute => {
+                    std::option::Option::Some("FORBIDDEN_TO_SCAN_COMPUTE")
+                }
+                Self::ForbiddenUpdateToManagedScan => {
+                    std::option::Option::Some("FORBIDDEN_UPDATE_TO_MANAGED_SCAN")
+                }
+                Self::MalformedFilter => std::option::Option::Some("MALFORMED_FILTER"),
+                Self::MalformedResourceName => std::option::Option::Some("MALFORMED_RESOURCE_NAME"),
+                Self::ProjectInactive => std::option::Option::Some("PROJECT_INACTIVE"),
+                Self::RequiredField => std::option::Option::Some("REQUIRED_FIELD"),
+                Self::ResourceNameInconsistent => {
+                    std::option::Option::Some("RESOURCE_NAME_INCONSISTENT")
+                }
+                Self::ScanAlreadyRunning => std::option::Option::Some("SCAN_ALREADY_RUNNING"),
+                Self::ScanNotRunning => std::option::Option::Some("SCAN_NOT_RUNNING"),
+                Self::SeedUrlDoesNotBelongToCurrentProject => {
+                    std::option::Option::Some("SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT")
+                }
+                Self::SeedUrlMalformed => std::option::Option::Some("SEED_URL_MALFORMED"),
+                Self::SeedUrlMappedToNonRoutableAddress => {
+                    std::option::Option::Some("SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS")
+                }
+                Self::SeedUrlMappedToUnreservedAddress => {
+                    std::option::Option::Some("SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS")
+                }
+                Self::SeedUrlHasNonRoutableIpAddress => {
+                    std::option::Option::Some("SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS")
+                }
+                Self::SeedUrlHasUnreservedIpAddress => {
+                    std::option::Option::Some("SEED_URL_HAS_UNRESERVED_IP_ADDRESS")
+                }
+                Self::ServiceAccountNotConfigured => {
+                    std::option::Option::Some("SERVICE_ACCOUNT_NOT_CONFIGURED")
+                }
+                Self::TooManyScans => std::option::Option::Some("TOO_MANY_SCANS"),
+                Self::UnableToResolveProjectInfo => {
+                    std::option::Option::Some("UNABLE_TO_RESOLVE_PROJECT_INFO")
+                }
+                Self::UnsupportedBlacklistPatternFormat => {
+                    std::option::Option::Some("UNSUPPORTED_BLACKLIST_PATTERN_FORMAT")
+                }
+                Self::UnsupportedFilter => std::option::Option::Some("UNSUPPORTED_FILTER"),
+                Self::UnsupportedFindingType => {
+                    std::option::Option::Some("UNSUPPORTED_FINDING_TYPE")
+                }
+                Self::UnsupportedUrlScheme => std::option::Option::Some("UNSUPPORTED_URL_SCHEME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                "OK" => std::option::Option::Some(Self::OK),
-                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
-                "APPENGINE_API_BACKEND_ERROR" => {
-                    std::option::Option::Some(Self::APPENGINE_API_BACKEND_ERROR)
-                }
-                "APPENGINE_API_NOT_ACCESSIBLE" => {
-                    std::option::Option::Some(Self::APPENGINE_API_NOT_ACCESSIBLE)
-                }
-                "APPENGINE_DEFAULT_HOST_MISSING" => {
-                    std::option::Option::Some(Self::APPENGINE_DEFAULT_HOST_MISSING)
-                }
-                "CANNOT_USE_GOOGLE_COM_ACCOUNT" => {
-                    std::option::Option::Some(Self::CANNOT_USE_GOOGLE_COM_ACCOUNT)
-                }
-                "CANNOT_USE_OWNER_ACCOUNT" => {
-                    std::option::Option::Some(Self::CANNOT_USE_OWNER_ACCOUNT)
-                }
-                "COMPUTE_API_BACKEND_ERROR" => {
-                    std::option::Option::Some(Self::COMPUTE_API_BACKEND_ERROR)
-                }
-                "COMPUTE_API_NOT_ACCESSIBLE" => {
-                    std::option::Option::Some(Self::COMPUTE_API_NOT_ACCESSIBLE)
-                }
-                "CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT" => std::option::Option::Some(
-                    Self::CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT,
-                ),
-                "CUSTOM_LOGIN_URL_MALFORMED" => {
-                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_MALFORMED)
-                }
-                "CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS" => {
-                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS)
-                }
-                "CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS" => {
-                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS)
-                }
-                "CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS" => {
-                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS)
-                }
-                "CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS" => {
-                    std::option::Option::Some(Self::CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS)
-                }
-                "DUPLICATE_SCAN_NAME" => std::option::Option::Some(Self::DUPLICATE_SCAN_NAME),
-                "INVALID_FIELD_VALUE" => std::option::Option::Some(Self::INVALID_FIELD_VALUE),
-                "FAILED_TO_AUTHENTICATE_TO_TARGET" => {
-                    std::option::Option::Some(Self::FAILED_TO_AUTHENTICATE_TO_TARGET)
-                }
-                "FINDING_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FINDING_TYPE_UNSPECIFIED)
-                }
-                "FORBIDDEN_TO_SCAN_COMPUTE" => {
-                    std::option::Option::Some(Self::FORBIDDEN_TO_SCAN_COMPUTE)
-                }
-                "FORBIDDEN_UPDATE_TO_MANAGED_SCAN" => {
-                    std::option::Option::Some(Self::FORBIDDEN_UPDATE_TO_MANAGED_SCAN)
-                }
-                "MALFORMED_FILTER" => std::option::Option::Some(Self::MALFORMED_FILTER),
-                "MALFORMED_RESOURCE_NAME" => {
-                    std::option::Option::Some(Self::MALFORMED_RESOURCE_NAME)
-                }
-                "PROJECT_INACTIVE" => std::option::Option::Some(Self::PROJECT_INACTIVE),
-                "REQUIRED_FIELD" => std::option::Option::Some(Self::REQUIRED_FIELD),
-                "RESOURCE_NAME_INCONSISTENT" => {
-                    std::option::Option::Some(Self::RESOURCE_NAME_INCONSISTENT)
-                }
-                "SCAN_ALREADY_RUNNING" => std::option::Option::Some(Self::SCAN_ALREADY_RUNNING),
-                "SCAN_NOT_RUNNING" => std::option::Option::Some(Self::SCAN_NOT_RUNNING),
-                "SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT" => {
-                    std::option::Option::Some(Self::SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT)
-                }
-                "SEED_URL_MALFORMED" => std::option::Option::Some(Self::SEED_URL_MALFORMED),
-                "SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS" => {
-                    std::option::Option::Some(Self::SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS)
-                }
-                "SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS" => {
-                    std::option::Option::Some(Self::SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS)
-                }
-                "SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS" => {
-                    std::option::Option::Some(Self::SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS)
-                }
-                "SEED_URL_HAS_UNRESERVED_IP_ADDRESS" => {
-                    std::option::Option::Some(Self::SEED_URL_HAS_UNRESERVED_IP_ADDRESS)
-                }
-                "SERVICE_ACCOUNT_NOT_CONFIGURED" => {
-                    std::option::Option::Some(Self::SERVICE_ACCOUNT_NOT_CONFIGURED)
-                }
-                "TOO_MANY_SCANS" => std::option::Option::Some(Self::TOO_MANY_SCANS),
-                "UNABLE_TO_RESOLVE_PROJECT_INFO" => {
-                    std::option::Option::Some(Self::UNABLE_TO_RESOLVE_PROJECT_INFO)
-                }
-                "UNSUPPORTED_BLACKLIST_PATTERN_FORMAT" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_BLACKLIST_PATTERN_FORMAT)
-                }
-                "UNSUPPORTED_FILTER" => std::option::Option::Some(Self::UNSUPPORTED_FILTER),
-                "UNSUPPORTED_FINDING_TYPE" => {
-                    std::option::Option::Some(Self::UNSUPPORTED_FINDING_TYPE)
-                }
-                "UNSUPPORTED_URL_SCHEME" => std::option::Option::Some(Self::UNSUPPORTED_URL_SCHEME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Ok,
+                1 => Self::InternalError,
+                2 => Self::AppengineApiBackendError,
+                3 => Self::AppengineApiNotAccessible,
+                4 => Self::AppengineDefaultHostMissing,
+                6 => Self::CannotUseGoogleComAccount,
+                7 => Self::CannotUseOwnerAccount,
+                8 => Self::ComputeApiBackendError,
+                9 => Self::ComputeApiNotAccessible,
+                10 => Self::CustomLoginUrlDoesNotBelongToCurrentProject,
+                11 => Self::CustomLoginUrlMalformed,
+                12 => Self::CustomLoginUrlMappedToNonRoutableAddress,
+                13 => Self::CustomLoginUrlMappedToUnreservedAddress,
+                14 => Self::CustomLoginUrlHasNonRoutableIpAddress,
+                15 => Self::CustomLoginUrlHasUnreservedIpAddress,
+                16 => Self::DuplicateScanName,
+                18 => Self::InvalidFieldValue,
+                19 => Self::FailedToAuthenticateToTarget,
+                20 => Self::FindingTypeUnspecified,
+                21 => Self::ForbiddenToScanCompute,
+                22 => Self::MalformedFilter,
+                23 => Self::MalformedResourceName,
+                24 => Self::ProjectInactive,
+                25 => Self::RequiredField,
+                26 => Self::ResourceNameInconsistent,
+                27 => Self::ScanAlreadyRunning,
+                28 => Self::ScanNotRunning,
+                29 => Self::SeedUrlDoesNotBelongToCurrentProject,
+                30 => Self::SeedUrlMalformed,
+                31 => Self::SeedUrlMappedToNonRoutableAddress,
+                32 => Self::SeedUrlMappedToUnreservedAddress,
+                33 => Self::SeedUrlHasNonRoutableIpAddress,
+                35 => Self::SeedUrlHasUnreservedIpAddress,
+                36 => Self::ServiceAccountNotConfigured,
+                37 => Self::TooManyScans,
+                38 => Self::UnableToResolveProjectInfo,
+                39 => Self::UnsupportedBlacklistPatternFormat,
+                40 => Self::UnsupportedFilter,
+                41 => Self::UnsupportedFindingType,
+                42 => Self::UnsupportedUrlScheme,
+                43 => Self::ForbiddenUpdateToManagedScan,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CODE_UNSPECIFIED" => Self::Unspecified,
+                "OK" => Self::Ok,
+                "INTERNAL_ERROR" => Self::InternalError,
+                "APPENGINE_API_BACKEND_ERROR" => Self::AppengineApiBackendError,
+                "APPENGINE_API_NOT_ACCESSIBLE" => Self::AppengineApiNotAccessible,
+                "APPENGINE_DEFAULT_HOST_MISSING" => Self::AppengineDefaultHostMissing,
+                "CANNOT_USE_GOOGLE_COM_ACCOUNT" => Self::CannotUseGoogleComAccount,
+                "CANNOT_USE_OWNER_ACCOUNT" => Self::CannotUseOwnerAccount,
+                "COMPUTE_API_BACKEND_ERROR" => Self::ComputeApiBackendError,
+                "COMPUTE_API_NOT_ACCESSIBLE" => Self::ComputeApiNotAccessible,
+                "CUSTOM_LOGIN_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT" => {
+                    Self::CustomLoginUrlDoesNotBelongToCurrentProject
+                }
+                "CUSTOM_LOGIN_URL_MALFORMED" => Self::CustomLoginUrlMalformed,
+                "CUSTOM_LOGIN_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS" => {
+                    Self::CustomLoginUrlMappedToNonRoutableAddress
+                }
+                "CUSTOM_LOGIN_URL_MAPPED_TO_UNRESERVED_ADDRESS" => {
+                    Self::CustomLoginUrlMappedToUnreservedAddress
+                }
+                "CUSTOM_LOGIN_URL_HAS_NON_ROUTABLE_IP_ADDRESS" => {
+                    Self::CustomLoginUrlHasNonRoutableIpAddress
+                }
+                "CUSTOM_LOGIN_URL_HAS_UNRESERVED_IP_ADDRESS" => {
+                    Self::CustomLoginUrlHasUnreservedIpAddress
+                }
+                "DUPLICATE_SCAN_NAME" => Self::DuplicateScanName,
+                "INVALID_FIELD_VALUE" => Self::InvalidFieldValue,
+                "FAILED_TO_AUTHENTICATE_TO_TARGET" => Self::FailedToAuthenticateToTarget,
+                "FINDING_TYPE_UNSPECIFIED" => Self::FindingTypeUnspecified,
+                "FORBIDDEN_TO_SCAN_COMPUTE" => Self::ForbiddenToScanCompute,
+                "FORBIDDEN_UPDATE_TO_MANAGED_SCAN" => Self::ForbiddenUpdateToManagedScan,
+                "MALFORMED_FILTER" => Self::MalformedFilter,
+                "MALFORMED_RESOURCE_NAME" => Self::MalformedResourceName,
+                "PROJECT_INACTIVE" => Self::ProjectInactive,
+                "REQUIRED_FIELD" => Self::RequiredField,
+                "RESOURCE_NAME_INCONSISTENT" => Self::ResourceNameInconsistent,
+                "SCAN_ALREADY_RUNNING" => Self::ScanAlreadyRunning,
+                "SCAN_NOT_RUNNING" => Self::ScanNotRunning,
+                "SEED_URL_DOES_NOT_BELONG_TO_CURRENT_PROJECT" => {
+                    Self::SeedUrlDoesNotBelongToCurrentProject
+                }
+                "SEED_URL_MALFORMED" => Self::SeedUrlMalformed,
+                "SEED_URL_MAPPED_TO_NON_ROUTABLE_ADDRESS" => {
+                    Self::SeedUrlMappedToNonRoutableAddress
+                }
+                "SEED_URL_MAPPED_TO_UNRESERVED_ADDRESS" => Self::SeedUrlMappedToUnreservedAddress,
+                "SEED_URL_HAS_NON_ROUTABLE_IP_ADDRESS" => Self::SeedUrlHasNonRoutableIpAddress,
+                "SEED_URL_HAS_UNRESERVED_IP_ADDRESS" => Self::SeedUrlHasUnreservedIpAddress,
+                "SERVICE_ACCOUNT_NOT_CONFIGURED" => Self::ServiceAccountNotConfigured,
+                "TOO_MANY_SCANS" => Self::TooManyScans,
+                "UNABLE_TO_RESOLVE_PROJECT_INFO" => Self::UnableToResolveProjectInfo,
+                "UNSUPPORTED_BLACKLIST_PATTERN_FORMAT" => Self::UnsupportedBlacklistPatternFormat,
+                "UNSUPPORTED_FILTER" => Self::UnsupportedFilter,
+                "UNSUPPORTED_FINDING_TYPE" => Self::UnsupportedFindingType,
+                "UNSUPPORTED_URL_SCHEME" => Self::UnsupportedUrlScheme,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(0),
+                Self::InternalError => serializer.serialize_i32(1),
+                Self::AppengineApiBackendError => serializer.serialize_i32(2),
+                Self::AppengineApiNotAccessible => serializer.serialize_i32(3),
+                Self::AppengineDefaultHostMissing => serializer.serialize_i32(4),
+                Self::CannotUseGoogleComAccount => serializer.serialize_i32(6),
+                Self::CannotUseOwnerAccount => serializer.serialize_i32(7),
+                Self::ComputeApiBackendError => serializer.serialize_i32(8),
+                Self::ComputeApiNotAccessible => serializer.serialize_i32(9),
+                Self::CustomLoginUrlDoesNotBelongToCurrentProject => serializer.serialize_i32(10),
+                Self::CustomLoginUrlMalformed => serializer.serialize_i32(11),
+                Self::CustomLoginUrlMappedToNonRoutableAddress => serializer.serialize_i32(12),
+                Self::CustomLoginUrlMappedToUnreservedAddress => serializer.serialize_i32(13),
+                Self::CustomLoginUrlHasNonRoutableIpAddress => serializer.serialize_i32(14),
+                Self::CustomLoginUrlHasUnreservedIpAddress => serializer.serialize_i32(15),
+                Self::DuplicateScanName => serializer.serialize_i32(16),
+                Self::InvalidFieldValue => serializer.serialize_i32(18),
+                Self::FailedToAuthenticateToTarget => serializer.serialize_i32(19),
+                Self::FindingTypeUnspecified => serializer.serialize_i32(20),
+                Self::ForbiddenToScanCompute => serializer.serialize_i32(21),
+                Self::ForbiddenUpdateToManagedScan => serializer.serialize_i32(43),
+                Self::MalformedFilter => serializer.serialize_i32(22),
+                Self::MalformedResourceName => serializer.serialize_i32(23),
+                Self::ProjectInactive => serializer.serialize_i32(24),
+                Self::RequiredField => serializer.serialize_i32(25),
+                Self::ResourceNameInconsistent => serializer.serialize_i32(26),
+                Self::ScanAlreadyRunning => serializer.serialize_i32(27),
+                Self::ScanNotRunning => serializer.serialize_i32(28),
+                Self::SeedUrlDoesNotBelongToCurrentProject => serializer.serialize_i32(29),
+                Self::SeedUrlMalformed => serializer.serialize_i32(30),
+                Self::SeedUrlMappedToNonRoutableAddress => serializer.serialize_i32(31),
+                Self::SeedUrlMappedToUnreservedAddress => serializer.serialize_i32(32),
+                Self::SeedUrlHasNonRoutableIpAddress => serializer.serialize_i32(33),
+                Self::SeedUrlHasUnreservedIpAddress => serializer.serialize_i32(35),
+                Self::ServiceAccountNotConfigured => serializer.serialize_i32(36),
+                Self::TooManyScans => serializer.serialize_i32(37),
+                Self::UnableToResolveProjectInfo => serializer.serialize_i32(38),
+                Self::UnsupportedBlacklistPatternFormat => serializer.serialize_i32(39),
+                Self::UnsupportedFilter => serializer.serialize_i32(40),
+                Self::UnsupportedFindingType => serializer.serialize_i32(41),
+                Self::UnsupportedUrlScheme => serializer.serialize_i32(42),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.cloud.websecurityscanner.v1.ScanConfigError.Code",
+            ))
         }
     }
 }
@@ -2427,132 +2971,254 @@ pub mod scan_run {
     use super::*;
 
     /// Types of ScanRun execution state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExecutionState(i32);
-
-    impl ExecutionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExecutionState {
         /// Represents an invalid state caused by internal server error. This value
         /// should never be returned.
-        pub const EXECUTION_STATE_UNSPECIFIED: ExecutionState = ExecutionState::new(0);
-
+        Unspecified,
         /// The scan is waiting in the queue.
-        pub const QUEUED: ExecutionState = ExecutionState::new(1);
-
+        Queued,
         /// The scan is in progress.
-        pub const SCANNING: ExecutionState = ExecutionState::new(2);
-
+        Scanning,
         /// The scan is either finished or stopped by user.
-        pub const FINISHED: ExecutionState = ExecutionState::new(3);
+        Finished,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExecutionState::value] or
+        /// [ExecutionState::name].
+        UnknownValue(execution_state::UnknownValue),
+    }
 
-        /// Creates a new ExecutionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod execution_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExecutionState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Queued => std::option::Option::Some(1),
+                Self::Scanning => std::option::Option::Some(2),
+                Self::Finished => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXECUTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("QUEUED"),
-                2 => std::borrow::Cow::Borrowed("SCANNING"),
-                3 => std::borrow::Cow::Borrowed("FINISHED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXECUTION_STATE_UNSPECIFIED"),
+                Self::Queued => std::option::Option::Some("QUEUED"),
+                Self::Scanning => std::option::Option::Some("SCANNING"),
+                Self::Finished => std::option::Option::Some("FINISHED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXECUTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXECUTION_STATE_UNSPECIFIED)
-                }
-                "QUEUED" => std::option::Option::Some(Self::QUEUED),
-                "SCANNING" => std::option::Option::Some(Self::SCANNING),
-                "FINISHED" => std::option::Option::Some(Self::FINISHED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExecutionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExecutionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExecutionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExecutionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Queued,
+                2 => Self::Scanning,
+                3 => Self::Finished,
+                _ => Self::UnknownValue(execution_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExecutionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXECUTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "QUEUED" => Self::Queued,
+                "SCANNING" => Self::Scanning,
+                "FINISHED" => Self::Finished,
+                _ => Self::UnknownValue(execution_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExecutionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Queued => serializer.serialize_i32(1),
+                Self::Scanning => serializer.serialize_i32(2),
+                Self::Finished => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExecutionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionState>::new(
+                ".google.cloud.websecurityscanner.v1.ScanRun.ExecutionState",
+            ))
         }
     }
 
     /// Types of ScanRun result state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ResultState(i32);
-
-    impl ResultState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ResultState {
         /// Default value. This value is returned when the ScanRun is not yet
         /// finished.
-        pub const RESULT_STATE_UNSPECIFIED: ResultState = ResultState::new(0);
-
+        Unspecified,
         /// The scan finished without errors.
-        pub const SUCCESS: ResultState = ResultState::new(1);
-
+        Success,
         /// The scan finished with errors.
-        pub const ERROR: ResultState = ResultState::new(2);
-
+        Error,
         /// The scan was terminated by user.
-        pub const KILLED: ResultState = ResultState::new(3);
+        Killed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ResultState::value] or
+        /// [ResultState::name].
+        UnknownValue(result_state::UnknownValue),
+    }
 
-        /// Creates a new ResultState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod result_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ResultState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Success => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::Killed => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESULT_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCESS"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                3 => std::borrow::Cow::Borrowed("KILLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESULT_STATE_UNSPECIFIED"),
+                Self::Success => std::option::Option::Some("SUCCESS"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Killed => std::option::Option::Some("KILLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESULT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::RESULT_STATE_UNSPECIFIED)
-                }
-                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "KILLED" => std::option::Option::Some(Self::KILLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ResultState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ResultState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ResultState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ResultState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Success,
+                2 => Self::Error,
+                3 => Self::Killed,
+                _ => Self::UnknownValue(result_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ResultState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESULT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCESS" => Self::Success,
+                "ERROR" => Self::Error,
+                "KILLED" => Self::Killed,
+                _ => Self::UnknownValue(result_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ResultState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Success => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::Killed => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ResultState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResultState>::new(
+                ".google.cloud.websecurityscanner.v1.ScanRun.ResultState",
+            ))
         }
     }
 }
@@ -2629,88 +3295,157 @@ pub mod scan_run_error_trace {
     /// Output only.
     /// Defines an error reason code.
     /// Next id: 8
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// Default value is never used.
-        pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+        Unspecified,
         /// Indicates that the scan run failed due to an internal server error.
-        pub const INTERNAL_ERROR: Code = Code::new(1);
-
+        InternalError,
         /// Indicates a scan configuration error, usually due to outdated ScanConfig
         /// settings, such as starting_urls or the DNS configuration.
-        pub const SCAN_CONFIG_ISSUE: Code = Code::new(2);
-
+        ScanConfigIssue,
         /// Indicates an authentication error, usually due to outdated ScanConfig
         /// authentication settings.
-        pub const AUTHENTICATION_CONFIG_ISSUE: Code = Code::new(3);
-
+        AuthenticationConfigIssue,
         /// Indicates a scan operation timeout, usually caused by a very large site.
-        pub const TIMED_OUT_WHILE_SCANNING: Code = Code::new(4);
-
+        TimedOutWhileScanning,
         /// Indicates that a scan encountered excessive redirects, either to
         /// authentication or some other page outside of the scan scope.
-        pub const TOO_MANY_REDIRECTS: Code = Code::new(5);
-
+        TooManyRedirects,
         /// Indicates that a scan encountered numerous errors from the web site
         /// pages. When available, most_common_http_error_code field indicates the
         /// most common HTTP error code encountered during the scan.
-        pub const TOO_MANY_HTTP_ERRORS: Code = Code::new(6);
+        TooManyHttpErrors,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InternalError => std::option::Option::Some(1),
+                Self::ScanConfigIssue => std::option::Option::Some(2),
+                Self::AuthenticationConfigIssue => std::option::Option::Some(3),
+                Self::TimedOutWhileScanning => std::option::Option::Some(4),
+                Self::TooManyRedirects => std::option::Option::Some(5),
+                Self::TooManyHttpErrors => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
-                2 => std::borrow::Cow::Borrowed("SCAN_CONFIG_ISSUE"),
-                3 => std::borrow::Cow::Borrowed("AUTHENTICATION_CONFIG_ISSUE"),
-                4 => std::borrow::Cow::Borrowed("TIMED_OUT_WHILE_SCANNING"),
-                5 => std::borrow::Cow::Borrowed("TOO_MANY_REDIRECTS"),
-                6 => std::borrow::Cow::Borrowed("TOO_MANY_HTTP_ERRORS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
-                "SCAN_CONFIG_ISSUE" => std::option::Option::Some(Self::SCAN_CONFIG_ISSUE),
-                "AUTHENTICATION_CONFIG_ISSUE" => {
-                    std::option::Option::Some(Self::AUTHENTICATION_CONFIG_ISSUE)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                Self::InternalError => std::option::Option::Some("INTERNAL_ERROR"),
+                Self::ScanConfigIssue => std::option::Option::Some("SCAN_CONFIG_ISSUE"),
+                Self::AuthenticationConfigIssue => {
+                    std::option::Option::Some("AUTHENTICATION_CONFIG_ISSUE")
                 }
-                "TIMED_OUT_WHILE_SCANNING" => {
-                    std::option::Option::Some(Self::TIMED_OUT_WHILE_SCANNING)
+                Self::TimedOutWhileScanning => {
+                    std::option::Option::Some("TIMED_OUT_WHILE_SCANNING")
                 }
-                "TOO_MANY_REDIRECTS" => std::option::Option::Some(Self::TOO_MANY_REDIRECTS),
-                "TOO_MANY_HTTP_ERRORS" => std::option::Option::Some(Self::TOO_MANY_HTTP_ERRORS),
-                _ => std::option::Option::None,
+                Self::TooManyRedirects => std::option::Option::Some("TOO_MANY_REDIRECTS"),
+                Self::TooManyHttpErrors => std::option::Option::Some("TOO_MANY_HTTP_ERRORS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InternalError,
+                2 => Self::ScanConfigIssue,
+                3 => Self::AuthenticationConfigIssue,
+                4 => Self::TimedOutWhileScanning,
+                5 => Self::TooManyRedirects,
+                6 => Self::TooManyHttpErrors,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CODE_UNSPECIFIED" => Self::Unspecified,
+                "INTERNAL_ERROR" => Self::InternalError,
+                "SCAN_CONFIG_ISSUE" => Self::ScanConfigIssue,
+                "AUTHENTICATION_CONFIG_ISSUE" => Self::AuthenticationConfigIssue,
+                "TIMED_OUT_WHILE_SCANNING" => Self::TimedOutWhileScanning,
+                "TOO_MANY_REDIRECTS" => Self::TooManyRedirects,
+                "TOO_MANY_HTTP_ERRORS" => Self::TooManyHttpErrors,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InternalError => serializer.serialize_i32(1),
+                Self::ScanConfigIssue => serializer.serialize_i32(2),
+                Self::AuthenticationConfigIssue => serializer.serialize_i32(3),
+                Self::TimedOutWhileScanning => serializer.serialize_i32(4),
+                Self::TooManyRedirects => serializer.serialize_i32(5),
+                Self::TooManyHttpErrors => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.cloud.websecurityscanner.v1.ScanRunErrorTrace.Code",
+            ))
         }
     }
 }
@@ -2872,83 +3607,150 @@ pub mod scan_run_warning_trace {
     /// Output only.
     /// Defines a warning message code.
     /// Next id: 6
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// Default value is never used.
-        pub const CODE_UNSPECIFIED: Code = Code::new(0);
-
+        Unspecified,
         /// Indicates that a scan discovered an unexpectedly low number of URLs. This
         /// is sometimes caused by complex navigation features or by using a single
         /// URL for numerous pages.
-        pub const INSUFFICIENT_CRAWL_RESULTS: Code = Code::new(1);
-
+        InsufficientCrawlResults,
         /// Indicates that a scan discovered too many URLs to test, or excessive
         /// redundant URLs.
-        pub const TOO_MANY_CRAWL_RESULTS: Code = Code::new(2);
-
+        TooManyCrawlResults,
         /// Indicates that too many tests have been generated for the scan. Customer
         /// should try reducing the number of starting URLs, increasing the QPS rate,
         /// or narrowing down the scope of the scan using the excluded patterns.
-        pub const TOO_MANY_FUZZ_TASKS: Code = Code::new(3);
-
+        TooManyFuzzTasks,
         /// Indicates that a scan is blocked by IAP.
-        pub const BLOCKED_BY_IAP: Code = Code::new(4);
-
+        BlockedByIap,
         /// Indicates that no seeds is found for a scan
-        pub const NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN: Code = Code::new(5);
+        NoStartingUrlFoundForManagedScan,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InsufficientCrawlResults => std::option::Option::Some(1),
+                Self::TooManyCrawlResults => std::option::Option::Some(2),
+                Self::TooManyFuzzTasks => std::option::Option::Some(3),
+                Self::BlockedByIap => std::option::Option::Some(4),
+                Self::NoStartingUrlFoundForManagedScan => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INSUFFICIENT_CRAWL_RESULTS"),
-                2 => std::borrow::Cow::Borrowed("TOO_MANY_CRAWL_RESULTS"),
-                3 => std::borrow::Cow::Borrowed("TOO_MANY_FUZZ_TASKS"),
-                4 => std::borrow::Cow::Borrowed("BLOCKED_BY_IAP"),
-                5 => std::borrow::Cow::Borrowed("NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CODE_UNSPECIFIED" => std::option::Option::Some(Self::CODE_UNSPECIFIED),
-                "INSUFFICIENT_CRAWL_RESULTS" => {
-                    std::option::Option::Some(Self::INSUFFICIENT_CRAWL_RESULTS)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CODE_UNSPECIFIED"),
+                Self::InsufficientCrawlResults => {
+                    std::option::Option::Some("INSUFFICIENT_CRAWL_RESULTS")
                 }
-                "TOO_MANY_CRAWL_RESULTS" => std::option::Option::Some(Self::TOO_MANY_CRAWL_RESULTS),
-                "TOO_MANY_FUZZ_TASKS" => std::option::Option::Some(Self::TOO_MANY_FUZZ_TASKS),
-                "BLOCKED_BY_IAP" => std::option::Option::Some(Self::BLOCKED_BY_IAP),
-                "NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN" => {
-                    std::option::Option::Some(Self::NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN)
+                Self::TooManyCrawlResults => std::option::Option::Some("TOO_MANY_CRAWL_RESULTS"),
+                Self::TooManyFuzzTasks => std::option::Option::Some("TOO_MANY_FUZZ_TASKS"),
+                Self::BlockedByIap => std::option::Option::Some("BLOCKED_BY_IAP"),
+                Self::NoStartingUrlFoundForManagedScan => {
+                    std::option::Option::Some("NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InsufficientCrawlResults,
+                2 => Self::TooManyCrawlResults,
+                3 => Self::TooManyFuzzTasks,
+                4 => Self::BlockedByIap,
+                5 => Self::NoStartingUrlFoundForManagedScan,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CODE_UNSPECIFIED" => Self::Unspecified,
+                "INSUFFICIENT_CRAWL_RESULTS" => Self::InsufficientCrawlResults,
+                "TOO_MANY_CRAWL_RESULTS" => Self::TooManyCrawlResults,
+                "TOO_MANY_FUZZ_TASKS" => Self::TooManyFuzzTasks,
+                "BLOCKED_BY_IAP" => Self::BlockedByIap,
+                "NO_STARTING_URL_FOUND_FOR_MANAGED_SCAN" => Self::NoStartingUrlFoundForManagedScan,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InsufficientCrawlResults => serializer.serialize_i32(1),
+                Self::TooManyCrawlResults => serializer.serialize_i32(2),
+                Self::TooManyFuzzTasks => serializer.serialize_i32(3),
+                Self::BlockedByIap => serializer.serialize_i32(4),
+                Self::NoStartingUrlFoundForManagedScan => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.cloud.websecurityscanner.v1.ScanRunWarningTrace.Code",
+            ))
         }
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -601,199 +601,391 @@ pub mod execution {
         use super::*;
 
         /// Describes the possible types of a state error.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// No type specified.
+            Unspecified,
+            /// Caused by an issue with KMS.
+            KmsError,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// No type specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// Caused by an issue with KMS.
-            pub const KMS_ERROR: Type = Type::new(1);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::KmsError => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("KMS_ERROR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::KmsError => std::option::Option::Some("KMS_ERROR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "KMS_ERROR" => std::option::Option::Some(Self::KMS_ERROR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::KmsError,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "KMS_ERROR" => Self::KmsError,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::KmsError => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.workflows.executions.v1.Execution.StateError.Type",
+                ))
             }
         }
     }
 
     /// Describes the current state of the execution. More states might be added
     /// in the future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Invalid state.
+        Unspecified,
+        /// The execution is in progress.
+        Active,
+        /// The execution finished successfully.
+        Succeeded,
+        /// The execution failed with an error.
+        Failed,
+        /// The execution was stopped intentionally.
+        Cancelled,
+        /// Execution data is unavailable. See the `state_error` field.
+        Unavailable,
+        /// Request has been placed in the backlog for processing at a later time.
+        Queued,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The execution is in progress.
-        pub const ACTIVE: State = State::new(1);
-
-        /// The execution finished successfully.
-        pub const SUCCEEDED: State = State::new(2);
-
-        /// The execution failed with an error.
-        pub const FAILED: State = State::new(3);
-
-        /// The execution was stopped intentionally.
-        pub const CANCELLED: State = State::new(4);
-
-        /// Execution data is unavailable. See the `state_error` field.
-        pub const UNAVAILABLE: State = State::new(5);
-
-        /// Request has been placed in the backlog for processing at a later time.
-        pub const QUEUED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Succeeded => std::option::Option::Some(2),
+                Self::Failed => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::Unavailable => std::option::Option::Some(5),
+                Self::Queued => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                3 => std::borrow::Cow::Borrowed("FAILED"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                5 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-                6 => std::borrow::Cow::Borrowed("QUEUED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+                Self::Queued => std::option::Option::Some("QUEUED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-                "QUEUED" => std::option::Option::Some(Self::QUEUED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Succeeded,
+                3 => Self::Failed,
+                4 => Self::Cancelled,
+                5 => Self::Unavailable,
+                6 => Self::Queued,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                "UNAVAILABLE" => Self::Unavailable,
+                "QUEUED" => Self::Queued,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Succeeded => serializer.serialize_i32(2),
+                Self::Failed => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::Unavailable => serializer.serialize_i32(5),
+                Self::Queued => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.workflows.executions.v1.Execution.State",
+            ))
         }
     }
 
     /// Describes the level of platform logging to apply to calls and call
     /// responses during workflow executions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallLogLevel(i32);
-
-    impl CallLogLevel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CallLogLevel {
         /// No call logging level specified.
-        pub const CALL_LOG_LEVEL_UNSPECIFIED: CallLogLevel = CallLogLevel::new(0);
-
+        Unspecified,
         /// Log all call steps within workflows, all call returns, and all exceptions
         /// raised.
-        pub const LOG_ALL_CALLS: CallLogLevel = CallLogLevel::new(1);
-
+        LogAllCalls,
         /// Log only exceptions that are raised from call steps within workflows.
-        pub const LOG_ERRORS_ONLY: CallLogLevel = CallLogLevel::new(2);
-
+        LogErrorsOnly,
         /// Explicitly log nothing.
-        pub const LOG_NONE: CallLogLevel = CallLogLevel::new(3);
+        LogNone,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CallLogLevel::value] or
+        /// [CallLogLevel::name].
+        UnknownValue(call_log_level::UnknownValue),
+    }
 
-        /// Creates a new CallLogLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod call_log_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CallLogLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LogAllCalls => std::option::Option::Some(1),
+                Self::LogErrorsOnly => std::option::Option::Some(2),
+                Self::LogNone => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CALL_LOG_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOG_ALL_CALLS"),
-                2 => std::borrow::Cow::Borrowed("LOG_ERRORS_ONLY"),
-                3 => std::borrow::Cow::Borrowed("LOG_NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CALL_LOG_LEVEL_UNSPECIFIED"),
+                Self::LogAllCalls => std::option::Option::Some("LOG_ALL_CALLS"),
+                Self::LogErrorsOnly => std::option::Option::Some("LOG_ERRORS_ONLY"),
+                Self::LogNone => std::option::Option::Some("LOG_NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CALL_LOG_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CALL_LOG_LEVEL_UNSPECIFIED)
-                }
-                "LOG_ALL_CALLS" => std::option::Option::Some(Self::LOG_ALL_CALLS),
-                "LOG_ERRORS_ONLY" => std::option::Option::Some(Self::LOG_ERRORS_ONLY),
-                "LOG_NONE" => std::option::Option::Some(Self::LOG_NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CallLogLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CallLogLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CallLogLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CallLogLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LogAllCalls,
+                2 => Self::LogErrorsOnly,
+                3 => Self::LogNone,
+                _ => Self::UnknownValue(call_log_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CallLogLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CALL_LOG_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "LOG_ALL_CALLS" => Self::LogAllCalls,
+                "LOG_ERRORS_ONLY" => Self::LogErrorsOnly,
+                "LOG_NONE" => Self::LogNone,
+                _ => Self::UnknownValue(call_log_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CallLogLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LogAllCalls => serializer.serialize_i32(1),
+                Self::LogErrorsOnly => serializer.serialize_i32(2),
+                Self::LogNone => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CallLogLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CallLogLevel>::new(
+                ".google.cloud.workflows.executions.v1.Execution.CallLogLevel",
+            ))
         }
     }
 }
@@ -1104,62 +1296,121 @@ impl wkt::message::Message for CancelExecutionRequest {
 }
 
 /// Defines possible views for execution resource.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExecutionView(i32);
-
-impl ExecutionView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ExecutionView {
     /// The default / unset value.
-    pub const EXECUTION_VIEW_UNSPECIFIED: ExecutionView = ExecutionView::new(0);
-
+    Unspecified,
     /// Includes only basic metadata about the execution.
     /// The following fields are returned: name, start_time, end_time, duration,
     /// state, and workflow_revision_id.
-    pub const BASIC: ExecutionView = ExecutionView::new(1);
-
+    Basic,
     /// Includes all data.
-    pub const FULL: ExecutionView = ExecutionView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ExecutionView::value] or
+    /// [ExecutionView::name].
+    UnknownValue(execution_view::UnknownValue),
+}
 
-    /// Creates a new ExecutionView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod execution_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ExecutionView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EXECUTION_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EXECUTION_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EXECUTION_VIEW_UNSPECIFIED" => {
-                std::option::Option::Some(Self::EXECUTION_VIEW_UNSPECIFIED)
-            }
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ExecutionView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ExecutionView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ExecutionView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ExecutionView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(execution_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ExecutionView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EXECUTION_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(execution_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ExecutionView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ExecutionView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionView>::new(
+            ".google.cloud.workflows.executions.v1.ExecutionView",
+        ))
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/transport.rs
@@ -59,7 +59,7 @@ impl super::stub::Executions for Executions {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         self.inner
@@ -103,7 +103,7 @@ impl super::stub::Executions for Executions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -445,178 +445,362 @@ pub mod workflow {
         use super::*;
 
         /// Describes the possibled types of a state error.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// No type specified.
+            Unspecified,
+            /// Caused by an issue with KMS.
+            KmsError,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// No type specified.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// Caused by an issue with KMS.
-            pub const KMS_ERROR: Type = Type::new(1);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::KmsError => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("KMS_ERROR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::KmsError => std::option::Option::Some("KMS_ERROR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "KMS_ERROR" => std::option::Option::Some(Self::KMS_ERROR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::KmsError,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "KMS_ERROR" => Self::KmsError,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::KmsError => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.cloud.workflows.v1.Workflow.StateError.Type",
+                ))
             }
         }
     }
 
     /// Describes the current state of workflow deployment.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Invalid state.
+        Unspecified,
+        /// The workflow has been deployed successfully and is serving.
+        Active,
+        /// Workflow data is unavailable. See the `state_error` field.
+        Unavailable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Invalid state.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The workflow has been deployed successfully and is serving.
-        pub const ACTIVE: State = State::new(1);
-
-        /// Workflow data is unavailable. See the `state_error` field.
-        pub const UNAVAILABLE: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Unavailable => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Unavailable,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "UNAVAILABLE" => Self::Unavailable,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Unavailable => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.workflows.v1.Workflow.State",
+            ))
         }
     }
 
     /// Describes the level of platform logging to apply to calls and call
     /// responses during workflow executions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CallLogLevel(i32);
-
-    impl CallLogLevel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CallLogLevel {
         /// No call logging level specified.
-        pub const CALL_LOG_LEVEL_UNSPECIFIED: CallLogLevel = CallLogLevel::new(0);
-
+        Unspecified,
         /// Log all call steps within workflows, all call returns, and all exceptions
         /// raised.
-        pub const LOG_ALL_CALLS: CallLogLevel = CallLogLevel::new(1);
-
+        LogAllCalls,
         /// Log only exceptions that are raised from call steps within workflows.
-        pub const LOG_ERRORS_ONLY: CallLogLevel = CallLogLevel::new(2);
-
+        LogErrorsOnly,
         /// Explicitly log nothing.
-        pub const LOG_NONE: CallLogLevel = CallLogLevel::new(3);
+        LogNone,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CallLogLevel::value] or
+        /// [CallLogLevel::name].
+        UnknownValue(call_log_level::UnknownValue),
+    }
 
-        /// Creates a new CallLogLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod call_log_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CallLogLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::LogAllCalls => std::option::Option::Some(1),
+                Self::LogErrorsOnly => std::option::Option::Some(2),
+                Self::LogNone => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CALL_LOG_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOG_ALL_CALLS"),
-                2 => std::borrow::Cow::Borrowed("LOG_ERRORS_ONLY"),
-                3 => std::borrow::Cow::Borrowed("LOG_NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CALL_LOG_LEVEL_UNSPECIFIED"),
+                Self::LogAllCalls => std::option::Option::Some("LOG_ALL_CALLS"),
+                Self::LogErrorsOnly => std::option::Option::Some("LOG_ERRORS_ONLY"),
+                Self::LogNone => std::option::Option::Some("LOG_NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CALL_LOG_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CALL_LOG_LEVEL_UNSPECIFIED)
-                }
-                "LOG_ALL_CALLS" => std::option::Option::Some(Self::LOG_ALL_CALLS),
-                "LOG_ERRORS_ONLY" => std::option::Option::Some(Self::LOG_ERRORS_ONLY),
-                "LOG_NONE" => std::option::Option::Some(Self::LOG_NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CallLogLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CallLogLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CallLogLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CallLogLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::LogAllCalls,
+                2 => Self::LogErrorsOnly,
+                3 => Self::LogNone,
+                _ => Self::UnknownValue(call_log_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CallLogLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CALL_LOG_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "LOG_ALL_CALLS" => Self::LogAllCalls,
+                "LOG_ERRORS_ONLY" => Self::LogErrorsOnly,
+                "LOG_NONE" => Self::LogNone,
+                _ => Self::UnknownValue(call_log_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CallLogLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::LogAllCalls => serializer.serialize_i32(1),
+                Self::LogErrorsOnly => serializer.serialize_i32(2),
+                Self::LogNone => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CallLogLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CallLogLevel>::new(
+                ".google.cloud.workflows.v1.Workflow.CallLogLevel",
+            ))
         }
     }
 
@@ -1222,63 +1406,121 @@ impl gax::paginator::internal::PageableResponse for ListWorkflowRevisionsRespons
 }
 
 /// Define possible options for enabling the execution history level.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExecutionHistoryLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ExecutionHistoryLevel {
+    /// The default/unset value.
+    Unspecified,
+    /// Enable execution history basic feature.
+    ExecutionHistoryBasic,
+    /// Enable execution history detailed feature.
+    ExecutionHistoryDetailed,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ExecutionHistoryLevel::value] or
+    /// [ExecutionHistoryLevel::name].
+    UnknownValue(execution_history_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod execution_history_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ExecutionHistoryLevel {
-    /// The default/unset value.
-    pub const EXECUTION_HISTORY_LEVEL_UNSPECIFIED: ExecutionHistoryLevel =
-        ExecutionHistoryLevel::new(0);
-
-    /// Enable execution history basic feature.
-    pub const EXECUTION_HISTORY_BASIC: ExecutionHistoryLevel = ExecutionHistoryLevel::new(1);
-
-    /// Enable execution history detailed feature.
-    pub const EXECUTION_HISTORY_DETAILED: ExecutionHistoryLevel = ExecutionHistoryLevel::new(2);
-
-    /// Creates a new ExecutionHistoryLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ExecutionHistoryBasic => std::option::Option::Some(1),
+            Self::ExecutionHistoryDetailed => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EXECUTION_HISTORY_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EXECUTION_HISTORY_BASIC"),
-            2 => std::borrow::Cow::Borrowed("EXECUTION_HISTORY_DETAILED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EXECUTION_HISTORY_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::EXECUTION_HISTORY_LEVEL_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("EXECUTION_HISTORY_LEVEL_UNSPECIFIED"),
+            Self::ExecutionHistoryBasic => std::option::Option::Some("EXECUTION_HISTORY_BASIC"),
+            Self::ExecutionHistoryDetailed => {
+                std::option::Option::Some("EXECUTION_HISTORY_DETAILED")
             }
-            "EXECUTION_HISTORY_BASIC" => std::option::Option::Some(Self::EXECUTION_HISTORY_BASIC),
-            "EXECUTION_HISTORY_DETAILED" => {
-                std::option::Option::Some(Self::EXECUTION_HISTORY_DETAILED)
-            }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ExecutionHistoryLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ExecutionHistoryLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ExecutionHistoryLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ExecutionHistoryLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ExecutionHistoryBasic,
+            2 => Self::ExecutionHistoryDetailed,
+            _ => Self::UnknownValue(execution_history_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ExecutionHistoryLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EXECUTION_HISTORY_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "EXECUTION_HISTORY_BASIC" => Self::ExecutionHistoryBasic,
+            "EXECUTION_HISTORY_DETAILED" => Self::ExecutionHistoryDetailed,
+            _ => Self::UnknownValue(execution_history_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ExecutionHistoryLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ExecutionHistoryBasic => serializer.serialize_i32(1),
+            Self::ExecutionHistoryDetailed => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ExecutionHistoryLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExecutionHistoryLevel>::new(
+            ".google.cloud.workflows.v1.ExecutionHistoryLevel",
+        ))
     }
 }

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -1379,62 +1379,125 @@ pub mod workstation_config {
 
             /// Value representing what should happen to the disk after the workstation
             /// is deleted.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ReclaimPolicy(i32);
-
-            impl ReclaimPolicy {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ReclaimPolicy {
                 /// Do not use.
-                pub const RECLAIM_POLICY_UNSPECIFIED: ReclaimPolicy = ReclaimPolicy::new(0);
-
+                Unspecified,
                 /// Delete the persistent disk when deleting the workstation.
-                pub const DELETE: ReclaimPolicy = ReclaimPolicy::new(1);
-
+                Delete,
                 /// Keep the persistent disk when deleting the workstation.
                 /// An administrator must manually delete the disk.
-                pub const RETAIN: ReclaimPolicy = ReclaimPolicy::new(2);
+                Retain,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ReclaimPolicy::value] or
+                /// [ReclaimPolicy::name].
+                UnknownValue(reclaim_policy::UnknownValue),
+            }
 
-                /// Creates a new ReclaimPolicy instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod reclaim_policy {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl ReclaimPolicy {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Delete => std::option::Option::Some(1),
+                        Self::Retain => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("RECLAIM_POLICY_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("DELETE"),
-                        2 => std::borrow::Cow::Borrowed("RETAIN"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "RECLAIM_POLICY_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::RECLAIM_POLICY_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("RECLAIM_POLICY_UNSPECIFIED")
                         }
-                        "DELETE" => std::option::Option::Some(Self::DELETE),
-                        "RETAIN" => std::option::Option::Some(Self::RETAIN),
-                        _ => std::option::Option::None,
+                        Self::Delete => std::option::Option::Some("DELETE"),
+                        Self::Retain => std::option::Option::Some("RETAIN"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for ReclaimPolicy {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ReclaimPolicy {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ReclaimPolicy {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ReclaimPolicy {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Delete,
+                        2 => Self::Retain,
+                        _ => Self::UnknownValue(reclaim_policy::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ReclaimPolicy {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "RECLAIM_POLICY_UNSPECIFIED" => Self::Unspecified,
+                        "DELETE" => Self::Delete,
+                        "RETAIN" => Self::Retain,
+                        _ => Self::UnknownValue(reclaim_policy::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ReclaimPolicy {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Delete => serializer.serialize_i32(1),
+                        Self::Retain => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ReclaimPolicy {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReclaimPolicy>::new(
+                        ".google.cloud.workstations.v1.WorkstationConfig.PersistentDirectory.GceRegionalPersistentDisk.ReclaimPolicy"))
                 }
             }
         }
@@ -1856,71 +1919,136 @@ pub mod workstation {
     use super::*;
 
     /// Whether a workstation is running and ready to receive user requests.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Do not use.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The workstation is not yet ready to accept requests from users but will
         /// be soon.
-        pub const STATE_STARTING: State = State::new(1);
-
+        Starting,
         /// The workstation is ready to accept requests from users.
-        pub const STATE_RUNNING: State = State::new(2);
-
+        Running,
         /// The workstation is being stopped.
-        pub const STATE_STOPPING: State = State::new(3);
-
+        Stopping,
         /// The workstation is stopped and will not be able to receive requests until
         /// it is started.
-        pub const STATE_STOPPED: State = State::new(4);
+        Stopped,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Starting => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Stopping => std::option::Option::Some(3),
+                Self::Stopped => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATE_STARTING"),
-                2 => std::borrow::Cow::Borrowed("STATE_RUNNING"),
-                3 => std::borrow::Cow::Borrowed("STATE_STOPPING"),
-                4 => std::borrow::Cow::Borrowed("STATE_STOPPED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Starting => std::option::Option::Some("STATE_STARTING"),
+                Self::Running => std::option::Option::Some("STATE_RUNNING"),
+                Self::Stopping => std::option::Option::Some("STATE_STOPPING"),
+                Self::Stopped => std::option::Option::Some("STATE_STOPPED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STATE_STARTING" => std::option::Option::Some(Self::STATE_STARTING),
-                "STATE_RUNNING" => std::option::Option::Some(Self::STATE_RUNNING),
-                "STATE_STOPPING" => std::option::Option::Some(Self::STATE_STOPPING),
-                "STATE_STOPPED" => std::option::Option::Some(Self::STATE_STOPPED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Starting,
+                2 => Self::Running,
+                3 => Self::Stopping,
+                4 => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STATE_STARTING" => Self::Starting,
+                "STATE_RUNNING" => Self::Running,
+                "STATE_STOPPING" => Self::Stopping,
+                "STATE_STOPPED" => Self::Stopped,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Starting => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Stopping => serializer.serialize_i32(3),
+                Self::Stopped => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.cloud.workstations.v1.Workstation.State",
+            ))
         }
     }
 }

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -170,64 +170,123 @@ pub mod linux_node_config {
     }
 
     /// Possible cgroup modes that can be used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CgroupMode(i32);
-
-    impl CgroupMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CgroupMode {
         /// CGROUP_MODE_UNSPECIFIED is when unspecified cgroup configuration is used.
         /// The default for the GKE node OS image will be used.
-        pub const CGROUP_MODE_UNSPECIFIED: CgroupMode = CgroupMode::new(0);
-
+        Unspecified,
         /// CGROUP_MODE_V1 specifies to use cgroupv1 for the cgroup configuration on
         /// the node image.
-        pub const CGROUP_MODE_V1: CgroupMode = CgroupMode::new(1);
-
+        V1,
         /// CGROUP_MODE_V2 specifies to use cgroupv2 for the cgroup configuration on
         /// the node image.
-        pub const CGROUP_MODE_V2: CgroupMode = CgroupMode::new(2);
+        V2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CgroupMode::value] or
+        /// [CgroupMode::name].
+        UnknownValue(cgroup_mode::UnknownValue),
+    }
 
-        /// Creates a new CgroupMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cgroup_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CgroupMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V1 => std::option::Option::Some(1),
+                Self::V2 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CGROUP_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CGROUP_MODE_V1"),
-                2 => std::borrow::Cow::Borrowed("CGROUP_MODE_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CGROUP_MODE_UNSPECIFIED"),
+                Self::V1 => std::option::Option::Some("CGROUP_MODE_V1"),
+                Self::V2 => std::option::Option::Some("CGROUP_MODE_V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CGROUP_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CGROUP_MODE_UNSPECIFIED)
-                }
-                "CGROUP_MODE_V1" => std::option::Option::Some(Self::CGROUP_MODE_V1),
-                "CGROUP_MODE_V2" => std::option::Option::Some(Self::CGROUP_MODE_V2),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CgroupMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CgroupMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CgroupMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CgroupMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::V1,
+                2 => Self::V2,
+                _ => Self::UnknownValue(cgroup_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CgroupMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CGROUP_MODE_UNSPECIFIED" => Self::Unspecified,
+                "CGROUP_MODE_V1" => Self::V1,
+                "CGROUP_MODE_V2" => Self::V2,
+                _ => Self::UnknownValue(cgroup_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CgroupMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V1 => serializer.serialize_i32(1),
+                Self::V2 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CgroupMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CgroupMode>::new(
+                ".google.container.v1.LinuxNodeConfig.CgroupMode",
+            ))
         }
     }
 }
@@ -274,59 +333,120 @@ pub mod windows_node_config {
     use super::*;
 
     /// Possible OS version that can be used.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OSVersion(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OSVersion {
+        /// When OSVersion is not specified
+        Unspecified,
+        /// LTSC2019 specifies to use LTSC2019 as the Windows Servercore Base Image
+        Ltsc2019,
+        /// LTSC2022 specifies to use LTSC2022 as the Windows Servercore Base Image
+        Ltsc2022,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OSVersion::value] or
+        /// [OSVersion::name].
+        UnknownValue(os_version::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod os_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OSVersion {
-        /// When OSVersion is not specified
-        pub const OS_VERSION_UNSPECIFIED: OSVersion = OSVersion::new(0);
-
-        /// LTSC2019 specifies to use LTSC2019 as the Windows Servercore Base Image
-        pub const OS_VERSION_LTSC2019: OSVersion = OSVersion::new(1);
-
-        /// LTSC2022 specifies to use LTSC2022 as the Windows Servercore Base Image
-        pub const OS_VERSION_LTSC2022: OSVersion = OSVersion::new(2);
-
-        /// Creates a new OSVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ltsc2019 => std::option::Option::Some(1),
+                Self::Ltsc2022 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OS_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OS_VERSION_LTSC2019"),
-                2 => std::borrow::Cow::Borrowed("OS_VERSION_LTSC2022"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OS_VERSION_UNSPECIFIED"),
+                Self::Ltsc2019 => std::option::Option::Some("OS_VERSION_LTSC2019"),
+                Self::Ltsc2022 => std::option::Option::Some("OS_VERSION_LTSC2022"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OS_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::OS_VERSION_UNSPECIFIED),
-                "OS_VERSION_LTSC2019" => std::option::Option::Some(Self::OS_VERSION_LTSC2019),
-                "OS_VERSION_LTSC2022" => std::option::Option::Some(Self::OS_VERSION_LTSC2022),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OSVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OSVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OSVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OSVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ltsc2019,
+                2 => Self::Ltsc2022,
+                _ => Self::UnknownValue(os_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OSVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OS_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "OS_VERSION_LTSC2019" => Self::Ltsc2019,
+                "OS_VERSION_LTSC2022" => Self::Ltsc2022,
+                _ => Self::UnknownValue(os_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OSVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ltsc2019 => serializer.serialize_i32(1),
+                Self::Ltsc2022 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OSVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OSVersion>::new(
+                ".google.container.v1.WindowsNodeConfig.OSVersion",
+            ))
         }
     }
 }
@@ -1163,138 +1283,252 @@ pub mod node_config {
 
     /// LocalSsdEncryptionMode specifies the method used for encrypting the Local
     /// SSDs attached to the node.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocalSsdEncryptionMode(i32);
-
-    impl LocalSsdEncryptionMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LocalSsdEncryptionMode {
         /// The given node will be encrypted using keys managed by Google
         /// infrastructure and the keys will be deleted when the node is
         /// deleted.
-        pub const LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED: LocalSsdEncryptionMode =
-            LocalSsdEncryptionMode::new(0);
-
+        Unspecified,
         /// The given node will be encrypted using keys managed by Google
         /// infrastructure and the keys will be deleted when the node is
         /// deleted.
-        pub const STANDARD_ENCRYPTION: LocalSsdEncryptionMode = LocalSsdEncryptionMode::new(1);
-
+        StandardEncryption,
         /// The given node will opt-in for using ephemeral key for
         /// encryption of Local SSDs.
         /// The Local SSDs will not be able to recover data in case of node
         /// crash.
-        pub const EPHEMERAL_KEY_ENCRYPTION: LocalSsdEncryptionMode = LocalSsdEncryptionMode::new(2);
+        EphemeralKeyEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LocalSsdEncryptionMode::value] or
+        /// [LocalSsdEncryptionMode::name].
+        UnknownValue(local_ssd_encryption_mode::UnknownValue),
+    }
 
-        /// Creates a new LocalSsdEncryptionMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod local_ssd_encryption_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LocalSsdEncryptionMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StandardEncryption => std::option::Option::Some(1),
+                Self::EphemeralKeyEncryption => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("EPHEMERAL_KEY_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED")
                 }
-                "STANDARD_ENCRYPTION" => std::option::Option::Some(Self::STANDARD_ENCRYPTION),
-                "EPHEMERAL_KEY_ENCRYPTION" => {
-                    std::option::Option::Some(Self::EPHEMERAL_KEY_ENCRYPTION)
+                Self::StandardEncryption => std::option::Option::Some("STANDARD_ENCRYPTION"),
+                Self::EphemeralKeyEncryption => {
+                    std::option::Option::Some("EPHEMERAL_KEY_ENCRYPTION")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for LocalSsdEncryptionMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LocalSsdEncryptionMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LocalSsdEncryptionMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LocalSsdEncryptionMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StandardEncryption,
+                2 => Self::EphemeralKeyEncryption,
+                _ => Self::UnknownValue(local_ssd_encryption_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LocalSsdEncryptionMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCAL_SSD_ENCRYPTION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD_ENCRYPTION" => Self::StandardEncryption,
+                "EPHEMERAL_KEY_ENCRYPTION" => Self::EphemeralKeyEncryption,
+                _ => Self::UnknownValue(local_ssd_encryption_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LocalSsdEncryptionMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StandardEncryption => serializer.serialize_i32(1),
+                Self::EphemeralKeyEncryption => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LocalSsdEncryptionMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocalSsdEncryptionMode>::new(
+                ".google.container.v1.NodeConfig.LocalSsdEncryptionMode",
+            ))
         }
     }
 
     /// Possible effective cgroup modes for the node.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EffectiveCgroupMode(i32);
-
-    impl EffectiveCgroupMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EffectiveCgroupMode {
         /// EFFECTIVE_CGROUP_MODE_UNSPECIFIED means the cgroup configuration for the
         /// node pool is unspecified, i.e. the node pool is a Windows node pool.
-        pub const EFFECTIVE_CGROUP_MODE_UNSPECIFIED: EffectiveCgroupMode =
-            EffectiveCgroupMode::new(0);
-
+        Unspecified,
         /// CGROUP_MODE_V1 means the node pool is configured to use cgroupv1 for the
         /// cgroup configuration.
-        pub const EFFECTIVE_CGROUP_MODE_V1: EffectiveCgroupMode = EffectiveCgroupMode::new(1);
-
+        V1,
         /// CGROUP_MODE_V2 means the node pool is configured to use cgroupv2 for the
         /// cgroup configuration.
-        pub const EFFECTIVE_CGROUP_MODE_V2: EffectiveCgroupMode = EffectiveCgroupMode::new(2);
+        V2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EffectiveCgroupMode::value] or
+        /// [EffectiveCgroupMode::name].
+        UnknownValue(effective_cgroup_mode::UnknownValue),
+    }
 
-        /// Creates a new EffectiveCgroupMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod effective_cgroup_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EffectiveCgroupMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V1 => std::option::Option::Some(1),
+                Self::V2 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EFFECTIVE_CGROUP_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EFFECTIVE_CGROUP_MODE_V1"),
-                2 => std::borrow::Cow::Borrowed("EFFECTIVE_CGROUP_MODE_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EFFECTIVE_CGROUP_MODE_UNSPECIFIED"),
+                Self::V1 => std::option::Option::Some("EFFECTIVE_CGROUP_MODE_V1"),
+                Self::V2 => std::option::Option::Some("EFFECTIVE_CGROUP_MODE_V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EFFECTIVE_CGROUP_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EFFECTIVE_CGROUP_MODE_UNSPECIFIED)
-                }
-                "EFFECTIVE_CGROUP_MODE_V1" => {
-                    std::option::Option::Some(Self::EFFECTIVE_CGROUP_MODE_V1)
-                }
-                "EFFECTIVE_CGROUP_MODE_V2" => {
-                    std::option::Option::Some(Self::EFFECTIVE_CGROUP_MODE_V2)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EffectiveCgroupMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EffectiveCgroupMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EffectiveCgroupMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EffectiveCgroupMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::V1,
+                2 => Self::V2,
+                _ => Self::UnknownValue(effective_cgroup_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EffectiveCgroupMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EFFECTIVE_CGROUP_MODE_UNSPECIFIED" => Self::Unspecified,
+                "EFFECTIVE_CGROUP_MODE_V1" => Self::V1,
+                "EFFECTIVE_CGROUP_MODE_V2" => Self::V2,
+                _ => Self::UnknownValue(effective_cgroup_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EffectiveCgroupMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V1 => serializer.serialize_i32(1),
+                Self::V2 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EffectiveCgroupMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EffectiveCgroupMode>::new(
+                ".google.container.v1.NodeConfig.EffectiveCgroupMode",
+            ))
         }
     }
 }
@@ -1595,54 +1829,116 @@ pub mod node_network_config {
         use super::*;
 
         /// Node network tier
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Tier(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Tier {
+            /// Default value
+            Unspecified,
+            /// Higher bandwidth, actual values based on VM size.
+            _1,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Tier::value] or
+            /// [Tier::name].
+            UnknownValue(tier::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod tier {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Tier {
-            /// Default value
-            pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
-            /// Higher bandwidth, actual values based on VM size.
-            pub const TIER_1: Tier = Tier::new(1);
-
-            /// Creates a new Tier instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::_1 => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TIER_1"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                    Self::_1 => std::option::Option::Some("TIER_1"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                    "TIER_1" => std::option::Option::Some(Self::TIER_1),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Tier {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Tier {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Tier {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Tier {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::_1,
+                    _ => Self::UnknownValue(tier::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Tier {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TIER_UNSPECIFIED" => Self::Unspecified,
+                    "TIER_1" => Self::_1,
+                    _ => Self::UnknownValue(tier::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Tier {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::_1 => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Tier {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                    ".google.container.v1.NodeNetworkConfig.NetworkPerformanceConfig.Tier",
+                ))
             }
         }
     }
@@ -1845,54 +2141,113 @@ pub mod sandbox_config {
     use super::*;
 
     /// Possible types of sandboxes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Default value. This should not be used.
+        Unspecified,
+        /// Run sandbox using gvisor.
+        Gvisor,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Default value. This should not be used.
-        pub const UNSPECIFIED: Type = Type::new(0);
-
-        /// Run sandbox using gvisor.
-        pub const GVISOR: Type = Type::new(1);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gvisor => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GVISOR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Gvisor => std::option::Option::Some("GVISOR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "GVISOR" => std::option::Option::Some(Self::GVISOR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Gvisor,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "GVISOR" => Self::Gvisor,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gvisor => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.container.v1.SandboxConfig.Type",
+            ))
         }
     }
 }
@@ -2002,65 +2357,128 @@ pub mod reservation_affinity {
     use super::*;
 
     /// Indicates whether to consume capacity from a reservation or not.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Default value. This should not be used.
-        pub const UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// Do not consume from any reserved capacity.
-        pub const NO_RESERVATION: Type = Type::new(1);
-
+        NoReservation,
         /// Consume any reservation available.
-        pub const ANY_RESERVATION: Type = Type::new(2);
-
+        AnyReservation,
         /// Must consume from a specific reservation. Must specify key value fields
         /// for specifying the reservations.
-        pub const SPECIFIC_RESERVATION: Type = Type::new(3);
+        SpecificReservation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoReservation => std::option::Option::Some(1),
+                Self::AnyReservation => std::option::Option::Some(2),
+                Self::SpecificReservation => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_RESERVATION"),
-                2 => std::borrow::Cow::Borrowed("ANY_RESERVATION"),
-                3 => std::borrow::Cow::Borrowed("SPECIFIC_RESERVATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::NoReservation => std::option::Option::Some("NO_RESERVATION"),
+                Self::AnyReservation => std::option::Option::Some("ANY_RESERVATION"),
+                Self::SpecificReservation => std::option::Option::Some("SPECIFIC_RESERVATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "NO_RESERVATION" => std::option::Option::Some(Self::NO_RESERVATION),
-                "ANY_RESERVATION" => std::option::Option::Some(Self::ANY_RESERVATION),
-                "SPECIFIC_RESERVATION" => std::option::Option::Some(Self::SPECIFIC_RESERVATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoReservation,
+                2 => Self::AnyReservation,
+                3 => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "NO_RESERVATION" => Self::NoReservation,
+                "ANY_RESERVATION" => Self::AnyReservation,
+                "SPECIFIC_RESERVATION" => Self::SpecificReservation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoReservation => serializer.serialize_i32(1),
+                Self::AnyReservation => serializer.serialize_i32(2),
+                Self::SpecificReservation => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.container.v1.ReservationAffinity.Type",
+            ))
         }
     }
 }
@@ -2178,59 +2596,123 @@ pub mod sole_tenant_config {
 
         /// Operator allows user to specify affinity or anti-affinity for the
         /// given key values.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Operator(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Operator {
+            /// Invalid or unspecified affinity operator.
+            Unspecified,
+            /// Affinity operator.
+            In,
+            /// Anti-affinity operator.
+            NotIn,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Operator::value] or
+            /// [Operator::name].
+            UnknownValue(operator::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Operator {
-            /// Invalid or unspecified affinity operator.
-            pub const OPERATOR_UNSPECIFIED: Operator = Operator::new(0);
-
-            /// Affinity operator.
-            pub const IN: Operator = Operator::new(1);
-
-            /// Anti-affinity operator.
-            pub const NOT_IN: Operator = Operator::new(2);
-
-            /// Creates a new Operator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::In => std::option::Option::Some(1),
+                    Self::NotIn => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("IN"),
-                    2 => std::borrow::Cow::Borrowed("NOT_IN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("OPERATOR_UNSPECIFIED"),
+                    Self::In => std::option::Option::Some("IN"),
+                    Self::NotIn => std::option::Option::Some("NOT_IN"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "OPERATOR_UNSPECIFIED" => std::option::Option::Some(Self::OPERATOR_UNSPECIFIED),
-                    "IN" => std::option::Option::Some(Self::IN),
-                    "NOT_IN" => std::option::Option::Some(Self::NOT_IN),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Operator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Operator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Operator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Operator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::In,
+                    2 => Self::NotIn,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Operator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "IN" => Self::In,
+                    "NOT_IN" => Self::NotIn,
+                    _ => Self::UnknownValue(operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Operator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::In => serializer.serialize_i32(1),
+                    Self::NotIn => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Operator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operator>::new(
+                    ".google.container.v1.SoleTenantConfig.NodeAffinity.Operator",
+                ))
             }
         }
     }
@@ -2544,64 +3026,127 @@ pub mod node_taint {
     use super::*;
 
     /// Possible values for Effect in taint.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Effect(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Effect {
+        /// Not set
+        Unspecified,
+        /// NoSchedule
+        NoSchedule,
+        /// PreferNoSchedule
+        PreferNoSchedule,
+        /// NoExecute
+        NoExecute,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Effect::value] or
+        /// [Effect::name].
+        UnknownValue(effect::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod effect {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Effect {
-        /// Not set
-        pub const EFFECT_UNSPECIFIED: Effect = Effect::new(0);
-
-        /// NoSchedule
-        pub const NO_SCHEDULE: Effect = Effect::new(1);
-
-        /// PreferNoSchedule
-        pub const PREFER_NO_SCHEDULE: Effect = Effect::new(2);
-
-        /// NoExecute
-        pub const NO_EXECUTE: Effect = Effect::new(3);
-
-        /// Creates a new Effect instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NoSchedule => std::option::Option::Some(1),
+                Self::PreferNoSchedule => std::option::Option::Some(2),
+                Self::NoExecute => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EFFECT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NO_SCHEDULE"),
-                2 => std::borrow::Cow::Borrowed("PREFER_NO_SCHEDULE"),
-                3 => std::borrow::Cow::Borrowed("NO_EXECUTE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EFFECT_UNSPECIFIED"),
+                Self::NoSchedule => std::option::Option::Some("NO_SCHEDULE"),
+                Self::PreferNoSchedule => std::option::Option::Some("PREFER_NO_SCHEDULE"),
+                Self::NoExecute => std::option::Option::Some("NO_EXECUTE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EFFECT_UNSPECIFIED" => std::option::Option::Some(Self::EFFECT_UNSPECIFIED),
-                "NO_SCHEDULE" => std::option::Option::Some(Self::NO_SCHEDULE),
-                "PREFER_NO_SCHEDULE" => std::option::Option::Some(Self::PREFER_NO_SCHEDULE),
-                "NO_EXECUTE" => std::option::Option::Some(Self::NO_EXECUTE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Effect {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Effect {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Effect {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Effect {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NoSchedule,
+                2 => Self::PreferNoSchedule,
+                3 => Self::NoExecute,
+                _ => Self::UnknownValue(effect::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Effect {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EFFECT_UNSPECIFIED" => Self::Unspecified,
+                "NO_SCHEDULE" => Self::NoSchedule,
+                "PREFER_NO_SCHEDULE" => Self::PreferNoSchedule,
+                "NO_EXECUTE" => Self::NoExecute,
+                _ => Self::UnknownValue(effect::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Effect {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NoSchedule => serializer.serialize_i32(1),
+                Self::PreferNoSchedule => serializer.serialize_i32(2),
+                Self::NoExecute => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Effect {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Effect>::new(
+                ".google.container.v1.NodeTaint.Effect",
+            ))
         }
     }
 }
@@ -3612,65 +4157,120 @@ pub mod cloud_run_config {
     use super::*;
 
     /// Load balancer type of ingress service of Cloud Run.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoadBalancerType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoadBalancerType {
+        /// Load balancer type for Cloud Run is unspecified.
+        Unspecified,
+        /// Install external load balancer for Cloud Run.
+        External,
+        /// Install internal load balancer for Cloud Run.
+        Internal,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoadBalancerType::value] or
+        /// [LoadBalancerType::name].
+        UnknownValue(load_balancer_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod load_balancer_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LoadBalancerType {
-        /// Load balancer type for Cloud Run is unspecified.
-        pub const LOAD_BALANCER_TYPE_UNSPECIFIED: LoadBalancerType = LoadBalancerType::new(0);
-
-        /// Install external load balancer for Cloud Run.
-        pub const LOAD_BALANCER_TYPE_EXTERNAL: LoadBalancerType = LoadBalancerType::new(1);
-
-        /// Install internal load balancer for Cloud Run.
-        pub const LOAD_BALANCER_TYPE_INTERNAL: LoadBalancerType = LoadBalancerType::new(2);
-
-        /// Creates a new LoadBalancerType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::External => std::option::Option::Some(1),
+                Self::Internal => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_EXTERNAL"),
-                2 => std::borrow::Cow::Borrowed("LOAD_BALANCER_TYPE_INTERNAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOAD_BALANCER_TYPE_UNSPECIFIED"),
+                Self::External => std::option::Option::Some("LOAD_BALANCER_TYPE_EXTERNAL"),
+                Self::Internal => std::option::Option::Some("LOAD_BALANCER_TYPE_INTERNAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOAD_BALANCER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_UNSPECIFIED)
-                }
-                "LOAD_BALANCER_TYPE_EXTERNAL" => {
-                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_EXTERNAL)
-                }
-                "LOAD_BALANCER_TYPE_INTERNAL" => {
-                    std::option::Option::Some(Self::LOAD_BALANCER_TYPE_INTERNAL)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoadBalancerType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoadBalancerType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoadBalancerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoadBalancerType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::External,
+                2 => Self::Internal,
+                _ => Self::UnknownValue(load_balancer_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoadBalancerType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOAD_BALANCER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "LOAD_BALANCER_TYPE_EXTERNAL" => Self::External,
+                "LOAD_BALANCER_TYPE_INTERNAL" => Self::Internal,
+                _ => Self::UnknownValue(load_balancer_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoadBalancerType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::External => serializer.serialize_i32(1),
+                Self::Internal => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoadBalancerType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoadBalancerType>::new(
+                ".google.container.v1.CloudRunConfig.LoadBalancerType",
+            ))
         }
     }
 }
@@ -4180,54 +4780,113 @@ pub mod network_policy {
     use super::*;
 
     /// Allowed Network Policy providers.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Provider(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Provider {
+        /// Not set
+        Unspecified,
+        /// Tigera (Calico Felix).
+        Calico,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Provider::value] or
+        /// [Provider::name].
+        UnknownValue(provider::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod provider {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Provider {
-        /// Not set
-        pub const PROVIDER_UNSPECIFIED: Provider = Provider::new(0);
-
-        /// Tigera (Calico Felix).
-        pub const CALICO: Provider = Provider::new(1);
-
-        /// Creates a new Provider instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Calico => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROVIDER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CALICO"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROVIDER_UNSPECIFIED"),
+                Self::Calico => std::option::Option::Some("CALICO"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROVIDER_UNSPECIFIED" => std::option::Option::Some(Self::PROVIDER_UNSPECIFIED),
-                "CALICO" => std::option::Option::Some(Self::CALICO),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Provider {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Provider {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Provider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Provider {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Calico,
+                _ => Self::UnknownValue(provider::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Provider {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROVIDER_UNSPECIFIED" => Self::Unspecified,
+                "CALICO" => Self::Calico,
+                _ => Self::UnknownValue(provider::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Provider {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Calico => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Provider {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Provider>::new(
+                ".google.container.v1.NetworkPolicy.Provider",
+            ))
         }
     }
 }
@@ -4287,65 +4946,124 @@ pub mod binary_authorization {
     use super::*;
 
     /// Binary Authorization mode of operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EvaluationMode(i32);
-
-    impl EvaluationMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EvaluationMode {
         /// Default value
-        pub const EVALUATION_MODE_UNSPECIFIED: EvaluationMode = EvaluationMode::new(0);
-
+        Unspecified,
         /// Disable BinaryAuthorization
-        pub const DISABLED: EvaluationMode = EvaluationMode::new(1);
-
+        Disabled,
         /// Enforce Kubernetes admission requests with BinaryAuthorization using the
         /// project's singleton policy. This is equivalent to setting the
         /// enabled boolean to true.
-        pub const PROJECT_SINGLETON_POLICY_ENFORCE: EvaluationMode = EvaluationMode::new(2);
+        ProjectSingletonPolicyEnforce,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EvaluationMode::value] or
+        /// [EvaluationMode::name].
+        UnknownValue(evaluation_mode::UnknownValue),
+    }
 
-        /// Creates a new EvaluationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod evaluation_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EvaluationMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::ProjectSingletonPolicyEnforce => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVALUATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("PROJECT_SINGLETON_POLICY_ENFORCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVALUATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EVALUATION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVALUATION_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::ProjectSingletonPolicyEnforce => {
+                    std::option::Option::Some("PROJECT_SINGLETON_POLICY_ENFORCE")
                 }
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "PROJECT_SINGLETON_POLICY_ENFORCE" => {
-                    std::option::Option::Some(Self::PROJECT_SINGLETON_POLICY_ENFORCE)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for EvaluationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EvaluationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EvaluationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EvaluationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::ProjectSingletonPolicyEnforce,
+                _ => Self::UnknownValue(evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EvaluationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVALUATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "PROJECT_SINGLETON_POLICY_ENFORCE" => Self::ProjectSingletonPolicyEnforce,
+                _ => Self::UnknownValue(evaluation_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EvaluationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::ProjectSingletonPolicyEnforce => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EvaluationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EvaluationMode>::new(
+                ".google.container.v1.BinaryAuthorization.EvaluationMode",
+            ))
         }
     }
 }
@@ -5896,84 +6614,153 @@ pub mod cluster {
     use super::*;
 
     /// The current status of the cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// Not set.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the cluster is being created.
-        pub const PROVISIONING: Status = Status::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the cluster has been created and is fully
         /// usable.
-        pub const RUNNING: Status = Status::new(2);
-
+        Running,
         /// The RECONCILING state indicates that some work is actively being done on
         /// the cluster, such as upgrading the master or node software. Details can
         /// be found in the `statusMessage` field.
-        pub const RECONCILING: Status = Status::new(3);
-
+        Reconciling,
         /// The STOPPING state indicates the cluster is being deleted.
-        pub const STOPPING: Status = Status::new(4);
-
+        Stopping,
         /// The ERROR state indicates the cluster is unusable. It will be
         /// automatically deleted. Details can be found in the `statusMessage` field.
-        pub const ERROR: Status = Status::new(5);
-
+        Error,
         /// The DEGRADED state indicates the cluster requires user action to restore
         /// full functionality. Details can be found in the `statusMessage` field.
-        pub const DEGRADED: Status = Status::new(6);
+        Degraded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Reconciling => std::option::Option::Some(3),
+                Self::Stopping => std::option::Option::Some(4),
+                Self::Error => std::option::Option::Some(5),
+                Self::Degraded => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RECONCILING"),
-                4 => std::borrow::Cow::Borrowed("STOPPING"),
-                5 => std::borrow::Cow::Borrowed("ERROR"),
-                6 => std::borrow::Cow::Borrowed("DEGRADED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Degraded => std::option::Option::Some("DEGRADED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "DEGRADED" => std::option::Option::Some(Self::DEGRADED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::Reconciling,
+                4 => Self::Stopping,
+                5 => Self::Error,
+                6 => Self::Degraded,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                "DEGRADED" => Self::Degraded,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Reconciling => serializer.serialize_i32(3),
+                Self::Stopping => serializer.serialize_i32(4),
+                Self::Error => serializer.serialize_i32(5),
+                Self::Degraded => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.container.v1.Cluster.Status",
+            ))
         }
     }
 }
@@ -6261,59 +7048,120 @@ pub mod compliance_posture_config {
     }
 
     /// Mode defines enablement mode for Compliance Posture.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Default value not specified.
+        Unspecified,
+        /// Disables Compliance Posture features on the cluster.
+        Disabled,
+        /// Enables Compliance Posture features on the cluster.
+        Enabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Default value not specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// Disables Compliance Posture features on the cluster.
-        pub const DISABLED: Mode = Mode::new(1);
-
-        /// Enables Compliance Posture features on the cluster.
-        pub const ENABLED: Mode = Mode::new(2);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Enabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Enabled,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "ENABLED" => Self::Enabled,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Enabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.container.v1.CompliancePostureConfig.Mode",
+            ))
         }
     }
 }
@@ -6417,131 +7265,255 @@ pub mod security_posture_config {
     use super::*;
 
     /// Mode defines enablement mode for GKE Security posture features.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Default value not specified.
+        Unspecified,
+        /// Disables Security Posture features on the cluster.
+        Disabled,
+        /// Applies Security Posture features on the cluster.
+        Basic,
+        /// Applies the Security Posture off cluster Enterprise level features.
+        Enterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Default value not specified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// Disables Security Posture features on the cluster.
-        pub const DISABLED: Mode = Mode::new(1);
-
-        /// Applies Security Posture features on the cluster.
-        pub const BASIC: Mode = Mode::new(2);
-
-        /// Applies the Security Posture off cluster Enterprise level features.
-        pub const ENTERPRISE: Mode = Mode::new(3);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Basic => std::option::Option::Some(2),
+                Self::Enterprise => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                2 => std::borrow::Cow::Borrowed("BASIC"),
-                3 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Basic => std::option::Option::Some("BASIC"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "BASIC" => std::option::Option::Some(Self::BASIC),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                2 => Self::Basic,
+                3 => Self::Enterprise,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "BASIC" => Self::Basic,
+                "ENTERPRISE" => Self::Enterprise,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Basic => serializer.serialize_i32(2),
+                Self::Enterprise => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.container.v1.SecurityPostureConfig.Mode",
+            ))
         }
     }
 
     /// VulnerabilityMode defines enablement mode for vulnerability scanning.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VulnerabilityMode(i32);
-
-    impl VulnerabilityMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VulnerabilityMode {
         /// Default value not specified.
-        pub const VULNERABILITY_MODE_UNSPECIFIED: VulnerabilityMode = VulnerabilityMode::new(0);
-
+        Unspecified,
         /// Disables vulnerability scanning on the cluster.
-        pub const VULNERABILITY_DISABLED: VulnerabilityMode = VulnerabilityMode::new(1);
-
+        VulnerabilityDisabled,
         /// Applies basic vulnerability scanning on the cluster.
-        pub const VULNERABILITY_BASIC: VulnerabilityMode = VulnerabilityMode::new(2);
-
+        VulnerabilityBasic,
         /// Applies the Security Posture's vulnerability on cluster Enterprise level
         /// features.
-        pub const VULNERABILITY_ENTERPRISE: VulnerabilityMode = VulnerabilityMode::new(3);
+        VulnerabilityEnterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VulnerabilityMode::value] or
+        /// [VulnerabilityMode::name].
+        UnknownValue(vulnerability_mode::UnknownValue),
+    }
 
-        /// Creates a new VulnerabilityMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod vulnerability_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl VulnerabilityMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VulnerabilityDisabled => std::option::Option::Some(1),
+                Self::VulnerabilityBasic => std::option::Option::Some(2),
+                Self::VulnerabilityEnterprise => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VULNERABILITY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("VULNERABILITY_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("VULNERABILITY_BASIC"),
-                3 => std::borrow::Cow::Borrowed("VULNERABILITY_ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VULNERABILITY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VULNERABILITY_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VULNERABILITY_MODE_UNSPECIFIED"),
+                Self::VulnerabilityDisabled => std::option::Option::Some("VULNERABILITY_DISABLED"),
+                Self::VulnerabilityBasic => std::option::Option::Some("VULNERABILITY_BASIC"),
+                Self::VulnerabilityEnterprise => {
+                    std::option::Option::Some("VULNERABILITY_ENTERPRISE")
                 }
-                "VULNERABILITY_DISABLED" => std::option::Option::Some(Self::VULNERABILITY_DISABLED),
-                "VULNERABILITY_BASIC" => std::option::Option::Some(Self::VULNERABILITY_BASIC),
-                "VULNERABILITY_ENTERPRISE" => {
-                    std::option::Option::Some(Self::VULNERABILITY_ENTERPRISE)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for VulnerabilityMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VulnerabilityMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VulnerabilityMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VulnerabilityMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VulnerabilityDisabled,
+                2 => Self::VulnerabilityBasic,
+                3 => Self::VulnerabilityEnterprise,
+                _ => Self::UnknownValue(vulnerability_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VulnerabilityMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VULNERABILITY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "VULNERABILITY_DISABLED" => Self::VulnerabilityDisabled,
+                "VULNERABILITY_BASIC" => Self::VulnerabilityBasic,
+                "VULNERABILITY_ENTERPRISE" => Self::VulnerabilityEnterprise,
+                _ => Self::UnknownValue(vulnerability_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VulnerabilityMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VulnerabilityDisabled => serializer.serialize_i32(1),
+                Self::VulnerabilityBasic => serializer.serialize_i32(2),
+                Self::VulnerabilityEnterprise => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VulnerabilityMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VulnerabilityMode>::new(
+                ".google.container.v1.SecurityPostureConfig.VulnerabilityMode",
+            ))
         }
     }
 }
@@ -8183,89 +9155,151 @@ pub mod operation {
     use super::*;
 
     /// Current status of the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
+        /// Not set.
+        Unspecified,
+        /// The operation has been created.
+        Pending,
+        /// The operation is currently running.
+        Running,
+        /// The operation is done, either cancelled or completed.
+        Done,
+        /// The operation is aborting.
+        Aborting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Status {
-        /// Not set.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
-        /// The operation has been created.
-        pub const PENDING: Status = Status::new(1);
-
-        /// The operation is currently running.
-        pub const RUNNING: Status = Status::new(2);
-
-        /// The operation is done, either cancelled or completed.
-        pub const DONE: Status = Status::new(3);
-
-        /// The operation is aborting.
-        pub const ABORTING: Status = Status::new(4);
-
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::Aborting => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                4 => std::borrow::Cow::Borrowed("ABORTING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::Aborting => std::option::Option::Some("ABORTING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "ABORTING" => std::option::Option::Some(Self::ABORTING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Done,
+                4 => Self::Aborting,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                "ABORTING" => Self::Aborting,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::Aborting => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.container.v1.Operation.Status",
+            ))
         }
     }
 
     /// Operation type categorizes the operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Not set.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The cluster is being created. The cluster should be assumed to be
         /// unusable until the operation finishes.
         ///
         /// In the event of the operation failing, the cluster will enter the [ERROR
         /// state][Cluster.Status.ERROR] and eventually be deleted.
         ///
-        /// [Cluster.Status.ERROR]: crate::model::cluster::status::ERROR
-        pub const CREATE_CLUSTER: Type = Type::new(1);
-
+        /// [Cluster.Status.ERROR]: crate::model::cluster::Status::Error
+        CreateCluster,
         /// The cluster is being deleted. The cluster should be assumed to be
         /// unusable as soon as this operation starts.
         ///
@@ -8273,9 +9307,8 @@ pub mod operation {
         /// state][Cluster.Status.ERROR] and the deletion will be automatically
         /// retried until completed.
         ///
-        /// [Cluster.Status.ERROR]: crate::model::cluster::status::ERROR
-        pub const DELETE_CLUSTER: Type = Type::new(2);
-
+        /// [Cluster.Status.ERROR]: crate::model::cluster::Status::Error
+        DeleteCluster,
         /// The [cluster
         /// version][google.container.v1.ClusterUpdate.desired_master_version] is
         /// being updated. Note that this includes "upgrades" to the same version,
@@ -8285,8 +9318,7 @@ pub mod operation {
         /// upgrades](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-upgrades#cluster_upgrades).
         ///
         /// [google.container.v1.ClusterUpdate.desired_master_version]: crate::model::ClusterUpdate::desired_master_version
-        pub const UPGRADE_MASTER: Type = Type::new(3);
-
+        UpgradeMaster,
         /// A node pool is being updated. Despite calling this an "upgrade", this
         /// includes most forms of updates to node pools. This also includes
         /// [auto-upgrades](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades).
@@ -8301,14 +9333,12 @@ pub mod operation {
         ///
         /// [google.container.v1.ClusterManager.CancelOperation]: crate::client::ClusterManager::cancel_operation
         /// [google.container.v1.Operation.progress]: crate::model::Operation::progress
-        pub const UPGRADE_NODES: Type = Type::new(4);
-
+        UpgradeNodes,
         /// A problem has been detected with the control plane and is being repaired.
         /// This operation type is initiated by GKE. For more details, see
         /// [documentation on
         /// repairs](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#repairs).
-        pub const REPAIR_CLUSTER: Type = Type::new(5);
-
+        RepairCluster,
         /// The cluster is being updated. This is a broad category of operations and
         /// includes operations that only change metadata as well as those that must
         /// recreate the entire cluster. If the control plane must be recreated, this
@@ -8322,8 +9352,7 @@ pub mod operation {
         ///
         /// Some GKE-initiated operations use this type. This includes certain types
         /// of auto-upgrades and incident mitigations.
-        pub const UPDATE_CLUSTER: Type = Type::new(6);
-
+        UpdateCluster,
         /// A node pool is being created. The node pool should be assumed to be
         /// unusable until this operation finishes. In the event of an error, the
         /// node pool may be partially created.
@@ -8331,146 +9360,247 @@ pub mod operation {
         /// If enabled, [node
         /// autoprovisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)
         /// may have automatically initiated such operations.
-        pub const CREATE_NODE_POOL: Type = Type::new(7);
-
+        CreateNodePool,
         /// The node pool is being deleted. The node pool should be assumed to be
         /// unusable as soon as this operation starts.
-        pub const DELETE_NODE_POOL: Type = Type::new(8);
-
+        DeleteNodePool,
         /// The node pool's [manamagent][google.container.v1.NodePool.management]
         /// field is being updated. These operations only update metadata and may be
         /// concurrent with most other operations.
         ///
         /// [google.container.v1.NodePool.management]: crate::model::NodePool::management
-        pub const SET_NODE_POOL_MANAGEMENT: Type = Type::new(9);
-
+        SetNodePoolManagement,
         /// A problem has been detected with nodes and [they are being
         /// repaired](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair).
         /// This operation type is initiated by GKE, typically automatically. This
         /// operation may be concurrent with other operations and there may be
         /// multiple repairs occurring on the same node pool.
-        pub const AUTO_REPAIR_NODES: Type = Type::new(10);
-
+        AutoRepairNodes,
         /// Unused. Automatic node upgrade uses
         /// [UPGRADE_NODES][google.container.v1.Operation.Type.UPGRADE_NODES].
         ///
-        /// [google.container.v1.Operation.Type.UPGRADE_NODES]: crate::model::operation::r#type::UPGRADE_NODES
-        pub const AUTO_UPGRADE_NODES: Type = Type::new(11);
-
+        /// [google.container.v1.Operation.Type.UPGRADE_NODES]: crate::model::operation::Type::UpgradeNodes
+        AutoUpgradeNodes,
         /// Unused. Updating labels uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
-        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_LABELS: Type = Type::new(12);
-
+        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        SetLabels,
         /// Unused. Updating master auth uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
-        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_MASTER_AUTH: Type = Type::new(13);
-
+        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        SetMasterAuth,
         /// The node pool is being resized. With the exception of resizing to or from
         /// size zero, the node pool is generally usable during this operation.
-        pub const SET_NODE_POOL_SIZE: Type = Type::new(14);
-
+        SetNodePoolSize,
         /// Unused. Updating network policy uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
-        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_NETWORK_POLICY: Type = Type::new(15);
-
+        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        SetNetworkPolicy,
         /// Unused. Updating maintenance policy uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
-        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::r#type::UPDATE_CLUSTER
-        pub const SET_MAINTENANCE_POLICY: Type = Type::new(16);
-
+        /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        SetMaintenancePolicy,
         /// The control plane is being resized. This operation type is initiated by
         /// GKE. These operations are often performed preemptively to ensure that the
         /// control plane has sufficient resources and is not typically an indication
         /// of issues. For more details, see
         /// [documentation on
         /// resizes](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#repairs).
-        pub const RESIZE_CLUSTER: Type = Type::new(18);
-
+        ResizeCluster,
         /// Fleet features of GKE Enterprise are being upgraded. The cluster should
         /// be assumed to be blocked for other upgrades until the operation finishes.
-        pub const FLEET_FEATURE_UPGRADE: Type = Type::new(19);
+        FleetFeatureUpgrade,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::CreateCluster => std::option::Option::Some(1),
+                Self::DeleteCluster => std::option::Option::Some(2),
+                Self::UpgradeMaster => std::option::Option::Some(3),
+                Self::UpgradeNodes => std::option::Option::Some(4),
+                Self::RepairCluster => std::option::Option::Some(5),
+                Self::UpdateCluster => std::option::Option::Some(6),
+                Self::CreateNodePool => std::option::Option::Some(7),
+                Self::DeleteNodePool => std::option::Option::Some(8),
+                Self::SetNodePoolManagement => std::option::Option::Some(9),
+                Self::AutoRepairNodes => std::option::Option::Some(10),
+                Self::AutoUpgradeNodes => std::option::Option::Some(11),
+                Self::SetLabels => std::option::Option::Some(12),
+                Self::SetMasterAuth => std::option::Option::Some(13),
+                Self::SetNodePoolSize => std::option::Option::Some(14),
+                Self::SetNetworkPolicy => std::option::Option::Some(15),
+                Self::SetMaintenancePolicy => std::option::Option::Some(16),
+                Self::ResizeCluster => std::option::Option::Some(18),
+                Self::FleetFeatureUpgrade => std::option::Option::Some(19),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE_CLUSTER"),
-                2 => std::borrow::Cow::Borrowed("DELETE_CLUSTER"),
-                3 => std::borrow::Cow::Borrowed("UPGRADE_MASTER"),
-                4 => std::borrow::Cow::Borrowed("UPGRADE_NODES"),
-                5 => std::borrow::Cow::Borrowed("REPAIR_CLUSTER"),
-                6 => std::borrow::Cow::Borrowed("UPDATE_CLUSTER"),
-                7 => std::borrow::Cow::Borrowed("CREATE_NODE_POOL"),
-                8 => std::borrow::Cow::Borrowed("DELETE_NODE_POOL"),
-                9 => std::borrow::Cow::Borrowed("SET_NODE_POOL_MANAGEMENT"),
-                10 => std::borrow::Cow::Borrowed("AUTO_REPAIR_NODES"),
-                11 => std::borrow::Cow::Borrowed("AUTO_UPGRADE_NODES"),
-                12 => std::borrow::Cow::Borrowed("SET_LABELS"),
-                13 => std::borrow::Cow::Borrowed("SET_MASTER_AUTH"),
-                14 => std::borrow::Cow::Borrowed("SET_NODE_POOL_SIZE"),
-                15 => std::borrow::Cow::Borrowed("SET_NETWORK_POLICY"),
-                16 => std::borrow::Cow::Borrowed("SET_MAINTENANCE_POLICY"),
-                18 => std::borrow::Cow::Borrowed("RESIZE_CLUSTER"),
-                19 => std::borrow::Cow::Borrowed("FLEET_FEATURE_UPGRADE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "CREATE_CLUSTER" => std::option::Option::Some(Self::CREATE_CLUSTER),
-                "DELETE_CLUSTER" => std::option::Option::Some(Self::DELETE_CLUSTER),
-                "UPGRADE_MASTER" => std::option::Option::Some(Self::UPGRADE_MASTER),
-                "UPGRADE_NODES" => std::option::Option::Some(Self::UPGRADE_NODES),
-                "REPAIR_CLUSTER" => std::option::Option::Some(Self::REPAIR_CLUSTER),
-                "UPDATE_CLUSTER" => std::option::Option::Some(Self::UPDATE_CLUSTER),
-                "CREATE_NODE_POOL" => std::option::Option::Some(Self::CREATE_NODE_POOL),
-                "DELETE_NODE_POOL" => std::option::Option::Some(Self::DELETE_NODE_POOL),
-                "SET_NODE_POOL_MANAGEMENT" => {
-                    std::option::Option::Some(Self::SET_NODE_POOL_MANAGEMENT)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::CreateCluster => std::option::Option::Some("CREATE_CLUSTER"),
+                Self::DeleteCluster => std::option::Option::Some("DELETE_CLUSTER"),
+                Self::UpgradeMaster => std::option::Option::Some("UPGRADE_MASTER"),
+                Self::UpgradeNodes => std::option::Option::Some("UPGRADE_NODES"),
+                Self::RepairCluster => std::option::Option::Some("REPAIR_CLUSTER"),
+                Self::UpdateCluster => std::option::Option::Some("UPDATE_CLUSTER"),
+                Self::CreateNodePool => std::option::Option::Some("CREATE_NODE_POOL"),
+                Self::DeleteNodePool => std::option::Option::Some("DELETE_NODE_POOL"),
+                Self::SetNodePoolManagement => {
+                    std::option::Option::Some("SET_NODE_POOL_MANAGEMENT")
                 }
-                "AUTO_REPAIR_NODES" => std::option::Option::Some(Self::AUTO_REPAIR_NODES),
-                "AUTO_UPGRADE_NODES" => std::option::Option::Some(Self::AUTO_UPGRADE_NODES),
-                "SET_LABELS" => std::option::Option::Some(Self::SET_LABELS),
-                "SET_MASTER_AUTH" => std::option::Option::Some(Self::SET_MASTER_AUTH),
-                "SET_NODE_POOL_SIZE" => std::option::Option::Some(Self::SET_NODE_POOL_SIZE),
-                "SET_NETWORK_POLICY" => std::option::Option::Some(Self::SET_NETWORK_POLICY),
-                "SET_MAINTENANCE_POLICY" => std::option::Option::Some(Self::SET_MAINTENANCE_POLICY),
-                "RESIZE_CLUSTER" => std::option::Option::Some(Self::RESIZE_CLUSTER),
-                "FLEET_FEATURE_UPGRADE" => std::option::Option::Some(Self::FLEET_FEATURE_UPGRADE),
-                _ => std::option::Option::None,
+                Self::AutoRepairNodes => std::option::Option::Some("AUTO_REPAIR_NODES"),
+                Self::AutoUpgradeNodes => std::option::Option::Some("AUTO_UPGRADE_NODES"),
+                Self::SetLabels => std::option::Option::Some("SET_LABELS"),
+                Self::SetMasterAuth => std::option::Option::Some("SET_MASTER_AUTH"),
+                Self::SetNodePoolSize => std::option::Option::Some("SET_NODE_POOL_SIZE"),
+                Self::SetNetworkPolicy => std::option::Option::Some("SET_NETWORK_POLICY"),
+                Self::SetMaintenancePolicy => std::option::Option::Some("SET_MAINTENANCE_POLICY"),
+                Self::ResizeCluster => std::option::Option::Some("RESIZE_CLUSTER"),
+                Self::FleetFeatureUpgrade => std::option::Option::Some("FLEET_FEATURE_UPGRADE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::CreateCluster,
+                2 => Self::DeleteCluster,
+                3 => Self::UpgradeMaster,
+                4 => Self::UpgradeNodes,
+                5 => Self::RepairCluster,
+                6 => Self::UpdateCluster,
+                7 => Self::CreateNodePool,
+                8 => Self::DeleteNodePool,
+                9 => Self::SetNodePoolManagement,
+                10 => Self::AutoRepairNodes,
+                11 => Self::AutoUpgradeNodes,
+                12 => Self::SetLabels,
+                13 => Self::SetMasterAuth,
+                14 => Self::SetNodePoolSize,
+                15 => Self::SetNetworkPolicy,
+                16 => Self::SetMaintenancePolicy,
+                18 => Self::ResizeCluster,
+                19 => Self::FleetFeatureUpgrade,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "CREATE_CLUSTER" => Self::CreateCluster,
+                "DELETE_CLUSTER" => Self::DeleteCluster,
+                "UPGRADE_MASTER" => Self::UpgradeMaster,
+                "UPGRADE_NODES" => Self::UpgradeNodes,
+                "REPAIR_CLUSTER" => Self::RepairCluster,
+                "UPDATE_CLUSTER" => Self::UpdateCluster,
+                "CREATE_NODE_POOL" => Self::CreateNodePool,
+                "DELETE_NODE_POOL" => Self::DeleteNodePool,
+                "SET_NODE_POOL_MANAGEMENT" => Self::SetNodePoolManagement,
+                "AUTO_REPAIR_NODES" => Self::AutoRepairNodes,
+                "AUTO_UPGRADE_NODES" => Self::AutoUpgradeNodes,
+                "SET_LABELS" => Self::SetLabels,
+                "SET_MASTER_AUTH" => Self::SetMasterAuth,
+                "SET_NODE_POOL_SIZE" => Self::SetNodePoolSize,
+                "SET_NETWORK_POLICY" => Self::SetNetworkPolicy,
+                "SET_MAINTENANCE_POLICY" => Self::SetMaintenancePolicy,
+                "RESIZE_CLUSTER" => Self::ResizeCluster,
+                "FLEET_FEATURE_UPGRADE" => Self::FleetFeatureUpgrade,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::CreateCluster => serializer.serialize_i32(1),
+                Self::DeleteCluster => serializer.serialize_i32(2),
+                Self::UpgradeMaster => serializer.serialize_i32(3),
+                Self::UpgradeNodes => serializer.serialize_i32(4),
+                Self::RepairCluster => serializer.serialize_i32(5),
+                Self::UpdateCluster => serializer.serialize_i32(6),
+                Self::CreateNodePool => serializer.serialize_i32(7),
+                Self::DeleteNodePool => serializer.serialize_i32(8),
+                Self::SetNodePoolManagement => serializer.serialize_i32(9),
+                Self::AutoRepairNodes => serializer.serialize_i32(10),
+                Self::AutoUpgradeNodes => serializer.serialize_i32(11),
+                Self::SetLabels => serializer.serialize_i32(12),
+                Self::SetMasterAuth => serializer.serialize_i32(13),
+                Self::SetNodePoolSize => serializer.serialize_i32(14),
+                Self::SetNetworkPolicy => serializer.serialize_i32(15),
+                Self::SetMaintenancePolicy => serializer.serialize_i32(16),
+                Self::ResizeCluster => serializer.serialize_i32(18),
+                Self::FleetFeatureUpgrade => serializer.serialize_i32(19),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.container.v1.Operation.Type",
+            ))
         }
     }
 }
@@ -10061,67 +11191,130 @@ pub mod set_master_auth_request {
     use super::*;
 
     /// Operation type: what type update to perform.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
-
-    impl Action {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
         /// Operation is unknown and will error out.
-        pub const UNKNOWN: Action = Action::new(0);
-
+        Unknown,
         /// Set the password to a user generated value.
-        pub const SET_PASSWORD: Action = Action::new(1);
-
+        SetPassword,
         /// Generate a new password and set it to that.
-        pub const GENERATE_PASSWORD: Action = Action::new(2);
-
+        GeneratePassword,
         /// Set the username.  If an empty username is provided, basic authentication
         /// is disabled for the cluster.  If a non-empty username is provided, basic
         /// authentication is enabled, with either a provided password or a generated
         /// one.
-        pub const SET_USERNAME: Action = Action::new(3);
+        SetUsername,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
 
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Action {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::SetPassword => std::option::Option::Some(1),
+                Self::GeneratePassword => std::option::Option::Some(2),
+                Self::SetUsername => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("SET_PASSWORD"),
-                2 => std::borrow::Cow::Borrowed("GENERATE_PASSWORD"),
-                3 => std::borrow::Cow::Borrowed("SET_USERNAME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::SetPassword => std::option::Option::Some("SET_PASSWORD"),
+                Self::GeneratePassword => std::option::Option::Some("GENERATE_PASSWORD"),
+                Self::SetUsername => std::option::Option::Some("SET_USERNAME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "SET_PASSWORD" => std::option::Option::Some(Self::SET_PASSWORD),
-                "GENERATE_PASSWORD" => std::option::Option::Some(Self::GENERATE_PASSWORD),
-                "SET_USERNAME" => std::option::Option::Some(Self::SET_USERNAME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::SetPassword,
+                2 => Self::GeneratePassword,
+                3 => Self::SetUsername,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "SET_PASSWORD" => Self::SetPassword,
+                "GENERATE_PASSWORD" => Self::GeneratePassword,
+                "SET_USERNAME" => Self::SetUsername,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::SetPassword => serializer.serialize_i32(1),
+                Self::GeneratePassword => serializer.serialize_i32(2),
+                Self::SetUsername => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.container.v1.SetMasterAuthRequest.Action",
+            ))
         }
     }
 }
@@ -11961,88 +13154,158 @@ pub mod node_pool {
             use super::*;
 
             /// Phase represents the different stages blue-green upgrade is running in.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Phase(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Phase {
+                /// Unspecified phase.
+                Unspecified,
+                /// blue-green upgrade has been initiated.
+                UpdateStarted,
+                /// Start creating green pool nodes.
+                CreatingGreenPool,
+                /// Start cordoning blue pool nodes.
+                CordoningBluePool,
+                /// Start draining blue pool nodes.
+                DrainingBluePool,
+                /// Start soaking time after draining entire blue pool.
+                NodePoolSoaking,
+                /// Start deleting blue nodes.
+                DeletingBluePool,
+                /// Rollback has been initiated.
+                RollbackStarted,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Phase::value] or
+                /// [Phase::name].
+                UnknownValue(phase::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod phase {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl Phase {
-                /// Unspecified phase.
-                pub const PHASE_UNSPECIFIED: Phase = Phase::new(0);
-
-                /// blue-green upgrade has been initiated.
-                pub const UPDATE_STARTED: Phase = Phase::new(1);
-
-                /// Start creating green pool nodes.
-                pub const CREATING_GREEN_POOL: Phase = Phase::new(2);
-
-                /// Start cordoning blue pool nodes.
-                pub const CORDONING_BLUE_POOL: Phase = Phase::new(3);
-
-                /// Start draining blue pool nodes.
-                pub const DRAINING_BLUE_POOL: Phase = Phase::new(4);
-
-                /// Start soaking time after draining entire blue pool.
-                pub const NODE_POOL_SOAKING: Phase = Phase::new(5);
-
-                /// Start deleting blue nodes.
-                pub const DELETING_BLUE_POOL: Phase = Phase::new(6);
-
-                /// Rollback has been initiated.
-                pub const ROLLBACK_STARTED: Phase = Phase::new(7);
-
-                /// Creates a new Phase instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::UpdateStarted => std::option::Option::Some(1),
+                        Self::CreatingGreenPool => std::option::Option::Some(2),
+                        Self::CordoningBluePool => std::option::Option::Some(3),
+                        Self::DrainingBluePool => std::option::Option::Some(4),
+                        Self::NodePoolSoaking => std::option::Option::Some(5),
+                        Self::DeletingBluePool => std::option::Option::Some(6),
+                        Self::RollbackStarted => std::option::Option::Some(7),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("PHASE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("UPDATE_STARTED"),
-                        2 => std::borrow::Cow::Borrowed("CREATING_GREEN_POOL"),
-                        3 => std::borrow::Cow::Borrowed("CORDONING_BLUE_POOL"),
-                        4 => std::borrow::Cow::Borrowed("DRAINING_BLUE_POOL"),
-                        5 => std::borrow::Cow::Borrowed("NODE_POOL_SOAKING"),
-                        6 => std::borrow::Cow::Borrowed("DELETING_BLUE_POOL"),
-                        7 => std::borrow::Cow::Borrowed("ROLLBACK_STARTED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("PHASE_UNSPECIFIED"),
+                        Self::UpdateStarted => std::option::Option::Some("UPDATE_STARTED"),
+                        Self::CreatingGreenPool => std::option::Option::Some("CREATING_GREEN_POOL"),
+                        Self::CordoningBluePool => std::option::Option::Some("CORDONING_BLUE_POOL"),
+                        Self::DrainingBluePool => std::option::Option::Some("DRAINING_BLUE_POOL"),
+                        Self::NodePoolSoaking => std::option::Option::Some("NODE_POOL_SOAKING"),
+                        Self::DeletingBluePool => std::option::Option::Some("DELETING_BLUE_POOL"),
+                        Self::RollbackStarted => std::option::Option::Some("ROLLBACK_STARTED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "PHASE_UNSPECIFIED" => std::option::Option::Some(Self::PHASE_UNSPECIFIED),
-                        "UPDATE_STARTED" => std::option::Option::Some(Self::UPDATE_STARTED),
-                        "CREATING_GREEN_POOL" => {
-                            std::option::Option::Some(Self::CREATING_GREEN_POOL)
-                        }
-                        "CORDONING_BLUE_POOL" => {
-                            std::option::Option::Some(Self::CORDONING_BLUE_POOL)
-                        }
-                        "DRAINING_BLUE_POOL" => std::option::Option::Some(Self::DRAINING_BLUE_POOL),
-                        "NODE_POOL_SOAKING" => std::option::Option::Some(Self::NODE_POOL_SOAKING),
-                        "DELETING_BLUE_POOL" => std::option::Option::Some(Self::DELETING_BLUE_POOL),
-                        "ROLLBACK_STARTED" => std::option::Option::Some(Self::ROLLBACK_STARTED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Phase {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Phase {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Phase {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Phase {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::UpdateStarted,
+                        2 => Self::CreatingGreenPool,
+                        3 => Self::CordoningBluePool,
+                        4 => Self::DrainingBluePool,
+                        5 => Self::NodePoolSoaking,
+                        6 => Self::DeletingBluePool,
+                        7 => Self::RollbackStarted,
+                        _ => Self::UnknownValue(phase::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Phase {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "PHASE_UNSPECIFIED" => Self::Unspecified,
+                        "UPDATE_STARTED" => Self::UpdateStarted,
+                        "CREATING_GREEN_POOL" => Self::CreatingGreenPool,
+                        "CORDONING_BLUE_POOL" => Self::CordoningBluePool,
+                        "DRAINING_BLUE_POOL" => Self::DrainingBluePool,
+                        "NODE_POOL_SOAKING" => Self::NodePoolSoaking,
+                        "DELETING_BLUE_POOL" => Self::DeletingBluePool,
+                        "ROLLBACK_STARTED" => Self::RollbackStarted,
+                        _ => Self::UnknownValue(phase::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Phase {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::UpdateStarted => serializer.serialize_i32(1),
+                        Self::CreatingGreenPool => serializer.serialize_i32(2),
+                        Self::CordoningBluePool => serializer.serialize_i32(3),
+                        Self::DrainingBluePool => serializer.serialize_i32(4),
+                        Self::NodePoolSoaking => serializer.serialize_i32(5),
+                        Self::DeletingBluePool => serializer.serialize_i32(6),
+                        Self::RollbackStarted => serializer.serialize_i32(7),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Phase {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Phase>::new(
+                        ".google.container.v1.NodePool.UpdateInfo.BlueGreenInfo.Phase",
+                    ))
                 }
             }
         }
@@ -12115,56 +13378,118 @@ pub mod node_pool {
         use super::*;
 
         /// Type defines the type of placement policy.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
-
-        impl Type {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
             /// TYPE_UNSPECIFIED specifies no requirements on nodes
             /// placement.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+            Unspecified,
             /// COMPACT specifies node placement in the same availability domain to
             /// ensure low communication latency.
-            pub const COMPACT: Type = Type::new(1);
+            Compact,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
 
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Type {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Compact => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("COMPACT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::Compact => std::option::Option::Some("COMPACT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "COMPACT" => std::option::Option::Some(Self::COMPACT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Compact,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "COMPACT" => Self::Compact,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Compact => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.container.v1.NodePool.PlacementPolicy.Type",
+                ))
             }
         }
     }
@@ -12204,86 +13529,155 @@ pub mod node_pool {
     }
 
     /// The current status of the node pool instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// Not set.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+        Unspecified,
         /// The PROVISIONING state indicates the node pool is being created.
-        pub const PROVISIONING: Status = Status::new(1);
-
+        Provisioning,
         /// The RUNNING state indicates the node pool has been created
         /// and is fully usable.
-        pub const RUNNING: Status = Status::new(2);
-
+        Running,
         /// The RUNNING_WITH_ERROR state indicates the node pool has been created
         /// and is partially usable. Some error state has occurred and some
         /// functionality may be impaired. Customer may need to reissue a request
         /// or trigger a new update.
-        pub const RUNNING_WITH_ERROR: Status = Status::new(3);
-
+        RunningWithError,
         /// The RECONCILING state indicates that some work is actively being done on
         /// the node pool, such as upgrading node software. Details can
         /// be found in the `statusMessage` field.
-        pub const RECONCILING: Status = Status::new(4);
-
+        Reconciling,
         /// The STOPPING state indicates the node pool is being deleted.
-        pub const STOPPING: Status = Status::new(5);
-
+        Stopping,
         /// The ERROR state indicates the node pool may be unusable. Details
         /// can be found in the `statusMessage` field.
-        pub const ERROR: Status = Status::new(6);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioning => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::RunningWithError => std::option::Option::Some(3),
+                Self::Reconciling => std::option::Option::Some(4),
+                Self::Stopping => std::option::Option::Some(5),
+                Self::Error => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("RUNNING_WITH_ERROR"),
-                4 => std::borrow::Cow::Borrowed("RECONCILING"),
-                5 => std::borrow::Cow::Borrowed("STOPPING"),
-                6 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Provisioning => std::option::Option::Some("PROVISIONING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::RunningWithError => std::option::Option::Some("RUNNING_WITH_ERROR"),
+                Self::Reconciling => std::option::Option::Some("RECONCILING"),
+                Self::Stopping => std::option::Option::Some("STOPPING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "PROVISIONING" => std::option::Option::Some(Self::PROVISIONING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "RUNNING_WITH_ERROR" => std::option::Option::Some(Self::RUNNING_WITH_ERROR),
-                "RECONCILING" => std::option::Option::Some(Self::RECONCILING),
-                "STOPPING" => std::option::Option::Some(Self::STOPPING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioning,
+                2 => Self::Running,
+                3 => Self::RunningWithError,
+                4 => Self::Reconciling,
+                5 => Self::Stopping,
+                6 => Self::Error,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONING" => Self::Provisioning,
+                "RUNNING" => Self::Running,
+                "RUNNING_WITH_ERROR" => Self::RunningWithError,
+                "RECONCILING" => Self::Reconciling,
+                "STOPPING" => Self::Stopping,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioning => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::RunningWithError => serializer.serialize_i32(3),
+                Self::Reconciling => serializer.serialize_i32(4),
+                Self::Stopping => serializer.serialize_i32(5),
+                Self::Error => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.container.v1.NodePool.Status",
+            ))
         }
     }
 }
@@ -12793,66 +14187,127 @@ pub mod maintenance_exclusion_options {
     use super::*;
 
     /// Scope of exclusion.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
-
-    impl Scope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
         /// NO_UPGRADES excludes all upgrades, including patch upgrades and minor
         /// upgrades across control planes and nodes. This is the default exclusion
         /// behavior.
-        pub const NO_UPGRADES: Scope = Scope::new(0);
-
+        NoUpgrades,
         /// NO_MINOR_UPGRADES excludes all minor upgrades for the cluster, only
         /// patches are allowed.
-        pub const NO_MINOR_UPGRADES: Scope = Scope::new(1);
-
+        NoMinorUpgrades,
         /// NO_MINOR_OR_NODE_UPGRADES excludes all minor upgrades for the cluster,
         /// and also exclude all node pool upgrades. Only control
         /// plane patches are allowed.
-        pub const NO_MINOR_OR_NODE_UPGRADES: Scope = Scope::new(2);
+        NoMinorOrNodeUpgrades,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
 
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Scope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NoUpgrades => std::option::Option::Some(0),
+                Self::NoMinorUpgrades => std::option::Option::Some(1),
+                Self::NoMinorOrNodeUpgrades => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NO_UPGRADES"),
-                1 => std::borrow::Cow::Borrowed("NO_MINOR_UPGRADES"),
-                2 => std::borrow::Cow::Borrowed("NO_MINOR_OR_NODE_UPGRADES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NO_UPGRADES" => std::option::Option::Some(Self::NO_UPGRADES),
-                "NO_MINOR_UPGRADES" => std::option::Option::Some(Self::NO_MINOR_UPGRADES),
-                "NO_MINOR_OR_NODE_UPGRADES" => {
-                    std::option::Option::Some(Self::NO_MINOR_OR_NODE_UPGRADES)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NoUpgrades => std::option::Option::Some("NO_UPGRADES"),
+                Self::NoMinorUpgrades => std::option::Option::Some("NO_MINOR_UPGRADES"),
+                Self::NoMinorOrNodeUpgrades => {
+                    std::option::Option::Some("NO_MINOR_OR_NODE_UPGRADES")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NoUpgrades,
+                1 => Self::NoMinorUpgrades,
+                2 => Self::NoMinorOrNodeUpgrades,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NO_UPGRADES" => Self::NoUpgrades,
+                "NO_MINOR_UPGRADES" => Self::NoMinorUpgrades,
+                "NO_MINOR_OR_NODE_UPGRADES" => Self::NoMinorOrNodeUpgrades,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NoUpgrades => serializer.serialize_i32(0),
+                Self::NoMinorUpgrades => serializer.serialize_i32(1),
+                Self::NoMinorOrNodeUpgrades => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".google.container.v1.MaintenanceExclusionOptions.Scope",
+            ))
         }
     }
 }
@@ -13441,59 +14896,120 @@ pub mod cluster_autoscaling {
     use super::*;
 
     /// Defines possible options for autoscaling_profile field.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AutoscalingProfile(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AutoscalingProfile {
+        /// No change to autoscaling configuration.
+        ProfileUnspecified,
+        /// Prioritize optimizing utilization of resources.
+        OptimizeUtilization,
+        /// Use default (balanced) autoscaling configuration.
+        Balanced,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AutoscalingProfile::value] or
+        /// [AutoscalingProfile::name].
+        UnknownValue(autoscaling_profile::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod autoscaling_profile {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AutoscalingProfile {
-        /// No change to autoscaling configuration.
-        pub const PROFILE_UNSPECIFIED: AutoscalingProfile = AutoscalingProfile::new(0);
-
-        /// Prioritize optimizing utilization of resources.
-        pub const OPTIMIZE_UTILIZATION: AutoscalingProfile = AutoscalingProfile::new(1);
-
-        /// Use default (balanced) autoscaling configuration.
-        pub const BALANCED: AutoscalingProfile = AutoscalingProfile::new(2);
-
-        /// Creates a new AutoscalingProfile instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::ProfileUnspecified => std::option::Option::Some(0),
+                Self::OptimizeUtilization => std::option::Option::Some(1),
+                Self::Balanced => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROFILE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OPTIMIZE_UTILIZATION"),
-                2 => std::borrow::Cow::Borrowed("BALANCED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::ProfileUnspecified => std::option::Option::Some("PROFILE_UNSPECIFIED"),
+                Self::OptimizeUtilization => std::option::Option::Some("OPTIMIZE_UTILIZATION"),
+                Self::Balanced => std::option::Option::Some("BALANCED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROFILE_UNSPECIFIED" => std::option::Option::Some(Self::PROFILE_UNSPECIFIED),
-                "OPTIMIZE_UTILIZATION" => std::option::Option::Some(Self::OPTIMIZE_UTILIZATION),
-                "BALANCED" => std::option::Option::Some(Self::BALANCED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AutoscalingProfile {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AutoscalingProfile {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AutoscalingProfile {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AutoscalingProfile {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::ProfileUnspecified,
+                1 => Self::OptimizeUtilization,
+                2 => Self::Balanced,
+                _ => Self::UnknownValue(autoscaling_profile::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AutoscalingProfile {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROFILE_UNSPECIFIED" => Self::ProfileUnspecified,
+                "OPTIMIZE_UTILIZATION" => Self::OptimizeUtilization,
+                "BALANCED" => Self::Balanced,
+                _ => Self::UnknownValue(autoscaling_profile::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AutoscalingProfile {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::ProfileUnspecified => serializer.serialize_i32(0),
+                Self::OptimizeUtilization => serializer.serialize_i32(1),
+                Self::Balanced => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AutoscalingProfile {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AutoscalingProfile>::new(
+                ".google.container.v1.ClusterAutoscaling.AutoscalingProfile",
+            ))
         }
     }
 }
@@ -13852,62 +15368,121 @@ pub mod node_pool_autoscaling {
 
     /// Location policy specifies how zones are picked when scaling up the
     /// nodepool.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocationPolicy(i32);
-
-    impl LocationPolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LocationPolicy {
         /// Not set.
-        pub const LOCATION_POLICY_UNSPECIFIED: LocationPolicy = LocationPolicy::new(0);
-
+        Unspecified,
         /// BALANCED is a best effort policy that aims to balance the sizes of
         /// different zones.
-        pub const BALANCED: LocationPolicy = LocationPolicy::new(1);
-
+        Balanced,
         /// ANY policy picks zones that have the highest capacity available.
-        pub const ANY: LocationPolicy = LocationPolicy::new(2);
+        Any,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LocationPolicy::value] or
+        /// [LocationPolicy::name].
+        UnknownValue(location_policy::UnknownValue),
+    }
 
-        /// Creates a new LocationPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod location_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LocationPolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Balanced => std::option::Option::Some(1),
+                Self::Any => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCATION_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BALANCED"),
-                2 => std::borrow::Cow::Borrowed("ANY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOCATION_POLICY_UNSPECIFIED"),
+                Self::Balanced => std::option::Option::Some("BALANCED"),
+                Self::Any => std::option::Option::Some("ANY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCATION_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOCATION_POLICY_UNSPECIFIED)
-                }
-                "BALANCED" => std::option::Option::Some(Self::BALANCED),
-                "ANY" => std::option::Option::Some(Self::ANY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LocationPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LocationPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LocationPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LocationPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Balanced,
+                2 => Self::Any,
+                _ => Self::UnknownValue(location_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LocationPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCATION_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "BALANCED" => Self::Balanced,
+                "ANY" => Self::Any,
+                _ => Self::UnknownValue(location_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LocationPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Balanced => serializer.serialize_i32(1),
+                Self::Any => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LocationPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocationPolicy>::new(
+                ".google.container.v1.NodePoolAutoscaling.LocationPolicy",
+            ))
         }
     }
 }
@@ -14397,61 +15972,120 @@ pub mod gpu_sharing_config {
     use super::*;
 
     /// The type of GPU sharing strategy currently provided.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GPUSharingStrategy(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum GPUSharingStrategy {
+        /// Default value.
+        Unspecified,
+        /// GPUs are time-shared between containers.
+        TimeSharing,
+        /// GPUs are shared between containers with NVIDIA MPS.
+        Mps,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [GPUSharingStrategy::value] or
+        /// [GPUSharingStrategy::name].
+        UnknownValue(gpu_sharing_strategy::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod gpu_sharing_strategy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl GPUSharingStrategy {
-        /// Default value.
-        pub const GPU_SHARING_STRATEGY_UNSPECIFIED: GPUSharingStrategy = GPUSharingStrategy::new(0);
-
-        /// GPUs are time-shared between containers.
-        pub const TIME_SHARING: GPUSharingStrategy = GPUSharingStrategy::new(1);
-
-        /// GPUs are shared between containers with NVIDIA MPS.
-        pub const MPS: GPUSharingStrategy = GPUSharingStrategy::new(2);
-
-        /// Creates a new GPUSharingStrategy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TimeSharing => std::option::Option::Some(1),
+                Self::Mps => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GPU_SHARING_STRATEGY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TIME_SHARING"),
-                2 => std::borrow::Cow::Borrowed("MPS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("GPU_SHARING_STRATEGY_UNSPECIFIED"),
+                Self::TimeSharing => std::option::Option::Some("TIME_SHARING"),
+                Self::Mps => std::option::Option::Some("MPS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GPU_SHARING_STRATEGY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::GPU_SHARING_STRATEGY_UNSPECIFIED)
-                }
-                "TIME_SHARING" => std::option::Option::Some(Self::TIME_SHARING),
-                "MPS" => std::option::Option::Some(Self::MPS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for GPUSharingStrategy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for GPUSharingStrategy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for GPUSharingStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for GPUSharingStrategy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TimeSharing,
+                2 => Self::Mps,
+                _ => Self::UnknownValue(gpu_sharing_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for GPUSharingStrategy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GPU_SHARING_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+                "TIME_SHARING" => Self::TimeSharing,
+                "MPS" => Self::Mps,
+                _ => Self::UnknownValue(gpu_sharing_strategy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for GPUSharingStrategy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TimeSharing => serializer.serialize_i32(1),
+                Self::Mps => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for GPUSharingStrategy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<GPUSharingStrategy>::new(
+                ".google.container.v1.GPUSharingConfig.GPUSharingStrategy",
+            ))
         }
     }
 }
@@ -14503,66 +16137,127 @@ pub mod gpu_driver_installation_config {
     use super::*;
 
     /// The GPU driver version to install.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct GPUDriverVersion(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum GPUDriverVersion {
+        /// Default value is to not install any GPU driver.
+        Unspecified,
+        /// Disable GPU driver auto installation and needs manual installation
+        InstallationDisabled,
+        /// "Default" GPU driver in COS and Ubuntu.
+        Default,
+        /// "Latest" GPU driver in COS.
+        Latest,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [GPUDriverVersion::value] or
+        /// [GPUDriverVersion::name].
+        UnknownValue(gpu_driver_version::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod gpu_driver_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl GPUDriverVersion {
-        /// Default value is to not install any GPU driver.
-        pub const GPU_DRIVER_VERSION_UNSPECIFIED: GPUDriverVersion = GPUDriverVersion::new(0);
-
-        /// Disable GPU driver auto installation and needs manual installation
-        pub const INSTALLATION_DISABLED: GPUDriverVersion = GPUDriverVersion::new(1);
-
-        /// "Default" GPU driver in COS and Ubuntu.
-        pub const DEFAULT: GPUDriverVersion = GPUDriverVersion::new(2);
-
-        /// "Latest" GPU driver in COS.
-        pub const LATEST: GPUDriverVersion = GPUDriverVersion::new(3);
-
-        /// Creates a new GPUDriverVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InstallationDisabled => std::option::Option::Some(1),
+                Self::Default => std::option::Option::Some(2),
+                Self::Latest => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GPU_DRIVER_VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INSTALLATION_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("DEFAULT"),
-                3 => std::borrow::Cow::Borrowed("LATEST"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("GPU_DRIVER_VERSION_UNSPECIFIED"),
+                Self::InstallationDisabled => std::option::Option::Some("INSTALLATION_DISABLED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::Latest => std::option::Option::Some("LATEST"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GPU_DRIVER_VERSION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::GPU_DRIVER_VERSION_UNSPECIFIED)
-                }
-                "INSTALLATION_DISABLED" => std::option::Option::Some(Self::INSTALLATION_DISABLED),
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "LATEST" => std::option::Option::Some(Self::LATEST),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for GPUDriverVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for GPUDriverVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for GPUDriverVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for GPUDriverVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InstallationDisabled,
+                2 => Self::Default,
+                3 => Self::Latest,
+                _ => Self::UnknownValue(gpu_driver_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for GPUDriverVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GPU_DRIVER_VERSION_UNSPECIFIED" => Self::Unspecified,
+                "INSTALLATION_DISABLED" => Self::InstallationDisabled,
+                "DEFAULT" => Self::Default,
+                "LATEST" => Self::Latest,
+                _ => Self::UnknownValue(gpu_driver_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for GPUDriverVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InstallationDisabled => serializer.serialize_i32(1),
+                Self::Default => serializer.serialize_i32(2),
+                Self::Latest => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for GPUDriverVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<GPUDriverVersion>::new(
+                ".google.container.v1.GPUDriverInstallationConfig.GPUDriverVersion",
+            ))
         }
     }
 }
@@ -14610,63 +16305,124 @@ pub mod workload_metadata_config {
 
     /// Mode is the configuration for how to expose metadata to workloads running
     /// on the node.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
-
-    impl Mode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
         /// Not set.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+        Unspecified,
         /// Expose all Compute Engine metadata to pods.
-        pub const GCE_METADATA: Mode = Mode::new(1);
-
+        GceMetadata,
         /// Run the GKE Metadata Server on this node. The GKE Metadata Server exposes
         /// a metadata API to workloads that is compatible with the V1 Compute
         /// Metadata APIs exposed by the Compute Engine and App Engine Metadata
         /// Servers. This feature can only be enabled if Workload Identity is enabled
         /// at the cluster level.
-        pub const GKE_METADATA: Mode = Mode::new(2);
+        GkeMetadata,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
 
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Mode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GceMetadata => std::option::Option::Some(1),
+                Self::GkeMetadata => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GCE_METADATA"),
-                2 => std::borrow::Cow::Borrowed("GKE_METADATA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::GceMetadata => std::option::Option::Some("GCE_METADATA"),
+                Self::GkeMetadata => std::option::Option::Some("GKE_METADATA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "GCE_METADATA" => std::option::Option::Some(Self::GCE_METADATA),
-                "GKE_METADATA" => std::option::Option::Some(Self::GKE_METADATA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GceMetadata,
+                2 => Self::GkeMetadata,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "GCE_METADATA" => Self::GceMetadata,
+                "GKE_METADATA" => Self::GkeMetadata,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GceMetadata => serializer.serialize_i32(1),
+                Self::GkeMetadata => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.container.v1.WorkloadMetadataConfig.Mode",
+            ))
         }
     }
 }
@@ -14899,84 +16655,153 @@ pub mod status_condition {
     use super::*;
 
     /// Code for each condition
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Code(i32);
-
-    impl Code {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Code {
         /// UNKNOWN indicates a generic condition.
-        pub const UNKNOWN: Code = Code::new(0);
-
+        Unknown,
         /// GCE_STOCKOUT indicates that Google Compute Engine resources are
         /// temporarily unavailable.
-        pub const GCE_STOCKOUT: Code = Code::new(1);
-
+        GceStockout,
         /// GKE_SERVICE_ACCOUNT_DELETED indicates that the user deleted their robot
         /// service account.
-        pub const GKE_SERVICE_ACCOUNT_DELETED: Code = Code::new(2);
-
+        GkeServiceAccountDeleted,
         /// Google Compute Engine quota was exceeded.
-        pub const GCE_QUOTA_EXCEEDED: Code = Code::new(3);
-
+        GceQuotaExceeded,
         /// Cluster state was manually changed by an SRE due to a system logic error.
-        pub const SET_BY_OPERATOR: Code = Code::new(4);
-
+        SetByOperator,
         /// Unable to perform an encrypt operation against the CloudKMS key used for
         /// etcd level encryption.
-        pub const CLOUD_KMS_KEY_ERROR: Code = Code::new(7);
-
+        CloudKmsKeyError,
         /// Cluster CA is expiring soon.
-        pub const CA_EXPIRING: Code = Code::new(9);
+        CaExpiring,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Code::value] or
+        /// [Code::name].
+        UnknownValue(code::UnknownValue),
+    }
 
-        /// Creates a new Code instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Code {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::GceStockout => std::option::Option::Some(1),
+                Self::GkeServiceAccountDeleted => std::option::Option::Some(2),
+                Self::GceQuotaExceeded => std::option::Option::Some(3),
+                Self::SetByOperator => std::option::Option::Some(4),
+                Self::CloudKmsKeyError => std::option::Option::Some(7),
+                Self::CaExpiring => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("GCE_STOCKOUT"),
-                2 => std::borrow::Cow::Borrowed("GKE_SERVICE_ACCOUNT_DELETED"),
-                3 => std::borrow::Cow::Borrowed("GCE_QUOTA_EXCEEDED"),
-                4 => std::borrow::Cow::Borrowed("SET_BY_OPERATOR"),
-                7 => std::borrow::Cow::Borrowed("CLOUD_KMS_KEY_ERROR"),
-                9 => std::borrow::Cow::Borrowed("CA_EXPIRING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "GCE_STOCKOUT" => std::option::Option::Some(Self::GCE_STOCKOUT),
-                "GKE_SERVICE_ACCOUNT_DELETED" => {
-                    std::option::Option::Some(Self::GKE_SERVICE_ACCOUNT_DELETED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::GceStockout => std::option::Option::Some("GCE_STOCKOUT"),
+                Self::GkeServiceAccountDeleted => {
+                    std::option::Option::Some("GKE_SERVICE_ACCOUNT_DELETED")
                 }
-                "GCE_QUOTA_EXCEEDED" => std::option::Option::Some(Self::GCE_QUOTA_EXCEEDED),
-                "SET_BY_OPERATOR" => std::option::Option::Some(Self::SET_BY_OPERATOR),
-                "CLOUD_KMS_KEY_ERROR" => std::option::Option::Some(Self::CLOUD_KMS_KEY_ERROR),
-                "CA_EXPIRING" => std::option::Option::Some(Self::CA_EXPIRING),
-                _ => std::option::Option::None,
+                Self::GceQuotaExceeded => std::option::Option::Some("GCE_QUOTA_EXCEEDED"),
+                Self::SetByOperator => std::option::Option::Some("SET_BY_OPERATOR"),
+                Self::CloudKmsKeyError => std::option::Option::Some("CLOUD_KMS_KEY_ERROR"),
+                Self::CaExpiring => std::option::Option::Some("CA_EXPIRING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Code {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Code {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Code {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::GceStockout,
+                2 => Self::GkeServiceAccountDeleted,
+                3 => Self::GceQuotaExceeded,
+                4 => Self::SetByOperator,
+                7 => Self::CloudKmsKeyError,
+                9 => Self::CaExpiring,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Code {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "GCE_STOCKOUT" => Self::GceStockout,
+                "GKE_SERVICE_ACCOUNT_DELETED" => Self::GkeServiceAccountDeleted,
+                "GCE_QUOTA_EXCEEDED" => Self::GceQuotaExceeded,
+                "SET_BY_OPERATOR" => Self::SetByOperator,
+                "CLOUD_KMS_KEY_ERROR" => Self::CloudKmsKeyError,
+                "CA_EXPIRING" => Self::CaExpiring,
+                _ => Self::UnknownValue(code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Code {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::GceStockout => serializer.serialize_i32(1),
+                Self::GkeServiceAccountDeleted => serializer.serialize_i32(2),
+                Self::GceQuotaExceeded => serializer.serialize_i32(3),
+                Self::SetByOperator => serializer.serialize_i32(4),
+                Self::CloudKmsKeyError => serializer.serialize_i32(7),
+                Self::CaExpiring => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Code {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(
+                ".google.container.v1.StatusCondition.Code",
+            ))
         }
     }
 }
@@ -15288,54 +17113,116 @@ pub mod network_config {
         use super::*;
 
         /// Node network tier
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Tier(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Tier {
+            /// Default value
+            Unspecified,
+            /// Higher bandwidth, actual values based on VM size.
+            _1,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Tier::value] or
+            /// [Tier::name].
+            UnknownValue(tier::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod tier {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Tier {
-            /// Default value
-            pub const TIER_UNSPECIFIED: Tier = Tier::new(0);
-
-            /// Higher bandwidth, actual values based on VM size.
-            pub const TIER_1: Tier = Tier::new(1);
-
-            /// Creates a new Tier instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::_1 => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TIER_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TIER_1"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TIER_UNSPECIFIED"),
+                    Self::_1 => std::option::Option::Some("TIER_1"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TIER_UNSPECIFIED" => std::option::Option::Some(Self::TIER_UNSPECIFIED),
-                    "TIER_1" => std::option::Option::Some(Self::TIER_1),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Tier {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Tier {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Tier {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Tier {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::_1,
+                    _ => Self::UnknownValue(tier::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Tier {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TIER_UNSPECIFIED" => Self::Unspecified,
+                    "TIER_1" => Self::_1,
+                    _ => Self::UnknownValue(tier::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Tier {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::_1 => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Tier {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Tier>::new(
+                    ".google.container.v1.NetworkConfig.ClusterNetworkPerformanceConfig.Tier",
+                ))
             }
         }
     }
@@ -15382,65 +17269,128 @@ pub mod gateway_api_config {
 
     /// Channel describes if/how Gateway API should be installed and implemented in
     /// a cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Channel(i32);
-
-    impl Channel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Channel {
         /// Default value.
-        pub const CHANNEL_UNSPECIFIED: Channel = Channel::new(0);
-
+        Unspecified,
         /// Gateway API support is disabled
-        pub const CHANNEL_DISABLED: Channel = Channel::new(1);
-
+        Disabled,
         /// Deprecated: use CHANNEL_STANDARD instead.
         /// Gateway API support is enabled, experimental CRDs are installed
-        pub const CHANNEL_EXPERIMENTAL: Channel = Channel::new(3);
-
+        Experimental,
         /// Gateway API support is enabled, standard CRDs are installed
-        pub const CHANNEL_STANDARD: Channel = Channel::new(4);
+        Standard,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Channel::value] or
+        /// [Channel::name].
+        UnknownValue(channel::UnknownValue),
+    }
 
-        /// Creates a new Channel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod channel {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Channel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::Experimental => std::option::Option::Some(3),
+                Self::Standard => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CHANNEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CHANNEL_DISABLED"),
-                3 => std::borrow::Cow::Borrowed("CHANNEL_EXPERIMENTAL"),
-                4 => std::borrow::Cow::Borrowed("CHANNEL_STANDARD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CHANNEL_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("CHANNEL_DISABLED"),
+                Self::Experimental => std::option::Option::Some("CHANNEL_EXPERIMENTAL"),
+                Self::Standard => std::option::Option::Some("CHANNEL_STANDARD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CHANNEL_UNSPECIFIED" => std::option::Option::Some(Self::CHANNEL_UNSPECIFIED),
-                "CHANNEL_DISABLED" => std::option::Option::Some(Self::CHANNEL_DISABLED),
-                "CHANNEL_EXPERIMENTAL" => std::option::Option::Some(Self::CHANNEL_EXPERIMENTAL),
-                "CHANNEL_STANDARD" => std::option::Option::Some(Self::CHANNEL_STANDARD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Channel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Channel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Channel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Channel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                3 => Self::Experimental,
+                4 => Self::Standard,
+                _ => Self::UnknownValue(channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Channel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CHANNEL_UNSPECIFIED" => Self::Unspecified,
+                "CHANNEL_DISABLED" => Self::Disabled,
+                "CHANNEL_EXPERIMENTAL" => Self::Experimental,
+                "CHANNEL_STANDARD" => Self::Standard,
+                _ => Self::UnknownValue(channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Channel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::Experimental => serializer.serialize_i32(3),
+                Self::Standard => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Channel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Channel>::new(
+                ".google.container.v1.GatewayAPIConfig.Channel",
+            ))
         }
     }
 }
@@ -15954,72 +17904,135 @@ pub mod autopilot_compatibility_issue {
     use super::*;
 
     /// The type of the reported issue.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IssueType(i32);
-
-    impl IssueType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IssueType {
         /// Default value, should not be used.
-        pub const UNSPECIFIED: IssueType = IssueType::new(0);
-
+        Unspecified,
         /// Indicates that the issue is a known incompatibility between the
         /// cluster and Autopilot mode.
-        pub const INCOMPATIBILITY: IssueType = IssueType::new(1);
-
+        Incompatibility,
         /// Indicates the issue is an incompatibility if customers take no further
         /// action to resolve.
-        pub const ADDITIONAL_CONFIG_REQUIRED: IssueType = IssueType::new(2);
-
+        AdditionalConfigRequired,
         /// Indicates the issue is not an incompatibility, but depending on the
         /// workloads business logic, there is a potential that they won't work on
         /// Autopilot.
-        pub const PASSED_WITH_OPTIONAL_CONFIG: IssueType = IssueType::new(3);
+        PassedWithOptionalConfig,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IssueType::value] or
+        /// [IssueType::name].
+        UnknownValue(issue_type::UnknownValue),
+    }
 
-        /// Creates a new IssueType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod issue_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl IssueType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Incompatibility => std::option::Option::Some(1),
+                Self::AdditionalConfigRequired => std::option::Option::Some(2),
+                Self::PassedWithOptionalConfig => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INCOMPATIBILITY"),
-                2 => std::borrow::Cow::Borrowed("ADDITIONAL_CONFIG_REQUIRED"),
-                3 => std::borrow::Cow::Borrowed("PASSED_WITH_OPTIONAL_CONFIG"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "INCOMPATIBILITY" => std::option::Option::Some(Self::INCOMPATIBILITY),
-                "ADDITIONAL_CONFIG_REQUIRED" => {
-                    std::option::Option::Some(Self::ADDITIONAL_CONFIG_REQUIRED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Incompatibility => std::option::Option::Some("INCOMPATIBILITY"),
+                Self::AdditionalConfigRequired => {
+                    std::option::Option::Some("ADDITIONAL_CONFIG_REQUIRED")
                 }
-                "PASSED_WITH_OPTIONAL_CONFIG" => {
-                    std::option::Option::Some(Self::PASSED_WITH_OPTIONAL_CONFIG)
+                Self::PassedWithOptionalConfig => {
+                    std::option::Option::Some("PASSED_WITH_OPTIONAL_CONFIG")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for IssueType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IssueType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IssueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IssueType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Incompatibility,
+                2 => Self::AdditionalConfigRequired,
+                3 => Self::PassedWithOptionalConfig,
+                _ => Self::UnknownValue(issue_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IssueType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "INCOMPATIBILITY" => Self::Incompatibility,
+                "ADDITIONAL_CONFIG_REQUIRED" => Self::AdditionalConfigRequired,
+                "PASSED_WITH_OPTIONAL_CONFIG" => Self::PassedWithOptionalConfig,
+                _ => Self::UnknownValue(issue_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IssueType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Incompatibility => serializer.serialize_i32(1),
+                Self::AdditionalConfigRequired => serializer.serialize_i32(2),
+                Self::PassedWithOptionalConfig => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IssueType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IssueType>::new(
+                ".google.container.v1.AutopilotCompatibilityIssue.IssueType",
+            ))
         }
     }
 }
@@ -16116,78 +18129,143 @@ pub mod release_channel {
     use super::*;
 
     /// Possible values for 'channel'.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Channel(i32);
-
-    impl Channel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Channel {
         /// No channel specified.
-        pub const UNSPECIFIED: Channel = Channel::new(0);
-
+        Unspecified,
         /// RAPID channel is offered on an early access basis for customers who want
         /// to test new releases.
         ///
         /// WARNING: Versions available in the RAPID Channel may be subject to
         /// unresolved issues with no known workaround and are not subject to any
         /// SLAs.
-        pub const RAPID: Channel = Channel::new(1);
-
+        Rapid,
         /// Clusters subscribed to REGULAR receive versions that are considered GA
         /// quality. REGULAR is intended for production users who want to take
         /// advantage of new features.
-        pub const REGULAR: Channel = Channel::new(2);
-
+        Regular,
         /// Clusters subscribed to STABLE receive versions that are known to be
         /// stable and reliable in production.
-        pub const STABLE: Channel = Channel::new(3);
-
+        Stable,
         /// Clusters subscribed to EXTENDED receive extended support and availability
         /// for versions which are known to be stable and reliable in production.
-        pub const EXTENDED: Channel = Channel::new(4);
+        Extended,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Channel::value] or
+        /// [Channel::name].
+        UnknownValue(channel::UnknownValue),
+    }
 
-        /// Creates a new Channel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod channel {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Channel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Rapid => std::option::Option::Some(1),
+                Self::Regular => std::option::Option::Some(2),
+                Self::Stable => std::option::Option::Some(3),
+                Self::Extended => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RAPID"),
-                2 => std::borrow::Cow::Borrowed("REGULAR"),
-                3 => std::borrow::Cow::Borrowed("STABLE"),
-                4 => std::borrow::Cow::Borrowed("EXTENDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Rapid => std::option::Option::Some("RAPID"),
+                Self::Regular => std::option::Option::Some("REGULAR"),
+                Self::Stable => std::option::Option::Some("STABLE"),
+                Self::Extended => std::option::Option::Some("EXTENDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "RAPID" => std::option::Option::Some(Self::RAPID),
-                "REGULAR" => std::option::Option::Some(Self::REGULAR),
-                "STABLE" => std::option::Option::Some(Self::STABLE),
-                "EXTENDED" => std::option::Option::Some(Self::EXTENDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Channel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Channel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Channel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Channel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Rapid,
+                2 => Self::Regular,
+                3 => Self::Stable,
+                4 => Self::Extended,
+                _ => Self::UnknownValue(channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Channel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "RAPID" => Self::Rapid,
+                "REGULAR" => Self::Regular,
+                "STABLE" => Self::Stable,
+                "EXTENDED" => Self::Extended,
+                _ => Self::UnknownValue(channel::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Channel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Rapid => serializer.serialize_i32(1),
+                Self::Regular => serializer.serialize_i32(2),
+                Self::Stable => serializer.serialize_i32(3),
+                Self::Extended => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Channel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Channel>::new(
+                ".google.container.v1.ReleaseChannel.Channel",
+            ))
         }
     }
 }
@@ -16368,121 +18446,245 @@ pub mod dns_config {
     use super::*;
 
     /// Provider lists the various in-cluster DNS providers.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Provider(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Provider {
+        /// Default value
+        Unspecified,
+        /// Use GKE default DNS provider(kube-dns) for DNS resolution.
+        PlatformDefault,
+        /// Use CloudDNS for DNS resolution.
+        CloudDns,
+        /// Use KubeDNS for DNS resolution.
+        KubeDns,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Provider::value] or
+        /// [Provider::name].
+        UnknownValue(provider::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod provider {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Provider {
-        /// Default value
-        pub const PROVIDER_UNSPECIFIED: Provider = Provider::new(0);
-
-        /// Use GKE default DNS provider(kube-dns) for DNS resolution.
-        pub const PLATFORM_DEFAULT: Provider = Provider::new(1);
-
-        /// Use CloudDNS for DNS resolution.
-        pub const CLOUD_DNS: Provider = Provider::new(2);
-
-        /// Use KubeDNS for DNS resolution.
-        pub const KUBE_DNS: Provider = Provider::new(3);
-
-        /// Creates a new Provider instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PlatformDefault => std::option::Option::Some(1),
+                Self::CloudDns => std::option::Option::Some(2),
+                Self::KubeDns => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROVIDER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PLATFORM_DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("CLOUD_DNS"),
-                3 => std::borrow::Cow::Borrowed("KUBE_DNS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROVIDER_UNSPECIFIED"),
+                Self::PlatformDefault => std::option::Option::Some("PLATFORM_DEFAULT"),
+                Self::CloudDns => std::option::Option::Some("CLOUD_DNS"),
+                Self::KubeDns => std::option::Option::Some("KUBE_DNS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROVIDER_UNSPECIFIED" => std::option::Option::Some(Self::PROVIDER_UNSPECIFIED),
-                "PLATFORM_DEFAULT" => std::option::Option::Some(Self::PLATFORM_DEFAULT),
-                "CLOUD_DNS" => std::option::Option::Some(Self::CLOUD_DNS),
-                "KUBE_DNS" => std::option::Option::Some(Self::KUBE_DNS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Provider {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Provider {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Provider {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Provider {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PlatformDefault,
+                2 => Self::CloudDns,
+                3 => Self::KubeDns,
+                _ => Self::UnknownValue(provider::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Provider {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROVIDER_UNSPECIFIED" => Self::Unspecified,
+                "PLATFORM_DEFAULT" => Self::PlatformDefault,
+                "CLOUD_DNS" => Self::CloudDns,
+                "KUBE_DNS" => Self::KubeDns,
+                _ => Self::UnknownValue(provider::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Provider {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PlatformDefault => serializer.serialize_i32(1),
+                Self::CloudDns => serializer.serialize_i32(2),
+                Self::KubeDns => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Provider {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Provider>::new(
+                ".google.container.v1.DNSConfig.Provider",
+            ))
         }
     }
 
     /// DNSScope lists the various scopes of access to cluster DNS records.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DNSScope(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DNSScope {
+        /// Default value, will be inferred as cluster scope.
+        Unspecified,
+        /// DNS records are accessible from within the cluster.
+        ClusterScope,
+        /// DNS records are accessible from within the VPC.
+        VpcScope,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DNSScope::value] or
+        /// [DNSScope::name].
+        UnknownValue(dns_scope::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod dns_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DNSScope {
-        /// Default value, will be inferred as cluster scope.
-        pub const DNS_SCOPE_UNSPECIFIED: DNSScope = DNSScope::new(0);
-
-        /// DNS records are accessible from within the cluster.
-        pub const CLUSTER_SCOPE: DNSScope = DNSScope::new(1);
-
-        /// DNS records are accessible from within the VPC.
-        pub const VPC_SCOPE: DNSScope = DNSScope::new(2);
-
-        /// Creates a new DNSScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ClusterScope => std::option::Option::Some(1),
+                Self::VpcScope => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DNS_SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLUSTER_SCOPE"),
-                2 => std::borrow::Cow::Borrowed("VPC_SCOPE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DNS_SCOPE_UNSPECIFIED"),
+                Self::ClusterScope => std::option::Option::Some("CLUSTER_SCOPE"),
+                Self::VpcScope => std::option::Option::Some("VPC_SCOPE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DNS_SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::DNS_SCOPE_UNSPECIFIED),
-                "CLUSTER_SCOPE" => std::option::Option::Some(Self::CLUSTER_SCOPE),
-                "VPC_SCOPE" => std::option::Option::Some(Self::VPC_SCOPE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DNSScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DNSScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DNSScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DNSScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ClusterScope,
+                2 => Self::VpcScope,
+                _ => Self::UnknownValue(dns_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DNSScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DNS_SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "CLUSTER_SCOPE" => Self::ClusterScope,
+                "VPC_SCOPE" => Self::VpcScope,
+                _ => Self::UnknownValue(dns_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DNSScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ClusterScope => serializer.serialize_i32(1),
+                Self::VpcScope => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DNSScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DNSScope>::new(
+                ".google.container.v1.DNSConfig.DNSScope",
+            ))
         }
     }
 }
@@ -16790,154 +18992,278 @@ pub mod database_encryption {
     }
 
     /// State of etcd encryption.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Should never be set
-        pub const UNKNOWN: State = State::new(0);
-
+        Unknown,
         /// Secrets in etcd are encrypted.
-        pub const ENCRYPTED: State = State::new(1);
-
+        Encrypted,
         /// Secrets in etcd are stored in plain text (at etcd level) - this is
         /// unrelated to Compute Engine level full disk encryption.
-        pub const DECRYPTED: State = State::new(2);
+        Decrypted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Encrypted => std::option::Option::Some(1),
+                Self::Decrypted => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("ENCRYPTED"),
-                2 => std::borrow::Cow::Borrowed("DECRYPTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Encrypted => std::option::Option::Some("ENCRYPTED"),
+                Self::Decrypted => std::option::Option::Some("DECRYPTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "ENCRYPTED" => std::option::Option::Some(Self::ENCRYPTED),
-                "DECRYPTED" => std::option::Option::Some(Self::DECRYPTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Encrypted,
+                2 => Self::Decrypted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "ENCRYPTED" => Self::Encrypted,
+                "DECRYPTED" => Self::Decrypted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Encrypted => serializer.serialize_i32(1),
+                Self::Decrypted => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.container.v1.DatabaseEncryption.State",
+            ))
         }
     }
 
     /// Current State of etcd encryption.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CurrentState(i32);
-
-    impl CurrentState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CurrentState {
         /// Should never be set
-        pub const CURRENT_STATE_UNSPECIFIED: CurrentState = CurrentState::new(0);
-
+        Unspecified,
         /// Secrets in etcd are encrypted.
-        pub const CURRENT_STATE_ENCRYPTED: CurrentState = CurrentState::new(7);
-
+        Encrypted,
         /// Secrets in etcd are stored in plain text (at etcd level) - this is
         /// unrelated to Compute Engine level full disk encryption.
-        pub const CURRENT_STATE_DECRYPTED: CurrentState = CurrentState::new(2);
-
+        Decrypted,
         /// Encryption (or re-encryption with a different CloudKMS key)
         /// of Secrets is in progress.
-        pub const CURRENT_STATE_ENCRYPTION_PENDING: CurrentState = CurrentState::new(3);
-
+        EncryptionPending,
         /// Encryption (or re-encryption with a different CloudKMS key) of Secrets in
         /// etcd encountered an error.
-        pub const CURRENT_STATE_ENCRYPTION_ERROR: CurrentState = CurrentState::new(4);
-
+        EncryptionError,
         /// De-crypting Secrets to plain text in etcd is in progress.
-        pub const CURRENT_STATE_DECRYPTION_PENDING: CurrentState = CurrentState::new(5);
-
+        DecryptionPending,
         /// De-crypting Secrets to plain text in etcd encountered an error.
-        pub const CURRENT_STATE_DECRYPTION_ERROR: CurrentState = CurrentState::new(6);
+        DecryptionError,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CurrentState::value] or
+        /// [CurrentState::name].
+        UnknownValue(current_state::UnknownValue),
+    }
 
-        /// Creates a new CurrentState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod current_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CurrentState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Encrypted => std::option::Option::Some(7),
+                Self::Decrypted => std::option::Option::Some(2),
+                Self::EncryptionPending => std::option::Option::Some(3),
+                Self::EncryptionError => std::option::Option::Some(4),
+                Self::DecryptionPending => std::option::Option::Some(5),
+                Self::DecryptionError => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CURRENT_STATE_UNSPECIFIED"),
-                2 => std::borrow::Cow::Borrowed("CURRENT_STATE_DECRYPTED"),
-                3 => std::borrow::Cow::Borrowed("CURRENT_STATE_ENCRYPTION_PENDING"),
-                4 => std::borrow::Cow::Borrowed("CURRENT_STATE_ENCRYPTION_ERROR"),
-                5 => std::borrow::Cow::Borrowed("CURRENT_STATE_DECRYPTION_PENDING"),
-                6 => std::borrow::Cow::Borrowed("CURRENT_STATE_DECRYPTION_ERROR"),
-                7 => std::borrow::Cow::Borrowed("CURRENT_STATE_ENCRYPTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CURRENT_STATE_UNSPECIFIED"),
+                Self::Encrypted => std::option::Option::Some("CURRENT_STATE_ENCRYPTED"),
+                Self::Decrypted => std::option::Option::Some("CURRENT_STATE_DECRYPTED"),
+                Self::EncryptionPending => {
+                    std::option::Option::Some("CURRENT_STATE_ENCRYPTION_PENDING")
+                }
+                Self::EncryptionError => {
+                    std::option::Option::Some("CURRENT_STATE_ENCRYPTION_ERROR")
+                }
+                Self::DecryptionPending => {
+                    std::option::Option::Some("CURRENT_STATE_DECRYPTION_PENDING")
+                }
+                Self::DecryptionError => {
+                    std::option::Option::Some("CURRENT_STATE_DECRYPTION_ERROR")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CURRENT_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_UNSPECIFIED)
-                }
-                "CURRENT_STATE_ENCRYPTED" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_ENCRYPTED)
-                }
-                "CURRENT_STATE_DECRYPTED" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_DECRYPTED)
-                }
-                "CURRENT_STATE_ENCRYPTION_PENDING" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_ENCRYPTION_PENDING)
-                }
-                "CURRENT_STATE_ENCRYPTION_ERROR" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_ENCRYPTION_ERROR)
-                }
-                "CURRENT_STATE_DECRYPTION_PENDING" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_DECRYPTION_PENDING)
-                }
-                "CURRENT_STATE_DECRYPTION_ERROR" => {
-                    std::option::Option::Some(Self::CURRENT_STATE_DECRYPTION_ERROR)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CurrentState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CurrentState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CurrentState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CurrentState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                2 => Self::Decrypted,
+                3 => Self::EncryptionPending,
+                4 => Self::EncryptionError,
+                5 => Self::DecryptionPending,
+                6 => Self::DecryptionError,
+                7 => Self::Encrypted,
+                _ => Self::UnknownValue(current_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CurrentState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CURRENT_STATE_UNSPECIFIED" => Self::Unspecified,
+                "CURRENT_STATE_ENCRYPTED" => Self::Encrypted,
+                "CURRENT_STATE_DECRYPTED" => Self::Decrypted,
+                "CURRENT_STATE_ENCRYPTION_PENDING" => Self::EncryptionPending,
+                "CURRENT_STATE_ENCRYPTION_ERROR" => Self::EncryptionError,
+                "CURRENT_STATE_DECRYPTION_PENDING" => Self::DecryptionPending,
+                "CURRENT_STATE_DECRYPTION_ERROR" => Self::DecryptionError,
+                _ => Self::UnknownValue(current_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CurrentState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Encrypted => serializer.serialize_i32(7),
+                Self::Decrypted => serializer.serialize_i32(2),
+                Self::EncryptionPending => serializer.serialize_i32(3),
+                Self::EncryptionError => serializer.serialize_i32(4),
+                Self::DecryptionPending => serializer.serialize_i32(5),
+                Self::DecryptionError => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CurrentState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CurrentState>::new(
+                ".google.container.v1.DatabaseEncryption.CurrentState",
+            ))
         }
     }
 }
@@ -17141,74 +19467,139 @@ pub mod usable_subnetwork_secondary_range {
     use super::*;
 
     /// Status shows the current usage of a secondary IP range.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// UNKNOWN is the zero value of the Status enum. It's not a valid status.
-        pub const UNKNOWN: Status = Status::new(0);
-
+        Unknown,
         /// UNUSED denotes that this range is unclaimed by any cluster.
-        pub const UNUSED: Status = Status::new(1);
-
+        Unused,
         /// IN_USE_SERVICE denotes that this range is claimed by cluster(s) for
         /// services. User-managed services range can be shared between clusters
         /// within the same subnetwork.
-        pub const IN_USE_SERVICE: Status = Status::new(2);
-
+        InUseService,
         /// IN_USE_SHAREABLE_POD denotes this range was created by the network admin
         /// and is currently claimed by a cluster for pods. It can only be used by
         /// other clusters as a pod range.
-        pub const IN_USE_SHAREABLE_POD: Status = Status::new(3);
-
+        InUseShareablePod,
         /// IN_USE_MANAGED_POD denotes this range was created by GKE and is claimed
         /// for pods. It cannot be used for other clusters.
-        pub const IN_USE_MANAGED_POD: Status = Status::new(4);
+        InUseManagedPod,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Unused => std::option::Option::Some(1),
+                Self::InUseService => std::option::Option::Some(2),
+                Self::InUseShareablePod => std::option::Option::Some(3),
+                Self::InUseManagedPod => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("UNUSED"),
-                2 => std::borrow::Cow::Borrowed("IN_USE_SERVICE"),
-                3 => std::borrow::Cow::Borrowed("IN_USE_SHAREABLE_POD"),
-                4 => std::borrow::Cow::Borrowed("IN_USE_MANAGED_POD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::Unused => std::option::Option::Some("UNUSED"),
+                Self::InUseService => std::option::Option::Some("IN_USE_SERVICE"),
+                Self::InUseShareablePod => std::option::Option::Some("IN_USE_SHAREABLE_POD"),
+                Self::InUseManagedPod => std::option::Option::Some("IN_USE_MANAGED_POD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "UNUSED" => std::option::Option::Some(Self::UNUSED),
-                "IN_USE_SERVICE" => std::option::Option::Some(Self::IN_USE_SERVICE),
-                "IN_USE_SHAREABLE_POD" => std::option::Option::Some(Self::IN_USE_SHAREABLE_POD),
-                "IN_USE_MANAGED_POD" => std::option::Option::Some(Self::IN_USE_MANAGED_POD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Unused,
+                2 => Self::InUseService,
+                3 => Self::InUseShareablePod,
+                4 => Self::InUseManagedPod,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "UNUSED" => Self::Unused,
+                "IN_USE_SERVICE" => Self::InUseService,
+                "IN_USE_SHAREABLE_POD" => Self::InUseShareablePod,
+                "IN_USE_MANAGED_POD" => Self::InUseManagedPod,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Unused => serializer.serialize_i32(1),
+                Self::InUseService => serializer.serialize_i32(2),
+                Self::InUseShareablePod => serializer.serialize_i32(3),
+                Self::InUseManagedPod => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.container.v1.UsableSubnetworkSecondaryRange.Status",
+            ))
         }
     }
 }
@@ -17748,68 +20139,127 @@ pub mod notification_config {
 
     /// Types of notifications currently supported. Can be used to filter what
     /// notifications are sent.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
+        /// Not set, will be ignored.
+        Unspecified,
+        /// Corresponds with UpgradeAvailableEvent.
+        UpgradeAvailableEvent,
+        /// Corresponds with UpgradeEvent.
+        UpgradeEvent,
+        /// Corresponds with SecurityBulletinEvent.
+        SecurityBulletinEvent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EventType {
-        /// Not set, will be ignored.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
-        /// Corresponds with UpgradeAvailableEvent.
-        pub const UPGRADE_AVAILABLE_EVENT: EventType = EventType::new(1);
-
-        /// Corresponds with UpgradeEvent.
-        pub const UPGRADE_EVENT: EventType = EventType::new(2);
-
-        /// Corresponds with SecurityBulletinEvent.
-        pub const SECURITY_BULLETIN_EVENT: EventType = EventType::new(3);
-
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UpgradeAvailableEvent => std::option::Option::Some(1),
+                Self::UpgradeEvent => std::option::Option::Some(2),
+                Self::SecurityBulletinEvent => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UPGRADE_AVAILABLE_EVENT"),
-                2 => std::borrow::Cow::Borrowed("UPGRADE_EVENT"),
-                3 => std::borrow::Cow::Borrowed("SECURITY_BULLETIN_EVENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::UpgradeAvailableEvent => std::option::Option::Some("UPGRADE_AVAILABLE_EVENT"),
+                Self::UpgradeEvent => std::option::Option::Some("UPGRADE_EVENT"),
+                Self::SecurityBulletinEvent => std::option::Option::Some("SECURITY_BULLETIN_EVENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "UPGRADE_AVAILABLE_EVENT" => {
-                    std::option::Option::Some(Self::UPGRADE_AVAILABLE_EVENT)
-                }
-                "UPGRADE_EVENT" => std::option::Option::Some(Self::UPGRADE_EVENT),
-                "SECURITY_BULLETIN_EVENT" => {
-                    std::option::Option::Some(Self::SECURITY_BULLETIN_EVENT)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UpgradeAvailableEvent,
+                2 => Self::UpgradeEvent,
+                3 => Self::SecurityBulletinEvent,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "UPGRADE_AVAILABLE_EVENT" => Self::UpgradeAvailableEvent,
+                "UPGRADE_EVENT" => Self::UpgradeEvent,
+                "SECURITY_BULLETIN_EVENT" => Self::SecurityBulletinEvent,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UpgradeAvailableEvent => serializer.serialize_i32(1),
+                Self::UpgradeEvent => serializer.serialize_i32(2),
+                Self::SecurityBulletinEvent => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.container.v1.NotificationConfig.EventType",
+            ))
         }
     }
 }
@@ -18066,69 +20516,134 @@ pub mod upgrade_info_event {
     use super::*;
 
     /// The state of the upgrade.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// STATE_UNSPECIFIED indicates the state is unspecified.
+        Unspecified,
+        /// STARTED indicates the upgrade has started.
+        Started,
+        /// SUCCEEDED indicates the upgrade has completed successfully.
+        Succeeded,
+        /// FAILED indicates the upgrade has failed.
+        Failed,
+        /// CANCELED indicates the upgrade has canceled.
+        Canceled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// STATE_UNSPECIFIED indicates the state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// STARTED indicates the upgrade has started.
-        pub const STARTED: State = State::new(3);
-
-        /// SUCCEEDED indicates the upgrade has completed successfully.
-        pub const SUCCEEDED: State = State::new(4);
-
-        /// FAILED indicates the upgrade has failed.
-        pub const FAILED: State = State::new(5);
-
-        /// CANCELED indicates the upgrade has canceled.
-        pub const CANCELED: State = State::new(6);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Started => std::option::Option::Some(3),
+                Self::Succeeded => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Canceled => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                3 => std::borrow::Cow::Borrowed("STARTED"),
-                4 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("CANCELED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Started => std::option::Option::Some("STARTED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Canceled => std::option::Option::Some("CANCELED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "STARTED" => std::option::Option::Some(Self::STARTED),
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELED" => std::option::Option::Some(Self::CANCELED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                3 => Self::Started,
+                4 => Self::Succeeded,
+                5 => Self::Failed,
+                6 => Self::Canceled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "STARTED" => Self::Started,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                "CANCELED" => Self::Canceled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Started => serializer.serialize_i32(3),
+                Self::Succeeded => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Canceled => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.container.v1.UpgradeInfoEvent.State",
+            ))
         }
     }
 }
@@ -18523,84 +21038,155 @@ pub mod logging_component_config {
     use super::*;
 
     /// GKE components exposing logs
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Component(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Component {
+        /// Default value. This shouldn't be used.
+        Unspecified,
+        /// system components
+        SystemComponents,
+        /// workloads
+        Workloads,
+        /// kube-apiserver
+        Apiserver,
+        /// kube-scheduler
+        Scheduler,
+        /// kube-controller-manager
+        ControllerManager,
+        /// kcp-sshd
+        KcpSshd,
+        /// kcp connection logs
+        KcpConnection,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Component::value] or
+        /// [Component::name].
+        UnknownValue(component::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod component {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Component {
-        /// Default value. This shouldn't be used.
-        pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
-
-        /// system components
-        pub const SYSTEM_COMPONENTS: Component = Component::new(1);
-
-        /// workloads
-        pub const WORKLOADS: Component = Component::new(2);
-
-        /// kube-apiserver
-        pub const APISERVER: Component = Component::new(3);
-
-        /// kube-scheduler
-        pub const SCHEDULER: Component = Component::new(4);
-
-        /// kube-controller-manager
-        pub const CONTROLLER_MANAGER: Component = Component::new(5);
-
-        /// kcp-sshd
-        pub const KCP_SSHD: Component = Component::new(7);
-
-        /// kcp connection logs
-        pub const KCP_CONNECTION: Component = Component::new(8);
-
-        /// Creates a new Component instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SystemComponents => std::option::Option::Some(1),
+                Self::Workloads => std::option::Option::Some(2),
+                Self::Apiserver => std::option::Option::Some(3),
+                Self::Scheduler => std::option::Option::Some(4),
+                Self::ControllerManager => std::option::Option::Some(5),
+                Self::KcpSshd => std::option::Option::Some(7),
+                Self::KcpConnection => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SYSTEM_COMPONENTS"),
-                2 => std::borrow::Cow::Borrowed("WORKLOADS"),
-                3 => std::borrow::Cow::Borrowed("APISERVER"),
-                4 => std::borrow::Cow::Borrowed("SCHEDULER"),
-                5 => std::borrow::Cow::Borrowed("CONTROLLER_MANAGER"),
-                7 => std::borrow::Cow::Borrowed("KCP_SSHD"),
-                8 => std::borrow::Cow::Borrowed("KCP_CONNECTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPONENT_UNSPECIFIED"),
+                Self::SystemComponents => std::option::Option::Some("SYSTEM_COMPONENTS"),
+                Self::Workloads => std::option::Option::Some("WORKLOADS"),
+                Self::Apiserver => std::option::Option::Some("APISERVER"),
+                Self::Scheduler => std::option::Option::Some("SCHEDULER"),
+                Self::ControllerManager => std::option::Option::Some("CONTROLLER_MANAGER"),
+                Self::KcpSshd => std::option::Option::Some("KCP_SSHD"),
+                Self::KcpConnection => std::option::Option::Some("KCP_CONNECTION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
-                "SYSTEM_COMPONENTS" => std::option::Option::Some(Self::SYSTEM_COMPONENTS),
-                "WORKLOADS" => std::option::Option::Some(Self::WORKLOADS),
-                "APISERVER" => std::option::Option::Some(Self::APISERVER),
-                "SCHEDULER" => std::option::Option::Some(Self::SCHEDULER),
-                "CONTROLLER_MANAGER" => std::option::Option::Some(Self::CONTROLLER_MANAGER),
-                "KCP_SSHD" => std::option::Option::Some(Self::KCP_SSHD),
-                "KCP_CONNECTION" => std::option::Option::Some(Self::KCP_CONNECTION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Component {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Component {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Component {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Component {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SystemComponents,
+                2 => Self::Workloads,
+                3 => Self::Apiserver,
+                4 => Self::Scheduler,
+                5 => Self::ControllerManager,
+                7 => Self::KcpSshd,
+                8 => Self::KcpConnection,
+                _ => Self::UnknownValue(component::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Component {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPONENT_UNSPECIFIED" => Self::Unspecified,
+                "SYSTEM_COMPONENTS" => Self::SystemComponents,
+                "WORKLOADS" => Self::Workloads,
+                "APISERVER" => Self::Apiserver,
+                "SCHEDULER" => Self::Scheduler,
+                "CONTROLLER_MANAGER" => Self::ControllerManager,
+                "KCP_SSHD" => Self::KcpSshd,
+                "KCP_CONNECTION" => Self::KcpConnection,
+                _ => Self::UnknownValue(component::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Component {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SystemComponents => serializer.serialize_i32(1),
+                Self::Workloads => serializer.serialize_i32(2),
+                Self::Apiserver => serializer.serialize_i32(3),
+                Self::Scheduler => serializer.serialize_i32(4),
+                Self::ControllerManager => serializer.serialize_i32(5),
+                Self::KcpSshd => serializer.serialize_i32(7),
+                Self::KcpConnection => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Component {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Component>::new(
+                ".google.container.v1.LoggingComponentConfig.Component",
+            ))
         }
     }
 }
@@ -18772,64 +21358,127 @@ pub mod advanced_datapath_observability_config {
     use super::*;
 
     /// Supported Relay modes
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RelayMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RelayMode {
+        /// Default value. This shouldn't be used.
+        Unspecified,
+        /// disabled
+        Disabled,
+        /// exposed via internal load balancer
+        InternalVpcLb,
+        /// exposed via external load balancer
+        ExternalLb,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RelayMode::value] or
+        /// [RelayMode::name].
+        UnknownValue(relay_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod relay_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RelayMode {
-        /// Default value. This shouldn't be used.
-        pub const RELAY_MODE_UNSPECIFIED: RelayMode = RelayMode::new(0);
-
-        /// disabled
-        pub const DISABLED: RelayMode = RelayMode::new(1);
-
-        /// exposed via internal load balancer
-        pub const INTERNAL_VPC_LB: RelayMode = RelayMode::new(3);
-
-        /// exposed via external load balancer
-        pub const EXTERNAL_LB: RelayMode = RelayMode::new(4);
-
-        /// Creates a new RelayMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Disabled => std::option::Option::Some(1),
+                Self::InternalVpcLb => std::option::Option::Some(3),
+                Self::ExternalLb => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RELAY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("INTERNAL_VPC_LB"),
-                4 => std::borrow::Cow::Borrowed("EXTERNAL_LB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RELAY_MODE_UNSPECIFIED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::InternalVpcLb => std::option::Option::Some("INTERNAL_VPC_LB"),
+                Self::ExternalLb => std::option::Option::Some("EXTERNAL_LB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RELAY_MODE_UNSPECIFIED" => std::option::Option::Some(Self::RELAY_MODE_UNSPECIFIED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "INTERNAL_VPC_LB" => std::option::Option::Some(Self::INTERNAL_VPC_LB),
-                "EXTERNAL_LB" => std::option::Option::Some(Self::EXTERNAL_LB),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RelayMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RelayMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RelayMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RelayMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Disabled,
+                3 => Self::InternalVpcLb,
+                4 => Self::ExternalLb,
+                _ => Self::UnknownValue(relay_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RelayMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RELAY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "DISABLED" => Self::Disabled,
+                "INTERNAL_VPC_LB" => Self::InternalVpcLb,
+                "EXTERNAL_LB" => Self::ExternalLb,
+                _ => Self::UnknownValue(relay_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RelayMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Disabled => serializer.serialize_i32(1),
+                Self::InternalVpcLb => serializer.serialize_i32(3),
+                Self::ExternalLb => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RelayMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RelayMode>::new(
+                ".google.container.v1.AdvancedDatapathObservabilityConfig.RelayMode",
+            ))
         }
     }
 }
@@ -18944,59 +21593,120 @@ pub mod logging_variant_config {
     use super::*;
 
     /// Logging component variants.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Variant(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Variant {
+        /// Default value. This shouldn't be used.
+        Unspecified,
+        /// default logging variant.
+        Default,
+        /// maximum logging throughput variant.
+        MaxThroughput,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Variant::value] or
+        /// [Variant::name].
+        UnknownValue(variant::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod variant {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Variant {
-        /// Default value. This shouldn't be used.
-        pub const VARIANT_UNSPECIFIED: Variant = Variant::new(0);
-
-        /// default logging variant.
-        pub const DEFAULT: Variant = Variant::new(1);
-
-        /// maximum logging throughput variant.
-        pub const MAX_THROUGHPUT: Variant = Variant::new(2);
-
-        /// Creates a new Variant instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Default => std::option::Option::Some(1),
+                Self::MaxThroughput => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VARIANT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("MAX_THROUGHPUT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VARIANT_UNSPECIFIED"),
+                Self::Default => std::option::Option::Some("DEFAULT"),
+                Self::MaxThroughput => std::option::Option::Some("MAX_THROUGHPUT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VARIANT_UNSPECIFIED" => std::option::Option::Some(Self::VARIANT_UNSPECIFIED),
-                "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-                "MAX_THROUGHPUT" => std::option::Option::Some(Self::MAX_THROUGHPUT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Variant {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Variant {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Variant {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Variant {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Default,
+                2 => Self::MaxThroughput,
+                _ => Self::UnknownValue(variant::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Variant {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VARIANT_UNSPECIFIED" => Self::Unspecified,
+                "DEFAULT" => Self::Default,
+                "MAX_THROUGHPUT" => Self::MaxThroughput,
+                _ => Self::UnknownValue(variant::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Variant {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Default => serializer.serialize_i32(1),
+                Self::MaxThroughput => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Variant {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Variant>::new(
+                ".google.container.v1.LoggingVariantConfig.Variant",
+            ))
         }
     }
 }
@@ -19045,114 +21755,197 @@ pub mod monitoring_component_config {
     use super::*;
 
     /// GKE components exposing metrics
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Component(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Component {
+        /// Default value. This shouldn't be used.
+        Unspecified,
+        /// system components
+        SystemComponents,
+        /// kube-apiserver
+        Apiserver,
+        /// kube-scheduler
+        Scheduler,
+        /// kube-controller-manager
+        ControllerManager,
+        /// Storage
+        Storage,
+        /// Horizontal Pod Autoscaling
+        Hpa,
+        /// Pod
+        Pod,
+        /// DaemonSet
+        Daemonset,
+        /// Deployment
+        Deployment,
+        /// Statefulset
+        Statefulset,
+        /// CADVISOR
+        Cadvisor,
+        /// KUBELET
+        Kubelet,
+        /// NVIDIA Data Center GPU Manager (DCGM)
+        Dcgm,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Component::value] or
+        /// [Component::name].
+        UnknownValue(component::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod component {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Component {
-        /// Default value. This shouldn't be used.
-        pub const COMPONENT_UNSPECIFIED: Component = Component::new(0);
-
-        /// system components
-        pub const SYSTEM_COMPONENTS: Component = Component::new(1);
-
-        /// kube-apiserver
-        pub const APISERVER: Component = Component::new(3);
-
-        /// kube-scheduler
-        pub const SCHEDULER: Component = Component::new(4);
-
-        /// kube-controller-manager
-        pub const CONTROLLER_MANAGER: Component = Component::new(5);
-
-        /// Storage
-        pub const STORAGE: Component = Component::new(7);
-
-        /// Horizontal Pod Autoscaling
-        pub const HPA: Component = Component::new(8);
-
-        /// Pod
-        pub const POD: Component = Component::new(9);
-
-        /// DaemonSet
-        pub const DAEMONSET: Component = Component::new(10);
-
-        /// Deployment
-        pub const DEPLOYMENT: Component = Component::new(11);
-
-        /// Statefulset
-        pub const STATEFULSET: Component = Component::new(12);
-
-        /// CADVISOR
-        pub const CADVISOR: Component = Component::new(13);
-
-        /// KUBELET
-        pub const KUBELET: Component = Component::new(14);
-
-        /// NVIDIA Data Center GPU Manager (DCGM)
-        pub const DCGM: Component = Component::new(15);
-
-        /// Creates a new Component instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SystemComponents => std::option::Option::Some(1),
+                Self::Apiserver => std::option::Option::Some(3),
+                Self::Scheduler => std::option::Option::Some(4),
+                Self::ControllerManager => std::option::Option::Some(5),
+                Self::Storage => std::option::Option::Some(7),
+                Self::Hpa => std::option::Option::Some(8),
+                Self::Pod => std::option::Option::Some(9),
+                Self::Daemonset => std::option::Option::Some(10),
+                Self::Deployment => std::option::Option::Some(11),
+                Self::Statefulset => std::option::Option::Some(12),
+                Self::Cadvisor => std::option::Option::Some(13),
+                Self::Kubelet => std::option::Option::Some(14),
+                Self::Dcgm => std::option::Option::Some(15),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMPONENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SYSTEM_COMPONENTS"),
-                3 => std::borrow::Cow::Borrowed("APISERVER"),
-                4 => std::borrow::Cow::Borrowed("SCHEDULER"),
-                5 => std::borrow::Cow::Borrowed("CONTROLLER_MANAGER"),
-                7 => std::borrow::Cow::Borrowed("STORAGE"),
-                8 => std::borrow::Cow::Borrowed("HPA"),
-                9 => std::borrow::Cow::Borrowed("POD"),
-                10 => std::borrow::Cow::Borrowed("DAEMONSET"),
-                11 => std::borrow::Cow::Borrowed("DEPLOYMENT"),
-                12 => std::borrow::Cow::Borrowed("STATEFULSET"),
-                13 => std::borrow::Cow::Borrowed("CADVISOR"),
-                14 => std::borrow::Cow::Borrowed("KUBELET"),
-                15 => std::borrow::Cow::Borrowed("DCGM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COMPONENT_UNSPECIFIED"),
+                Self::SystemComponents => std::option::Option::Some("SYSTEM_COMPONENTS"),
+                Self::Apiserver => std::option::Option::Some("APISERVER"),
+                Self::Scheduler => std::option::Option::Some("SCHEDULER"),
+                Self::ControllerManager => std::option::Option::Some("CONTROLLER_MANAGER"),
+                Self::Storage => std::option::Option::Some("STORAGE"),
+                Self::Hpa => std::option::Option::Some("HPA"),
+                Self::Pod => std::option::Option::Some("POD"),
+                Self::Daemonset => std::option::Option::Some("DAEMONSET"),
+                Self::Deployment => std::option::Option::Some("DEPLOYMENT"),
+                Self::Statefulset => std::option::Option::Some("STATEFULSET"),
+                Self::Cadvisor => std::option::Option::Some("CADVISOR"),
+                Self::Kubelet => std::option::Option::Some("KUBELET"),
+                Self::Dcgm => std::option::Option::Some("DCGM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMPONENT_UNSPECIFIED" => std::option::Option::Some(Self::COMPONENT_UNSPECIFIED),
-                "SYSTEM_COMPONENTS" => std::option::Option::Some(Self::SYSTEM_COMPONENTS),
-                "APISERVER" => std::option::Option::Some(Self::APISERVER),
-                "SCHEDULER" => std::option::Option::Some(Self::SCHEDULER),
-                "CONTROLLER_MANAGER" => std::option::Option::Some(Self::CONTROLLER_MANAGER),
-                "STORAGE" => std::option::Option::Some(Self::STORAGE),
-                "HPA" => std::option::Option::Some(Self::HPA),
-                "POD" => std::option::Option::Some(Self::POD),
-                "DAEMONSET" => std::option::Option::Some(Self::DAEMONSET),
-                "DEPLOYMENT" => std::option::Option::Some(Self::DEPLOYMENT),
-                "STATEFULSET" => std::option::Option::Some(Self::STATEFULSET),
-                "CADVISOR" => std::option::Option::Some(Self::CADVISOR),
-                "KUBELET" => std::option::Option::Some(Self::KUBELET),
-                "DCGM" => std::option::Option::Some(Self::DCGM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Component {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Component {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Component {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Component {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SystemComponents,
+                3 => Self::Apiserver,
+                4 => Self::Scheduler,
+                5 => Self::ControllerManager,
+                7 => Self::Storage,
+                8 => Self::Hpa,
+                9 => Self::Pod,
+                10 => Self::Daemonset,
+                11 => Self::Deployment,
+                12 => Self::Statefulset,
+                13 => Self::Cadvisor,
+                14 => Self::Kubelet,
+                15 => Self::Dcgm,
+                _ => Self::UnknownValue(component::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Component {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMPONENT_UNSPECIFIED" => Self::Unspecified,
+                "SYSTEM_COMPONENTS" => Self::SystemComponents,
+                "APISERVER" => Self::Apiserver,
+                "SCHEDULER" => Self::Scheduler,
+                "CONTROLLER_MANAGER" => Self::ControllerManager,
+                "STORAGE" => Self::Storage,
+                "HPA" => Self::Hpa,
+                "POD" => Self::Pod,
+                "DAEMONSET" => Self::Daemonset,
+                "DEPLOYMENT" => Self::Deployment,
+                "STATEFULSET" => Self::Statefulset,
+                "CADVISOR" => Self::Cadvisor,
+                "KUBELET" => Self::Kubelet,
+                "DCGM" => Self::Dcgm,
+                _ => Self::UnknownValue(component::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Component {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SystemComponents => serializer.serialize_i32(1),
+                Self::Apiserver => serializer.serialize_i32(3),
+                Self::Scheduler => serializer.serialize_i32(4),
+                Self::ControllerManager => serializer.serialize_i32(5),
+                Self::Storage => serializer.serialize_i32(7),
+                Self::Hpa => serializer.serialize_i32(8),
+                Self::Pod => serializer.serialize_i32(9),
+                Self::Daemonset => serializer.serialize_i32(10),
+                Self::Deployment => serializer.serialize_i32(11),
+                Self::Statefulset => serializer.serialize_i32(12),
+                Self::Cadvisor => serializer.serialize_i32(13),
+                Self::Kubelet => serializer.serialize_i32(14),
+                Self::Dcgm => serializer.serialize_i32(15),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Component {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Component>::new(
+                ".google.container.v1.MonitoringComponentConfig.Component",
+            ))
         }
     }
 }
@@ -19701,61 +22494,120 @@ pub mod enterprise_config {
     use super::*;
 
     /// Premium tiers for GKE Cluster.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ClusterTier(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ClusterTier {
+        /// CLUSTER_TIER_UNSPECIFIED is when cluster_tier is not set.
+        Unspecified,
+        /// STANDARD indicates a standard GKE cluster.
+        Standard,
+        /// ENTERPRISE indicates a GKE Enterprise cluster.
+        Enterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ClusterTier::value] or
+        /// [ClusterTier::name].
+        UnknownValue(cluster_tier::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod cluster_tier {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ClusterTier {
-        /// CLUSTER_TIER_UNSPECIFIED is when cluster_tier is not set.
-        pub const CLUSTER_TIER_UNSPECIFIED: ClusterTier = ClusterTier::new(0);
-
-        /// STANDARD indicates a standard GKE cluster.
-        pub const STANDARD: ClusterTier = ClusterTier::new(1);
-
-        /// ENTERPRISE indicates a GKE Enterprise cluster.
-        pub const ENTERPRISE: ClusterTier = ClusterTier::new(2);
-
-        /// Creates a new ClusterTier instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLUSTER_TIER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CLUSTER_TIER_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLUSTER_TIER_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLUSTER_TIER_UNSPECIFIED)
-                }
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ClusterTier {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ClusterTier {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ClusterTier {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ClusterTier {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Enterprise,
+                _ => Self::UnknownValue(cluster_tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ClusterTier {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLUSTER_TIER_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "ENTERPRISE" => Self::Enterprise,
+                _ => Self::UnknownValue(cluster_tier::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ClusterTier {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ClusterTier {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ClusterTier>::new(
+                ".google.container.v1.EnterpriseConfig.ClusterTier",
+            ))
         }
     }
 }
@@ -19844,55 +22696,114 @@ pub mod secondary_boot_disk {
 
     /// Mode specifies how the secondary boot disk will be used.
     /// This triggers mode-specified logic in the control plane.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
-
-    impl Mode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
         /// MODE_UNSPECIFIED is when mode is not set.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
+        Unspecified,
         /// CONTAINER_IMAGE_CACHE is for using the secondary boot disk as
         /// a container image cache.
-        pub const CONTAINER_IMAGE_CACHE: Mode = Mode::new(1);
+        ContainerImageCache,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
 
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Mode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ContainerImageCache => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CONTAINER_IMAGE_CACHE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::ContainerImageCache => std::option::Option::Some("CONTAINER_IMAGE_CACHE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "CONTAINER_IMAGE_CACHE" => std::option::Option::Some(Self::CONTAINER_IMAGE_CACHE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ContainerImageCache,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "CONTAINER_IMAGE_CACHE" => Self::ContainerImageCache,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ContainerImageCache => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.container.v1.SecondaryBootDisk.Mode",
+            ))
         }
     }
 }
@@ -19922,443 +22833,864 @@ impl wkt::message::Message for SecondaryBootDiskUpdateStrategy {
 
 /// PrivateIPv6GoogleAccess controls whether and how the pods can communicate
 /// with Google Services through gRPC over IPv6.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct PrivateIPv6GoogleAccess(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum PrivateIPv6GoogleAccess {
+    /// Default value. Same as DISABLED
+    PrivateIpv6GoogleAccessUnspecified,
+    /// No private access to or from Google Services
+    PrivateIpv6GoogleAccessDisabled,
+    /// Enables private IPv6 access to Google Services from GKE
+    PrivateIpv6GoogleAccessToGoogle,
+    /// Enables private IPv6 access to and from Google Services
+    PrivateIpv6GoogleAccessBidirectional,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [PrivateIPv6GoogleAccess::value] or
+    /// [PrivateIPv6GoogleAccess::name].
+    UnknownValue(private_i_pv_6_google_access::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod private_i_pv_6_google_access {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl PrivateIPv6GoogleAccess {
-    /// Default value. Same as DISABLED
-    pub const PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new(0);
-
-    /// No private access to or from Google Services
-    pub const PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new(1);
-
-    /// Enables private IPv6 access to Google Services from GKE
-    pub const PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new(2);
-
-    /// Enables private IPv6 access to and from Google Services
-    pub const PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL: PrivateIPv6GoogleAccess =
-        PrivateIPv6GoogleAccess::new(3);
-
-    /// Creates a new PrivateIPv6GoogleAccess instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::PrivateIpv6GoogleAccessUnspecified => std::option::Option::Some(0),
+            Self::PrivateIpv6GoogleAccessDisabled => std::option::Option::Some(1),
+            Self::PrivateIpv6GoogleAccessToGoogle => std::option::Option::Some(2),
+            Self::PrivateIpv6GoogleAccessBidirectional => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED"),
-            2 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE"),
-            3 => std::borrow::Cow::Borrowed("PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::PrivateIpv6GoogleAccessUnspecified => {
+                std::option::Option::Some("PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED")
+            }
+            Self::PrivateIpv6GoogleAccessDisabled => {
+                std::option::Option::Some("PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED")
+            }
+            Self::PrivateIpv6GoogleAccessToGoogle => {
+                std::option::Option::Some("PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE")
+            }
+            Self::PrivateIpv6GoogleAccessBidirectional => {
+                std::option::Option::Some("PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED)
-            }
-            "PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED" => {
-                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED)
-            }
-            "PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE" => {
-                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE)
-            }
-            "PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL" => {
-                std::option::Option::Some(Self::PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for PrivateIPv6GoogleAccess {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for PrivateIPv6GoogleAccess {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for PrivateIPv6GoogleAccess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for PrivateIPv6GoogleAccess {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::PrivateIpv6GoogleAccessUnspecified,
+            1 => Self::PrivateIpv6GoogleAccessDisabled,
+            2 => Self::PrivateIpv6GoogleAccessToGoogle,
+            3 => Self::PrivateIpv6GoogleAccessBidirectional,
+            _ => Self::UnknownValue(private_i_pv_6_google_access::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for PrivateIPv6GoogleAccess {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED" => Self::PrivateIpv6GoogleAccessUnspecified,
+            "PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED" => Self::PrivateIpv6GoogleAccessDisabled,
+            "PRIVATE_IPV6_GOOGLE_ACCESS_TO_GOOGLE" => Self::PrivateIpv6GoogleAccessToGoogle,
+            "PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL" => {
+                Self::PrivateIpv6GoogleAccessBidirectional
+            }
+            _ => Self::UnknownValue(private_i_pv_6_google_access::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for PrivateIPv6GoogleAccess {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::PrivateIpv6GoogleAccessUnspecified => serializer.serialize_i32(0),
+            Self::PrivateIpv6GoogleAccessDisabled => serializer.serialize_i32(1),
+            Self::PrivateIpv6GoogleAccessToGoogle => serializer.serialize_i32(2),
+            Self::PrivateIpv6GoogleAccessBidirectional => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PrivateIPv6GoogleAccess {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<PrivateIPv6GoogleAccess>::new(
+            ".google.container.v1.PrivateIPv6GoogleAccess",
+        ))
     }
 }
 
 /// UpgradeResourceType is the resource type that is upgrading. It is used
 /// in upgrade notifications.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UpgradeResourceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum UpgradeResourceType {
+    /// Default value. This shouldn't be used.
+    Unspecified,
+    /// Master / control plane
+    Master,
+    /// Node pool
+    NodePool,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [UpgradeResourceType::value] or
+    /// [UpgradeResourceType::name].
+    UnknownValue(upgrade_resource_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod upgrade_resource_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl UpgradeResourceType {
-    /// Default value. This shouldn't be used.
-    pub const UPGRADE_RESOURCE_TYPE_UNSPECIFIED: UpgradeResourceType = UpgradeResourceType::new(0);
-
-    /// Master / control plane
-    pub const MASTER: UpgradeResourceType = UpgradeResourceType::new(1);
-
-    /// Node pool
-    pub const NODE_POOL: UpgradeResourceType = UpgradeResourceType::new(2);
-
-    /// Creates a new UpgradeResourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Master => std::option::Option::Some(1),
+            Self::NodePool => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UPGRADE_RESOURCE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MASTER"),
-            2 => std::borrow::Cow::Borrowed("NODE_POOL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("UPGRADE_RESOURCE_TYPE_UNSPECIFIED"),
+            Self::Master => std::option::Option::Some("MASTER"),
+            Self::NodePool => std::option::Option::Some("NODE_POOL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UPGRADE_RESOURCE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::UPGRADE_RESOURCE_TYPE_UNSPECIFIED)
-            }
-            "MASTER" => std::option::Option::Some(Self::MASTER),
-            "NODE_POOL" => std::option::Option::Some(Self::NODE_POOL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for UpgradeResourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for UpgradeResourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for UpgradeResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for UpgradeResourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Master,
+            2 => Self::NodePool,
+            _ => Self::UnknownValue(upgrade_resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for UpgradeResourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UPGRADE_RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "MASTER" => Self::Master,
+            "NODE_POOL" => Self::NodePool,
+            _ => Self::UnknownValue(upgrade_resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for UpgradeResourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Master => serializer.serialize_i32(1),
+            Self::NodePool => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for UpgradeResourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<UpgradeResourceType>::new(
+            ".google.container.v1.UpgradeResourceType",
+        ))
     }
 }
 
 /// The datapath provider selects the implementation of the Kubernetes networking
 /// model for service resolution and network policy enforcement.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatapathProvider(i32);
-
-impl DatapathProvider {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatapathProvider {
     /// Default value.
-    pub const DATAPATH_PROVIDER_UNSPECIFIED: DatapathProvider = DatapathProvider::new(0);
-
+    Unspecified,
     /// Use the IPTables implementation based on kube-proxy.
-    pub const LEGACY_DATAPATH: DatapathProvider = DatapathProvider::new(1);
-
+    LegacyDatapath,
     /// Use the eBPF based GKE Dataplane V2 with additional features. See the [GKE
     /// Dataplane V2
     /// documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/dataplane-v2)
     /// for more.
-    pub const ADVANCED_DATAPATH: DatapathProvider = DatapathProvider::new(2);
+    AdvancedDatapath,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatapathProvider::value] or
+    /// [DatapathProvider::name].
+    UnknownValue(datapath_provider::UnknownValue),
+}
 
-    /// Creates a new DatapathProvider instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod datapath_provider {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DatapathProvider {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::LegacyDatapath => std::option::Option::Some(1),
+            Self::AdvancedDatapath => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATAPATH_PROVIDER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LEGACY_DATAPATH"),
-            2 => std::borrow::Cow::Borrowed("ADVANCED_DATAPATH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATAPATH_PROVIDER_UNSPECIFIED"),
+            Self::LegacyDatapath => std::option::Option::Some("LEGACY_DATAPATH"),
+            Self::AdvancedDatapath => std::option::Option::Some("ADVANCED_DATAPATH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATAPATH_PROVIDER_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATAPATH_PROVIDER_UNSPECIFIED)
-            }
-            "LEGACY_DATAPATH" => std::option::Option::Some(Self::LEGACY_DATAPATH),
-            "ADVANCED_DATAPATH" => std::option::Option::Some(Self::ADVANCED_DATAPATH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatapathProvider {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatapathProvider {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatapathProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatapathProvider {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::LegacyDatapath,
+            2 => Self::AdvancedDatapath,
+            _ => Self::UnknownValue(datapath_provider::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatapathProvider {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATAPATH_PROVIDER_UNSPECIFIED" => Self::Unspecified,
+            "LEGACY_DATAPATH" => Self::LegacyDatapath,
+            "ADVANCED_DATAPATH" => Self::AdvancedDatapath,
+            _ => Self::UnknownValue(datapath_provider::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatapathProvider {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::LegacyDatapath => serializer.serialize_i32(1),
+            Self::AdvancedDatapath => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatapathProvider {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatapathProvider>::new(
+            ".google.container.v1.DatapathProvider",
+        ))
     }
 }
 
 /// Strategy used for node pool update.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NodePoolUpdateStrategy(i32);
-
-impl NodePoolUpdateStrategy {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NodePoolUpdateStrategy {
     /// Default value if unset. GKE internally defaults the update strategy to
     /// SURGE for unspecified strategies.
-    pub const NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED: NodePoolUpdateStrategy =
-        NodePoolUpdateStrategy::new(0);
-
+    Unspecified,
     /// blue-green upgrade.
-    pub const BLUE_GREEN: NodePoolUpdateStrategy = NodePoolUpdateStrategy::new(2);
-
+    BlueGreen,
     /// SURGE is the traditional way of upgrade a node pool.
     /// max_surge and max_unavailable determines the level of upgrade parallelism.
-    pub const SURGE: NodePoolUpdateStrategy = NodePoolUpdateStrategy::new(3);
+    Surge,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NodePoolUpdateStrategy::value] or
+    /// [NodePoolUpdateStrategy::name].
+    UnknownValue(node_pool_update_strategy::UnknownValue),
+}
 
-    /// Creates a new NodePoolUpdateStrategy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod node_pool_update_strategy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl NodePoolUpdateStrategy {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::BlueGreen => std::option::Option::Some(2),
+            Self::Surge => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("BLUE_GREEN"),
-            3 => std::borrow::Cow::Borrowed("SURGE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED"),
+            Self::BlueGreen => std::option::Option::Some("BLUE_GREEN"),
+            Self::Surge => std::option::Option::Some("SURGE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED)
-            }
-            "BLUE_GREEN" => std::option::Option::Some(Self::BLUE_GREEN),
-            "SURGE" => std::option::Option::Some(Self::SURGE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NodePoolUpdateStrategy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NodePoolUpdateStrategy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NodePoolUpdateStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NodePoolUpdateStrategy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            2 => Self::BlueGreen,
+            3 => Self::Surge,
+            _ => Self::UnknownValue(node_pool_update_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NodePoolUpdateStrategy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED" => Self::Unspecified,
+            "BLUE_GREEN" => Self::BlueGreen,
+            "SURGE" => Self::Surge,
+            _ => Self::UnknownValue(node_pool_update_strategy::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NodePoolUpdateStrategy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::BlueGreen => serializer.serialize_i32(2),
+            Self::Surge => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NodePoolUpdateStrategy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NodePoolUpdateStrategy>::new(
+            ".google.container.v1.NodePoolUpdateStrategy",
+        ))
     }
 }
 
 /// Possible values for IP stack type
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StackType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum StackType {
+    /// Default value, will be defaulted as IPV4 only
+    Unspecified,
+    /// Cluster is IPV4 only
+    Ipv4,
+    /// Cluster can use both IPv4 and IPv6
+    Ipv4Ipv6,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [StackType::value] or
+    /// [StackType::name].
+    UnknownValue(stack_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod stack_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl StackType {
-    /// Default value, will be defaulted as IPV4 only
-    pub const STACK_TYPE_UNSPECIFIED: StackType = StackType::new(0);
-
-    /// Cluster is IPV4 only
-    pub const IPV4: StackType = StackType::new(1);
-
-    /// Cluster can use both IPv4 and IPv6
-    pub const IPV4_IPV6: StackType = StackType::new(2);
-
-    /// Creates a new StackType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Ipv4 => std::option::Option::Some(1),
+            Self::Ipv4Ipv6 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STACK_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IPV4"),
-            2 => std::borrow::Cow::Borrowed("IPV4_IPV6"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STACK_TYPE_UNSPECIFIED"),
+            Self::Ipv4 => std::option::Option::Some("IPV4"),
+            Self::Ipv4Ipv6 => std::option::Option::Some("IPV4_IPV6"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STACK_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STACK_TYPE_UNSPECIFIED),
-            "IPV4" => std::option::Option::Some(Self::IPV4),
-            "IPV4_IPV6" => std::option::Option::Some(Self::IPV4_IPV6),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for StackType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for StackType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for StackType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for StackType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Ipv4,
+            2 => Self::Ipv4Ipv6,
+            _ => Self::UnknownValue(stack_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for StackType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STACK_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "IPV4" => Self::Ipv4,
+            "IPV4_IPV6" => Self::Ipv4Ipv6,
+            _ => Self::UnknownValue(stack_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for StackType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Ipv4 => serializer.serialize_i32(1),
+            Self::Ipv4Ipv6 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for StackType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<StackType>::new(
+            ".google.container.v1.StackType",
+        ))
     }
 }
 
 /// Possible values for IPv6 access type
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IPv6AccessType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IPv6AccessType {
+    /// Default value, will be defaulted as type external.
+    Ipv6AccessTypeUnspecified,
+    /// Access type internal (all v6 addresses are internal IPs)
+    Internal,
+    /// Access type external (all v6 addresses are external IPs)
+    External,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IPv6AccessType::value] or
+    /// [IPv6AccessType::name].
+    UnknownValue(i_pv_6_access_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod i_pv_6_access_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl IPv6AccessType {
-    /// Default value, will be defaulted as type external.
-    pub const IPV6_ACCESS_TYPE_UNSPECIFIED: IPv6AccessType = IPv6AccessType::new(0);
-
-    /// Access type internal (all v6 addresses are internal IPs)
-    pub const INTERNAL: IPv6AccessType = IPv6AccessType::new(1);
-
-    /// Access type external (all v6 addresses are external IPs)
-    pub const EXTERNAL: IPv6AccessType = IPv6AccessType::new(2);
-
-    /// Creates a new IPv6AccessType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Ipv6AccessTypeUnspecified => std::option::Option::Some(0),
+            Self::Internal => std::option::Option::Some(1),
+            Self::External => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IPV6_ACCESS_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INTERNAL"),
-            2 => std::borrow::Cow::Borrowed("EXTERNAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IPV6_ACCESS_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::IPV6_ACCESS_TYPE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Ipv6AccessTypeUnspecified => {
+                std::option::Option::Some("IPV6_ACCESS_TYPE_UNSPECIFIED")
             }
-            "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
-            "EXTERNAL" => std::option::Option::Some(Self::EXTERNAL),
-            _ => std::option::Option::None,
+            Self::Internal => std::option::Option::Some("INTERNAL"),
+            Self::External => std::option::Option::Some("EXTERNAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for IPv6AccessType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IPv6AccessType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IPv6AccessType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IPv6AccessType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Ipv6AccessTypeUnspecified,
+            1 => Self::Internal,
+            2 => Self::External,
+            _ => Self::UnknownValue(i_pv_6_access_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IPv6AccessType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IPV6_ACCESS_TYPE_UNSPECIFIED" => Self::Ipv6AccessTypeUnspecified,
+            "INTERNAL" => Self::Internal,
+            "EXTERNAL" => Self::External,
+            _ => Self::UnknownValue(i_pv_6_access_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IPv6AccessType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Ipv6AccessTypeUnspecified => serializer.serialize_i32(0),
+            Self::Internal => serializer.serialize_i32(1),
+            Self::External => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IPv6AccessType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IPv6AccessType>::new(
+            ".google.container.v1.IPv6AccessType",
+        ))
     }
 }
 
 /// Options for in-transit encryption.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InTransitEncryptionConfig(i32);
-
-impl InTransitEncryptionConfig {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum InTransitEncryptionConfig {
     /// Unspecified, will be inferred as default -
     /// IN_TRANSIT_ENCRYPTION_UNSPECIFIED.
-    pub const IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED: InTransitEncryptionConfig =
-        InTransitEncryptionConfig::new(0);
-
+    Unspecified,
     /// In-transit encryption is disabled.
-    pub const IN_TRANSIT_ENCRYPTION_DISABLED: InTransitEncryptionConfig =
-        InTransitEncryptionConfig::new(1);
-
+    InTransitEncryptionDisabled,
     /// Data in-transit is encrypted using inter-node transparent encryption.
-    pub const IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT: InTransitEncryptionConfig =
-        InTransitEncryptionConfig::new(2);
+    InTransitEncryptionInterNodeTransparent,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [InTransitEncryptionConfig::value] or
+    /// [InTransitEncryptionConfig::name].
+    UnknownValue(in_transit_encryption_config::UnknownValue),
+}
 
-    /// Creates a new InTransitEncryptionConfig instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod in_transit_encryption_config {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl InTransitEncryptionConfig {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::InTransitEncryptionDisabled => std::option::Option::Some(1),
+            Self::InTransitEncryptionInterNodeTransparent => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("IN_TRANSIT_ENCRYPTION_DISABLED"),
-            2 => std::borrow::Cow::Borrowed("IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => {
+                std::option::Option::Some("IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED")
+            }
+            Self::InTransitEncryptionDisabled => {
+                std::option::Option::Some("IN_TRANSIT_ENCRYPTION_DISABLED")
+            }
+            Self::InTransitEncryptionInterNodeTransparent => {
+                std::option::Option::Some("IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED" => {
-                std::option::Option::Some(Self::IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED)
-            }
-            "IN_TRANSIT_ENCRYPTION_DISABLED" => {
-                std::option::Option::Some(Self::IN_TRANSIT_ENCRYPTION_DISABLED)
-            }
-            "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT" => {
-                std::option::Option::Some(Self::IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for InTransitEncryptionConfig {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for InTransitEncryptionConfig {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for InTransitEncryptionConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for InTransitEncryptionConfig {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::InTransitEncryptionDisabled,
+            2 => Self::InTransitEncryptionInterNodeTransparent,
+            _ => Self::UnknownValue(in_transit_encryption_config::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for InTransitEncryptionConfig {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "IN_TRANSIT_ENCRYPTION_CONFIG_UNSPECIFIED" => Self::Unspecified,
+            "IN_TRANSIT_ENCRYPTION_DISABLED" => Self::InTransitEncryptionDisabled,
+            "IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT" => {
+                Self::InTransitEncryptionInterNodeTransparent
+            }
+            _ => Self::UnknownValue(in_transit_encryption_config::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for InTransitEncryptionConfig {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::InTransitEncryptionDisabled => serializer.serialize_i32(1),
+            Self::InTransitEncryptionInterNodeTransparent => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for InTransitEncryptionConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<InTransitEncryptionConfig>::new(
+                ".google.container.v1.InTransitEncryptionConfig",
+            ),
+        )
     }
 }

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -128,86 +128,157 @@ pub mod common_metadata {
     use super::*;
 
     /// The various possible states for an ongoing Operation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// Request is being prepared for processing.
-        pub const INITIALIZING: State = State::new(1);
-
+        Initializing,
         /// Request is actively being processed.
-        pub const PROCESSING: State = State::new(2);
-
+        Processing,
         /// Request is in the process of being cancelled after user called
         /// google.longrunning.Operations.CancelOperation on the operation.
-        pub const CANCELLING: State = State::new(3);
-
+        Cancelling,
         /// Request has been processed and is in its finalization stage.
-        pub const FINALIZING: State = State::new(4);
-
+        Finalizing,
         /// Request has completed successfully.
-        pub const SUCCESSFUL: State = State::new(5);
-
+        Successful,
         /// Request has finished being processed, but encountered an error.
-        pub const FAILED: State = State::new(6);
-
+        Failed,
         /// Request has finished being cancelled after user called
         /// google.longrunning.Operations.CancelOperation.
-        pub const CANCELLED: State = State::new(7);
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Initializing => std::option::Option::Some(1),
+                Self::Processing => std::option::Option::Some(2),
+                Self::Cancelling => std::option::Option::Some(3),
+                Self::Finalizing => std::option::Option::Some(4),
+                Self::Successful => std::option::Option::Some(5),
+                Self::Failed => std::option::Option::Some(6),
+                Self::Cancelled => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INITIALIZING"),
-                2 => std::borrow::Cow::Borrowed("PROCESSING"),
-                3 => std::borrow::Cow::Borrowed("CANCELLING"),
-                4 => std::borrow::Cow::Borrowed("FINALIZING"),
-                5 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
-                6 => std::borrow::Cow::Borrowed("FAILED"),
-                7 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Initializing => std::option::Option::Some("INITIALIZING"),
+                Self::Processing => std::option::Option::Some("PROCESSING"),
+                Self::Cancelling => std::option::Option::Some("CANCELLING"),
+                Self::Finalizing => std::option::Option::Some("FINALIZING"),
+                Self::Successful => std::option::Option::Some("SUCCESSFUL"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
-                "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
-                "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-                "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
-                "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Initializing,
+                2 => Self::Processing,
+                3 => Self::Cancelling,
+                4 => Self::Finalizing,
+                5 => Self::Successful,
+                6 => Self::Failed,
+                7 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "INITIALIZING" => Self::Initializing,
+                "PROCESSING" => Self::Processing,
+                "CANCELLING" => Self::Cancelling,
+                "FINALIZING" => Self::Finalizing,
+                "SUCCESSFUL" => Self::Successful,
+                "FAILED" => Self::Failed,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Initializing => serializer.serialize_i32(1),
+                Self::Processing => serializer.serialize_i32(2),
+                Self::Cancelling => serializer.serialize_i32(3),
+                Self::Finalizing => serializer.serialize_i32(4),
+                Self::Successful => serializer.serialize_i32(5),
+                Self::Failed => serializer.serialize_i32(6),
+                Self::Cancelled => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.datastore.admin.v1.CommonMetadata.State",
+            ))
         }
     }
 }
@@ -1289,200 +1360,385 @@ pub mod index {
 
     /// For an ordered index, specifies whether each of the entity's ancestors
     /// will be included.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AncestorMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AncestorMode {
+        /// The ancestor mode is unspecified.
+        Unspecified,
+        /// Do not include the entity's ancestors in the index.
+        None,
+        /// Include all the entity's ancestors in the index.
+        AllAncestors,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AncestorMode::value] or
+        /// [AncestorMode::name].
+        UnknownValue(ancestor_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ancestor_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AncestorMode {
-        /// The ancestor mode is unspecified.
-        pub const ANCESTOR_MODE_UNSPECIFIED: AncestorMode = AncestorMode::new(0);
-
-        /// Do not include the entity's ancestors in the index.
-        pub const NONE: AncestorMode = AncestorMode::new(1);
-
-        /// Include all the entity's ancestors in the index.
-        pub const ALL_ANCESTORS: AncestorMode = AncestorMode::new(2);
-
-        /// Creates a new AncestorMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::AllAncestors => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANCESTOR_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("ALL_ANCESTORS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANCESTOR_MODE_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::AllAncestors => std::option::Option::Some("ALL_ANCESTORS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANCESTOR_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ANCESTOR_MODE_UNSPECIFIED)
-                }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "ALL_ANCESTORS" => std::option::Option::Some(Self::ALL_ANCESTORS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AncestorMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AncestorMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AncestorMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AncestorMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::AllAncestors,
+                _ => Self::UnknownValue(ancestor_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AncestorMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANCESTOR_MODE_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "ALL_ANCESTORS" => Self::AllAncestors,
+                _ => Self::UnknownValue(ancestor_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AncestorMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::AllAncestors => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AncestorMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AncestorMode>::new(
+                ".google.datastore.admin.v1.Index.AncestorMode",
+            ))
         }
     }
 
     /// The direction determines how a property is indexed.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Direction(i32);
-
-    impl Direction {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Direction {
         /// The direction is unspecified.
-        pub const DIRECTION_UNSPECIFIED: Direction = Direction::new(0);
-
+        Unspecified,
         /// The property's values are indexed so as to support sequencing in
         /// ascending order and also query by <, >, <=, >=, and =.
-        pub const ASCENDING: Direction = Direction::new(1);
-
+        Ascending,
         /// The property's values are indexed so as to support sequencing in
         /// descending order and also query by <, >, <=, >=, and =.
-        pub const DESCENDING: Direction = Direction::new(2);
+        Descending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Direction::value] or
+        /// [Direction::name].
+        UnknownValue(direction::UnknownValue),
+    }
 
-        /// Creates a new Direction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod direction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Direction {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ascending => std::option::Option::Some(1),
+                Self::Descending => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DIRECTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ASCENDING"),
-                2 => std::borrow::Cow::Borrowed("DESCENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DIRECTION_UNSPECIFIED"),
+                Self::Ascending => std::option::Option::Some("ASCENDING"),
+                Self::Descending => std::option::Option::Some("DESCENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DIRECTION_UNSPECIFIED" => std::option::Option::Some(Self::DIRECTION_UNSPECIFIED),
-                "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
-                "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Direction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Direction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Direction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Direction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ascending,
+                2 => Self::Descending,
+                _ => Self::UnknownValue(direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Direction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DIRECTION_UNSPECIFIED" => Self::Unspecified,
+                "ASCENDING" => Self::Ascending,
+                "DESCENDING" => Self::Descending,
+                _ => Self::UnknownValue(direction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Direction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ascending => serializer.serialize_i32(1),
+                Self::Descending => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Direction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Direction>::new(
+                ".google.datastore.admin.v1.Index.Direction",
+            ))
         }
     }
 
     /// The possible set of states of an index.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The index is being created, and cannot be used by queries.
         /// There is an active long-running operation for the index.
         /// The index is updated when writing an entity.
         /// Some index data may exist.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The index is ready to be used.
         /// The index is updated when writing an entity.
         /// The index is fully populated from all stored entities it applies to.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The index is being deleted, and cannot be used by queries.
         /// There is an active long-running operation for the index.
         /// The index is not updated when writing an entity.
         /// Some index data may exist.
-        pub const DELETING: State = State::new(3);
-
+        Deleting,
         /// The index was being created or deleted, but something went wrong.
         /// The index cannot by used by queries.
         /// There is no active long-running operation for the index,
         /// and the most recently finished long-running operation failed.
         /// The index is not updated when writing an entity.
         /// Some index data may exist.
-        pub const ERROR: State = State::new(4);
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Error => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::Deleting,
+                4 => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "DELETING" => Self::Deleting,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Error => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.datastore.admin.v1.Index.State",
+            ))
         }
     }
 }
@@ -1729,68 +1985,129 @@ pub mod migration_progress_event {
     }
 
     /// Concurrency modes for transactions in Cloud Firestore.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConcurrencyMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConcurrencyMode {
+        /// Unspecified.
+        Unspecified,
+        /// Pessimistic concurrency.
+        Pessimistic,
+        /// Optimistic concurrency.
+        Optimistic,
+        /// Optimistic concurrency with entity groups.
+        OptimisticWithEntityGroups,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConcurrencyMode::value] or
+        /// [ConcurrencyMode::name].
+        UnknownValue(concurrency_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod concurrency_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConcurrencyMode {
-        /// Unspecified.
-        pub const CONCURRENCY_MODE_UNSPECIFIED: ConcurrencyMode = ConcurrencyMode::new(0);
-
-        /// Pessimistic concurrency.
-        pub const PESSIMISTIC: ConcurrencyMode = ConcurrencyMode::new(1);
-
-        /// Optimistic concurrency.
-        pub const OPTIMISTIC: ConcurrencyMode = ConcurrencyMode::new(2);
-
-        /// Optimistic concurrency with entity groups.
-        pub const OPTIMISTIC_WITH_ENTITY_GROUPS: ConcurrencyMode = ConcurrencyMode::new(3);
-
-        /// Creates a new ConcurrencyMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pessimistic => std::option::Option::Some(1),
+                Self::Optimistic => std::option::Option::Some(2),
+                Self::OptimisticWithEntityGroups => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONCURRENCY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PESSIMISTIC"),
-                2 => std::borrow::Cow::Borrowed("OPTIMISTIC"),
-                3 => std::borrow::Cow::Borrowed("OPTIMISTIC_WITH_ENTITY_GROUPS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONCURRENCY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONCURRENCY_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONCURRENCY_MODE_UNSPECIFIED"),
+                Self::Pessimistic => std::option::Option::Some("PESSIMISTIC"),
+                Self::Optimistic => std::option::Option::Some("OPTIMISTIC"),
+                Self::OptimisticWithEntityGroups => {
+                    std::option::Option::Some("OPTIMISTIC_WITH_ENTITY_GROUPS")
                 }
-                "PESSIMISTIC" => std::option::Option::Some(Self::PESSIMISTIC),
-                "OPTIMISTIC" => std::option::Option::Some(Self::OPTIMISTIC),
-                "OPTIMISTIC_WITH_ENTITY_GROUPS" => {
-                    std::option::Option::Some(Self::OPTIMISTIC_WITH_ENTITY_GROUPS)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ConcurrencyMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConcurrencyMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConcurrencyMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConcurrencyMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pessimistic,
+                2 => Self::Optimistic,
+                3 => Self::OptimisticWithEntityGroups,
+                _ => Self::UnknownValue(concurrency_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConcurrencyMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONCURRENCY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "PESSIMISTIC" => Self::Pessimistic,
+                "OPTIMISTIC" => Self::Optimistic,
+                "OPTIMISTIC_WITH_ENTITY_GROUPS" => Self::OptimisticWithEntityGroups,
+                _ => Self::UnknownValue(concurrency_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConcurrencyMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pessimistic => serializer.serialize_i32(1),
+                Self::Optimistic => serializer.serialize_i32(2),
+                Self::OptimisticWithEntityGroups => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConcurrencyMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConcurrencyMode>::new(
+                ".google.datastore.admin.v1.MigrationProgressEvent.ConcurrencyMode",
+            ))
         }
     }
 
@@ -1811,225 +2128,418 @@ pub mod migration_progress_event {
 }
 
 /// Operation types.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperationType {
+    /// Unspecified.
+    Unspecified,
+    /// ExportEntities.
+    ExportEntities,
+    /// ImportEntities.
+    ImportEntities,
+    /// CreateIndex.
+    CreateIndex,
+    /// DeleteIndex.
+    DeleteIndex,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperationType::value] or
+    /// [OperationType::name].
+    UnknownValue(operation_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod operation_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl OperationType {
-    /// Unspecified.
-    pub const OPERATION_TYPE_UNSPECIFIED: OperationType = OperationType::new(0);
-
-    /// ExportEntities.
-    pub const EXPORT_ENTITIES: OperationType = OperationType::new(1);
-
-    /// ImportEntities.
-    pub const IMPORT_ENTITIES: OperationType = OperationType::new(2);
-
-    /// CreateIndex.
-    pub const CREATE_INDEX: OperationType = OperationType::new(3);
-
-    /// DeleteIndex.
-    pub const DELETE_INDEX: OperationType = OperationType::new(4);
-
-    /// Creates a new OperationType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::ExportEntities => std::option::Option::Some(1),
+            Self::ImportEntities => std::option::Option::Some(2),
+            Self::CreateIndex => std::option::Option::Some(3),
+            Self::DeleteIndex => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EXPORT_ENTITIES"),
-            2 => std::borrow::Cow::Borrowed("IMPORT_ENTITIES"),
-            3 => std::borrow::Cow::Borrowed("CREATE_INDEX"),
-            4 => std::borrow::Cow::Borrowed("DELETE_INDEX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OPERATION_TYPE_UNSPECIFIED"),
+            Self::ExportEntities => std::option::Option::Some("EXPORT_ENTITIES"),
+            Self::ImportEntities => std::option::Option::Some("IMPORT_ENTITIES"),
+            Self::CreateIndex => std::option::Option::Some("CREATE_INDEX"),
+            Self::DeleteIndex => std::option::Option::Some("DELETE_INDEX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATION_TYPE_UNSPECIFIED)
-            }
-            "EXPORT_ENTITIES" => std::option::Option::Some(Self::EXPORT_ENTITIES),
-            "IMPORT_ENTITIES" => std::option::Option::Some(Self::IMPORT_ENTITIES),
-            "CREATE_INDEX" => std::option::Option::Some(Self::CREATE_INDEX),
-            "DELETE_INDEX" => std::option::Option::Some(Self::DELETE_INDEX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperationType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperationType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::ExportEntities,
+            2 => Self::ImportEntities,
+            3 => Self::CreateIndex,
+            4 => Self::DeleteIndex,
+            _ => Self::UnknownValue(operation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperationType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "EXPORT_ENTITIES" => Self::ExportEntities,
+            "IMPORT_ENTITIES" => Self::ImportEntities,
+            "CREATE_INDEX" => Self::CreateIndex,
+            "DELETE_INDEX" => Self::DeleteIndex,
+            _ => Self::UnknownValue(operation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperationType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::ExportEntities => serializer.serialize_i32(1),
+            Self::ImportEntities => serializer.serialize_i32(2),
+            Self::CreateIndex => serializer.serialize_i32(3),
+            Self::DeleteIndex => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperationType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationType>::new(
+            ".google.datastore.admin.v1.OperationType",
+        ))
     }
 }
 
 /// States for a migration.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MigrationState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MigrationState {
+    /// Unspecified.
+    Unspecified,
+    /// The migration is running.
+    Running,
+    /// The migration is paused.
+    Paused,
+    /// The migration is complete.
+    Complete,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MigrationState::value] or
+    /// [MigrationState::name].
+    UnknownValue(migration_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod migration_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl MigrationState {
-    /// Unspecified.
-    pub const MIGRATION_STATE_UNSPECIFIED: MigrationState = MigrationState::new(0);
-
-    /// The migration is running.
-    pub const RUNNING: MigrationState = MigrationState::new(1);
-
-    /// The migration is paused.
-    pub const PAUSED: MigrationState = MigrationState::new(2);
-
-    /// The migration is complete.
-    pub const COMPLETE: MigrationState = MigrationState::new(3);
-
-    /// Creates a new MigrationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Running => std::option::Option::Some(1),
+            Self::Paused => std::option::Option::Some(2),
+            Self::Complete => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MIGRATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RUNNING"),
-            2 => std::borrow::Cow::Borrowed("PAUSED"),
-            3 => std::borrow::Cow::Borrowed("COMPLETE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MIGRATION_STATE_UNSPECIFIED"),
+            Self::Running => std::option::Option::Some("RUNNING"),
+            Self::Paused => std::option::Option::Some("PAUSED"),
+            Self::Complete => std::option::Option::Some("COMPLETE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MIGRATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MIGRATION_STATE_UNSPECIFIED)
-            }
-            "RUNNING" => std::option::Option::Some(Self::RUNNING),
-            "PAUSED" => std::option::Option::Some(Self::PAUSED),
-            "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MigrationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MigrationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MigrationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MigrationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Running,
+            2 => Self::Paused,
+            3 => Self::Complete,
+            _ => Self::UnknownValue(migration_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MigrationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MIGRATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "RUNNING" => Self::Running,
+            "PAUSED" => Self::Paused,
+            "COMPLETE" => Self::Complete,
+            _ => Self::UnknownValue(migration_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MigrationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Running => serializer.serialize_i32(1),
+            Self::Paused => serializer.serialize_i32(2),
+            Self::Complete => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MigrationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MigrationState>::new(
+            ".google.datastore.admin.v1.MigrationState",
+        ))
     }
 }
 
 /// Steps in a migration.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MigrationStep(i32);
-
-impl MigrationStep {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MigrationStep {
     /// Unspecified.
-    pub const MIGRATION_STEP_UNSPECIFIED: MigrationStep = MigrationStep::new(0);
-
+    Unspecified,
     /// Pre-migration: the database is prepared for migration.
-    pub const PREPARE: MigrationStep = MigrationStep::new(6);
-
+    Prepare,
     /// Start of migration.
-    pub const START: MigrationStep = MigrationStep::new(1);
-
+    Start,
     /// Writes are applied synchronously to at least one replica.
-    pub const APPLY_WRITES_SYNCHRONOUSLY: MigrationStep = MigrationStep::new(7);
-
+    ApplyWritesSynchronously,
     /// Data is copied to Cloud Firestore and then verified to match the data in
     /// Cloud Datastore.
-    pub const COPY_AND_VERIFY: MigrationStep = MigrationStep::new(2);
-
+    CopyAndVerify,
     /// Eventually-consistent reads are redirected to Cloud Firestore.
-    pub const REDIRECT_EVENTUALLY_CONSISTENT_READS: MigrationStep = MigrationStep::new(3);
-
+    RedirectEventuallyConsistentReads,
     /// Strongly-consistent reads are redirected to Cloud Firestore.
-    pub const REDIRECT_STRONGLY_CONSISTENT_READS: MigrationStep = MigrationStep::new(4);
-
+    RedirectStronglyConsistentReads,
     /// Writes are redirected to Cloud Firestore.
-    pub const REDIRECT_WRITES: MigrationStep = MigrationStep::new(5);
+    RedirectWrites,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MigrationStep::value] or
+    /// [MigrationStep::name].
+    UnknownValue(migration_step::UnknownValue),
+}
 
-    /// Creates a new MigrationStep instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod migration_step {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl MigrationStep {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Prepare => std::option::Option::Some(6),
+            Self::Start => std::option::Option::Some(1),
+            Self::ApplyWritesSynchronously => std::option::Option::Some(7),
+            Self::CopyAndVerify => std::option::Option::Some(2),
+            Self::RedirectEventuallyConsistentReads => std::option::Option::Some(3),
+            Self::RedirectStronglyConsistentReads => std::option::Option::Some(4),
+            Self::RedirectWrites => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MIGRATION_STEP_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("START"),
-            2 => std::borrow::Cow::Borrowed("COPY_AND_VERIFY"),
-            3 => std::borrow::Cow::Borrowed("REDIRECT_EVENTUALLY_CONSISTENT_READS"),
-            4 => std::borrow::Cow::Borrowed("REDIRECT_STRONGLY_CONSISTENT_READS"),
-            5 => std::borrow::Cow::Borrowed("REDIRECT_WRITES"),
-            6 => std::borrow::Cow::Borrowed("PREPARE"),
-            7 => std::borrow::Cow::Borrowed("APPLY_WRITES_SYNCHRONOUSLY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MIGRATION_STEP_UNSPECIFIED"),
+            Self::Prepare => std::option::Option::Some("PREPARE"),
+            Self::Start => std::option::Option::Some("START"),
+            Self::ApplyWritesSynchronously => {
+                std::option::Option::Some("APPLY_WRITES_SYNCHRONOUSLY")
+            }
+            Self::CopyAndVerify => std::option::Option::Some("COPY_AND_VERIFY"),
+            Self::RedirectEventuallyConsistentReads => {
+                std::option::Option::Some("REDIRECT_EVENTUALLY_CONSISTENT_READS")
+            }
+            Self::RedirectStronglyConsistentReads => {
+                std::option::Option::Some("REDIRECT_STRONGLY_CONSISTENT_READS")
+            }
+            Self::RedirectWrites => std::option::Option::Some("REDIRECT_WRITES"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MIGRATION_STEP_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MIGRATION_STEP_UNSPECIFIED)
-            }
-            "PREPARE" => std::option::Option::Some(Self::PREPARE),
-            "START" => std::option::Option::Some(Self::START),
-            "APPLY_WRITES_SYNCHRONOUSLY" => {
-                std::option::Option::Some(Self::APPLY_WRITES_SYNCHRONOUSLY)
-            }
-            "COPY_AND_VERIFY" => std::option::Option::Some(Self::COPY_AND_VERIFY),
-            "REDIRECT_EVENTUALLY_CONSISTENT_READS" => {
-                std::option::Option::Some(Self::REDIRECT_EVENTUALLY_CONSISTENT_READS)
-            }
-            "REDIRECT_STRONGLY_CONSISTENT_READS" => {
-                std::option::Option::Some(Self::REDIRECT_STRONGLY_CONSISTENT_READS)
-            }
-            "REDIRECT_WRITES" => std::option::Option::Some(Self::REDIRECT_WRITES),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MigrationStep {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MigrationStep {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MigrationStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MigrationStep {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Start,
+            2 => Self::CopyAndVerify,
+            3 => Self::RedirectEventuallyConsistentReads,
+            4 => Self::RedirectStronglyConsistentReads,
+            5 => Self::RedirectWrites,
+            6 => Self::Prepare,
+            7 => Self::ApplyWritesSynchronously,
+            _ => Self::UnknownValue(migration_step::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MigrationStep {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MIGRATION_STEP_UNSPECIFIED" => Self::Unspecified,
+            "PREPARE" => Self::Prepare,
+            "START" => Self::Start,
+            "APPLY_WRITES_SYNCHRONOUSLY" => Self::ApplyWritesSynchronously,
+            "COPY_AND_VERIFY" => Self::CopyAndVerify,
+            "REDIRECT_EVENTUALLY_CONSISTENT_READS" => Self::RedirectEventuallyConsistentReads,
+            "REDIRECT_STRONGLY_CONSISTENT_READS" => Self::RedirectStronglyConsistentReads,
+            "REDIRECT_WRITES" => Self::RedirectWrites,
+            _ => Self::UnknownValue(migration_step::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MigrationStep {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Prepare => serializer.serialize_i32(6),
+            Self::Start => serializer.serialize_i32(1),
+            Self::ApplyWritesSynchronously => serializer.serialize_i32(7),
+            Self::CopyAndVerify => serializer.serialize_i32(2),
+            Self::RedirectEventuallyConsistentReads => serializer.serialize_i32(3),
+            Self::RedirectStronglyConsistentReads => serializer.serialize_i32(4),
+            Self::RedirectWrites => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MigrationStep {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MigrationStep>::new(
+            ".google.datastore.admin.v1.MigrationStep",
+        ))
     }
 }

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -129,61 +129,120 @@ pub mod apt_artifact {
     use super::*;
 
     /// Package type is either binary or source.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PackageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PackageType {
+        /// Package type is not specified.
+        Unspecified,
+        /// Binary package.
+        Binary,
+        /// Source package.
+        Source,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PackageType::value] or
+        /// [PackageType::name].
+        UnknownValue(package_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod package_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PackageType {
-        /// Package type is not specified.
-        pub const PACKAGE_TYPE_UNSPECIFIED: PackageType = PackageType::new(0);
-
-        /// Binary package.
-        pub const BINARY: PackageType = PackageType::new(1);
-
-        /// Source package.
-        pub const SOURCE: PackageType = PackageType::new(2);
-
-        /// Creates a new PackageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Binary => std::option::Option::Some(1),
+                Self::Source => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PACKAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BINARY"),
-                2 => std::borrow::Cow::Borrowed("SOURCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PACKAGE_TYPE_UNSPECIFIED"),
+                Self::Binary => std::option::Option::Some("BINARY"),
+                Self::Source => std::option::Option::Some("SOURCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PACKAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PACKAGE_TYPE_UNSPECIFIED)
-                }
-                "BINARY" => std::option::Option::Some(Self::BINARY),
-                "SOURCE" => std::option::Option::Some(Self::SOURCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PackageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PackageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PackageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PackageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Binary,
+                2 => Self::Source,
+                _ => Self::UnknownValue(package_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PackageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PACKAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BINARY" => Self::Binary,
+                "SOURCE" => Self::Source,
+                _ => Self::UnknownValue(package_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PackageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Binary => serializer.serialize_i32(1),
+                Self::Source => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PackageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PackageType>::new(
+                ".google.devtools.artifactregistry.v1.AptArtifact.PackageType",
+            ))
         }
     }
 }
@@ -2003,59 +2062,120 @@ pub mod hash {
     use super::*;
 
     /// The algorithm used to compute the hash.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HashType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HashType {
+        /// Unspecified.
+        Unspecified,
+        /// SHA256 hash.
+        Sha256,
+        /// MD5 hash.
+        Md5,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HashType::value] or
+        /// [HashType::name].
+        UnknownValue(hash_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod hash_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HashType {
-        /// Unspecified.
-        pub const HASH_TYPE_UNSPECIFIED: HashType = HashType::new(0);
-
-        /// SHA256 hash.
-        pub const SHA256: HashType = HashType::new(1);
-
-        /// MD5 hash.
-        pub const MD5: HashType = HashType::new(2);
-
-        /// Creates a new HashType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Sha256 => std::option::Option::Some(1),
+                Self::Md5 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("HASH_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SHA256"),
-                2 => std::borrow::Cow::Borrowed("MD5"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("HASH_TYPE_UNSPECIFIED"),
+                Self::Sha256 => std::option::Option::Some("SHA256"),
+                Self::Md5 => std::option::Option::Some("MD5"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "HASH_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::HASH_TYPE_UNSPECIFIED),
-                "SHA256" => std::option::Option::Some(Self::SHA256),
-                "MD5" => std::option::Option::Some(Self::MD5),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HashType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HashType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HashType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HashType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Sha256,
+                2 => Self::Md5,
+                _ => Self::UnknownValue(hash_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HashType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "HASH_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SHA256" => Self::Sha256,
+                "MD5" => Self::Md5,
+                _ => Self::UnknownValue(hash_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HashType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Sha256 => serializer.serialize_i32(1),
+                Self::Md5 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HashType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HashType>::new(
+                ".google.devtools.artifactregistry.v1.Hash.HashType",
+            ))
         }
     }
 }
@@ -3219,64 +3339,127 @@ pub mod cleanup_policy_condition {
     use super::*;
 
     /// Statuses applying to versions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TagState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TagState {
+        /// Tag status not specified.
+        Unspecified,
+        /// Applies to tagged versions only.
+        Tagged,
+        /// Applies to untagged versions only.
+        Untagged,
+        /// Applies to all versions.
+        Any,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TagState::value] or
+        /// [TagState::name].
+        UnknownValue(tag_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod tag_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TagState {
-        /// Tag status not specified.
-        pub const TAG_STATE_UNSPECIFIED: TagState = TagState::new(0);
-
-        /// Applies to tagged versions only.
-        pub const TAGGED: TagState = TagState::new(1);
-
-        /// Applies to untagged versions only.
-        pub const UNTAGGED: TagState = TagState::new(2);
-
-        /// Applies to all versions.
-        pub const ANY: TagState = TagState::new(3);
-
-        /// Creates a new TagState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tagged => std::option::Option::Some(1),
+                Self::Untagged => std::option::Option::Some(2),
+                Self::Any => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TAG_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TAGGED"),
-                2 => std::borrow::Cow::Borrowed("UNTAGGED"),
-                3 => std::borrow::Cow::Borrowed("ANY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TAG_STATE_UNSPECIFIED"),
+                Self::Tagged => std::option::Option::Some("TAGGED"),
+                Self::Untagged => std::option::Option::Some("UNTAGGED"),
+                Self::Any => std::option::Option::Some("ANY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TAG_STATE_UNSPECIFIED" => std::option::Option::Some(Self::TAG_STATE_UNSPECIFIED),
-                "TAGGED" => std::option::Option::Some(Self::TAGGED),
-                "UNTAGGED" => std::option::Option::Some(Self::UNTAGGED),
-                "ANY" => std::option::Option::Some(Self::ANY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TagState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TagState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TagState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TagState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tagged,
+                2 => Self::Untagged,
+                3 => Self::Any,
+                _ => Self::UnknownValue(tag_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TagState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TAG_STATE_UNSPECIFIED" => Self::Unspecified,
+                "TAGGED" => Self::Tagged,
+                "UNTAGGED" => Self::Untagged,
+                "ANY" => Self::Any,
+                _ => Self::UnknownValue(tag_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TagState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tagged => serializer.serialize_i32(1),
+                Self::Untagged => serializer.serialize_i32(2),
+                Self::Any => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TagState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TagState>::new(
+                ".google.devtools.artifactregistry.v1.CleanupPolicyCondition.TagState",
+            ))
         }
     }
 }
@@ -3460,59 +3643,120 @@ pub mod cleanup_policy {
     use super::*;
 
     /// Action type for a cleanup policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Action not specified.
+        Unspecified,
+        /// Delete action.
+        Delete,
+        /// Keep action.
+        Keep,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Action not specified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Delete action.
-        pub const DELETE: Action = Action::new(1);
-
-        /// Keep action.
-        pub const KEEP: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Delete => std::option::Option::Some(1),
+                Self::Keep => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DELETE"),
-                2 => std::borrow::Cow::Borrowed("KEEP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Keep => std::option::Option::Some("KEEP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "KEEP" => std::option::Option::Some(Self::KEEP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Delete,
+                2 => Self::Keep,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "DELETE" => Self::Delete,
+                "KEEP" => Self::Keep,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Delete => serializer.serialize_i32(1),
+                Self::Keep => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.devtools.artifactregistry.v1.CleanupPolicy.Action",
+            ))
         }
     }
 
@@ -4191,56 +4435,115 @@ pub mod remote_repository_config {
 
         /// Predefined list of publicly available Docker repositories like Docker
         /// Hub.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PublicRepository {
+            /// Unspecified repository.
+            Unspecified,
+            /// Docker Hub.
+            DockerHub,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PublicRepository::value] or
+            /// [PublicRepository::name].
+            UnknownValue(public_repository::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod public_repository {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PublicRepository {
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
-
-            /// Docker Hub.
-            pub const DOCKER_HUB: PublicRepository = PublicRepository::new(1);
-
-            /// Creates a new PublicRepository instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::DockerHub => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("DOCKER_HUB"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    Self::DockerHub => std::option::Option::Some("DOCKER_HUB"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
-                    }
-                    "DOCKER_HUB" => std::option::Option::Some(Self::DOCKER_HUB),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for PublicRepository {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PublicRepository {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::DockerHub,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PublicRepository {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => Self::Unspecified,
+                    "DOCKER_HUB" => Self::DockerHub,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PublicRepository {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::DockerHub => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PublicRepository {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PublicRepository>::new(
+                    ".google.devtools.artifactregistry.v1.RemoteRepositoryConfig.DockerRepository.PublicRepository"))
             }
         }
 
@@ -4424,56 +4727,115 @@ pub mod remote_repository_config {
 
         /// Predefined list of publicly available Maven repositories like Maven
         /// Central.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PublicRepository {
+            /// Unspecified repository.
+            Unspecified,
+            /// Maven Central.
+            MavenCentral,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PublicRepository::value] or
+            /// [PublicRepository::name].
+            UnknownValue(public_repository::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod public_repository {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PublicRepository {
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
-
-            /// Maven Central.
-            pub const MAVEN_CENTRAL: PublicRepository = PublicRepository::new(1);
-
-            /// Creates a new PublicRepository instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::MavenCentral => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("MAVEN_CENTRAL"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    Self::MavenCentral => std::option::Option::Some("MAVEN_CENTRAL"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
-                    }
-                    "MAVEN_CENTRAL" => std::option::Option::Some(Self::MAVEN_CENTRAL),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for PublicRepository {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PublicRepository {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::MavenCentral,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PublicRepository {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => Self::Unspecified,
+                    "MAVEN_CENTRAL" => Self::MavenCentral,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PublicRepository {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::MavenCentral => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PublicRepository {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PublicRepository>::new(
+                    ".google.devtools.artifactregistry.v1.RemoteRepositoryConfig.MavenRepository.PublicRepository"))
             }
         }
 
@@ -4656,56 +5018,115 @@ pub mod remote_repository_config {
         }
 
         /// Predefined list of publicly available NPM repositories like npmjs.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PublicRepository {
+            /// Unspecified repository.
+            Unspecified,
+            /// npmjs.
+            Npmjs,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PublicRepository::value] or
+            /// [PublicRepository::name].
+            UnknownValue(public_repository::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod public_repository {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PublicRepository {
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
-
-            /// npmjs.
-            pub const NPMJS: PublicRepository = PublicRepository::new(1);
-
-            /// Creates a new PublicRepository instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Npmjs => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NPMJS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    Self::Npmjs => std::option::Option::Some("NPMJS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
-                    }
-                    "NPMJS" => std::option::Option::Some(Self::NPMJS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for PublicRepository {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PublicRepository {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Npmjs,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PublicRepository {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => Self::Unspecified,
+                    "NPMJS" => Self::Npmjs,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PublicRepository {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Npmjs => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PublicRepository {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PublicRepository>::new(
+                    ".google.devtools.artifactregistry.v1.RemoteRepositoryConfig.NpmRepository.PublicRepository"))
             }
         }
 
@@ -4889,56 +5310,115 @@ pub mod remote_repository_config {
         }
 
         /// Predefined list of publicly available Python repositories like PyPI.org.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PublicRepository(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PublicRepository {
+            /// Unspecified repository.
+            Unspecified,
+            /// PyPI.
+            Pypi,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PublicRepository::value] or
+            /// [PublicRepository::name].
+            UnknownValue(public_repository::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod public_repository {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PublicRepository {
-            /// Unspecified repository.
-            pub const PUBLIC_REPOSITORY_UNSPECIFIED: PublicRepository = PublicRepository::new(0);
-
-            /// PyPI.
-            pub const PYPI: PublicRepository = PublicRepository::new(1);
-
-            /// Creates a new PublicRepository instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Pypi => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PUBLIC_REPOSITORY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PYPI"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PUBLIC_REPOSITORY_UNSPECIFIED"),
+                    Self::Pypi => std::option::Option::Some("PYPI"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PUBLIC_REPOSITORY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::PUBLIC_REPOSITORY_UNSPECIFIED)
-                    }
-                    "PYPI" => std::option::Option::Some(Self::PYPI),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for PublicRepository {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PublicRepository {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PublicRepository {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PublicRepository {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Pypi,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PublicRepository {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PUBLIC_REPOSITORY_UNSPECIFIED" => Self::Unspecified,
+                    "PYPI" => Self::Pypi,
+                    _ => Self::UnknownValue(public_repository::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PublicRepository {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Pypi => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PublicRepository {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PublicRepository>::new(
+                    ".google.devtools.artifactregistry.v1.RemoteRepositoryConfig.PythonRepository.PublicRepository"))
             }
         }
 
@@ -5143,66 +5623,131 @@ pub mod remote_repository_config {
             use super::*;
 
             /// Predefined list of publicly available repository bases for Apt.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct RepositoryBase(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum RepositoryBase {
+                /// Unspecified repository base.
+                Unspecified,
+                /// Debian.
+                Debian,
+                /// Ubuntu LTS/Pro.
+                Ubuntu,
+                /// Archived Debian.
+                DebianSnapshot,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [RepositoryBase::value] or
+                /// [RepositoryBase::name].
+                UnknownValue(repository_base::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod repository_base {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl RepositoryBase {
-                /// Unspecified repository base.
-                pub const REPOSITORY_BASE_UNSPECIFIED: RepositoryBase = RepositoryBase::new(0);
-
-                /// Debian.
-                pub const DEBIAN: RepositoryBase = RepositoryBase::new(1);
-
-                /// Ubuntu LTS/Pro.
-                pub const UBUNTU: RepositoryBase = RepositoryBase::new(2);
-
-                /// Archived Debian.
-                pub const DEBIAN_SNAPSHOT: RepositoryBase = RepositoryBase::new(3);
-
-                /// Creates a new RepositoryBase instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Debian => std::option::Option::Some(1),
+                        Self::Ubuntu => std::option::Option::Some(2),
+                        Self::DebianSnapshot => std::option::Option::Some(3),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("REPOSITORY_BASE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("DEBIAN"),
-                        2 => std::borrow::Cow::Borrowed("UBUNTU"),
-                        3 => std::borrow::Cow::Borrowed("DEBIAN_SNAPSHOT"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "REPOSITORY_BASE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::REPOSITORY_BASE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("REPOSITORY_BASE_UNSPECIFIED")
                         }
-                        "DEBIAN" => std::option::Option::Some(Self::DEBIAN),
-                        "UBUNTU" => std::option::Option::Some(Self::UBUNTU),
-                        "DEBIAN_SNAPSHOT" => std::option::Option::Some(Self::DEBIAN_SNAPSHOT),
-                        _ => std::option::Option::None,
+                        Self::Debian => std::option::Option::Some("DEBIAN"),
+                        Self::Ubuntu => std::option::Option::Some("UBUNTU"),
+                        Self::DebianSnapshot => std::option::Option::Some("DEBIAN_SNAPSHOT"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for RepositoryBase {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for RepositoryBase {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for RepositoryBase {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for RepositoryBase {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Debian,
+                        2 => Self::Ubuntu,
+                        3 => Self::DebianSnapshot,
+                        _ => Self::UnknownValue(repository_base::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for RepositoryBase {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "REPOSITORY_BASE_UNSPECIFIED" => Self::Unspecified,
+                        "DEBIAN" => Self::Debian,
+                        "UBUNTU" => Self::Ubuntu,
+                        "DEBIAN_SNAPSHOT" => Self::DebianSnapshot,
+                        _ => Self::UnknownValue(repository_base::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for RepositoryBase {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Debian => serializer.serialize_i32(1),
+                        Self::Ubuntu => serializer.serialize_i32(2),
+                        Self::DebianSnapshot => serializer.serialize_i32(3),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for RepositoryBase {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<RepositoryBase>::new(
+                        ".google.devtools.artifactregistry.v1.RemoteRepositoryConfig.AptRepository.PublicRepository.RepositoryBase"))
                 }
             }
         }
@@ -5443,81 +5988,152 @@ pub mod remote_repository_config {
             use super::*;
 
             /// Predefined list of publicly available repository bases for Yum.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct RepositoryBase(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum RepositoryBase {
+                /// Unspecified repository base.
+                Unspecified,
+                /// CentOS.
+                Centos,
+                /// CentOS Debug.
+                CentosDebug,
+                /// CentOS Vault.
+                CentosVault,
+                /// CentOS Stream.
+                CentosStream,
+                /// Rocky.
+                Rocky,
+                /// Fedora Extra Packages for Enterprise Linux (EPEL).
+                Epel,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [RepositoryBase::value] or
+                /// [RepositoryBase::name].
+                UnknownValue(repository_base::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod repository_base {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl RepositoryBase {
-                /// Unspecified repository base.
-                pub const REPOSITORY_BASE_UNSPECIFIED: RepositoryBase = RepositoryBase::new(0);
-
-                /// CentOS.
-                pub const CENTOS: RepositoryBase = RepositoryBase::new(1);
-
-                /// CentOS Debug.
-                pub const CENTOS_DEBUG: RepositoryBase = RepositoryBase::new(2);
-
-                /// CentOS Vault.
-                pub const CENTOS_VAULT: RepositoryBase = RepositoryBase::new(3);
-
-                /// CentOS Stream.
-                pub const CENTOS_STREAM: RepositoryBase = RepositoryBase::new(4);
-
-                /// Rocky.
-                pub const ROCKY: RepositoryBase = RepositoryBase::new(5);
-
-                /// Fedora Extra Packages for Enterprise Linux (EPEL).
-                pub const EPEL: RepositoryBase = RepositoryBase::new(6);
-
-                /// Creates a new RepositoryBase instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Centos => std::option::Option::Some(1),
+                        Self::CentosDebug => std::option::Option::Some(2),
+                        Self::CentosVault => std::option::Option::Some(3),
+                        Self::CentosStream => std::option::Option::Some(4),
+                        Self::Rocky => std::option::Option::Some(5),
+                        Self::Epel => std::option::Option::Some(6),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("REPOSITORY_BASE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("CENTOS"),
-                        2 => std::borrow::Cow::Borrowed("CENTOS_DEBUG"),
-                        3 => std::borrow::Cow::Borrowed("CENTOS_VAULT"),
-                        4 => std::borrow::Cow::Borrowed("CENTOS_STREAM"),
-                        5 => std::borrow::Cow::Borrowed("ROCKY"),
-                        6 => std::borrow::Cow::Borrowed("EPEL"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "REPOSITORY_BASE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::REPOSITORY_BASE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("REPOSITORY_BASE_UNSPECIFIED")
                         }
-                        "CENTOS" => std::option::Option::Some(Self::CENTOS),
-                        "CENTOS_DEBUG" => std::option::Option::Some(Self::CENTOS_DEBUG),
-                        "CENTOS_VAULT" => std::option::Option::Some(Self::CENTOS_VAULT),
-                        "CENTOS_STREAM" => std::option::Option::Some(Self::CENTOS_STREAM),
-                        "ROCKY" => std::option::Option::Some(Self::ROCKY),
-                        "EPEL" => std::option::Option::Some(Self::EPEL),
-                        _ => std::option::Option::None,
+                        Self::Centos => std::option::Option::Some("CENTOS"),
+                        Self::CentosDebug => std::option::Option::Some("CENTOS_DEBUG"),
+                        Self::CentosVault => std::option::Option::Some("CENTOS_VAULT"),
+                        Self::CentosStream => std::option::Option::Some("CENTOS_STREAM"),
+                        Self::Rocky => std::option::Option::Some("ROCKY"),
+                        Self::Epel => std::option::Option::Some("EPEL"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for RepositoryBase {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for RepositoryBase {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for RepositoryBase {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for RepositoryBase {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Centos,
+                        2 => Self::CentosDebug,
+                        3 => Self::CentosVault,
+                        4 => Self::CentosStream,
+                        5 => Self::Rocky,
+                        6 => Self::Epel,
+                        _ => Self::UnknownValue(repository_base::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for RepositoryBase {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "REPOSITORY_BASE_UNSPECIFIED" => Self::Unspecified,
+                        "CENTOS" => Self::Centos,
+                        "CENTOS_DEBUG" => Self::CentosDebug,
+                        "CENTOS_VAULT" => Self::CentosVault,
+                        "CENTOS_STREAM" => Self::CentosStream,
+                        "ROCKY" => Self::Rocky,
+                        "EPEL" => Self::Epel,
+                        _ => Self::UnknownValue(repository_base::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for RepositoryBase {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Centos => serializer.serialize_i32(1),
+                        Self::CentosDebug => serializer.serialize_i32(2),
+                        Self::CentosVault => serializer.serialize_i32(3),
+                        Self::CentosStream => serializer.serialize_i32(4),
+                        Self::Rocky => serializer.serialize_i32(5),
+                        Self::Epel => serializer.serialize_i32(6),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for RepositoryBase {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<RepositoryBase>::new(
+                        ".google.devtools.artifactregistry.v1.RemoteRepositoryConfig.YumRepository.PublicRepository.RepositoryBase"))
                 }
             }
         }
@@ -6085,63 +6701,124 @@ pub mod repository {
         use super::*;
 
         /// VersionPolicy is the version policy for the repository.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct VersionPolicy(i32);
-
-        impl VersionPolicy {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum VersionPolicy {
             /// VERSION_POLICY_UNSPECIFIED - the version policy is not defined.
             /// When the version policy is not defined, no validation is performed
             /// for the versions.
-            pub const VERSION_POLICY_UNSPECIFIED: VersionPolicy = VersionPolicy::new(0);
-
+            Unspecified,
             /// RELEASE - repository will accept only Release versions.
-            pub const RELEASE: VersionPolicy = VersionPolicy::new(1);
-
+            Release,
             /// SNAPSHOT - repository will accept only Snapshot versions.
-            pub const SNAPSHOT: VersionPolicy = VersionPolicy::new(2);
+            Snapshot,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [VersionPolicy::value] or
+            /// [VersionPolicy::name].
+            UnknownValue(version_policy::UnknownValue),
+        }
 
-            /// Creates a new VersionPolicy instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod version_policy {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl VersionPolicy {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Release => std::option::Option::Some(1),
+                    Self::Snapshot => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("VERSION_POLICY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RELEASE"),
-                    2 => std::borrow::Cow::Borrowed("SNAPSHOT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("VERSION_POLICY_UNSPECIFIED"),
+                    Self::Release => std::option::Option::Some("RELEASE"),
+                    Self::Snapshot => std::option::Option::Some("SNAPSHOT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "VERSION_POLICY_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::VERSION_POLICY_UNSPECIFIED)
-                    }
-                    "RELEASE" => std::option::Option::Some(Self::RELEASE),
-                    "SNAPSHOT" => std::option::Option::Some(Self::SNAPSHOT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for VersionPolicy {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for VersionPolicy {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for VersionPolicy {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for VersionPolicy {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Release,
+                    2 => Self::Snapshot,
+                    _ => Self::UnknownValue(version_policy::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for VersionPolicy {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "VERSION_POLICY_UNSPECIFIED" => Self::Unspecified,
+                    "RELEASE" => Self::Release,
+                    "SNAPSHOT" => Self::Snapshot,
+                    _ => Self::UnknownValue(version_policy::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for VersionPolicy {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Release => serializer.serialize_i32(1),
+                    Self::Snapshot => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for VersionPolicy {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionPolicy>::new(
+                    ".google.devtools.artifactregistry.v1.Repository.MavenRepositoryConfig.VersionPolicy"))
             }
         }
     }
@@ -6273,283 +6950,545 @@ pub mod repository {
         use super::*;
 
         /// Config for vulnerability scanning of resources in this repository.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EnablementConfig(i32);
-
-        impl EnablementConfig {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EnablementConfig {
             /// Not set. This will be treated as INHERITED.
-            pub const ENABLEMENT_CONFIG_UNSPECIFIED: EnablementConfig = EnablementConfig::new(0);
-
+            Unspecified,
             /// Scanning is Enabled, but dependent on API enablement.
-            pub const INHERITED: EnablementConfig = EnablementConfig::new(1);
-
+            Inherited,
             /// No automatic vulnerability scanning will be performed for this
             /// repository.
-            pub const DISABLED: EnablementConfig = EnablementConfig::new(2);
+            Disabled,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EnablementConfig::value] or
+            /// [EnablementConfig::name].
+            UnknownValue(enablement_config::UnknownValue),
+        }
 
-            /// Creates a new EnablementConfig instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod enablement_config {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl EnablementConfig {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Inherited => std::option::Option::Some(1),
+                    Self::Disabled => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENABLEMENT_CONFIG_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("INHERITED"),
-                    2 => std::borrow::Cow::Borrowed("DISABLED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENABLEMENT_CONFIG_UNSPECIFIED"),
+                    Self::Inherited => std::option::Option::Some("INHERITED"),
+                    Self::Disabled => std::option::Option::Some("DISABLED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENABLEMENT_CONFIG_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ENABLEMENT_CONFIG_UNSPECIFIED)
-                    }
-                    "INHERITED" => std::option::Option::Some(Self::INHERITED),
-                    "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EnablementConfig {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EnablementConfig {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EnablementConfig {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EnablementConfig {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Inherited,
+                    2 => Self::Disabled,
+                    _ => Self::UnknownValue(enablement_config::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EnablementConfig {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENABLEMENT_CONFIG_UNSPECIFIED" => Self::Unspecified,
+                    "INHERITED" => Self::Inherited,
+                    "DISABLED" => Self::Disabled,
+                    _ => Self::UnknownValue(enablement_config::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EnablementConfig {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Inherited => serializer.serialize_i32(1),
+                    Self::Disabled => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EnablementConfig {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnablementConfig>::new(
+                    ".google.devtools.artifactregistry.v1.Repository.VulnerabilityScanningConfig.EnablementConfig"))
             }
         }
 
         /// Describes the state of vulnerability scanning in this repository,
         /// including both repository enablement and API enablement.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EnablementState(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EnablementState {
+            /// Enablement state is unclear.
+            Unspecified,
+            /// Repository does not support vulnerability scanning.
+            ScanningUnsupported,
+            /// Vulnerability scanning is disabled for this repository.
+            ScanningDisabled,
+            /// Vulnerability scanning is active for this repository.
+            ScanningActive,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EnablementState::value] or
+            /// [EnablementState::name].
+            UnknownValue(enablement_state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod enablement_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl EnablementState {
-            /// Enablement state is unclear.
-            pub const ENABLEMENT_STATE_UNSPECIFIED: EnablementState = EnablementState::new(0);
-
-            /// Repository does not support vulnerability scanning.
-            pub const SCANNING_UNSUPPORTED: EnablementState = EnablementState::new(1);
-
-            /// Vulnerability scanning is disabled for this repository.
-            pub const SCANNING_DISABLED: EnablementState = EnablementState::new(2);
-
-            /// Vulnerability scanning is active for this repository.
-            pub const SCANNING_ACTIVE: EnablementState = EnablementState::new(3);
-
-            /// Creates a new EnablementState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ScanningUnsupported => std::option::Option::Some(1),
+                    Self::ScanningDisabled => std::option::Option::Some(2),
+                    Self::ScanningActive => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ENABLEMENT_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SCANNING_UNSUPPORTED"),
-                    2 => std::borrow::Cow::Borrowed("SCANNING_DISABLED"),
-                    3 => std::borrow::Cow::Borrowed("SCANNING_ACTIVE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ENABLEMENT_STATE_UNSPECIFIED"),
+                    Self::ScanningUnsupported => std::option::Option::Some("SCANNING_UNSUPPORTED"),
+                    Self::ScanningDisabled => std::option::Option::Some("SCANNING_DISABLED"),
+                    Self::ScanningActive => std::option::Option::Some("SCANNING_ACTIVE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ENABLEMENT_STATE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ENABLEMENT_STATE_UNSPECIFIED)
-                    }
-                    "SCANNING_UNSUPPORTED" => std::option::Option::Some(Self::SCANNING_UNSUPPORTED),
-                    "SCANNING_DISABLED" => std::option::Option::Some(Self::SCANNING_DISABLED),
-                    "SCANNING_ACTIVE" => std::option::Option::Some(Self::SCANNING_ACTIVE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EnablementState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EnablementState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EnablementState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EnablementState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ScanningUnsupported,
+                    2 => Self::ScanningDisabled,
+                    3 => Self::ScanningActive,
+                    _ => Self::UnknownValue(enablement_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EnablementState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ENABLEMENT_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "SCANNING_UNSUPPORTED" => Self::ScanningUnsupported,
+                    "SCANNING_DISABLED" => Self::ScanningDisabled,
+                    "SCANNING_ACTIVE" => Self::ScanningActive,
+                    _ => Self::UnknownValue(enablement_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EnablementState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ScanningUnsupported => serializer.serialize_i32(1),
+                    Self::ScanningDisabled => serializer.serialize_i32(2),
+                    Self::ScanningActive => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EnablementState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnablementState>::new(
+                    ".google.devtools.artifactregistry.v1.Repository.VulnerabilityScanningConfig.EnablementState"))
             }
         }
     }
 
     /// A package format.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Format(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Format {
+        /// Unspecified package format.
+        Unspecified,
+        /// Docker package format.
+        Docker,
+        /// Maven package format.
+        Maven,
+        /// NPM package format.
+        Npm,
+        /// APT package format.
+        Apt,
+        /// YUM package format.
+        Yum,
+        /// Python package format.
+        Python,
+        /// Kubeflow Pipelines package format.
+        Kfp,
+        /// Go package format.
+        Go,
+        /// Generic package format.
+        Generic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Format::value] or
+        /// [Format::name].
+        UnknownValue(format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Format {
-        /// Unspecified package format.
-        pub const FORMAT_UNSPECIFIED: Format = Format::new(0);
-
-        /// Docker package format.
-        pub const DOCKER: Format = Format::new(1);
-
-        /// Maven package format.
-        pub const MAVEN: Format = Format::new(2);
-
-        /// NPM package format.
-        pub const NPM: Format = Format::new(3);
-
-        /// APT package format.
-        pub const APT: Format = Format::new(5);
-
-        /// YUM package format.
-        pub const YUM: Format = Format::new(6);
-
-        /// Python package format.
-        pub const PYTHON: Format = Format::new(8);
-
-        /// Kubeflow Pipelines package format.
-        pub const KFP: Format = Format::new(9);
-
-        /// Go package format.
-        pub const GO: Format = Format::new(10);
-
-        /// Generic package format.
-        pub const GENERIC: Format = Format::new(11);
-
-        /// Creates a new Format instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Docker => std::option::Option::Some(1),
+                Self::Maven => std::option::Option::Some(2),
+                Self::Npm => std::option::Option::Some(3),
+                Self::Apt => std::option::Option::Some(5),
+                Self::Yum => std::option::Option::Some(6),
+                Self::Python => std::option::Option::Some(8),
+                Self::Kfp => std::option::Option::Some(9),
+                Self::Go => std::option::Option::Some(10),
+                Self::Generic => std::option::Option::Some(11),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DOCKER"),
-                2 => std::borrow::Cow::Borrowed("MAVEN"),
-                3 => std::borrow::Cow::Borrowed("NPM"),
-                5 => std::borrow::Cow::Borrowed("APT"),
-                6 => std::borrow::Cow::Borrowed("YUM"),
-                8 => std::borrow::Cow::Borrowed("PYTHON"),
-                9 => std::borrow::Cow::Borrowed("KFP"),
-                10 => std::borrow::Cow::Borrowed("GO"),
-                11 => std::borrow::Cow::Borrowed("GENERIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("FORMAT_UNSPECIFIED"),
+                Self::Docker => std::option::Option::Some("DOCKER"),
+                Self::Maven => std::option::Option::Some("MAVEN"),
+                Self::Npm => std::option::Option::Some("NPM"),
+                Self::Apt => std::option::Option::Some("APT"),
+                Self::Yum => std::option::Option::Some("YUM"),
+                Self::Python => std::option::Option::Some("PYTHON"),
+                Self::Kfp => std::option::Option::Some("KFP"),
+                Self::Go => std::option::Option::Some("GO"),
+                Self::Generic => std::option::Option::Some("GENERIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::FORMAT_UNSPECIFIED),
-                "DOCKER" => std::option::Option::Some(Self::DOCKER),
-                "MAVEN" => std::option::Option::Some(Self::MAVEN),
-                "NPM" => std::option::Option::Some(Self::NPM),
-                "APT" => std::option::Option::Some(Self::APT),
-                "YUM" => std::option::Option::Some(Self::YUM),
-                "PYTHON" => std::option::Option::Some(Self::PYTHON),
-                "KFP" => std::option::Option::Some(Self::KFP),
-                "GO" => std::option::Option::Some(Self::GO),
-                "GENERIC" => std::option::Option::Some(Self::GENERIC),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Format {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Format {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Format {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Format {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Docker,
+                2 => Self::Maven,
+                3 => Self::Npm,
+                5 => Self::Apt,
+                6 => Self::Yum,
+                8 => Self::Python,
+                9 => Self::Kfp,
+                10 => Self::Go,
+                11 => Self::Generic,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Format {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "DOCKER" => Self::Docker,
+                "MAVEN" => Self::Maven,
+                "NPM" => Self::Npm,
+                "APT" => Self::Apt,
+                "YUM" => Self::Yum,
+                "PYTHON" => Self::Python,
+                "KFP" => Self::Kfp,
+                "GO" => Self::Go,
+                "GENERIC" => Self::Generic,
+                _ => Self::UnknownValue(format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Format {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Docker => serializer.serialize_i32(1),
+                Self::Maven => serializer.serialize_i32(2),
+                Self::Npm => serializer.serialize_i32(3),
+                Self::Apt => serializer.serialize_i32(5),
+                Self::Yum => serializer.serialize_i32(6),
+                Self::Python => serializer.serialize_i32(8),
+                Self::Kfp => serializer.serialize_i32(9),
+                Self::Go => serializer.serialize_i32(10),
+                Self::Generic => serializer.serialize_i32(11),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Format {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Format>::new(
+                ".google.devtools.artifactregistry.v1.Repository.Format",
+            ))
         }
     }
 
     /// The mode configures the repository to serve artifacts from different
     /// sources.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Unspecified mode.
+        Unspecified,
+        /// A standard repository storing artifacts.
+        StandardRepository,
+        /// A virtual repository to serve artifacts from one or more sources.
+        VirtualRepository,
+        /// A remote repository to serve artifacts from a remote source.
+        RemoteRepository,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Unspecified mode.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// A standard repository storing artifacts.
-        pub const STANDARD_REPOSITORY: Mode = Mode::new(1);
-
-        /// A virtual repository to serve artifacts from one or more sources.
-        pub const VIRTUAL_REPOSITORY: Mode = Mode::new(2);
-
-        /// A remote repository to serve artifacts from a remote source.
-        pub const REMOTE_REPOSITORY: Mode = Mode::new(3);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StandardRepository => std::option::Option::Some(1),
+                Self::VirtualRepository => std::option::Option::Some(2),
+                Self::RemoteRepository => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD_REPOSITORY"),
-                2 => std::borrow::Cow::Borrowed("VIRTUAL_REPOSITORY"),
-                3 => std::borrow::Cow::Borrowed("REMOTE_REPOSITORY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::StandardRepository => std::option::Option::Some("STANDARD_REPOSITORY"),
+                Self::VirtualRepository => std::option::Option::Some("VIRTUAL_REPOSITORY"),
+                Self::RemoteRepository => std::option::Option::Some("REMOTE_REPOSITORY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "STANDARD_REPOSITORY" => std::option::Option::Some(Self::STANDARD_REPOSITORY),
-                "VIRTUAL_REPOSITORY" => std::option::Option::Some(Self::VIRTUAL_REPOSITORY),
-                "REMOTE_REPOSITORY" => std::option::Option::Some(Self::REMOTE_REPOSITORY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StandardRepository,
+                2 => Self::VirtualRepository,
+                3 => Self::RemoteRepository,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD_REPOSITORY" => Self::StandardRepository,
+                "VIRTUAL_REPOSITORY" => Self::VirtualRepository,
+                "REMOTE_REPOSITORY" => Self::RemoteRepository,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StandardRepository => serializer.serialize_i32(1),
+                Self::VirtualRepository => serializer.serialize_i32(2),
+                Self::RemoteRepository => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.devtools.artifactregistry.v1.Repository.Mode",
+            ))
         }
     }
 
@@ -6988,111 +7927,231 @@ pub mod rule {
     use super::*;
 
     /// Defines the action of the rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Action not specified.
+        Unspecified,
+        /// Allow the operation.
+        Allow,
+        /// Deny the operation.
+        Deny,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Action not specified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Allow the operation.
-        pub const ALLOW: Action = Action::new(1);
-
-        /// Deny the operation.
-        pub const DENY: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::Deny => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("DENY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "DENY" => std::option::Option::Some(Self::DENY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                2 => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                "DENY" => Self::Deny,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::Deny => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.devtools.artifactregistry.v1.Rule.Action",
+            ))
         }
     }
 
     /// The operation the rule applies to.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Operation(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Operation {
+        /// Operation not specified.
+        Unspecified,
+        /// Download operation.
+        Download,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Operation::value] or
+        /// [Operation::name].
+        UnknownValue(operation::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod operation {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Operation {
-        /// Operation not specified.
-        pub const OPERATION_UNSPECIFIED: Operation = Operation::new(0);
-
-        /// Download operation.
-        pub const DOWNLOAD: Operation = Operation::new(1);
-
-        /// Creates a new Operation instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Download => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OPERATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DOWNLOAD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OPERATION_UNSPECIFIED"),
+                Self::Download => std::option::Option::Some("DOWNLOAD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OPERATION_UNSPECIFIED" => std::option::Option::Some(Self::OPERATION_UNSPECIFIED),
-                "DOWNLOAD" => std::option::Option::Some(Self::DOWNLOAD),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Operation {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Operation {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Operation {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Download,
+                _ => Self::UnknownValue(operation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Operation {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OPERATION_UNSPECIFIED" => Self::Unspecified,
+                "DOWNLOAD" => Self::Download,
+                _ => Self::UnknownValue(operation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Operation {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Download => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Operation {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Operation>::new(
+                ".google.devtools.artifactregistry.v1.Rule.Operation",
+            ))
         }
     }
 }
@@ -7473,88 +8532,155 @@ pub mod project_settings {
     use super::*;
 
     /// The possible redirection states for legacy repositories.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RedirectionState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RedirectionState {
+        /// No redirection status has been set.
+        Unspecified,
+        /// Redirection is disabled.
+        RedirectionFromGcrIoDisabled,
+        /// Redirection is enabled.
+        RedirectionFromGcrIoEnabled,
+        /// Redirection is enabled, and has been finalized so cannot be reverted.
+        RedirectionFromGcrIoFinalized,
+        /// Redirection is enabled and missing images are copied from GCR
+        RedirectionFromGcrIoEnabledAndCopying,
+        /// Redirection is partially enabled and missing images are copied from GCR
+        RedirectionFromGcrIoPartialAndCopying,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RedirectionState::value] or
+        /// [RedirectionState::name].
+        UnknownValue(redirection_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod redirection_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RedirectionState {
-        /// No redirection status has been set.
-        pub const REDIRECTION_STATE_UNSPECIFIED: RedirectionState = RedirectionState::new(0);
-
-        /// Redirection is disabled.
-        pub const REDIRECTION_FROM_GCR_IO_DISABLED: RedirectionState = RedirectionState::new(1);
-
-        /// Redirection is enabled.
-        pub const REDIRECTION_FROM_GCR_IO_ENABLED: RedirectionState = RedirectionState::new(2);
-
-        /// Redirection is enabled, and has been finalized so cannot be reverted.
-        pub const REDIRECTION_FROM_GCR_IO_FINALIZED: RedirectionState = RedirectionState::new(3);
-
-        /// Redirection is enabled and missing images are copied from GCR
-        pub const REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING: RedirectionState =
-            RedirectionState::new(5);
-
-        /// Redirection is partially enabled and missing images are copied from GCR
-        pub const REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING: RedirectionState =
-            RedirectionState::new(6);
-
-        /// Creates a new RedirectionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RedirectionFromGcrIoDisabled => std::option::Option::Some(1),
+                Self::RedirectionFromGcrIoEnabled => std::option::Option::Some(2),
+                Self::RedirectionFromGcrIoFinalized => std::option::Option::Some(3),
+                Self::RedirectionFromGcrIoEnabledAndCopying => std::option::Option::Some(5),
+                Self::RedirectionFromGcrIoPartialAndCopying => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REDIRECTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_ENABLED"),
-                3 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_FINALIZED"),
-                5 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING"),
-                6 => std::borrow::Cow::Borrowed("REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REDIRECTION_STATE_UNSPECIFIED"),
+                Self::RedirectionFromGcrIoDisabled => {
+                    std::option::Option::Some("REDIRECTION_FROM_GCR_IO_DISABLED")
+                }
+                Self::RedirectionFromGcrIoEnabled => {
+                    std::option::Option::Some("REDIRECTION_FROM_GCR_IO_ENABLED")
+                }
+                Self::RedirectionFromGcrIoFinalized => {
+                    std::option::Option::Some("REDIRECTION_FROM_GCR_IO_FINALIZED")
+                }
+                Self::RedirectionFromGcrIoEnabledAndCopying => {
+                    std::option::Option::Some("REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING")
+                }
+                Self::RedirectionFromGcrIoPartialAndCopying => {
+                    std::option::Option::Some("REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REDIRECTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REDIRECTION_STATE_UNSPECIFIED)
-                }
-                "REDIRECTION_FROM_GCR_IO_DISABLED" => {
-                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_DISABLED)
-                }
-                "REDIRECTION_FROM_GCR_IO_ENABLED" => {
-                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_ENABLED)
-                }
-                "REDIRECTION_FROM_GCR_IO_FINALIZED" => {
-                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_FINALIZED)
-                }
-                "REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING" => {
-                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING)
-                }
-                "REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING" => {
-                    std::option::Option::Some(Self::REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RedirectionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RedirectionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RedirectionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RedirectionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RedirectionFromGcrIoDisabled,
+                2 => Self::RedirectionFromGcrIoEnabled,
+                3 => Self::RedirectionFromGcrIoFinalized,
+                5 => Self::RedirectionFromGcrIoEnabledAndCopying,
+                6 => Self::RedirectionFromGcrIoPartialAndCopying,
+                _ => Self::UnknownValue(redirection_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RedirectionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REDIRECTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "REDIRECTION_FROM_GCR_IO_DISABLED" => Self::RedirectionFromGcrIoDisabled,
+                "REDIRECTION_FROM_GCR_IO_ENABLED" => Self::RedirectionFromGcrIoEnabled,
+                "REDIRECTION_FROM_GCR_IO_FINALIZED" => Self::RedirectionFromGcrIoFinalized,
+                "REDIRECTION_FROM_GCR_IO_ENABLED_AND_COPYING" => {
+                    Self::RedirectionFromGcrIoEnabledAndCopying
+                }
+                "REDIRECTION_FROM_GCR_IO_PARTIAL_AND_COPYING" => {
+                    Self::RedirectionFromGcrIoPartialAndCopying
+                }
+                _ => Self::UnknownValue(redirection_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RedirectionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RedirectionFromGcrIoDisabled => serializer.serialize_i32(1),
+                Self::RedirectionFromGcrIoEnabled => serializer.serialize_i32(2),
+                Self::RedirectionFromGcrIoFinalized => serializer.serialize_i32(3),
+                Self::RedirectionFromGcrIoEnabledAndCopying => serializer.serialize_i32(5),
+                Self::RedirectionFromGcrIoPartialAndCopying => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RedirectionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RedirectionState>::new(
+                ".google.devtools.artifactregistry.v1.ProjectSettings.RedirectionState",
+            ))
         }
     }
 }
@@ -8611,65 +9737,124 @@ pub mod vpcsc_config {
     use super::*;
 
     /// VPCSCPolicy is the VPC SC policy for project and location.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VPCSCPolicy(i32);
-
-    impl VPCSCPolicy {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VPCSCPolicy {
         /// VPCSC_POLICY_UNSPECIFIED - the VPS SC policy is not defined.
         /// When VPS SC policy is not defined - the Service will use the default
         /// behavior (VPCSC_DENY).
-        pub const VPCSC_POLICY_UNSPECIFIED: VPCSCPolicy = VPCSCPolicy::new(0);
-
+        Unspecified,
         /// VPCSC_DENY - repository will block the requests to the Upstreams for the
         /// Remote Repositories if the resource is in the perimeter.
-        pub const DENY: VPCSCPolicy = VPCSCPolicy::new(1);
-
+        Deny,
         /// VPCSC_ALLOW - repository will allow the requests to the Upstreams for the
         /// Remote Repositories if the resource is in the perimeter.
-        pub const ALLOW: VPCSCPolicy = VPCSCPolicy::new(2);
+        Allow,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VPCSCPolicy::value] or
+        /// [VPCSCPolicy::name].
+        UnknownValue(vpcsc_policy::UnknownValue),
+    }
 
-        /// Creates a new VPCSCPolicy instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod vpcsc_policy {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl VPCSCPolicy {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Deny => std::option::Option::Some(1),
+                Self::Allow => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VPCSC_POLICY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DENY"),
-                2 => std::borrow::Cow::Borrowed("ALLOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VPCSC_POLICY_UNSPECIFIED"),
+                Self::Deny => std::option::Option::Some("DENY"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VPCSC_POLICY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VPCSC_POLICY_UNSPECIFIED)
-                }
-                "DENY" => std::option::Option::Some(Self::DENY),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VPCSCPolicy {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VPCSCPolicy {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VPCSCPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VPCSCPolicy {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Deny,
+                2 => Self::Allow,
+                _ => Self::UnknownValue(vpcsc_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VPCSCPolicy {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VPCSC_POLICY_UNSPECIFIED" => Self::Unspecified,
+                "DENY" => Self::Deny,
+                "ALLOW" => Self::Allow,
+                _ => Self::UnknownValue(vpcsc_policy::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VPCSCPolicy {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Deny => serializer.serialize_i32(1),
+                Self::Allow => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VPCSCPolicy {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VPCSCPolicy>::new(
+                ".google.devtools.artifactregistry.v1.VPCSCConfig.VPCSCPolicy",
+            ))
         }
     }
 }
@@ -8826,61 +10011,120 @@ pub mod yum_artifact {
     use super::*;
 
     /// Package type is either binary or source.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PackageType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PackageType {
+        /// Package type is not specified.
+        Unspecified,
+        /// Binary package (.rpm).
+        Binary,
+        /// Source package (.srpm).
+        Source,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PackageType::value] or
+        /// [PackageType::name].
+        UnknownValue(package_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod package_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PackageType {
-        /// Package type is not specified.
-        pub const PACKAGE_TYPE_UNSPECIFIED: PackageType = PackageType::new(0);
-
-        /// Binary package (.rpm).
-        pub const BINARY: PackageType = PackageType::new(1);
-
-        /// Source package (.srpm).
-        pub const SOURCE: PackageType = PackageType::new(2);
-
-        /// Creates a new PackageType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Binary => std::option::Option::Some(1),
+                Self::Source => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PACKAGE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BINARY"),
-                2 => std::borrow::Cow::Borrowed("SOURCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PACKAGE_TYPE_UNSPECIFIED"),
+                Self::Binary => std::option::Option::Some("BINARY"),
+                Self::Source => std::option::Option::Some("SOURCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PACKAGE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PACKAGE_TYPE_UNSPECIFIED)
-                }
-                "BINARY" => std::option::Option::Some(Self::BINARY),
-                "SOURCE" => std::option::Option::Some(Self::SOURCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PackageType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PackageType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PackageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PackageType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Binary,
+                2 => Self::Source,
+                _ => Self::UnknownValue(package_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PackageType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PACKAGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "BINARY" => Self::Binary,
+                "SOURCE" => Self::Source,
+                _ => Self::UnknownValue(package_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PackageType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Binary => serializer.serialize_i32(1),
+                Self::Source => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PackageType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PackageType>::new(
+                ".google.devtools.artifactregistry.v1.YumArtifact.PackageType",
+            ))
         }
     }
 }
@@ -9207,59 +10451,120 @@ impl wkt::message::Message for ImportYumArtifactsMetadata {
 
 /// The view, which determines what version information is returned in a
 /// response.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct VersionView(i32);
-
-impl VersionView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum VersionView {
     /// The default / unset value.
     /// The API will default to the BASIC view.
-    pub const VERSION_VIEW_UNSPECIFIED: VersionView = VersionView::new(0);
-
+    Unspecified,
     /// Includes basic information about the version, but not any related tags.
-    pub const BASIC: VersionView = VersionView::new(1);
-
+    Basic,
     /// Include everything.
-    pub const FULL: VersionView = VersionView::new(2);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [VersionView::value] or
+    /// [VersionView::name].
+    UnknownValue(version_view::UnknownValue),
+}
 
-    /// Creates a new VersionView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod version_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl VersionView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Full => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("VERSION_VIEW_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BASIC"),
-            2 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("VERSION_VIEW_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "VERSION_VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VERSION_VIEW_UNSPECIFIED),
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for VersionView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for VersionView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for VersionView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for VersionView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Full,
+            _ => Self::UnknownValue(version_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for VersionView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "VERSION_VIEW_UNSPECIFIED" => Self::Unspecified,
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(version_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for VersionView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Full => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for VersionView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionView>::new(
+            ".google.devtools.artifactregistry.v1.VersionView",
+        ))
     }
 }

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -451,7 +451,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         let builder = builder.query(&[("filter", &req.filter)]);
         self.inner
@@ -473,7 +473,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -232,61 +232,120 @@ pub mod storage_source {
     use super::*;
 
     /// Specifies the tool to fetch the source file for the build.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SourceFetcher(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SourceFetcher {
+        /// Unspecified. Defaults to GSUTIL.
+        Unspecified,
+        /// Use the "gsutil" tool to download the source file.
+        Gsutil,
+        /// Use the Cloud Storage Fetcher tool to download the source file.
+        GcsFetcher,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SourceFetcher::value] or
+        /// [SourceFetcher::name].
+        UnknownValue(source_fetcher::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod source_fetcher {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl SourceFetcher {
-        /// Unspecified. Defaults to GSUTIL.
-        pub const SOURCE_FETCHER_UNSPECIFIED: SourceFetcher = SourceFetcher::new(0);
-
-        /// Use the "gsutil" tool to download the source file.
-        pub const GSUTIL: SourceFetcher = SourceFetcher::new(1);
-
-        /// Use the Cloud Storage Fetcher tool to download the source file.
-        pub const GCS_FETCHER: SourceFetcher = SourceFetcher::new(2);
-
-        /// Creates a new SourceFetcher instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gsutil => std::option::Option::Some(1),
+                Self::GcsFetcher => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SOURCE_FETCHER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GSUTIL"),
-                2 => std::borrow::Cow::Borrowed("GCS_FETCHER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SOURCE_FETCHER_UNSPECIFIED"),
+                Self::Gsutil => std::option::Option::Some("GSUTIL"),
+                Self::GcsFetcher => std::option::Option::Some("GCS_FETCHER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SOURCE_FETCHER_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SOURCE_FETCHER_UNSPECIFIED)
-                }
-                "GSUTIL" => std::option::Option::Some(Self::GSUTIL),
-                "GCS_FETCHER" => std::option::Option::Some(Self::GCS_FETCHER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SourceFetcher {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SourceFetcher {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SourceFetcher {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SourceFetcher {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Gsutil,
+                2 => Self::GcsFetcher,
+                _ => Self::UnknownValue(source_fetcher::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SourceFetcher {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SOURCE_FETCHER_UNSPECIFIED" => Self::Unspecified,
+                "GSUTIL" => Self::Gsutil,
+                "GCS_FETCHER" => Self::GcsFetcher,
+                _ => Self::UnknownValue(source_fetcher::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SourceFetcher {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gsutil => serializer.serialize_i32(1),
+                Self::GcsFetcher => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SourceFetcher {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SourceFetcher>::new(
+                ".google.devtools.cloudbuild.v1.StorageSource.SourceFetcher",
+            ))
         }
     }
 }
@@ -2198,64 +2257,130 @@ pub mod build {
         use super::*;
 
         /// The relative importance of this warning.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Priority(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Priority {
+            /// Should not be used.
+            Unspecified,
+            /// e.g. deprecation warnings and alternative feature highlights.
+            Info,
+            /// e.g. automated detection of possible issues with the build.
+            Warning,
+            /// e.g. alerts that a feature used in the build is pending removal
+            Alert,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Priority::value] or
+            /// [Priority::name].
+            UnknownValue(priority::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod priority {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Priority {
-            /// Should not be used.
-            pub const PRIORITY_UNSPECIFIED: Priority = Priority::new(0);
-
-            /// e.g. deprecation warnings and alternative feature highlights.
-            pub const INFO: Priority = Priority::new(1);
-
-            /// e.g. automated detection of possible issues with the build.
-            pub const WARNING: Priority = Priority::new(2);
-
-            /// e.g. alerts that a feature used in the build is pending removal
-            pub const ALERT: Priority = Priority::new(3);
-
-            /// Creates a new Priority instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Info => std::option::Option::Some(1),
+                    Self::Warning => std::option::Option::Some(2),
+                    Self::Alert => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("PRIORITY_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("INFO"),
-                    2 => std::borrow::Cow::Borrowed("WARNING"),
-                    3 => std::borrow::Cow::Borrowed("ALERT"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("PRIORITY_UNSPECIFIED"),
+                    Self::Info => std::option::Option::Some("INFO"),
+                    Self::Warning => std::option::Option::Some("WARNING"),
+                    Self::Alert => std::option::Option::Some("ALERT"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "PRIORITY_UNSPECIFIED" => std::option::Option::Some(Self::PRIORITY_UNSPECIFIED),
-                    "INFO" => std::option::Option::Some(Self::INFO),
-                    "WARNING" => std::option::Option::Some(Self::WARNING),
-                    "ALERT" => std::option::Option::Some(Self::ALERT),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Priority {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Priority {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Priority {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Priority {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Info,
+                    2 => Self::Warning,
+                    3 => Self::Alert,
+                    _ => Self::UnknownValue(priority::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Priority {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "PRIORITY_UNSPECIFIED" => Self::Unspecified,
+                    "INFO" => Self::Info,
+                    "WARNING" => Self::Warning,
+                    "ALERT" => Self::Alert,
+                    _ => Self::UnknownValue(priority::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Priority {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Info => serializer.serialize_i32(1),
+                    Self::Warning => serializer.serialize_i32(2),
+                    Self::Alert => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Priority {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Priority>::new(
+                    ".google.devtools.cloudbuild.v1.Build.Warning.Priority",
+                ))
             }
         }
     }
@@ -2312,175 +2437,320 @@ pub mod build {
 
         /// The name of a fatal problem encountered during the execution of the
         /// build.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct FailureType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum FailureType {
+            /// Type unspecified
+            Unspecified,
+            /// Unable to push the image to the repository.
+            PushFailed,
+            /// Final image not found.
+            PushImageNotFound,
+            /// Unauthorized push of the final image.
+            PushNotAuthorized,
+            /// Backend logging failures. Should retry.
+            LoggingFailure,
+            /// A build step has failed.
+            UserBuildStep,
+            /// The source fetching has failed.
+            FetchSourceFailed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [FailureType::value] or
+            /// [FailureType::name].
+            UnknownValue(failure_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod failure_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl FailureType {
-            /// Type unspecified
-            pub const FAILURE_TYPE_UNSPECIFIED: FailureType = FailureType::new(0);
-
-            /// Unable to push the image to the repository.
-            pub const PUSH_FAILED: FailureType = FailureType::new(1);
-
-            /// Final image not found.
-            pub const PUSH_IMAGE_NOT_FOUND: FailureType = FailureType::new(2);
-
-            /// Unauthorized push of the final image.
-            pub const PUSH_NOT_AUTHORIZED: FailureType = FailureType::new(3);
-
-            /// Backend logging failures. Should retry.
-            pub const LOGGING_FAILURE: FailureType = FailureType::new(4);
-
-            /// A build step has failed.
-            pub const USER_BUILD_STEP: FailureType = FailureType::new(5);
-
-            /// The source fetching has failed.
-            pub const FETCH_SOURCE_FAILED: FailureType = FailureType::new(6);
-
-            /// Creates a new FailureType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::PushFailed => std::option::Option::Some(1),
+                    Self::PushImageNotFound => std::option::Option::Some(2),
+                    Self::PushNotAuthorized => std::option::Option::Some(3),
+                    Self::LoggingFailure => std::option::Option::Some(4),
+                    Self::UserBuildStep => std::option::Option::Some(5),
+                    Self::FetchSourceFailed => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("FAILURE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PUSH_FAILED"),
-                    2 => std::borrow::Cow::Borrowed("PUSH_IMAGE_NOT_FOUND"),
-                    3 => std::borrow::Cow::Borrowed("PUSH_NOT_AUTHORIZED"),
-                    4 => std::borrow::Cow::Borrowed("LOGGING_FAILURE"),
-                    5 => std::borrow::Cow::Borrowed("USER_BUILD_STEP"),
-                    6 => std::borrow::Cow::Borrowed("FETCH_SOURCE_FAILED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("FAILURE_TYPE_UNSPECIFIED"),
+                    Self::PushFailed => std::option::Option::Some("PUSH_FAILED"),
+                    Self::PushImageNotFound => std::option::Option::Some("PUSH_IMAGE_NOT_FOUND"),
+                    Self::PushNotAuthorized => std::option::Option::Some("PUSH_NOT_AUTHORIZED"),
+                    Self::LoggingFailure => std::option::Option::Some("LOGGING_FAILURE"),
+                    Self::UserBuildStep => std::option::Option::Some("USER_BUILD_STEP"),
+                    Self::FetchSourceFailed => std::option::Option::Some("FETCH_SOURCE_FAILED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "FAILURE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::FAILURE_TYPE_UNSPECIFIED)
-                    }
-                    "PUSH_FAILED" => std::option::Option::Some(Self::PUSH_FAILED),
-                    "PUSH_IMAGE_NOT_FOUND" => std::option::Option::Some(Self::PUSH_IMAGE_NOT_FOUND),
-                    "PUSH_NOT_AUTHORIZED" => std::option::Option::Some(Self::PUSH_NOT_AUTHORIZED),
-                    "LOGGING_FAILURE" => std::option::Option::Some(Self::LOGGING_FAILURE),
-                    "USER_BUILD_STEP" => std::option::Option::Some(Self::USER_BUILD_STEP),
-                    "FETCH_SOURCE_FAILED" => std::option::Option::Some(Self::FETCH_SOURCE_FAILED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for FailureType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for FailureType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for FailureType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for FailureType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::PushFailed,
+                    2 => Self::PushImageNotFound,
+                    3 => Self::PushNotAuthorized,
+                    4 => Self::LoggingFailure,
+                    5 => Self::UserBuildStep,
+                    6 => Self::FetchSourceFailed,
+                    _ => Self::UnknownValue(failure_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for FailureType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "FAILURE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "PUSH_FAILED" => Self::PushFailed,
+                    "PUSH_IMAGE_NOT_FOUND" => Self::PushImageNotFound,
+                    "PUSH_NOT_AUTHORIZED" => Self::PushNotAuthorized,
+                    "LOGGING_FAILURE" => Self::LoggingFailure,
+                    "USER_BUILD_STEP" => Self::UserBuildStep,
+                    "FETCH_SOURCE_FAILED" => Self::FetchSourceFailed,
+                    _ => Self::UnknownValue(failure_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for FailureType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::PushFailed => serializer.serialize_i32(1),
+                    Self::PushImageNotFound => serializer.serialize_i32(2),
+                    Self::PushNotAuthorized => serializer.serialize_i32(3),
+                    Self::LoggingFailure => serializer.serialize_i32(4),
+                    Self::UserBuildStep => serializer.serialize_i32(5),
+                    Self::FetchSourceFailed => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for FailureType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<FailureType>::new(
+                    ".google.devtools.cloudbuild.v1.Build.FailureInfo.FailureType",
+                ))
             }
         }
     }
 
     /// Possible status of a build or build step.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// Status of the build is unknown.
-        pub const STATUS_UNKNOWN: Status = Status::new(0);
-
+        Unknown,
         /// Build has been created and is pending execution and queuing. It has not
         /// been queued.
-        pub const PENDING: Status = Status::new(10);
-
+        Pending,
         /// Build or step is queued; work has not yet begun.
-        pub const QUEUED: Status = Status::new(1);
-
+        Queued,
         /// Build or step is being executed.
-        pub const WORKING: Status = Status::new(2);
-
+        Working,
         /// Build or step finished successfully.
-        pub const SUCCESS: Status = Status::new(3);
-
+        Success,
         /// Build or step failed to complete successfully.
-        pub const FAILURE: Status = Status::new(4);
-
+        Failure,
         /// Build or step failed due to an internal cause.
-        pub const INTERNAL_ERROR: Status = Status::new(5);
-
+        InternalError,
         /// Build or step took longer than was allowed.
-        pub const TIMEOUT: Status = Status::new(6);
-
+        Timeout,
         /// Build or step was canceled by a user.
-        pub const CANCELLED: Status = Status::new(7);
-
+        Cancelled,
         /// Build was enqueued for longer than the value of `queue_ttl`.
-        pub const EXPIRED: Status = Status::new(9);
+        Expired,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(10),
+                Self::Queued => std::option::Option::Some(1),
+                Self::Working => std::option::Option::Some(2),
+                Self::Success => std::option::Option::Some(3),
+                Self::Failure => std::option::Option::Some(4),
+                Self::InternalError => std::option::Option::Some(5),
+                Self::Timeout => std::option::Option::Some(6),
+                Self::Cancelled => std::option::Option::Some(7),
+                Self::Expired => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("QUEUED"),
-                2 => std::borrow::Cow::Borrowed("WORKING"),
-                3 => std::borrow::Cow::Borrowed("SUCCESS"),
-                4 => std::borrow::Cow::Borrowed("FAILURE"),
-                5 => std::borrow::Cow::Borrowed("INTERNAL_ERROR"),
-                6 => std::borrow::Cow::Borrowed("TIMEOUT"),
-                7 => std::borrow::Cow::Borrowed("CANCELLED"),
-                9 => std::borrow::Cow::Borrowed("EXPIRED"),
-                10 => std::borrow::Cow::Borrowed("PENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("STATUS_UNKNOWN"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Queued => std::option::Option::Some("QUEUED"),
+                Self::Working => std::option::Option::Some("WORKING"),
+                Self::Success => std::option::Option::Some("SUCCESS"),
+                Self::Failure => std::option::Option::Some("FAILURE"),
+                Self::InternalError => std::option::Option::Some("INTERNAL_ERROR"),
+                Self::Timeout => std::option::Option::Some("TIMEOUT"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::Expired => std::option::Option::Some("EXPIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNKNOWN" => std::option::Option::Some(Self::STATUS_UNKNOWN),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "QUEUED" => std::option::Option::Some(Self::QUEUED),
-                "WORKING" => std::option::Option::Some(Self::WORKING),
-                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-                "FAILURE" => std::option::Option::Some(Self::FAILURE),
-                "INTERNAL_ERROR" => std::option::Option::Some(Self::INTERNAL_ERROR),
-                "TIMEOUT" => std::option::Option::Some(Self::TIMEOUT),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                "EXPIRED" => std::option::Option::Some(Self::EXPIRED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Queued,
+                2 => Self::Working,
+                3 => Self::Success,
+                4 => Self::Failure,
+                5 => Self::InternalError,
+                6 => Self::Timeout,
+                7 => Self::Cancelled,
+                9 => Self::Expired,
+                10 => Self::Pending,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNKNOWN" => Self::Unknown,
+                "PENDING" => Self::Pending,
+                "QUEUED" => Self::Queued,
+                "WORKING" => Self::Working,
+                "SUCCESS" => Self::Success,
+                "FAILURE" => Self::Failure,
+                "INTERNAL_ERROR" => Self::InternalError,
+                "TIMEOUT" => Self::Timeout,
+                "CANCELLED" => Self::Cancelled,
+                "EXPIRED" => Self::Expired,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(10),
+                Self::Queued => serializer.serialize_i32(1),
+                Self::Working => serializer.serialize_i32(2),
+                Self::Success => serializer.serialize_i32(3),
+                Self::Failure => serializer.serialize_i32(4),
+                Self::InternalError => serializer.serialize_i32(5),
+                Self::Timeout => serializer.serialize_i32(6),
+                Self::Cancelled => serializer.serialize_i32(7),
+                Self::Expired => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.devtools.cloudbuild.v1.Build.Status",
+            ))
         }
     }
 }
@@ -3659,69 +3929,134 @@ pub mod hash {
     use super::*;
 
     /// Specifies the hash algorithm, if any.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct HashType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum HashType {
+        /// No hash requested.
+        None,
+        /// Use a sha256 hash.
+        Sha256,
+        /// Use a md5 hash.
+        Md5,
+        /// Dirhash of a Go module's source code which is then hex-encoded.
+        GoModuleH1,
+        /// Use a sha512 hash.
+        Sha512,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [HashType::value] or
+        /// [HashType::name].
+        UnknownValue(hash_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod hash_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl HashType {
-        /// No hash requested.
-        pub const NONE: HashType = HashType::new(0);
-
-        /// Use a sha256 hash.
-        pub const SHA256: HashType = HashType::new(1);
-
-        /// Use a md5 hash.
-        pub const MD5: HashType = HashType::new(2);
-
-        /// Dirhash of a Go module's source code which is then hex-encoded.
-        pub const GO_MODULE_H1: HashType = HashType::new(3);
-
-        /// Use a sha512 hash.
-        pub const SHA512: HashType = HashType::new(4);
-
-        /// Creates a new HashType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::None => std::option::Option::Some(0),
+                Self::Sha256 => std::option::Option::Some(1),
+                Self::Md5 => std::option::Option::Some(2),
+                Self::GoModuleH1 => std::option::Option::Some(3),
+                Self::Sha512 => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NONE"),
-                1 => std::borrow::Cow::Borrowed("SHA256"),
-                2 => std::borrow::Cow::Borrowed("MD5"),
-                3 => std::borrow::Cow::Borrowed("GO_MODULE_H1"),
-                4 => std::borrow::Cow::Borrowed("SHA512"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Sha256 => std::option::Option::Some("SHA256"),
+                Self::Md5 => std::option::Option::Some("MD5"),
+                Self::GoModuleH1 => std::option::Option::Some("GO_MODULE_H1"),
+                Self::Sha512 => std::option::Option::Some("SHA512"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "SHA256" => std::option::Option::Some(Self::SHA256),
-                "MD5" => std::option::Option::Some(Self::MD5),
-                "GO_MODULE_H1" => std::option::Option::Some(Self::GO_MODULE_H1),
-                "SHA512" => std::option::Option::Some(Self::SHA512),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for HashType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for HashType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for HashType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for HashType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::None,
+                1 => Self::Sha256,
+                2 => Self::Md5,
+                3 => Self::GoModuleH1,
+                4 => Self::Sha512,
+                _ => Self::UnknownValue(hash_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for HashType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NONE" => Self::None,
+                "SHA256" => Self::Sha256,
+                "MD5" => Self::Md5,
+                "GO_MODULE_H1" => Self::GoModuleH1,
+                "SHA512" => Self::Sha512,
+                _ => Self::UnknownValue(hash_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for HashType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::None => serializer.serialize_i32(0),
+                Self::Sha256 => serializer.serialize_i32(1),
+                Self::Md5 => serializer.serialize_i32(2),
+                Self::GoModuleH1 => serializer.serialize_i32(3),
+                Self::Sha512 => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for HashType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<HashType>::new(
+                ".google.devtools.cloudbuild.v1.Hash.HashType",
+            ))
         }
     }
 }
@@ -4358,69 +4693,134 @@ pub mod build_approval {
     use super::*;
 
     /// Specifies the current state of a build's approval.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Default enum type. This should not be used.
+        Unspecified,
+        /// Build approval is pending.
+        Pending,
+        /// Build approval has been approved.
+        Approved,
+        /// Build approval has been rejected.
+        Rejected,
+        /// Build was cancelled while it was still pending approval.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Default enum type. This should not be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Build approval is pending.
-        pub const PENDING: State = State::new(1);
-
-        /// Build approval has been approved.
-        pub const APPROVED: State = State::new(2);
-
-        /// Build approval has been rejected.
-        pub const REJECTED: State = State::new(3);
-
-        /// Build was cancelled while it was still pending approval.
-        pub const CANCELLED: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Approved => std::option::Option::Some(2),
+                Self::Rejected => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("APPROVED"),
-                3 => std::borrow::Cow::Borrowed("REJECTED"),
-                5 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Approved => std::option::Option::Some("APPROVED"),
+                Self::Rejected => std::option::Option::Some("REJECTED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "APPROVED" => std::option::Option::Some(Self::APPROVED),
-                "REJECTED" => std::option::Option::Some(Self::REJECTED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Approved,
+                3 => Self::Rejected,
+                5 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "APPROVED" => Self::Approved,
+                "REJECTED" => Self::Rejected,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Approved => serializer.serialize_i32(2),
+                Self::Rejected => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.devtools.cloudbuild.v1.BuildApproval.State",
+            ))
         }
     }
 }
@@ -4551,59 +4951,120 @@ pub mod approval_result {
 
     /// Specifies whether or not this manual approval result is to approve
     /// or reject a build.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Decision(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Decision {
+        /// Default enum type. This should not be used.
+        Unspecified,
+        /// Build is approved.
+        Approved,
+        /// Build is rejected.
+        Rejected,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Decision::value] or
+        /// [Decision::name].
+        UnknownValue(decision::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod decision {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Decision {
-        /// Default enum type. This should not be used.
-        pub const DECISION_UNSPECIFIED: Decision = Decision::new(0);
-
-        /// Build is approved.
-        pub const APPROVED: Decision = Decision::new(1);
-
-        /// Build is rejected.
-        pub const REJECTED: Decision = Decision::new(2);
-
-        /// Creates a new Decision instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Approved => std::option::Option::Some(1),
+                Self::Rejected => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DECISION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("APPROVED"),
-                2 => std::borrow::Cow::Borrowed("REJECTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DECISION_UNSPECIFIED"),
+                Self::Approved => std::option::Option::Some("APPROVED"),
+                Self::Rejected => std::option::Option::Some("REJECTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DECISION_UNSPECIFIED" => std::option::Option::Some(Self::DECISION_UNSPECIFIED),
-                "APPROVED" => std::option::Option::Some(Self::APPROVED),
-                "REJECTED" => std::option::Option::Some(Self::REJECTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Decision {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Decision {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Decision {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Decision {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Approved,
+                2 => Self::Rejected,
+                _ => Self::UnknownValue(decision::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Decision {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DECISION_UNSPECIFIED" => Self::Unspecified,
+                "APPROVED" => Self::Approved,
+                "REJECTED" => Self::Rejected,
+                _ => Self::UnknownValue(decision::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Decision {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Approved => serializer.serialize_i32(1),
+                Self::Rejected => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Decision {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Decision>::new(
+                ".google.devtools.cloudbuild.v1.ApprovalResult.Decision",
+            ))
         }
     }
 }
@@ -4947,73 +5408,138 @@ pub mod git_file_source {
 
     /// The type of the repo, since it may not be explicit from the `repo` field
     /// (e.g from a URL).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RepoType(i32);
-
-    impl RepoType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RepoType {
         /// The default, unknown repo type. Don't use it, instead use one of
         /// the other repo types.
-        pub const UNKNOWN: RepoType = RepoType::new(0);
-
+        Unknown,
         /// A Google Cloud Source Repositories-hosted repo.
-        pub const CLOUD_SOURCE_REPOSITORIES: RepoType = RepoType::new(1);
-
+        CloudSourceRepositories,
         /// A GitHub-hosted repo not necessarily on "github.com" (i.e. GitHub
         /// Enterprise).
-        pub const GITHUB: RepoType = RepoType::new(2);
-
+        Github,
         /// A Bitbucket Server-hosted repo.
-        pub const BITBUCKET_SERVER: RepoType = RepoType::new(3);
-
+        BitbucketServer,
         /// A GitLab-hosted repo.
-        pub const GITLAB: RepoType = RepoType::new(4);
+        Gitlab,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RepoType::value] or
+        /// [RepoType::name].
+        UnknownValue(repo_type::UnknownValue),
+    }
 
-        /// Creates a new RepoType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod repo_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RepoType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::CloudSourceRepositories => std::option::Option::Some(1),
+                Self::Github => std::option::Option::Some(2),
+                Self::BitbucketServer => std::option::Option::Some(3),
+                Self::Gitlab => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("CLOUD_SOURCE_REPOSITORIES"),
-                2 => std::borrow::Cow::Borrowed("GITHUB"),
-                3 => std::borrow::Cow::Borrowed("BITBUCKET_SERVER"),
-                4 => std::borrow::Cow::Borrowed("GITLAB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-                "CLOUD_SOURCE_REPOSITORIES" => {
-                    std::option::Option::Some(Self::CLOUD_SOURCE_REPOSITORIES)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UNKNOWN"),
+                Self::CloudSourceRepositories => {
+                    std::option::Option::Some("CLOUD_SOURCE_REPOSITORIES")
                 }
-                "GITHUB" => std::option::Option::Some(Self::GITHUB),
-                "BITBUCKET_SERVER" => std::option::Option::Some(Self::BITBUCKET_SERVER),
-                "GITLAB" => std::option::Option::Some(Self::GITLAB),
-                _ => std::option::Option::None,
+                Self::Github => std::option::Option::Some("GITHUB"),
+                Self::BitbucketServer => std::option::Option::Some("BITBUCKET_SERVER"),
+                Self::Gitlab => std::option::Option::Some("GITLAB"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for RepoType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RepoType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RepoType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RepoType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::CloudSourceRepositories,
+                2 => Self::Github,
+                3 => Self::BitbucketServer,
+                4 => Self::Gitlab,
+                _ => Self::UnknownValue(repo_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RepoType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNKNOWN" => Self::Unknown,
+                "CLOUD_SOURCE_REPOSITORIES" => Self::CloudSourceRepositories,
+                "GITHUB" => Self::Github,
+                "BITBUCKET_SERVER" => Self::BitbucketServer,
+                "GITLAB" => Self::Gitlab,
+                _ => Self::UnknownValue(repo_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RepoType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::CloudSourceRepositories => serializer.serialize_i32(1),
+                Self::Github => serializer.serialize_i32(2),
+                Self::BitbucketServer => serializer.serialize_i32(3),
+                Self::Gitlab => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RepoType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RepoType>::new(
+                ".google.devtools.cloudbuild.v1.GitFileSource.RepoType",
+            ))
         }
     }
 
@@ -5629,66 +6155,127 @@ pub mod repository_event_config {
     use super::*;
 
     /// All possible SCM repo types from Repo API.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RepositoryType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RepositoryType {
+        /// If unspecified, RepositoryType defaults to GITHUB.
+        Unspecified,
+        /// The SCM repo is GITHUB.
+        Github,
+        /// The SCM repo is GITHUB Enterprise.
+        GithubEnterprise,
+        /// The SCM repo is GITLAB Enterprise.
+        GitlabEnterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RepositoryType::value] or
+        /// [RepositoryType::name].
+        UnknownValue(repository_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod repository_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RepositoryType {
-        /// If unspecified, RepositoryType defaults to GITHUB.
-        pub const REPOSITORY_TYPE_UNSPECIFIED: RepositoryType = RepositoryType::new(0);
-
-        /// The SCM repo is GITHUB.
-        pub const GITHUB: RepositoryType = RepositoryType::new(1);
-
-        /// The SCM repo is GITHUB Enterprise.
-        pub const GITHUB_ENTERPRISE: RepositoryType = RepositoryType::new(2);
-
-        /// The SCM repo is GITLAB Enterprise.
-        pub const GITLAB_ENTERPRISE: RepositoryType = RepositoryType::new(3);
-
-        /// Creates a new RepositoryType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Github => std::option::Option::Some(1),
+                Self::GithubEnterprise => std::option::Option::Some(2),
+                Self::GitlabEnterprise => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REPOSITORY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GITHUB"),
-                2 => std::borrow::Cow::Borrowed("GITHUB_ENTERPRISE"),
-                3 => std::borrow::Cow::Borrowed("GITLAB_ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REPOSITORY_TYPE_UNSPECIFIED"),
+                Self::Github => std::option::Option::Some("GITHUB"),
+                Self::GithubEnterprise => std::option::Option::Some("GITHUB_ENTERPRISE"),
+                Self::GitlabEnterprise => std::option::Option::Some("GITLAB_ENTERPRISE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REPOSITORY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REPOSITORY_TYPE_UNSPECIFIED)
-                }
-                "GITHUB" => std::option::Option::Some(Self::GITHUB),
-                "GITHUB_ENTERPRISE" => std::option::Option::Some(Self::GITHUB_ENTERPRISE),
-                "GITLAB_ENTERPRISE" => std::option::Option::Some(Self::GITLAB_ENTERPRISE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RepositoryType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RepositoryType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RepositoryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RepositoryType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Github,
+                2 => Self::GithubEnterprise,
+                3 => Self::GitlabEnterprise,
+                _ => Self::UnknownValue(repository_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RepositoryType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REPOSITORY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GITHUB" => Self::Github,
+                "GITHUB_ENTERPRISE" => Self::GithubEnterprise,
+                "GITLAB_ENTERPRISE" => Self::GitlabEnterprise,
+                _ => Self::UnknownValue(repository_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RepositoryType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Github => serializer.serialize_i32(1),
+                Self::GithubEnterprise => serializer.serialize_i32(2),
+                Self::GitlabEnterprise => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RepositoryType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RepositoryType>::new(
+                ".google.devtools.cloudbuild.v1.RepositoryEventConfig.RepositoryType",
+            ))
         }
     }
 
@@ -5933,71 +6520,136 @@ pub mod pubsub_config {
 
     /// Enumerates potential issues with the underlying Pub/Sub subscription
     /// configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The subscription configuration has not been checked.
+        Unspecified,
+        /// The Pub/Sub subscription is properly configured.
+        Ok,
+        /// The subscription has been deleted.
+        SubscriptionDeleted,
+        /// The topic has been deleted.
+        TopicDeleted,
+        /// Some of the subscription's field are misconfigured.
+        SubscriptionMisconfigured,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The subscription configuration has not been checked.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The Pub/Sub subscription is properly configured.
-        pub const OK: State = State::new(1);
-
-        /// The subscription has been deleted.
-        pub const SUBSCRIPTION_DELETED: State = State::new(2);
-
-        /// The topic has been deleted.
-        pub const TOPIC_DELETED: State = State::new(3);
-
-        /// Some of the subscription's field are misconfigured.
-        pub const SUBSCRIPTION_MISCONFIGURED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(1),
+                Self::SubscriptionDeleted => std::option::Option::Some(2),
+                Self::TopicDeleted => std::option::Option::Some(3),
+                Self::SubscriptionMisconfigured => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OK"),
-                2 => std::borrow::Cow::Borrowed("SUBSCRIPTION_DELETED"),
-                3 => std::borrow::Cow::Borrowed("TOPIC_DELETED"),
-                4 => std::borrow::Cow::Borrowed("SUBSCRIPTION_MISCONFIGURED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "OK" => std::option::Option::Some(Self::OK),
-                "SUBSCRIPTION_DELETED" => std::option::Option::Some(Self::SUBSCRIPTION_DELETED),
-                "TOPIC_DELETED" => std::option::Option::Some(Self::TOPIC_DELETED),
-                "SUBSCRIPTION_MISCONFIGURED" => {
-                    std::option::Option::Some(Self::SUBSCRIPTION_MISCONFIGURED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::SubscriptionDeleted => std::option::Option::Some("SUBSCRIPTION_DELETED"),
+                Self::TopicDeleted => std::option::Option::Some("TOPIC_DELETED"),
+                Self::SubscriptionMisconfigured => {
+                    std::option::Option::Some("SUBSCRIPTION_MISCONFIGURED")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ok,
+                2 => Self::SubscriptionDeleted,
+                3 => Self::TopicDeleted,
+                4 => Self::SubscriptionMisconfigured,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "OK" => Self::Ok,
+                "SUBSCRIPTION_DELETED" => Self::SubscriptionDeleted,
+                "TOPIC_DELETED" => Self::TopicDeleted,
+                "SUBSCRIPTION_MISCONFIGURED" => Self::SubscriptionMisconfigured,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(1),
+                Self::SubscriptionDeleted => serializer.serialize_i32(2),
+                Self::TopicDeleted => serializer.serialize_i32(3),
+                Self::SubscriptionMisconfigured => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.devtools.cloudbuild.v1.PubsubConfig.State",
+            ))
         }
     }
 }
@@ -6085,59 +6737,120 @@ pub mod webhook_config {
 
     /// Enumerates potential issues with the Secret Manager secret provided by the
     /// user.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The webhook auth configuration not been checked.
+        Unspecified,
+        /// The auth configuration is properly setup.
+        Ok,
+        /// The secret provided in auth_method has been deleted.
+        SecretDeleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The webhook auth configuration not been checked.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The auth configuration is properly setup.
-        pub const OK: State = State::new(1);
-
-        /// The secret provided in auth_method has been deleted.
-        pub const SECRET_DELETED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Ok => std::option::Option::Some(1),
+                Self::SecretDeleted => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OK"),
-                2 => std::borrow::Cow::Borrowed("SECRET_DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Ok => std::option::Option::Some("OK"),
+                Self::SecretDeleted => std::option::Option::Some("SECRET_DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "OK" => std::option::Option::Some(Self::OK),
-                "SECRET_DELETED" => std::option::Option::Some(Self::SECRET_DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Ok,
+                2 => Self::SecretDeleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "OK" => Self::Ok,
+                "SECRET_DELETED" => Self::SecretDeleted,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Ok => serializer.serialize_i32(1),
+                Self::SecretDeleted => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.devtools.cloudbuild.v1.WebhookConfig.State",
+            ))
         }
     }
 
@@ -6260,74 +6973,136 @@ pub mod pull_request_filter {
     /// [Bitbucket](https://cloud.google.com/build/docs/automating-builds/bitbucket/build-repos-from-bitbucket-server#creating_a_bitbucket_server_trigger),
     /// [GitLab](https://cloud.google.com/build/docs/automating-builds/gitlab/build-repos-from-gitlab#creating_a_gitlab_trigger)
     /// for details.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommentControl(i32);
-
-    impl CommentControl {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CommentControl {
         /// Do not require `/gcbrun` comments from a user with repository write
         /// permission or above on pull requests before builds are triggered.
         /// Comments that contain `/gcbrun` will still fire builds so this should
         /// be thought of as comments not required.
-        pub const COMMENTS_DISABLED: CommentControl = CommentControl::new(0);
-
+        CommentsDisabled,
         /// Builds will only fire in response to pull requests if:
         ///
         /// . The pull request author has repository write permission or above and
         ///   `/gcbrun` is in the PR description.
         /// . A user with repository writer permissions or above comments `/gcbrun`
         ///   on a pull request authored by any user.
-        pub const COMMENTS_ENABLED: CommentControl = CommentControl::new(1);
-
+        CommentsEnabled,
         /// Builds will only fire in response to pull requests if:
         ///
         /// . The pull request author is a repository writer or above.
         /// . If the author does not have write permissions, a user with write
         ///   permissions or above must comment `/gcbrun` in order to fire a build.
-        pub const COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY: CommentControl =
-            CommentControl::new(2);
+        CommentsEnabledForExternalContributorsOnly,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CommentControl::value] or
+        /// [CommentControl::name].
+        UnknownValue(comment_control::UnknownValue),
+    }
 
-        /// Creates a new CommentControl instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod comment_control {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CommentControl {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::CommentsDisabled => std::option::Option::Some(0),
+                Self::CommentsEnabled => std::option::Option::Some(1),
+                Self::CommentsEnabledForExternalContributorsOnly => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMMENTS_DISABLED"),
-                1 => std::borrow::Cow::Borrowed("COMMENTS_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMMENTS_DISABLED" => std::option::Option::Some(Self::COMMENTS_DISABLED),
-                "COMMENTS_ENABLED" => std::option::Option::Some(Self::COMMENTS_ENABLED),
-                "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY" => {
-                    std::option::Option::Some(Self::COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::CommentsDisabled => std::option::Option::Some("COMMENTS_DISABLED"),
+                Self::CommentsEnabled => std::option::Option::Some("COMMENTS_ENABLED"),
+                Self::CommentsEnabledForExternalContributorsOnly => {
+                    std::option::Option::Some("COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CommentControl {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CommentControl {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CommentControl {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CommentControl {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::CommentsDisabled,
+                1 => Self::CommentsEnabled,
+                2 => Self::CommentsEnabledForExternalContributorsOnly,
+                _ => Self::UnknownValue(comment_control::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CommentControl {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMMENTS_DISABLED" => Self::CommentsDisabled,
+                "COMMENTS_ENABLED" => Self::CommentsEnabled,
+                "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY" => {
+                    Self::CommentsEnabledForExternalContributorsOnly
+                }
+                _ => Self::UnknownValue(comment_control::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CommentControl {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::CommentsDisabled => serializer.serialize_i32(0),
+                Self::CommentsEnabled => serializer.serialize_i32(1),
+                Self::CommentsEnabledForExternalContributorsOnly => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CommentControl {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommentControl>::new(
+                ".google.devtools.cloudbuild.v1.PullRequestFilter.CommentControl",
+            ))
         }
     }
 
@@ -7141,379 +7916,753 @@ pub mod build_options {
     ///
     /// For more information, see [Viewing Build
     /// Provenance](https://cloud.google.com/build/docs/securing-builds/view-build-provenance).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VerifyOption(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VerifyOption {
+        /// Not a verifiable build (the default).
+        NotVerified,
+        /// Build must be verified.
+        Verified,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VerifyOption::value] or
+        /// [VerifyOption::name].
+        UnknownValue(verify_option::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod verify_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VerifyOption {
-        /// Not a verifiable build (the default).
-        pub const NOT_VERIFIED: VerifyOption = VerifyOption::new(0);
-
-        /// Build must be verified.
-        pub const VERIFIED: VerifyOption = VerifyOption::new(1);
-
-        /// Creates a new VerifyOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::NotVerified => std::option::Option::Some(0),
+                Self::Verified => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NOT_VERIFIED"),
-                1 => std::borrow::Cow::Borrowed("VERIFIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::NotVerified => std::option::Option::Some("NOT_VERIFIED"),
+                Self::Verified => std::option::Option::Some("VERIFIED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NOT_VERIFIED" => std::option::Option::Some(Self::NOT_VERIFIED),
-                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VerifyOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VerifyOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VerifyOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VerifyOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::NotVerified,
+                1 => Self::Verified,
+                _ => Self::UnknownValue(verify_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VerifyOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NOT_VERIFIED" => Self::NotVerified,
+                "VERIFIED" => Self::Verified,
+                _ => Self::UnknownValue(verify_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VerifyOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::NotVerified => serializer.serialize_i32(0),
+                Self::Verified => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VerifyOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VerifyOption>::new(
+                ".google.devtools.cloudbuild.v1.BuildOptions.VerifyOption",
+            ))
         }
     }
 
     /// Supported Compute Engine machine types.
     /// For more information, see [Machine
     /// types](https://cloud.google.com/compute/docs/machine-types).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MachineType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MachineType {
+        /// Standard machine type.
+        Unspecified,
+        /// Highcpu machine with 8 CPUs.
+        N1Highcpu8,
+        /// Highcpu machine with 32 CPUs.
+        N1Highcpu32,
+        /// Highcpu e2 machine with 8 CPUs.
+        E2Highcpu8,
+        /// Highcpu e2 machine with 32 CPUs.
+        E2Highcpu32,
+        /// E2 machine with 1 CPU.
+        E2Medium,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MachineType::value] or
+        /// [MachineType::name].
+        UnknownValue(machine_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod machine_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MachineType {
-        /// Standard machine type.
-        pub const UNSPECIFIED: MachineType = MachineType::new(0);
-
-        /// Highcpu machine with 8 CPUs.
-        pub const N1_HIGHCPU_8: MachineType = MachineType::new(1);
-
-        /// Highcpu machine with 32 CPUs.
-        pub const N1_HIGHCPU_32: MachineType = MachineType::new(2);
-
-        /// Highcpu e2 machine with 8 CPUs.
-        pub const E2_HIGHCPU_8: MachineType = MachineType::new(5);
-
-        /// Highcpu e2 machine with 32 CPUs.
-        pub const E2_HIGHCPU_32: MachineType = MachineType::new(6);
-
-        /// E2 machine with 1 CPU.
-        pub const E2_MEDIUM: MachineType = MachineType::new(7);
-
-        /// Creates a new MachineType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::N1Highcpu8 => std::option::Option::Some(1),
+                Self::N1Highcpu32 => std::option::Option::Some(2),
+                Self::E2Highcpu8 => std::option::Option::Some(5),
+                Self::E2Highcpu32 => std::option::Option::Some(6),
+                Self::E2Medium => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("N1_HIGHCPU_8"),
-                2 => std::borrow::Cow::Borrowed("N1_HIGHCPU_32"),
-                5 => std::borrow::Cow::Borrowed("E2_HIGHCPU_8"),
-                6 => std::borrow::Cow::Borrowed("E2_HIGHCPU_32"),
-                7 => std::borrow::Cow::Borrowed("E2_MEDIUM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::N1Highcpu8 => std::option::Option::Some("N1_HIGHCPU_8"),
+                Self::N1Highcpu32 => std::option::Option::Some("N1_HIGHCPU_32"),
+                Self::E2Highcpu8 => std::option::Option::Some("E2_HIGHCPU_8"),
+                Self::E2Highcpu32 => std::option::Option::Some("E2_HIGHCPU_32"),
+                Self::E2Medium => std::option::Option::Some("E2_MEDIUM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "N1_HIGHCPU_8" => std::option::Option::Some(Self::N1_HIGHCPU_8),
-                "N1_HIGHCPU_32" => std::option::Option::Some(Self::N1_HIGHCPU_32),
-                "E2_HIGHCPU_8" => std::option::Option::Some(Self::E2_HIGHCPU_8),
-                "E2_HIGHCPU_32" => std::option::Option::Some(Self::E2_HIGHCPU_32),
-                "E2_MEDIUM" => std::option::Option::Some(Self::E2_MEDIUM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MachineType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MachineType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for MachineType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MachineType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::N1Highcpu8,
+                2 => Self::N1Highcpu32,
+                5 => Self::E2Highcpu8,
+                6 => Self::E2Highcpu32,
+                7 => Self::E2Medium,
+                _ => Self::UnknownValue(machine_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MachineType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "N1_HIGHCPU_8" => Self::N1Highcpu8,
+                "N1_HIGHCPU_32" => Self::N1Highcpu32,
+                "E2_HIGHCPU_8" => Self::E2Highcpu8,
+                "E2_HIGHCPU_32" => Self::E2Highcpu32,
+                "E2_MEDIUM" => Self::E2Medium,
+                _ => Self::UnknownValue(machine_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MachineType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::N1Highcpu8 => serializer.serialize_i32(1),
+                Self::N1Highcpu32 => serializer.serialize_i32(2),
+                Self::E2Highcpu8 => serializer.serialize_i32(5),
+                Self::E2Highcpu32 => serializer.serialize_i32(6),
+                Self::E2Medium => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MachineType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MachineType>::new(
+                ".google.devtools.cloudbuild.v1.BuildOptions.MachineType",
+            ))
         }
     }
 
     /// Specifies the behavior when there is an error in the substitution checks.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SubstitutionOption(i32);
-
-    impl SubstitutionOption {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SubstitutionOption {
         /// Fails the build if error in substitutions checks, like missing
         /// a substitution in the template or in the map.
-        pub const MUST_MATCH: SubstitutionOption = SubstitutionOption::new(0);
-
+        MustMatch,
         /// Do not fail the build if error in substitutions checks.
-        pub const ALLOW_LOOSE: SubstitutionOption = SubstitutionOption::new(1);
+        AllowLoose,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SubstitutionOption::value] or
+        /// [SubstitutionOption::name].
+        UnknownValue(substitution_option::UnknownValue),
+    }
 
-        /// Creates a new SubstitutionOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod substitution_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SubstitutionOption {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::MustMatch => std::option::Option::Some(0),
+                Self::AllowLoose => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MUST_MATCH"),
-                1 => std::borrow::Cow::Borrowed("ALLOW_LOOSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::MustMatch => std::option::Option::Some("MUST_MATCH"),
+                Self::AllowLoose => std::option::Option::Some("ALLOW_LOOSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MUST_MATCH" => std::option::Option::Some(Self::MUST_MATCH),
-                "ALLOW_LOOSE" => std::option::Option::Some(Self::ALLOW_LOOSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SubstitutionOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SubstitutionOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SubstitutionOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SubstitutionOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::MustMatch,
+                1 => Self::AllowLoose,
+                _ => Self::UnknownValue(substitution_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SubstitutionOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MUST_MATCH" => Self::MustMatch,
+                "ALLOW_LOOSE" => Self::AllowLoose,
+                _ => Self::UnknownValue(substitution_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SubstitutionOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::MustMatch => serializer.serialize_i32(0),
+                Self::AllowLoose => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SubstitutionOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SubstitutionOption>::new(
+                ".google.devtools.cloudbuild.v1.BuildOptions.SubstitutionOption",
+            ))
         }
     }
 
     /// Specifies the behavior when writing build logs to Cloud Storage.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogStreamingOption(i32);
-
-    impl LogStreamingOption {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogStreamingOption {
         /// Service may automatically determine build log streaming behavior.
-        pub const STREAM_DEFAULT: LogStreamingOption = LogStreamingOption::new(0);
-
+        StreamDefault,
         /// Build logs should be streamed to Cloud Storage.
-        pub const STREAM_ON: LogStreamingOption = LogStreamingOption::new(1);
-
+        StreamOn,
         /// Build logs should not be streamed to Cloud Storage; they will be
         /// written when the build is completed.
-        pub const STREAM_OFF: LogStreamingOption = LogStreamingOption::new(2);
+        StreamOff,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogStreamingOption::value] or
+        /// [LogStreamingOption::name].
+        UnknownValue(log_streaming_option::UnknownValue),
+    }
 
-        /// Creates a new LogStreamingOption instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod log_streaming_option {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LogStreamingOption {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::StreamDefault => std::option::Option::Some(0),
+                Self::StreamOn => std::option::Option::Some(1),
+                Self::StreamOff => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STREAM_DEFAULT"),
-                1 => std::borrow::Cow::Borrowed("STREAM_ON"),
-                2 => std::borrow::Cow::Borrowed("STREAM_OFF"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::StreamDefault => std::option::Option::Some("STREAM_DEFAULT"),
+                Self::StreamOn => std::option::Option::Some("STREAM_ON"),
+                Self::StreamOff => std::option::Option::Some("STREAM_OFF"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STREAM_DEFAULT" => std::option::Option::Some(Self::STREAM_DEFAULT),
-                "STREAM_ON" => std::option::Option::Some(Self::STREAM_ON),
-                "STREAM_OFF" => std::option::Option::Some(Self::STREAM_OFF),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LogStreamingOption {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LogStreamingOption {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LogStreamingOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LogStreamingOption {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::StreamDefault,
+                1 => Self::StreamOn,
+                2 => Self::StreamOff,
+                _ => Self::UnknownValue(log_streaming_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LogStreamingOption {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STREAM_DEFAULT" => Self::StreamDefault,
+                "STREAM_ON" => Self::StreamOn,
+                "STREAM_OFF" => Self::StreamOff,
+                _ => Self::UnknownValue(log_streaming_option::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LogStreamingOption {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::StreamDefault => serializer.serialize_i32(0),
+                Self::StreamOn => serializer.serialize_i32(1),
+                Self::StreamOff => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LogStreamingOption {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogStreamingOption>::new(
+                ".google.devtools.cloudbuild.v1.BuildOptions.LogStreamingOption",
+            ))
         }
     }
 
     /// Specifies the logging mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggingMode(i32);
-
-    impl LoggingMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoggingMode {
         /// The service determines the logging mode. The default is `LEGACY`. Do not
         /// rely on the default logging behavior as it may change in the future.
-        pub const LOGGING_UNSPECIFIED: LoggingMode = LoggingMode::new(0);
-
+        LoggingUnspecified,
         /// Build logs are stored in Cloud Logging and Cloud Storage.
-        pub const LEGACY: LoggingMode = LoggingMode::new(1);
-
+        Legacy,
         /// Build logs are stored in Cloud Storage.
-        pub const GCS_ONLY: LoggingMode = LoggingMode::new(2);
-
+        GcsOnly,
         /// This option is the same as CLOUD_LOGGING_ONLY.
-        pub const STACKDRIVER_ONLY: LoggingMode = LoggingMode::new(3);
-
+        StackdriverOnly,
         /// Build logs are stored in Cloud Logging. Selecting this option will not
         /// allow [logs
         /// streaming](https://cloud.google.com/sdk/gcloud/reference/builds/log).
-        pub const CLOUD_LOGGING_ONLY: LoggingMode = LoggingMode::new(5);
-
+        CloudLoggingOnly,
         /// Turn off all logging. No build logs will be captured.
-        pub const NONE: LoggingMode = LoggingMode::new(4);
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoggingMode::value] or
+        /// [LoggingMode::name].
+        UnknownValue(logging_mode::UnknownValue),
+    }
 
-        /// Creates a new LoggingMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod logging_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LoggingMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::LoggingUnspecified => std::option::Option::Some(0),
+                Self::Legacy => std::option::Option::Some(1),
+                Self::GcsOnly => std::option::Option::Some(2),
+                Self::StackdriverOnly => std::option::Option::Some(3),
+                Self::CloudLoggingOnly => std::option::Option::Some(5),
+                Self::None => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOGGING_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LEGACY"),
-                2 => std::borrow::Cow::Borrowed("GCS_ONLY"),
-                3 => std::borrow::Cow::Borrowed("STACKDRIVER_ONLY"),
-                4 => std::borrow::Cow::Borrowed("NONE"),
-                5 => std::borrow::Cow::Borrowed("CLOUD_LOGGING_ONLY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::LoggingUnspecified => std::option::Option::Some("LOGGING_UNSPECIFIED"),
+                Self::Legacy => std::option::Option::Some("LEGACY"),
+                Self::GcsOnly => std::option::Option::Some("GCS_ONLY"),
+                Self::StackdriverOnly => std::option::Option::Some("STACKDRIVER_ONLY"),
+                Self::CloudLoggingOnly => std::option::Option::Some("CLOUD_LOGGING_ONLY"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOGGING_UNSPECIFIED" => std::option::Option::Some(Self::LOGGING_UNSPECIFIED),
-                "LEGACY" => std::option::Option::Some(Self::LEGACY),
-                "GCS_ONLY" => std::option::Option::Some(Self::GCS_ONLY),
-                "STACKDRIVER_ONLY" => std::option::Option::Some(Self::STACKDRIVER_ONLY),
-                "CLOUD_LOGGING_ONLY" => std::option::Option::Some(Self::CLOUD_LOGGING_ONLY),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoggingMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggingMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoggingMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoggingMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::LoggingUnspecified,
+                1 => Self::Legacy,
+                2 => Self::GcsOnly,
+                3 => Self::StackdriverOnly,
+                4 => Self::None,
+                5 => Self::CloudLoggingOnly,
+                _ => Self::UnknownValue(logging_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoggingMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOGGING_UNSPECIFIED" => Self::LoggingUnspecified,
+                "LEGACY" => Self::Legacy,
+                "GCS_ONLY" => Self::GcsOnly,
+                "STACKDRIVER_ONLY" => Self::StackdriverOnly,
+                "CLOUD_LOGGING_ONLY" => Self::CloudLoggingOnly,
+                "NONE" => Self::None,
+                _ => Self::UnknownValue(logging_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoggingMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::LoggingUnspecified => serializer.serialize_i32(0),
+                Self::Legacy => serializer.serialize_i32(1),
+                Self::GcsOnly => serializer.serialize_i32(2),
+                Self::StackdriverOnly => serializer.serialize_i32(3),
+                Self::CloudLoggingOnly => serializer.serialize_i32(5),
+                Self::None => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoggingMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoggingMode>::new(
+                ".google.devtools.cloudbuild.v1.BuildOptions.LoggingMode",
+            ))
         }
     }
 
     /// Default Cloud Storage log bucket behavior options.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DefaultLogsBucketBehavior(i32);
-
-    impl DefaultLogsBucketBehavior {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DefaultLogsBucketBehavior {
         /// Unspecified.
-        pub const DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED: DefaultLogsBucketBehavior =
-            DefaultLogsBucketBehavior::new(0);
-
+        Unspecified,
         /// Bucket is located in user-owned project in the same region as the
         /// build. The builder service account must have access to create and write
         /// to Cloud Storage buckets in the build project.
-        pub const REGIONAL_USER_OWNED_BUCKET: DefaultLogsBucketBehavior =
-            DefaultLogsBucketBehavior::new(1);
-
+        RegionalUserOwnedBucket,
         /// Bucket is located in a Google-owned project and is not regionalized.
-        pub const LEGACY_BUCKET: DefaultLogsBucketBehavior = DefaultLogsBucketBehavior::new(2);
+        LegacyBucket,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DefaultLogsBucketBehavior::value] or
+        /// [DefaultLogsBucketBehavior::name].
+        UnknownValue(default_logs_bucket_behavior::UnknownValue),
+    }
 
-        /// Creates a new DefaultLogsBucketBehavior instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod default_logs_bucket_behavior {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DefaultLogsBucketBehavior {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::RegionalUserOwnedBucket => std::option::Option::Some(1),
+                Self::LegacyBucket => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGIONAL_USER_OWNED_BUCKET"),
-                2 => std::borrow::Cow::Borrowed("LEGACY_BUCKET"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED")
                 }
-                "REGIONAL_USER_OWNED_BUCKET" => {
-                    std::option::Option::Some(Self::REGIONAL_USER_OWNED_BUCKET)
+                Self::RegionalUserOwnedBucket => {
+                    std::option::Option::Some("REGIONAL_USER_OWNED_BUCKET")
                 }
-                "LEGACY_BUCKET" => std::option::Option::Some(Self::LEGACY_BUCKET),
-                _ => std::option::Option::None,
+                Self::LegacyBucket => std::option::Option::Some("LEGACY_BUCKET"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DefaultLogsBucketBehavior {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DefaultLogsBucketBehavior {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DefaultLogsBucketBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DefaultLogsBucketBehavior {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::RegionalUserOwnedBucket,
+                2 => Self::LegacyBucket,
+                _ => Self::UnknownValue(default_logs_bucket_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DefaultLogsBucketBehavior {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEFAULT_LOGS_BUCKET_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+                "REGIONAL_USER_OWNED_BUCKET" => Self::RegionalUserOwnedBucket,
+                "LEGACY_BUCKET" => Self::LegacyBucket,
+                _ => Self::UnknownValue(default_logs_bucket_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DefaultLogsBucketBehavior {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::RegionalUserOwnedBucket => serializer.serialize_i32(1),
+                Self::LegacyBucket => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DefaultLogsBucketBehavior {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<DefaultLogsBucketBehavior>::new(
+                    ".google.devtools.cloudbuild.v1.BuildOptions.DefaultLogsBucketBehavior",
+                ),
+            )
         }
     }
 }
@@ -8037,74 +9186,141 @@ pub mod worker_pool {
     use super::*;
 
     /// State of the `WorkerPool`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// State of the `WorkerPool` is unknown.
+        Unspecified,
+        /// `WorkerPool` is being created.
+        Creating,
+        /// `WorkerPool` is running.
+        Running,
+        /// `WorkerPool` is being deleted: cancelling builds and draining workers.
+        Deleting,
+        /// `WorkerPool` is deleted.
+        Deleted,
+        /// `WorkerPool` is being updated; new builds cannot be run.
+        Updating,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// State of the `WorkerPool` is unknown.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// `WorkerPool` is being created.
-        pub const CREATING: State = State::new(1);
-
-        /// `WorkerPool` is running.
-        pub const RUNNING: State = State::new(2);
-
-        /// `WorkerPool` is being deleted: cancelling builds and draining workers.
-        pub const DELETING: State = State::new(3);
-
-        /// `WorkerPool` is deleted.
-        pub const DELETED: State = State::new(4);
-
-        /// `WorkerPool` is being updated; new builds cannot be run.
-        pub const UPDATING: State = State::new(5);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::Deleted => std::option::Option::Some(4),
+                Self::Updating => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                4 => std::borrow::Cow::Borrowed("DELETED"),
-                5 => std::borrow::Cow::Borrowed("UPDATING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::Updating => std::option::Option::Some("UPDATING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                "UPDATING" => std::option::Option::Some(Self::UPDATING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Running,
+                3 => Self::Deleting,
+                4 => Self::Deleted,
+                5 => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "RUNNING" => Self::Running,
+                "DELETING" => Self::Deleting,
+                "DELETED" => Self::Deleted,
+                "UPDATING" => Self::Updating,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::Deleted => serializer.serialize_i32(4),
+                Self::Updating => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.devtools.cloudbuild.v1.WorkerPool.State",
+            ))
         }
     }
 
@@ -8333,63 +9549,125 @@ pub mod private_pool_v_1_config {
         use super::*;
 
         /// Defines the egress option for the pool.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EgressOption(i32);
-
-        impl EgressOption {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EgressOption {
             /// If set, defaults to PUBLIC_EGRESS.
-            pub const EGRESS_OPTION_UNSPECIFIED: EgressOption = EgressOption::new(0);
-
+            Unspecified,
             /// If set, workers are created without any public address, which prevents
             /// network egress to public IPs unless a network proxy is configured.
-            pub const NO_PUBLIC_EGRESS: EgressOption = EgressOption::new(1);
-
+            NoPublicEgress,
             /// If set, workers are created with a public address which allows for
             /// public internet egress.
-            pub const PUBLIC_EGRESS: EgressOption = EgressOption::new(2);
+            PublicEgress,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EgressOption::value] or
+            /// [EgressOption::name].
+            UnknownValue(egress_option::UnknownValue),
+        }
 
-            /// Creates a new EgressOption instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod egress_option {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl EgressOption {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::NoPublicEgress => std::option::Option::Some(1),
+                    Self::PublicEgress => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("EGRESS_OPTION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NO_PUBLIC_EGRESS"),
-                    2 => std::borrow::Cow::Borrowed("PUBLIC_EGRESS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("EGRESS_OPTION_UNSPECIFIED"),
+                    Self::NoPublicEgress => std::option::Option::Some("NO_PUBLIC_EGRESS"),
+                    Self::PublicEgress => std::option::Option::Some("PUBLIC_EGRESS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "EGRESS_OPTION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::EGRESS_OPTION_UNSPECIFIED)
-                    }
-                    "NO_PUBLIC_EGRESS" => std::option::Option::Some(Self::NO_PUBLIC_EGRESS),
-                    "PUBLIC_EGRESS" => std::option::Option::Some(Self::PUBLIC_EGRESS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EgressOption {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EgressOption {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EgressOption {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EgressOption {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::NoPublicEgress,
+                    2 => Self::PublicEgress,
+                    _ => Self::UnknownValue(egress_option::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EgressOption {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "EGRESS_OPTION_UNSPECIFIED" => Self::Unspecified,
+                    "NO_PUBLIC_EGRESS" => Self::NoPublicEgress,
+                    "PUBLIC_EGRESS" => Self::PublicEgress,
+                    _ => Self::UnknownValue(egress_option::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EgressOption {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::NoPublicEgress => serializer.serialize_i32(1),
+                    Self::PublicEgress => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EgressOption {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<EgressOption>::new(
+                    ".google.devtools.cloudbuild.v1.PrivatePoolV1Config.NetworkConfig.EgressOption",
+                ))
             }
         }
     }

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -630,70 +630,135 @@ pub mod installation_state {
     use super::*;
 
     /// Stage of the installation process.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Stage(i32);
-
-    impl Stage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Stage {
         /// No stage specified.
-        pub const STAGE_UNSPECIFIED: Stage = Stage::new(0);
-
+        Unspecified,
         /// Only for GitHub Enterprise. An App creation has been requested.
         /// The user needs to confirm the creation in their GitHub enterprise host.
-        pub const PENDING_CREATE_APP: Stage = Stage::new(1);
-
+        PendingCreateApp,
         /// User needs to authorize the GitHub (or Enterprise) App via OAuth.
-        pub const PENDING_USER_OAUTH: Stage = Stage::new(2);
-
+        PendingUserOauth,
         /// User needs to follow the link to install the GitHub (or Enterprise) App.
-        pub const PENDING_INSTALL_APP: Stage = Stage::new(3);
-
+        PendingInstallApp,
         /// Installation process has been completed.
-        pub const COMPLETE: Stage = Stage::new(10);
+        Complete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Stage::value] or
+        /// [Stage::name].
+        UnknownValue(stage::UnknownValue),
+    }
 
-        /// Creates a new Stage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Stage {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PendingCreateApp => std::option::Option::Some(1),
+                Self::PendingUserOauth => std::option::Option::Some(2),
+                Self::PendingInstallApp => std::option::Option::Some(3),
+                Self::Complete => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STAGE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING_CREATE_APP"),
-                2 => std::borrow::Cow::Borrowed("PENDING_USER_OAUTH"),
-                3 => std::borrow::Cow::Borrowed("PENDING_INSTALL_APP"),
-                10 => std::borrow::Cow::Borrowed("COMPLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STAGE_UNSPECIFIED"),
+                Self::PendingCreateApp => std::option::Option::Some("PENDING_CREATE_APP"),
+                Self::PendingUserOauth => std::option::Option::Some("PENDING_USER_OAUTH"),
+                Self::PendingInstallApp => std::option::Option::Some("PENDING_INSTALL_APP"),
+                Self::Complete => std::option::Option::Some("COMPLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STAGE_UNSPECIFIED" => std::option::Option::Some(Self::STAGE_UNSPECIFIED),
-                "PENDING_CREATE_APP" => std::option::Option::Some(Self::PENDING_CREATE_APP),
-                "PENDING_USER_OAUTH" => std::option::Option::Some(Self::PENDING_USER_OAUTH),
-                "PENDING_INSTALL_APP" => std::option::Option::Some(Self::PENDING_INSTALL_APP),
-                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Stage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Stage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Stage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Stage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PendingCreateApp,
+                2 => Self::PendingUserOauth,
+                3 => Self::PendingInstallApp,
+                10 => Self::Complete,
+                _ => Self::UnknownValue(stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Stage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STAGE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING_CREATE_APP" => Self::PendingCreateApp,
+                "PENDING_USER_OAUTH" => Self::PendingUserOauth,
+                "PENDING_INSTALL_APP" => Self::PendingInstallApp,
+                "COMPLETE" => Self::Complete,
+                _ => Self::UnknownValue(stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Stage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PendingCreateApp => serializer.serialize_i32(1),
+                Self::PendingUserOauth => serializer.serialize_i32(2),
+                Self::PendingInstallApp => serializer.serialize_i32(3),
+                Self::Complete => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Stage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Stage>::new(
+                ".google.devtools.cloudbuild.v2.InstallationState.Stage",
+            ))
         }
     }
 }
@@ -2521,59 +2586,120 @@ pub mod fetch_git_refs_request {
     use super::*;
 
     /// Type of refs
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RefType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RefType {
+        /// No type specified.
+        Unspecified,
+        /// To fetch tags.
+        Tag,
+        /// To fetch branches.
+        Branch,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RefType::value] or
+        /// [RefType::name].
+        UnknownValue(ref_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ref_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RefType {
-        /// No type specified.
-        pub const REF_TYPE_UNSPECIFIED: RefType = RefType::new(0);
-
-        /// To fetch tags.
-        pub const TAG: RefType = RefType::new(1);
-
-        /// To fetch branches.
-        pub const BRANCH: RefType = RefType::new(2);
-
-        /// Creates a new RefType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Tag => std::option::Option::Some(1),
+                Self::Branch => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REF_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TAG"),
-                2 => std::borrow::Cow::Borrowed("BRANCH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REF_TYPE_UNSPECIFIED"),
+                Self::Tag => std::option::Option::Some("TAG"),
+                Self::Branch => std::option::Option::Some("BRANCH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REF_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::REF_TYPE_UNSPECIFIED),
-                "TAG" => std::option::Option::Some(Self::TAG),
-                "BRANCH" => std::option::Option::Some(Self::BRANCH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RefType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RefType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RefType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RefType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Tag,
+                2 => Self::Branch,
+                _ => Self::UnknownValue(ref_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RefType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REF_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TAG" => Self::Tag,
+                "BRANCH" => Self::Branch,
+                _ => Self::UnknownValue(ref_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RefType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Tag => serializer.serialize_i32(1),
+                Self::Branch => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RefType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RefType>::new(
+                ".google.devtools.cloudbuild.v2.FetchGitRefsRequest.RefType",
+            ))
         }
     }
 }

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -352,7 +352,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("refType", &req.ref_type.value())]);
+        let builder = builder.query(&[("refType", &req.ref_type)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/devtools/cloudprofiler/v2/src/model.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/model.rs
@@ -525,89 +525,160 @@ impl gax::paginator::internal::PageableResponse for ListProfilesResponse {
 /// ProfileType is type of profiling data.
 /// NOTE: the enumeration member names are used (in lowercase) as unique string
 /// identifiers of profile types, so they must not be renamed.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ProfileType(i32);
-
-impl ProfileType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ProfileType {
     /// Unspecified profile type.
-    pub const PROFILE_TYPE_UNSPECIFIED: ProfileType = ProfileType::new(0);
-
+    Unspecified,
     /// Thread CPU time sampling.
-    pub const CPU: ProfileType = ProfileType::new(1);
-
+    Cpu,
     /// Wallclock time sampling. More expensive as stops all threads.
-    pub const WALL: ProfileType = ProfileType::new(2);
-
+    Wall,
     /// In-use heap profile. Represents a snapshot of the allocations that are
     /// live at the time of the profiling.
-    pub const HEAP: ProfileType = ProfileType::new(3);
-
+    Heap,
     /// Single-shot collection of all thread stacks.
-    pub const THREADS: ProfileType = ProfileType::new(4);
-
+    Threads,
     /// Synchronization contention profile.
-    pub const CONTENTION: ProfileType = ProfileType::new(5);
-
+    Contention,
     /// Peak heap profile.
-    pub const PEAK_HEAP: ProfileType = ProfileType::new(6);
-
+    PeakHeap,
     /// Heap allocation profile. It represents the aggregation of all allocations
     /// made over the duration of the profile. All allocations are included,
     /// including those that might have been freed by the end of the profiling
     /// interval. The profile is in particular useful for garbage collecting
     /// languages to understand which parts of the code create most of the garbage
     /// collection pressure to see if those can be optimized.
-    pub const HEAP_ALLOC: ProfileType = ProfileType::new(7);
+    HeapAlloc,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ProfileType::value] or
+    /// [ProfileType::name].
+    UnknownValue(profile_type::UnknownValue),
+}
 
-    /// Creates a new ProfileType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod profile_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ProfileType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Cpu => std::option::Option::Some(1),
+            Self::Wall => std::option::Option::Some(2),
+            Self::Heap => std::option::Option::Some(3),
+            Self::Threads => std::option::Option::Some(4),
+            Self::Contention => std::option::Option::Some(5),
+            Self::PeakHeap => std::option::Option::Some(6),
+            Self::HeapAlloc => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PROFILE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CPU"),
-            2 => std::borrow::Cow::Borrowed("WALL"),
-            3 => std::borrow::Cow::Borrowed("HEAP"),
-            4 => std::borrow::Cow::Borrowed("THREADS"),
-            5 => std::borrow::Cow::Borrowed("CONTENTION"),
-            6 => std::borrow::Cow::Borrowed("PEAK_HEAP"),
-            7 => std::borrow::Cow::Borrowed("HEAP_ALLOC"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PROFILE_TYPE_UNSPECIFIED"),
+            Self::Cpu => std::option::Option::Some("CPU"),
+            Self::Wall => std::option::Option::Some("WALL"),
+            Self::Heap => std::option::Option::Some("HEAP"),
+            Self::Threads => std::option::Option::Some("THREADS"),
+            Self::Contention => std::option::Option::Some("CONTENTION"),
+            Self::PeakHeap => std::option::Option::Some("PEAK_HEAP"),
+            Self::HeapAlloc => std::option::Option::Some("HEAP_ALLOC"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PROFILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::PROFILE_TYPE_UNSPECIFIED),
-            "CPU" => std::option::Option::Some(Self::CPU),
-            "WALL" => std::option::Option::Some(Self::WALL),
-            "HEAP" => std::option::Option::Some(Self::HEAP),
-            "THREADS" => std::option::Option::Some(Self::THREADS),
-            "CONTENTION" => std::option::Option::Some(Self::CONTENTION),
-            "PEAK_HEAP" => std::option::Option::Some(Self::PEAK_HEAP),
-            "HEAP_ALLOC" => std::option::Option::Some(Self::HEAP_ALLOC),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ProfileType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ProfileType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ProfileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ProfileType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Cpu,
+            2 => Self::Wall,
+            3 => Self::Heap,
+            4 => Self::Threads,
+            5 => Self::Contention,
+            6 => Self::PeakHeap,
+            7 => Self::HeapAlloc,
+            _ => Self::UnknownValue(profile_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ProfileType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PROFILE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "CPU" => Self::Cpu,
+            "WALL" => Self::Wall,
+            "HEAP" => Self::Heap,
+            "THREADS" => Self::Threads,
+            "CONTENTION" => Self::Contention,
+            "PEAK_HEAP" => Self::PeakHeap,
+            "HEAP_ALLOC" => Self::HeapAlloc,
+            _ => Self::UnknownValue(profile_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ProfileType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Cpu => serializer.serialize_i32(1),
+            Self::Wall => serializer.serialize_i32(2),
+            Self::Heap => serializer.serialize_i32(3),
+            Self::Threads => serializer.serialize_i32(4),
+            Self::Contention => serializer.serialize_i32(5),
+            Self::PeakHeap => serializer.serialize_i32(6),
+            Self::HeapAlloc => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ProfileType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProfileType>::new(
+            ".google.devtools.cloudprofiler.v2.ProfileType",
+        ))
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -593,59 +593,123 @@ pub mod span {
             use super::*;
 
             /// Indicates whether the message was sent or received.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct Type(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum Type {
+                /// Unknown event type.
+                Unspecified,
+                /// Indicates a sent message.
+                Sent,
+                /// Indicates a received message.
+                Received,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [Type::value] or
+                /// [Type::name].
+                UnknownValue(r#type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod r#type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl Type {
-                /// Unknown event type.
-                pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-                /// Indicates a sent message.
-                pub const SENT: Type = Type::new(1);
-
-                /// Indicates a received message.
-                pub const RECEIVED: Type = Type::new(2);
-
-                /// Creates a new Type instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Sent => std::option::Option::Some(1),
+                        Self::Received => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("SENT"),
-                        2 => std::borrow::Cow::Borrowed("RECEIVED"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                        Self::Sent => std::option::Option::Some("SENT"),
+                        Self::Received => std::option::Option::Some("RECEIVED"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                        "SENT" => std::option::Option::Some(Self::SENT),
-                        "RECEIVED" => std::option::Option::Some(Self::RECEIVED),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for Type {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for Type {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for Type {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for Type {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Sent,
+                        2 => Self::Received,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for Type {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "SENT" => Self::Sent,
+                        "RECEIVED" => Self::Received,
+                        _ => Self::UnknownValue(r#type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for Type {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Sent => serializer.serialize_i32(1),
+                        Self::Received => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for Type {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                        ".google.devtools.cloudtrace.v2.Span.TimeEvent.MessageEvent.Type",
+                    ))
                 }
             }
         }
@@ -808,59 +872,123 @@ pub mod span {
 
         /// The relationship of the current span relative to the linked span: child,
         /// parent, or unspecified.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Type(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Type {
+            /// The relationship of the two spans is unknown.
+            Unspecified,
+            /// The linked span is a child of the current span.
+            ChildLinkedSpan,
+            /// The linked span is a parent of the current span.
+            ParentLinkedSpan,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Type::value] or
+            /// [Type::name].
+            UnknownValue(r#type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod r#type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Type {
-            /// The relationship of the two spans is unknown.
-            pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-            /// The linked span is a child of the current span.
-            pub const CHILD_LINKED_SPAN: Type = Type::new(1);
-
-            /// The linked span is a parent of the current span.
-            pub const PARENT_LINKED_SPAN: Type = Type::new(2);
-
-            /// Creates a new Type instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ChildLinkedSpan => std::option::Option::Some(1),
+                    Self::ParentLinkedSpan => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CHILD_LINKED_SPAN"),
-                    2 => std::borrow::Cow::Borrowed("PARENT_LINKED_SPAN"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::ChildLinkedSpan => std::option::Option::Some("CHILD_LINKED_SPAN"),
+                    Self::ParentLinkedSpan => std::option::Option::Some("PARENT_LINKED_SPAN"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "CHILD_LINKED_SPAN" => std::option::Option::Some(Self::CHILD_LINKED_SPAN),
-                    "PARENT_LINKED_SPAN" => std::option::Option::Some(Self::PARENT_LINKED_SPAN),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Type {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Type {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Type {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Type {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ChildLinkedSpan,
+                    2 => Self::ParentLinkedSpan,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Type {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "CHILD_LINKED_SPAN" => Self::ChildLinkedSpan,
+                    "PARENT_LINKED_SPAN" => Self::ParentLinkedSpan,
+                    _ => Self::UnknownValue(r#type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Type {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ChildLinkedSpan => serializer.serialize_i32(1),
+                    Self::ParentLinkedSpan => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Type {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                    ".google.devtools.cloudtrace.v2.Span.Link.Type",
+                ))
             }
         }
     }
@@ -916,83 +1044,150 @@ pub mod span {
 
     /// Type of span. Can be used to specify additional relationships between spans
     /// in addition to a parent/child relationship.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SpanKind(i32);
-
-    impl SpanKind {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SpanKind {
         /// Unspecified. Do NOT use as default.
         /// Implementations MAY assume SpanKind.INTERNAL to be default.
-        pub const SPAN_KIND_UNSPECIFIED: SpanKind = SpanKind::new(0);
-
+        Unspecified,
         /// Indicates that the span is used internally. Default value.
-        pub const INTERNAL: SpanKind = SpanKind::new(1);
-
+        Internal,
         /// Indicates that the span covers server-side handling of an RPC or other
         /// remote network request.
-        pub const SERVER: SpanKind = SpanKind::new(2);
-
+        Server,
         /// Indicates that the span covers the client-side wrapper around an RPC or
         /// other remote request.
-        pub const CLIENT: SpanKind = SpanKind::new(3);
-
+        Client,
         /// Indicates that the span describes producer sending a message to a broker.
         /// Unlike client and  server, there is no direct critical path latency
         /// relationship between producer and consumer spans (e.g. publishing a
         /// message to a pubsub service).
-        pub const PRODUCER: SpanKind = SpanKind::new(4);
-
+        Producer,
         /// Indicates that the span describes consumer receiving a message from a
         /// broker. Unlike client and  server, there is no direct critical path
         /// latency relationship between producer and consumer spans (e.g. receiving
         /// a message from a pubsub service subscription).
-        pub const CONSUMER: SpanKind = SpanKind::new(5);
+        Consumer,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SpanKind::value] or
+        /// [SpanKind::name].
+        UnknownValue(span_kind::UnknownValue),
+    }
 
-        /// Creates a new SpanKind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod span_kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SpanKind {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Internal => std::option::Option::Some(1),
+                Self::Server => std::option::Option::Some(2),
+                Self::Client => std::option::Option::Some(3),
+                Self::Producer => std::option::Option::Some(4),
+                Self::Consumer => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SPAN_KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("INTERNAL"),
-                2 => std::borrow::Cow::Borrowed("SERVER"),
-                3 => std::borrow::Cow::Borrowed("CLIENT"),
-                4 => std::borrow::Cow::Borrowed("PRODUCER"),
-                5 => std::borrow::Cow::Borrowed("CONSUMER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SPAN_KIND_UNSPECIFIED"),
+                Self::Internal => std::option::Option::Some("INTERNAL"),
+                Self::Server => std::option::Option::Some("SERVER"),
+                Self::Client => std::option::Option::Some("CLIENT"),
+                Self::Producer => std::option::Option::Some("PRODUCER"),
+                Self::Consumer => std::option::Option::Some("CONSUMER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SPAN_KIND_UNSPECIFIED" => std::option::Option::Some(Self::SPAN_KIND_UNSPECIFIED),
-                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
-                "SERVER" => std::option::Option::Some(Self::SERVER),
-                "CLIENT" => std::option::Option::Some(Self::CLIENT),
-                "PRODUCER" => std::option::Option::Some(Self::PRODUCER),
-                "CONSUMER" => std::option::Option::Some(Self::CONSUMER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SpanKind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SpanKind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SpanKind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SpanKind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Internal,
+                2 => Self::Server,
+                3 => Self::Client,
+                4 => Self::Producer,
+                5 => Self::Consumer,
+                _ => Self::UnknownValue(span_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SpanKind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SPAN_KIND_UNSPECIFIED" => Self::Unspecified,
+                "INTERNAL" => Self::Internal,
+                "SERVER" => Self::Server,
+                "CLIENT" => Self::Client,
+                "PRODUCER" => Self::Producer,
+                "CONSUMER" => Self::Consumer,
+                _ => Self::UnknownValue(span_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SpanKind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Internal => serializer.serialize_i32(1),
+                Self::Server => serializer.serialize_i32(2),
+                Self::Client => serializer.serialize_i32(3),
+                Self::Producer => serializer.serialize_i32(4),
+                Self::Consumer => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SpanKind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SpanKind>::new(
+                ".google.devtools.cloudtrace.v2.Span.SpanKind",
+            ))
         }
     }
 }

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -207,65 +207,128 @@ pub mod backup {
     }
 
     /// Indicate the current state of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The pending backup is still being created. Operations on the
         /// backup will be rejected in this state.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The backup is complete and ready to use.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The backup is not available at this moment.
-        pub const NOT_AVAILABLE: State = State::new(3);
+        NotAvailable,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::NotAvailable => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("NOT_AVAILABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::NotAvailable => std::option::Option::Some("NOT_AVAILABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "NOT_AVAILABLE" => std::option::Option::Some(Self::NOT_AVAILABLE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::NotAvailable,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "NOT_AVAILABLE" => Self::NotAvailable,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::NotAvailable => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.firestore.admin.v1.Backup.State",
+            ))
         }
     }
 }
@@ -1080,148 +1143,265 @@ pub mod database {
     /// information about how to choose.
     ///
     /// Mode changes are only allowed if the database is empty.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseType {
+        /// Not used.
+        Unspecified,
+        /// Firestore Native Mode
+        FirestoreNative,
+        /// Firestore in Datastore Mode.
+        DatastoreMode,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseType::value] or
+        /// [DatabaseType::name].
+        UnknownValue(database_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseType {
-        /// Not used.
-        pub const DATABASE_TYPE_UNSPECIFIED: DatabaseType = DatabaseType::new(0);
-
-        /// Firestore Native Mode
-        pub const FIRESTORE_NATIVE: DatabaseType = DatabaseType::new(1);
-
-        /// Firestore in Datastore Mode.
-        pub const DATASTORE_MODE: DatabaseType = DatabaseType::new(2);
-
-        /// Creates a new DatabaseType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FirestoreNative => std::option::Option::Some(1),
+                Self::DatastoreMode => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIRESTORE_NATIVE"),
-                2 => std::borrow::Cow::Borrowed("DATASTORE_MODE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_TYPE_UNSPECIFIED"),
+                Self::FirestoreNative => std::option::Option::Some("FIRESTORE_NATIVE"),
+                Self::DatastoreMode => std::option::Option::Some("DATASTORE_MODE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_TYPE_UNSPECIFIED)
-                }
-                "FIRESTORE_NATIVE" => std::option::Option::Some(Self::FIRESTORE_NATIVE),
-                "DATASTORE_MODE" => std::option::Option::Some(Self::DATASTORE_MODE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FirestoreNative,
+                2 => Self::DatastoreMode,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "FIRESTORE_NATIVE" => Self::FirestoreNative,
+                "DATASTORE_MODE" => Self::DatastoreMode,
+                _ => Self::UnknownValue(database_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FirestoreNative => serializer.serialize_i32(1),
+                Self::DatastoreMode => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseType>::new(
+                ".google.firestore.admin.v1.Database.DatabaseType",
+            ))
         }
     }
 
     /// The type of concurrency control mode for transactions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConcurrencyMode(i32);
-
-    impl ConcurrencyMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConcurrencyMode {
         /// Not used.
-        pub const CONCURRENCY_MODE_UNSPECIFIED: ConcurrencyMode = ConcurrencyMode::new(0);
-
+        Unspecified,
         /// Use optimistic concurrency control by default. This mode is available
         /// for Cloud Firestore databases.
-        pub const OPTIMISTIC: ConcurrencyMode = ConcurrencyMode::new(1);
-
+        Optimistic,
         /// Use pessimistic concurrency control by default. This mode is available
         /// for Cloud Firestore databases.
         ///
         /// This is the default setting for Cloud Firestore.
-        pub const PESSIMISTIC: ConcurrencyMode = ConcurrencyMode::new(2);
-
+        Pessimistic,
         /// Use optimistic concurrency control with entity groups by default.
         ///
         /// This is the only available mode for Cloud Datastore.
         ///
         /// This mode is also available for Cloud Firestore with Datastore Mode but
         /// is not recommended.
-        pub const OPTIMISTIC_WITH_ENTITY_GROUPS: ConcurrencyMode = ConcurrencyMode::new(3);
+        OptimisticWithEntityGroups,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConcurrencyMode::value] or
+        /// [ConcurrencyMode::name].
+        UnknownValue(concurrency_mode::UnknownValue),
+    }
 
-        /// Creates a new ConcurrencyMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod concurrency_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConcurrencyMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Optimistic => std::option::Option::Some(1),
+                Self::Pessimistic => std::option::Option::Some(2),
+                Self::OptimisticWithEntityGroups => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONCURRENCY_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("OPTIMISTIC"),
-                2 => std::borrow::Cow::Borrowed("PESSIMISTIC"),
-                3 => std::borrow::Cow::Borrowed("OPTIMISTIC_WITH_ENTITY_GROUPS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONCURRENCY_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONCURRENCY_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONCURRENCY_MODE_UNSPECIFIED"),
+                Self::Optimistic => std::option::Option::Some("OPTIMISTIC"),
+                Self::Pessimistic => std::option::Option::Some("PESSIMISTIC"),
+                Self::OptimisticWithEntityGroups => {
+                    std::option::Option::Some("OPTIMISTIC_WITH_ENTITY_GROUPS")
                 }
-                "OPTIMISTIC" => std::option::Option::Some(Self::OPTIMISTIC),
-                "PESSIMISTIC" => std::option::Option::Some(Self::PESSIMISTIC),
-                "OPTIMISTIC_WITH_ENTITY_GROUPS" => {
-                    std::option::Option::Some(Self::OPTIMISTIC_WITH_ENTITY_GROUPS)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ConcurrencyMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConcurrencyMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConcurrencyMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConcurrencyMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Optimistic,
+                2 => Self::Pessimistic,
+                3 => Self::OptimisticWithEntityGroups,
+                _ => Self::UnknownValue(concurrency_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConcurrencyMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONCURRENCY_MODE_UNSPECIFIED" => Self::Unspecified,
+                "OPTIMISTIC" => Self::Optimistic,
+                "PESSIMISTIC" => Self::Pessimistic,
+                "OPTIMISTIC_WITH_ENTITY_GROUPS" => Self::OptimisticWithEntityGroups,
+                _ => Self::UnknownValue(concurrency_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConcurrencyMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Optimistic => serializer.serialize_i32(1),
+                Self::Pessimistic => serializer.serialize_i32(2),
+                Self::OptimisticWithEntityGroups => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConcurrencyMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConcurrencyMode>::new(
+                ".google.firestore.admin.v1.Database.ConcurrencyMode",
+            ))
         }
     }
 
     /// Point In Time Recovery feature enablement.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PointInTimeRecoveryEnablement(i32);
-
-    impl PointInTimeRecoveryEnablement {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PointInTimeRecoveryEnablement {
         /// Not used.
-        pub const POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED: PointInTimeRecoveryEnablement =
-            PointInTimeRecoveryEnablement::new(0);
-
+        Unspecified,
         /// Reads are supported on selected versions of the data from within the past
         /// 7 days:
         ///
@@ -1230,251 +1410,495 @@ pub mod database {
         ///
         /// `version_retention_period` and `earliest_version_time` can be
         /// used to determine the supported versions.
-        pub const POINT_IN_TIME_RECOVERY_ENABLED: PointInTimeRecoveryEnablement =
-            PointInTimeRecoveryEnablement::new(1);
-
+        PointInTimeRecoveryEnabled,
         /// Reads are supported on any version of the data from within the past 1
         /// hour.
-        pub const POINT_IN_TIME_RECOVERY_DISABLED: PointInTimeRecoveryEnablement =
-            PointInTimeRecoveryEnablement::new(2);
+        PointInTimeRecoveryDisabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PointInTimeRecoveryEnablement::value] or
+        /// [PointInTimeRecoveryEnablement::name].
+        UnknownValue(point_in_time_recovery_enablement::UnknownValue),
+    }
 
-        /// Creates a new PointInTimeRecoveryEnablement instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod point_in_time_recovery_enablement {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PointInTimeRecoveryEnablement {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PointInTimeRecoveryEnabled => std::option::Option::Some(1),
+                Self::PointInTimeRecoveryDisabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("POINT_IN_TIME_RECOVERY_ENABLED"),
-                2 => std::borrow::Cow::Borrowed("POINT_IN_TIME_RECOVERY_DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED")
+                }
+                Self::PointInTimeRecoveryEnabled => {
+                    std::option::Option::Some("POINT_IN_TIME_RECOVERY_ENABLED")
+                }
+                Self::PointInTimeRecoveryDisabled => {
+                    std::option::Option::Some("POINT_IN_TIME_RECOVERY_DISABLED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED)
-                }
-                "POINT_IN_TIME_RECOVERY_ENABLED" => {
-                    std::option::Option::Some(Self::POINT_IN_TIME_RECOVERY_ENABLED)
-                }
-                "POINT_IN_TIME_RECOVERY_DISABLED" => {
-                    std::option::Option::Some(Self::POINT_IN_TIME_RECOVERY_DISABLED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PointInTimeRecoveryEnablement {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PointInTimeRecoveryEnablement {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PointInTimeRecoveryEnablement {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PointInTimeRecoveryEnablement {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PointInTimeRecoveryEnabled,
+                2 => Self::PointInTimeRecoveryDisabled,
+                _ => Self::UnknownValue(point_in_time_recovery_enablement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PointInTimeRecoveryEnablement {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POINT_IN_TIME_RECOVERY_ENABLEMENT_UNSPECIFIED" => Self::Unspecified,
+                "POINT_IN_TIME_RECOVERY_ENABLED" => Self::PointInTimeRecoveryEnabled,
+                "POINT_IN_TIME_RECOVERY_DISABLED" => Self::PointInTimeRecoveryDisabled,
+                _ => Self::UnknownValue(point_in_time_recovery_enablement::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PointInTimeRecoveryEnablement {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PointInTimeRecoveryEnabled => serializer.serialize_i32(1),
+                Self::PointInTimeRecoveryDisabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PointInTimeRecoveryEnablement {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<PointInTimeRecoveryEnablement>::new(
+                    ".google.firestore.admin.v1.Database.PointInTimeRecoveryEnablement",
+                ),
+            )
         }
     }
 
     /// The type of App Engine integration mode.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AppEngineIntegrationMode(i32);
-
-    impl AppEngineIntegrationMode {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AppEngineIntegrationMode {
         /// Not used.
-        pub const APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED: AppEngineIntegrationMode =
-            AppEngineIntegrationMode::new(0);
-
+        Unspecified,
         /// If an App Engine application exists in the same region as this database,
         /// App Engine configuration will impact this database. This includes
         /// disabling of the application & database, as well as disabling writes to
         /// the database.
-        pub const ENABLED: AppEngineIntegrationMode = AppEngineIntegrationMode::new(1);
-
+        Enabled,
         /// App Engine has no effect on the ability of this database to serve
         /// requests.
         ///
         /// This is the default setting for databases created with the Firestore API.
-        pub const DISABLED: AppEngineIntegrationMode = AppEngineIntegrationMode::new(2);
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AppEngineIntegrationMode::value] or
+        /// [AppEngineIntegrationMode::name].
+        UnknownValue(app_engine_integration_mode::UnknownValue),
+    }
 
-        /// Creates a new AppEngineIntegrationMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod app_engine_integration_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AppEngineIntegrationMode {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED")
                 }
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for AppEngineIntegrationMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AppEngineIntegrationMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AppEngineIntegrationMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AppEngineIntegrationMode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(app_engine_integration_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AppEngineIntegrationMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "APP_ENGINE_INTEGRATION_MODE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(app_engine_integration_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AppEngineIntegrationMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AppEngineIntegrationMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<AppEngineIntegrationMode>::new(
+                    ".google.firestore.admin.v1.Database.AppEngineIntegrationMode",
+                ),
+            )
         }
     }
 
     /// The delete protection state of the database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DeleteProtectionState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DeleteProtectionState {
+        /// The default value. Delete protection type is not specified
+        Unspecified,
+        /// Delete protection is disabled
+        DeleteProtectionDisabled,
+        /// Delete protection is enabled
+        DeleteProtectionEnabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DeleteProtectionState::value] or
+        /// [DeleteProtectionState::name].
+        UnknownValue(delete_protection_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod delete_protection_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DeleteProtectionState {
-        /// The default value. Delete protection type is not specified
-        pub const DELETE_PROTECTION_STATE_UNSPECIFIED: DeleteProtectionState =
-            DeleteProtectionState::new(0);
-
-        /// Delete protection is disabled
-        pub const DELETE_PROTECTION_DISABLED: DeleteProtectionState = DeleteProtectionState::new(1);
-
-        /// Delete protection is enabled
-        pub const DELETE_PROTECTION_ENABLED: DeleteProtectionState = DeleteProtectionState::new(2);
-
-        /// Creates a new DeleteProtectionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DeleteProtectionDisabled => std::option::Option::Some(1),
+                Self::DeleteProtectionEnabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DELETE_PROTECTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DELETE_PROTECTION_DISABLED"),
-                2 => std::borrow::Cow::Borrowed("DELETE_PROTECTION_ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DELETE_PROTECTION_STATE_UNSPECIFIED")
+                }
+                Self::DeleteProtectionDisabled => {
+                    std::option::Option::Some("DELETE_PROTECTION_DISABLED")
+                }
+                Self::DeleteProtectionEnabled => {
+                    std::option::Option::Some("DELETE_PROTECTION_ENABLED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DELETE_PROTECTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DELETE_PROTECTION_STATE_UNSPECIFIED)
-                }
-                "DELETE_PROTECTION_DISABLED" => {
-                    std::option::Option::Some(Self::DELETE_PROTECTION_DISABLED)
-                }
-                "DELETE_PROTECTION_ENABLED" => {
-                    std::option::Option::Some(Self::DELETE_PROTECTION_ENABLED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DeleteProtectionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DeleteProtectionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DeleteProtectionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DeleteProtectionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DeleteProtectionDisabled,
+                2 => Self::DeleteProtectionEnabled,
+                _ => Self::UnknownValue(delete_protection_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DeleteProtectionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DELETE_PROTECTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "DELETE_PROTECTION_DISABLED" => Self::DeleteProtectionDisabled,
+                "DELETE_PROTECTION_ENABLED" => Self::DeleteProtectionEnabled,
+                _ => Self::UnknownValue(delete_protection_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DeleteProtectionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DeleteProtectionDisabled => serializer.serialize_i32(1),
+                Self::DeleteProtectionEnabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DeleteProtectionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeleteProtectionState>::new(
+                ".google.firestore.admin.v1.Database.DeleteProtectionState",
+            ))
         }
     }
 
     /// The edition of the database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEdition(i32);
-
-    impl DatabaseEdition {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseEdition {
         /// Not used.
-        pub const DATABASE_EDITION_UNSPECIFIED: DatabaseEdition = DatabaseEdition::new(0);
-
+        Unspecified,
         /// Standard edition.
         ///
         /// This is the default setting if not specified.
-        pub const STANDARD: DatabaseEdition = DatabaseEdition::new(1);
-
+        Standard,
         /// Enterprise edition.
-        pub const ENTERPRISE: DatabaseEdition = DatabaseEdition::new(2);
+        Enterprise,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseEdition::value] or
+        /// [DatabaseEdition::name].
+        UnknownValue(database_edition::UnknownValue),
+    }
 
-        /// Creates a new DatabaseEdition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod database_edition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DatabaseEdition {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_EDITION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_EDITION_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_EDITION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_EDITION_UNSPECIFIED)
-                }
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseEdition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEdition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseEdition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseEdition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Enterprise,
+                _ => Self::UnknownValue(database_edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseEdition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_EDITION_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "ENTERPRISE" => Self::Enterprise,
+                _ => Self::UnknownValue(database_edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseEdition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseEdition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEdition>::new(
+                ".google.firestore.admin.v1.Database.DatabaseEdition",
+            ))
         }
     }
 }
@@ -1703,71 +2127,137 @@ pub mod field {
         use super::*;
 
         /// The state of applying the TTL configuration to all documents.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// The state is unspecified or unknown.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// The TTL is being applied. There is an active long-running operation to
             /// track the change. Newly written documents will have TTLs applied as
             /// requested. Requested TTLs on existing documents are still being
             /// processed. When TTLs on all existing documents have been processed, the
             /// state will move to 'ACTIVE'.
-            pub const CREATING: State = State::new(1);
-
+            Creating,
             /// The TTL is active for all documents.
-            pub const ACTIVE: State = State::new(2);
-
+            Active,
             /// The TTL configuration could not be enabled for all existing documents.
             /// Newly written documents will continue to have their TTL applied.
             /// The LRO returned when last attempting to enable TTL for this `Field`
             /// has failed, and may have more details.
-            pub const NEEDS_REPAIR: State = State::new(3);
+            NeedsRepair,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Creating => std::option::Option::Some(1),
+                    Self::Active => std::option::Option::Some(2),
+                    Self::NeedsRepair => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CREATING"),
-                    2 => std::borrow::Cow::Borrowed("ACTIVE"),
-                    3 => std::borrow::Cow::Borrowed("NEEDS_REPAIR"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Creating => std::option::Option::Some("CREATING"),
+                    Self::Active => std::option::Option::Some("ACTIVE"),
+                    Self::NeedsRepair => std::option::Option::Some("NEEDS_REPAIR"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "CREATING" => std::option::Option::Some(Self::CREATING),
-                    "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                    "NEEDS_REPAIR" => std::option::Option::Some(Self::NEEDS_REPAIR),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Creating,
+                    2 => Self::Active,
+                    3 => Self::NeedsRepair,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "CREATING" => Self::Creating,
+                    "ACTIVE" => Self::Active,
+                    "NEEDS_REPAIR" => Self::NeedsRepair,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Creating => serializer.serialize_i32(1),
+                    Self::Active => serializer.serialize_i32(2),
+                    Self::NeedsRepair => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".google.firestore.admin.v1.Field.TtlConfig.State",
+                ))
             }
         }
     }
@@ -4235,113 +4725,237 @@ pub mod index {
         }
 
         /// The supported orderings.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Order(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Order {
+            /// The ordering is unspecified. Not a valid option.
+            Unspecified,
+            /// The field is ordered by ascending field value.
+            Ascending,
+            /// The field is ordered by descending field value.
+            Descending,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Order::value] or
+            /// [Order::name].
+            UnknownValue(order::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod order {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Order {
-            /// The ordering is unspecified. Not a valid option.
-            pub const ORDER_UNSPECIFIED: Order = Order::new(0);
-
-            /// The field is ordered by ascending field value.
-            pub const ASCENDING: Order = Order::new(1);
-
-            /// The field is ordered by descending field value.
-            pub const DESCENDING: Order = Order::new(2);
-
-            /// Creates a new Order instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Ascending => std::option::Option::Some(1),
+                    Self::Descending => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ORDER_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ASCENDING"),
-                    2 => std::borrow::Cow::Borrowed("DESCENDING"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ORDER_UNSPECIFIED"),
+                    Self::Ascending => std::option::Option::Some("ASCENDING"),
+                    Self::Descending => std::option::Option::Some("DESCENDING"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ORDER_UNSPECIFIED" => std::option::Option::Some(Self::ORDER_UNSPECIFIED),
-                    "ASCENDING" => std::option::Option::Some(Self::ASCENDING),
-                    "DESCENDING" => std::option::Option::Some(Self::DESCENDING),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Order {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Order {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Order {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Order {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Ascending,
+                    2 => Self::Descending,
+                    _ => Self::UnknownValue(order::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Order {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ORDER_UNSPECIFIED" => Self::Unspecified,
+                    "ASCENDING" => Self::Ascending,
+                    "DESCENDING" => Self::Descending,
+                    _ => Self::UnknownValue(order::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Order {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Ascending => serializer.serialize_i32(1),
+                    Self::Descending => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Order {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Order>::new(
+                    ".google.firestore.admin.v1.Index.IndexField.Order",
+                ))
             }
         }
 
         /// The supported array value configurations.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ArrayConfig(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ArrayConfig {
+            /// The index does not support additional array queries.
+            Unspecified,
+            /// The index supports array containment queries.
+            Contains,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ArrayConfig::value] or
+            /// [ArrayConfig::name].
+            UnknownValue(array_config::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod array_config {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ArrayConfig {
-            /// The index does not support additional array queries.
-            pub const ARRAY_CONFIG_UNSPECIFIED: ArrayConfig = ArrayConfig::new(0);
-
-            /// The index supports array containment queries.
-            pub const CONTAINS: ArrayConfig = ArrayConfig::new(1);
-
-            /// Creates a new ArrayConfig instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Contains => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("ARRAY_CONFIG_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CONTAINS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("ARRAY_CONFIG_UNSPECIFIED"),
+                    Self::Contains => std::option::Option::Some("CONTAINS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "ARRAY_CONFIG_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::ARRAY_CONFIG_UNSPECIFIED)
-                    }
-                    "CONTAINS" => std::option::Option::Some(Self::CONTAINS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ArrayConfig {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ArrayConfig {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ArrayConfig {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ArrayConfig {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Contains,
+                    _ => Self::UnknownValue(array_config::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ArrayConfig {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "ARRAY_CONFIG_UNSPECIFIED" => Self::Unspecified,
+                    "CONTAINS" => Self::Contains,
+                    _ => Self::UnknownValue(array_config::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ArrayConfig {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Contains => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ArrayConfig {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ArrayConfig>::new(
+                    ".google.firestore.admin.v1.Index.IndexField.ArrayConfig",
+                ))
             }
         }
 
@@ -4363,130 +4977,252 @@ pub mod index {
 
     /// Query Scope defines the scope at which a query is run. This is specified on
     /// a StructuredQuery's `from` field.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QueryScope(i32);
-
-    impl QueryScope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum QueryScope {
         /// The query scope is unspecified. Not a valid option.
-        pub const QUERY_SCOPE_UNSPECIFIED: QueryScope = QueryScope::new(0);
-
+        Unspecified,
         /// Indexes with a collection query scope specified allow queries
         /// against a collection that is the child of a specific document, specified
         /// at query time, and that has the collection ID specified by the index.
-        pub const COLLECTION: QueryScope = QueryScope::new(1);
-
+        Collection,
         /// Indexes with a collection group query scope specified allow queries
         /// against all collections that has the collection ID specified by the
         /// index.
-        pub const COLLECTION_GROUP: QueryScope = QueryScope::new(2);
-
+        CollectionGroup,
         /// Include all the collections's ancestor in the index. Only available for
         /// Datastore Mode databases.
-        pub const COLLECTION_RECURSIVE: QueryScope = QueryScope::new(3);
+        CollectionRecursive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [QueryScope::value] or
+        /// [QueryScope::name].
+        UnknownValue(query_scope::UnknownValue),
+    }
 
-        /// Creates a new QueryScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod query_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl QueryScope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Collection => std::option::Option::Some(1),
+                Self::CollectionGroup => std::option::Option::Some(2),
+                Self::CollectionRecursive => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("QUERY_SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COLLECTION"),
-                2 => std::borrow::Cow::Borrowed("COLLECTION_GROUP"),
-                3 => std::borrow::Cow::Borrowed("COLLECTION_RECURSIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("QUERY_SCOPE_UNSPECIFIED"),
+                Self::Collection => std::option::Option::Some("COLLECTION"),
+                Self::CollectionGroup => std::option::Option::Some("COLLECTION_GROUP"),
+                Self::CollectionRecursive => std::option::Option::Some("COLLECTION_RECURSIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "QUERY_SCOPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::QUERY_SCOPE_UNSPECIFIED)
-                }
-                "COLLECTION" => std::option::Option::Some(Self::COLLECTION),
-                "COLLECTION_GROUP" => std::option::Option::Some(Self::COLLECTION_GROUP),
-                "COLLECTION_RECURSIVE" => std::option::Option::Some(Self::COLLECTION_RECURSIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for QueryScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for QueryScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for QueryScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for QueryScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Collection,
+                2 => Self::CollectionGroup,
+                3 => Self::CollectionRecursive,
+                _ => Self::UnknownValue(query_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for QueryScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "QUERY_SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "COLLECTION" => Self::Collection,
+                "COLLECTION_GROUP" => Self::CollectionGroup,
+                "COLLECTION_RECURSIVE" => Self::CollectionRecursive,
+                _ => Self::UnknownValue(query_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for QueryScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Collection => serializer.serialize_i32(1),
+                Self::CollectionGroup => serializer.serialize_i32(2),
+                Self::CollectionRecursive => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for QueryScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<QueryScope>::new(
+                ".google.firestore.admin.v1.Index.QueryScope",
+            ))
         }
     }
 
     /// API Scope defines the APIs (Firestore Native, or Firestore in
     /// Datastore Mode) that are supported for queries.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiScope(i32);
-
-    impl ApiScope {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ApiScope {
         /// The index can only be used by the Firestore Native query API.
         /// This is the default.
-        pub const ANY_API: ApiScope = ApiScope::new(0);
-
+        AnyApi,
         /// The index can only be used by the Firestore in Datastore Mode query API.
-        pub const DATASTORE_MODE_API: ApiScope = ApiScope::new(1);
-
+        DatastoreModeApi,
         /// The index can only be used by the MONGODB_COMPATIBLE_API.
-        pub const MONGODB_COMPATIBLE_API: ApiScope = ApiScope::new(2);
+        MongodbCompatibleApi,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ApiScope::value] or
+        /// [ApiScope::name].
+        UnknownValue(api_scope::UnknownValue),
+    }
 
-        /// Creates a new ApiScope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod api_scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ApiScope {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::AnyApi => std::option::Option::Some(0),
+                Self::DatastoreModeApi => std::option::Option::Some(1),
+                Self::MongodbCompatibleApi => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANY_API"),
-                1 => std::borrow::Cow::Borrowed("DATASTORE_MODE_API"),
-                2 => std::borrow::Cow::Borrowed("MONGODB_COMPATIBLE_API"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::AnyApi => std::option::Option::Some("ANY_API"),
+                Self::DatastoreModeApi => std::option::Option::Some("DATASTORE_MODE_API"),
+                Self::MongodbCompatibleApi => std::option::Option::Some("MONGODB_COMPATIBLE_API"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANY_API" => std::option::Option::Some(Self::ANY_API),
-                "DATASTORE_MODE_API" => std::option::Option::Some(Self::DATASTORE_MODE_API),
-                "MONGODB_COMPATIBLE_API" => std::option::Option::Some(Self::MONGODB_COMPATIBLE_API),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ApiScope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiScope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ApiScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ApiScope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::AnyApi,
+                1 => Self::DatastoreModeApi,
+                2 => Self::MongodbCompatibleApi,
+                _ => Self::UnknownValue(api_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ApiScope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANY_API" => Self::AnyApi,
+                "DATASTORE_MODE_API" => Self::DatastoreModeApi,
+                "MONGODB_COMPATIBLE_API" => Self::MongodbCompatibleApi,
+                _ => Self::UnknownValue(api_scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ApiScope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::AnyApi => serializer.serialize_i32(0),
+                Self::DatastoreModeApi => serializer.serialize_i32(1),
+                Self::MongodbCompatibleApi => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ApiScope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ApiScope>::new(
+                ".google.firestore.admin.v1.Index.ApiScope",
+            ))
         }
     }
 
@@ -4494,24 +5230,20 @@ pub mod index {
     /// `CREATING` state. If the index is created successfully, it will transition
     /// to the `READY` state. If the index creation encounters a problem, the index
     /// will transition to the `NEEDS_REPAIR` state.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// The state is unspecified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The index is being created.
         /// There is an active long-running operation for the index.
         /// The index is updated when writing a document.
         /// Some index data may exist.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The index is ready to be used.
         /// The index is updated when writing a document.
         /// The index is fully populated from all stored documents it applies to.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The index was being created, but something went wrong.
         /// There is no active long-running operation for the index,
         /// and the most recently finished long-running operation failed.
@@ -4520,123 +5252,253 @@ pub mod index {
         /// Use the google.longrunning.Operations API to determine why the operation
         /// that last attempted to create this index failed, then re-create the
         /// index.
-        pub const NEEDS_REPAIR: State = State::new(3);
+        NeedsRepair,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::NeedsRepair => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("NEEDS_REPAIR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::NeedsRepair => std::option::Option::Some("NEEDS_REPAIR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "NEEDS_REPAIR" => std::option::Option::Some(Self::NEEDS_REPAIR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::NeedsRepair,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "NEEDS_REPAIR" => Self::NeedsRepair,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::NeedsRepair => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.firestore.admin.v1.Index.State",
+            ))
         }
     }
 
     /// The density configuration for the index.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Density(i32);
-
-    impl Density {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Density {
         /// Unspecified. It will use database default setting. This value is input
         /// only.
-        pub const DENSITY_UNSPECIFIED: Density = Density::new(0);
-
+        Unspecified,
         /// In order for an index entry to be added, the document must
         /// contain all fields specified in the index.
         ///
         /// This is the only allowed value for indexes having ApiScope `ANY_API` and
         /// `DATASTORE_MODE_API`.
-        pub const SPARSE_ALL: Density = Density::new(1);
-
+        SparseAll,
         /// In order for an index entry to be added, the document must
         /// contain at least one of the fields specified in the index.
         /// Non-existent fields are treated as having a NULL value when generating
         /// index entries.
-        pub const SPARSE_ANY: Density = Density::new(2);
-
+        SparseAny,
         /// An index entry will be added regardless of whether the
         /// document contains any of the fields specified in the index.
         /// Non-existent fields are treated as having a NULL value when generating
         /// index entries.
-        pub const DENSE: Density = Density::new(3);
+        Dense,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Density::value] or
+        /// [Density::name].
+        UnknownValue(density::UnknownValue),
+    }
 
-        /// Creates a new Density instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod density {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Density {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::SparseAll => std::option::Option::Some(1),
+                Self::SparseAny => std::option::Option::Some(2),
+                Self::Dense => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DENSITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SPARSE_ALL"),
-                2 => std::borrow::Cow::Borrowed("SPARSE_ANY"),
-                3 => std::borrow::Cow::Borrowed("DENSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DENSITY_UNSPECIFIED"),
+                Self::SparseAll => std::option::Option::Some("SPARSE_ALL"),
+                Self::SparseAny => std::option::Option::Some("SPARSE_ANY"),
+                Self::Dense => std::option::Option::Some("DENSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DENSITY_UNSPECIFIED" => std::option::Option::Some(Self::DENSITY_UNSPECIFIED),
-                "SPARSE_ALL" => std::option::Option::Some(Self::SPARSE_ALL),
-                "SPARSE_ANY" => std::option::Option::Some(Self::SPARSE_ANY),
-                "DENSE" => std::option::Option::Some(Self::DENSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Density {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Density {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Density {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Density {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::SparseAll,
+                2 => Self::SparseAny,
+                3 => Self::Dense,
+                _ => Self::UnknownValue(density::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Density {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DENSITY_UNSPECIFIED" => Self::Unspecified,
+                "SPARSE_ALL" => Self::SparseAll,
+                "SPARSE_ANY" => Self::SparseAny,
+                "DENSE" => Self::Dense,
+                _ => Self::UnknownValue(density::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Density {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::SparseAll => serializer.serialize_i32(1),
+                Self::SparseAny => serializer.serialize_i32(2),
+                Self::Dense => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Density {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Density>::new(
+                ".google.firestore.admin.v1.Index.Density",
+            ))
         }
     }
 }
@@ -4974,61 +5836,123 @@ pub mod field_operation_metadata {
         use super::*;
 
         /// Specifies how the index is changing.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ChangeType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ChangeType {
+            /// The type of change is not specified or known.
+            Unspecified,
+            /// The single field index is being added.
+            Add,
+            /// The single field index is being removed.
+            Remove,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ChangeType::value] or
+            /// [ChangeType::name].
+            UnknownValue(change_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod change_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ChangeType {
-            /// The type of change is not specified or known.
-            pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new(0);
-
-            /// The single field index is being added.
-            pub const ADD: ChangeType = ChangeType::new(1);
-
-            /// The single field index is being removed.
-            pub const REMOVE: ChangeType = ChangeType::new(2);
-
-            /// Creates a new ChangeType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Add => std::option::Option::Some(1),
+                    Self::Remove => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CHANGE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ADD"),
-                    2 => std::borrow::Cow::Borrowed("REMOVE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CHANGE_TYPE_UNSPECIFIED"),
+                    Self::Add => std::option::Option::Some("ADD"),
+                    Self::Remove => std::option::Option::Some("REMOVE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CHANGE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CHANGE_TYPE_UNSPECIFIED)
-                    }
-                    "ADD" => std::option::Option::Some(Self::ADD),
-                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ChangeType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ChangeType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ChangeType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ChangeType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Add,
+                    2 => Self::Remove,
+                    _ => Self::UnknownValue(change_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ChangeType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CHANGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "ADD" => Self::Add,
+                    "REMOVE" => Self::Remove,
+                    _ => Self::UnknownValue(change_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ChangeType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Add => serializer.serialize_i32(1),
+                    Self::Remove => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ChangeType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ChangeType>::new(
+                    ".google.firestore.admin.v1.FieldOperationMetadata.IndexConfigDelta.ChangeType",
+                ))
             }
         }
     }
@@ -5077,61 +6001,123 @@ pub mod field_operation_metadata {
         use super::*;
 
         /// Specifies how the TTL config is changing.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ChangeType(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ChangeType {
+            /// The type of change is not specified or known.
+            Unspecified,
+            /// The TTL config is being added.
+            Add,
+            /// The TTL config is being removed.
+            Remove,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ChangeType::value] or
+            /// [ChangeType::name].
+            UnknownValue(change_type::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod change_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl ChangeType {
-            /// The type of change is not specified or known.
-            pub const CHANGE_TYPE_UNSPECIFIED: ChangeType = ChangeType::new(0);
-
-            /// The TTL config is being added.
-            pub const ADD: ChangeType = ChangeType::new(1);
-
-            /// The TTL config is being removed.
-            pub const REMOVE: ChangeType = ChangeType::new(2);
-
-            /// Creates a new ChangeType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Add => std::option::Option::Some(1),
+                    Self::Remove => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CHANGE_TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("ADD"),
-                    2 => std::borrow::Cow::Borrowed("REMOVE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("CHANGE_TYPE_UNSPECIFIED"),
+                    Self::Add => std::option::Option::Some("ADD"),
+                    Self::Remove => std::option::Option::Some("REMOVE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CHANGE_TYPE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CHANGE_TYPE_UNSPECIFIED)
-                    }
-                    "ADD" => std::option::Option::Some(Self::ADD),
-                    "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ChangeType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ChangeType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ChangeType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ChangeType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Add,
+                    2 => Self::Remove,
+                    _ => Self::UnknownValue(change_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ChangeType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CHANGE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                    "ADD" => Self::Add,
+                    "REMOVE" => Self::Remove,
+                    _ => Self::UnknownValue(change_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ChangeType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Add => serializer.serialize_i32(1),
+                    Self::Remove => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ChangeType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ChangeType>::new(
+                    ".google.firestore.admin.v1.FieldOperationMetadata.TtlConfigDelta.ChangeType",
+                ))
             }
         }
     }
@@ -6177,59 +7163,120 @@ pub mod user_creds {
     }
 
     /// The state of the user creds (ENABLED or DISABLED).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// The default value. Should not be used.
+        Unspecified,
+        /// The user creds are enabled.
+        Enabled,
+        /// The user creds are disabled.
+        Disabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// The default value. Should not be used.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// The user creds are enabled.
-        pub const ENABLED: State = State::new(1);
-
-        /// The user creds are disabled.
-        pub const DISABLED: State = State::new(2);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.firestore.admin.v1.UserCreds.State",
+            ))
         }
     }
 
@@ -6244,87 +7291,156 @@ pub mod user_creds {
 }
 
 /// Describes the state of the operation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationState(i32);
-
-impl OperationState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperationState {
     /// Unspecified.
-    pub const OPERATION_STATE_UNSPECIFIED: OperationState = OperationState::new(0);
-
+    Unspecified,
     /// Request is being prepared for processing.
-    pub const INITIALIZING: OperationState = OperationState::new(1);
-
+    Initializing,
     /// Request is actively being processed.
-    pub const PROCESSING: OperationState = OperationState::new(2);
-
+    Processing,
     /// Request is in the process of being cancelled after user called
     /// google.longrunning.Operations.CancelOperation on the operation.
-    pub const CANCELLING: OperationState = OperationState::new(3);
-
+    Cancelling,
     /// Request has been processed and is in its finalization stage.
-    pub const FINALIZING: OperationState = OperationState::new(4);
-
+    Finalizing,
     /// Request has completed successfully.
-    pub const SUCCESSFUL: OperationState = OperationState::new(5);
-
+    Successful,
     /// Request has finished being processed, but encountered an error.
-    pub const FAILED: OperationState = OperationState::new(6);
-
+    Failed,
     /// Request has finished being cancelled after user called
     /// google.longrunning.Operations.CancelOperation.
-    pub const CANCELLED: OperationState = OperationState::new(7);
+    Cancelled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperationState::value] or
+    /// [OperationState::name].
+    UnknownValue(operation_state::UnknownValue),
+}
 
-    /// Creates a new OperationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod operation_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl OperationState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Initializing => std::option::Option::Some(1),
+            Self::Processing => std::option::Option::Some(2),
+            Self::Cancelling => std::option::Option::Some(3),
+            Self::Finalizing => std::option::Option::Some(4),
+            Self::Successful => std::option::Option::Some(5),
+            Self::Failed => std::option::Option::Some(6),
+            Self::Cancelled => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INITIALIZING"),
-            2 => std::borrow::Cow::Borrowed("PROCESSING"),
-            3 => std::borrow::Cow::Borrowed("CANCELLING"),
-            4 => std::borrow::Cow::Borrowed("FINALIZING"),
-            5 => std::borrow::Cow::Borrowed("SUCCESSFUL"),
-            6 => std::borrow::Cow::Borrowed("FAILED"),
-            7 => std::borrow::Cow::Borrowed("CANCELLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OPERATION_STATE_UNSPECIFIED"),
+            Self::Initializing => std::option::Option::Some("INITIALIZING"),
+            Self::Processing => std::option::Option::Some("PROCESSING"),
+            Self::Cancelling => std::option::Option::Some("CANCELLING"),
+            Self::Finalizing => std::option::Option::Some("FINALIZING"),
+            Self::Successful => std::option::Option::Some("SUCCESSFUL"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::Cancelled => std::option::Option::Some("CANCELLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_UNSPECIFIED)
-            }
-            "INITIALIZING" => std::option::Option::Some(Self::INITIALIZING),
-            "PROCESSING" => std::option::Option::Some(Self::PROCESSING),
-            "CANCELLING" => std::option::Option::Some(Self::CANCELLING),
-            "FINALIZING" => std::option::Option::Some(Self::FINALIZING),
-            "SUCCESSFUL" => std::option::Option::Some(Self::SUCCESSFUL),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Initializing,
+            2 => Self::Processing,
+            3 => Self::Cancelling,
+            4 => Self::Finalizing,
+            5 => Self::Successful,
+            6 => Self::Failed,
+            7 => Self::Cancelled,
+            _ => Self::UnknownValue(operation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "INITIALIZING" => Self::Initializing,
+            "PROCESSING" => Self::Processing,
+            "CANCELLING" => Self::Cancelling,
+            "FINALIZING" => Self::Finalizing,
+            "SUCCESSFUL" => Self::Successful,
+            "FAILED" => Self::Failed,
+            "CANCELLED" => Self::Cancelled,
+            _ => Self::UnknownValue(operation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Initializing => serializer.serialize_i32(1),
+            Self::Processing => serializer.serialize_i32(2),
+            Self::Cancelling => serializer.serialize_i32(3),
+            Self::Finalizing => serializer.serialize_i32(4),
+            Self::Successful => serializer.serialize_i32(5),
+            Self::Failed => serializer.serialize_i32(6),
+            Self::Cancelled => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationState>::new(
+            ".google.firestore.admin.v1.OperationState",
+        ))
     }
 }

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -1295,353 +1295,711 @@ pub mod cvs_sv_3 {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackVector {
+        Unspecified,
+        Network,
+        Adjacent,
+        Local,
+        Physical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackVector::value] or
+        /// [AttackVector::name].
+        UnknownValue(attack_vector::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod attack_vector {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AttackVector {
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
-
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
-
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
-
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
-
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
-
-        /// Creates a new AttackVector instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Network => std::option::Option::Some(1),
+                Self::Adjacent => std::option::Option::Some(2),
+                Self::Local => std::option::Option::Some(3),
+                Self::Physical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
-                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
-                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_VECTOR_UNSPECIFIED"),
+                Self::Network => std::option::Option::Some("ATTACK_VECTOR_NETWORK"),
+                Self::Adjacent => std::option::Option::Some("ATTACK_VECTOR_ADJACENT"),
+                Self::Local => std::option::Option::Some("ATTACK_VECTOR_LOCAL"),
+                Self::Physical => std::option::Option::Some("ATTACK_VECTOR_PHYSICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_VECTOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
-                }
-                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
-                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
-                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
-                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackVector {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(i32);
+    impl std::fmt::Display for AttackVector {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Network,
+                2 => Self::Adjacent,
+                3 => Self::Local,
+                4 => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackVector {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_VECTOR_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_VECTOR_NETWORK" => Self::Network,
+                "ATTACK_VECTOR_ADJACENT" => Self::Adjacent,
+                "ATTACK_VECTOR_LOCAL" => Self::Local,
+                "ATTACK_VECTOR_PHYSICAL" => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackVector {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Network => serializer.serialize_i32(1),
+                Self::Adjacent => serializer.serialize_i32(2),
+                Self::Local => serializer.serialize_i32(3),
+                Self::Physical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackVector {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackVector>::new(
+                ".grafeas.v1.CVSSv3.AttackVector",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackComplexity {
+        Unspecified,
+        Low,
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackComplexity::value] or
+        /// [AttackComplexity::name].
+        UnknownValue(attack_complexity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod attack_complexity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AttackComplexity {
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
-
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
-
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
-
-        /// Creates a new AttackComplexity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("ATTACK_COMPLEXITY_LOW"),
+                Self::High => std::option::Option::Some("ATTACK_COMPLEXITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
-                }
-                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
-                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackComplexity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(i32);
+    impl std::fmt::Display for AttackComplexity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::High,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackComplexity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_COMPLEXITY_LOW" => Self::Low,
+                "ATTACK_COMPLEXITY_HIGH" => Self::High,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackComplexity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackComplexity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackComplexity>::new(
+                ".grafeas.v1.CVSSv3.AttackComplexity",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PrivilegesRequired {
+        Unspecified,
+        None,
+        Low,
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PrivilegesRequired::value] or
+        /// [PrivilegesRequired::name].
+        UnknownValue(privileges_required::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod privileges_required {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PrivilegesRequired {
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
-
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
-
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
-
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
-
-        /// Creates a new PrivilegesRequired instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
-                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
-                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("PRIVILEGES_REQUIRED_NONE"),
+                Self::Low => std::option::Option::Some("PRIVILEGES_REQUIRED_LOW"),
+                Self::High => std::option::Option::Some("PRIVILEGES_REQUIRED_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
-                }
-                "PRIVILEGES_REQUIRED_NONE" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
-                }
-                "PRIVILEGES_REQUIRED_LOW" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
-                }
-                "PRIVILEGES_REQUIRED_HIGH" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PrivilegesRequired {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(i32);
+    impl std::fmt::Display for PrivilegesRequired {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Low,
+                3 => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PrivilegesRequired {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => Self::Unspecified,
+                "PRIVILEGES_REQUIRED_NONE" => Self::None,
+                "PRIVILEGES_REQUIRED_LOW" => Self::Low,
+                "PRIVILEGES_REQUIRED_HIGH" => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PrivilegesRequired {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PrivilegesRequired {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PrivilegesRequired>::new(
+                ".grafeas.v1.CVSSv3.PrivilegesRequired",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserInteraction {
+        Unspecified,
+        None,
+        Required,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserInteraction::value] or
+        /// [UserInteraction::name].
+        UnknownValue(user_interaction::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod user_interaction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl UserInteraction {
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
-
-        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
-
-        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
-
-        /// Creates a new UserInteraction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Required => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
-                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("USER_INTERACTION_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("USER_INTERACTION_NONE"),
+                Self::Required => std::option::Option::Some("USER_INTERACTION_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_INTERACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
-                }
-                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
-                "USER_INTERACTION_REQUIRED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UserInteraction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
+    impl std::fmt::Display for UserInteraction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserInteraction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_INTERACTION_UNSPECIFIED" => Self::Unspecified,
+                "USER_INTERACTION_NONE" => Self::None,
+                "USER_INTERACTION_REQUIRED" => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserInteraction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Required => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserInteraction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserInteraction>::new(
+                ".grafeas.v1.CVSSv3.UserInteraction",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
+        Unspecified,
+        Unchanged,
+        Changed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Scope {
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
-
-        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
-
-        pub const SCOPE_CHANGED: Scope = Scope::new(2);
-
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unchanged => std::option::Option::Some(1),
+                Self::Changed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
-                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCOPE_UNSPECIFIED"),
+                Self::Unchanged => std::option::Option::Some("SCOPE_UNCHANGED"),
+                Self::Changed => std::option::Option::Some("SCOPE_CHANGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
-                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
-                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(i32);
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unchanged,
+                2 => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "SCOPE_UNCHANGED" => Self::Unchanged,
+                "SCOPE_CHANGED" => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unchanged => serializer.serialize_i32(1),
+                Self::Changed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".grafeas.v1.CVSSv3.Scope",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Impact {
+        Unspecified,
+        High,
+        Low,
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Impact::value] or
+        /// [Impact::name].
+        UnknownValue(impact::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod impact {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Impact {
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
-
-        pub const IMPACT_HIGH: Impact = Impact::new(1);
-
-        pub const IMPACT_LOW: Impact = Impact::new(2);
-
-        pub const IMPACT_NONE: Impact = Impact::new(3);
-
-        /// Creates a new Impact instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
-                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
-                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPACT_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("IMPACT_HIGH"),
+                Self::Low => std::option::Option::Some("IMPACT_LOW"),
+                Self::None => std::option::Option::Some("IMPACT_NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
-                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
-                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
-                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Impact {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Impact {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::Low,
+                3 => Self::None,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Impact {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPACT_UNSPECIFIED" => Self::Unspecified,
+                "IMPACT_HIGH" => Self::High,
+                "IMPACT_LOW" => Self::Low,
+                "IMPACT_NONE" => Self::None,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Impact {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Impact {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Impact>::new(
+                ".grafeas.v1.CVSSv3.Impact",
+            ))
         }
     }
 }
@@ -1805,428 +2163,849 @@ pub mod cvss {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackVector(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackVector {
+        Unspecified,
+        Network,
+        Adjacent,
+        Local,
+        Physical,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackVector::value] or
+        /// [AttackVector::name].
+        UnknownValue(attack_vector::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod attack_vector {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AttackVector {
-        pub const ATTACK_VECTOR_UNSPECIFIED: AttackVector = AttackVector::new(0);
-
-        pub const ATTACK_VECTOR_NETWORK: AttackVector = AttackVector::new(1);
-
-        pub const ATTACK_VECTOR_ADJACENT: AttackVector = AttackVector::new(2);
-
-        pub const ATTACK_VECTOR_LOCAL: AttackVector = AttackVector::new(3);
-
-        pub const ATTACK_VECTOR_PHYSICAL: AttackVector = AttackVector::new(4);
-
-        /// Creates a new AttackVector instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Network => std::option::Option::Some(1),
+                Self::Adjacent => std::option::Option::Some(2),
+                Self::Local => std::option::Option::Some(3),
+                Self::Physical => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_NETWORK"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_ADJACENT"),
-                3 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_LOCAL"),
-                4 => std::borrow::Cow::Borrowed("ATTACK_VECTOR_PHYSICAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_VECTOR_UNSPECIFIED"),
+                Self::Network => std::option::Option::Some("ATTACK_VECTOR_NETWORK"),
+                Self::Adjacent => std::option::Option::Some("ATTACK_VECTOR_ADJACENT"),
+                Self::Local => std::option::Option::Some("ATTACK_VECTOR_LOCAL"),
+                Self::Physical => std::option::Option::Some("ATTACK_VECTOR_PHYSICAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_VECTOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_VECTOR_UNSPECIFIED)
-                }
-                "ATTACK_VECTOR_NETWORK" => std::option::Option::Some(Self::ATTACK_VECTOR_NETWORK),
-                "ATTACK_VECTOR_ADJACENT" => std::option::Option::Some(Self::ATTACK_VECTOR_ADJACENT),
-                "ATTACK_VECTOR_LOCAL" => std::option::Option::Some(Self::ATTACK_VECTOR_LOCAL),
-                "ATTACK_VECTOR_PHYSICAL" => std::option::Option::Some(Self::ATTACK_VECTOR_PHYSICAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackVector {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackVector {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AttackComplexity(i32);
+    impl std::fmt::Display for AttackVector {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackVector {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Network,
+                2 => Self::Adjacent,
+                3 => Self::Local,
+                4 => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackVector {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_VECTOR_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_VECTOR_NETWORK" => Self::Network,
+                "ATTACK_VECTOR_ADJACENT" => Self::Adjacent,
+                "ATTACK_VECTOR_LOCAL" => Self::Local,
+                "ATTACK_VECTOR_PHYSICAL" => Self::Physical,
+                _ => Self::UnknownValue(attack_vector::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackVector {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Network => serializer.serialize_i32(1),
+                Self::Adjacent => serializer.serialize_i32(2),
+                Self::Local => serializer.serialize_i32(3),
+                Self::Physical => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackVector {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackVector>::new(
+                ".grafeas.v1.CVSS.AttackVector",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AttackComplexity {
+        Unspecified,
+        Low,
+        High,
+        Medium,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AttackComplexity::value] or
+        /// [AttackComplexity::name].
+        UnknownValue(attack_complexity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod attack_complexity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AttackComplexity {
-        pub const ATTACK_COMPLEXITY_UNSPECIFIED: AttackComplexity = AttackComplexity::new(0);
-
-        pub const ATTACK_COMPLEXITY_LOW: AttackComplexity = AttackComplexity::new(1);
-
-        pub const ATTACK_COMPLEXITY_HIGH: AttackComplexity = AttackComplexity::new(2);
-
-        pub const ATTACK_COMPLEXITY_MEDIUM: AttackComplexity = AttackComplexity::new(3);
-
-        /// Creates a new AttackComplexity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Low => std::option::Option::Some(1),
+                Self::High => std::option::Option::Some(2),
+                Self::Medium => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_LOW"),
-                2 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_HIGH"),
-                3 => std::borrow::Cow::Borrowed("ATTACK_COMPLEXITY_MEDIUM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ATTACK_COMPLEXITY_UNSPECIFIED"),
+                Self::Low => std::option::Option::Some("ATTACK_COMPLEXITY_LOW"),
+                Self::High => std::option::Option::Some("ATTACK_COMPLEXITY_HIGH"),
+                Self::Medium => std::option::Option::Some("ATTACK_COMPLEXITY_MEDIUM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ATTACK_COMPLEXITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_UNSPECIFIED)
-                }
-                "ATTACK_COMPLEXITY_LOW" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_LOW),
-                "ATTACK_COMPLEXITY_HIGH" => std::option::Option::Some(Self::ATTACK_COMPLEXITY_HIGH),
-                "ATTACK_COMPLEXITY_MEDIUM" => {
-                    std::option::Option::Some(Self::ATTACK_COMPLEXITY_MEDIUM)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AttackComplexity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AttackComplexity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Authentication(i32);
+    impl std::fmt::Display for AttackComplexity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AttackComplexity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Low,
+                2 => Self::High,
+                3 => Self::Medium,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AttackComplexity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ATTACK_COMPLEXITY_UNSPECIFIED" => Self::Unspecified,
+                "ATTACK_COMPLEXITY_LOW" => Self::Low,
+                "ATTACK_COMPLEXITY_HIGH" => Self::High,
+                "ATTACK_COMPLEXITY_MEDIUM" => Self::Medium,
+                _ => Self::UnknownValue(attack_complexity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AttackComplexity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Low => serializer.serialize_i32(1),
+                Self::High => serializer.serialize_i32(2),
+                Self::Medium => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AttackComplexity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AttackComplexity>::new(
+                ".grafeas.v1.CVSS.AttackComplexity",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Authentication {
+        Unspecified,
+        Multiple,
+        Single,
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Authentication::value] or
+        /// [Authentication::name].
+        UnknownValue(authentication::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod authentication {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Authentication {
-        pub const AUTHENTICATION_UNSPECIFIED: Authentication = Authentication::new(0);
-
-        pub const AUTHENTICATION_MULTIPLE: Authentication = Authentication::new(1);
-
-        pub const AUTHENTICATION_SINGLE: Authentication = Authentication::new(2);
-
-        pub const AUTHENTICATION_NONE: Authentication = Authentication::new(3);
-
-        /// Creates a new Authentication instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Multiple => std::option::Option::Some(1),
+                Self::Single => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTHENTICATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTHENTICATION_MULTIPLE"),
-                2 => std::borrow::Cow::Borrowed("AUTHENTICATION_SINGLE"),
-                3 => std::borrow::Cow::Borrowed("AUTHENTICATION_NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTHENTICATION_UNSPECIFIED"),
+                Self::Multiple => std::option::Option::Some("AUTHENTICATION_MULTIPLE"),
+                Self::Single => std::option::Option::Some("AUTHENTICATION_SINGLE"),
+                Self::None => std::option::Option::Some("AUTHENTICATION_NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTHENTICATION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTHENTICATION_UNSPECIFIED)
-                }
-                "AUTHENTICATION_MULTIPLE" => {
-                    std::option::Option::Some(Self::AUTHENTICATION_MULTIPLE)
-                }
-                "AUTHENTICATION_SINGLE" => std::option::Option::Some(Self::AUTHENTICATION_SINGLE),
-                "AUTHENTICATION_NONE" => std::option::Option::Some(Self::AUTHENTICATION_NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Authentication {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Authentication {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PrivilegesRequired(i32);
+    impl std::fmt::Display for Authentication {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Authentication {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Multiple,
+                2 => Self::Single,
+                3 => Self::None,
+                _ => Self::UnknownValue(authentication::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Authentication {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTHENTICATION_UNSPECIFIED" => Self::Unspecified,
+                "AUTHENTICATION_MULTIPLE" => Self::Multiple,
+                "AUTHENTICATION_SINGLE" => Self::Single,
+                "AUTHENTICATION_NONE" => Self::None,
+                _ => Self::UnknownValue(authentication::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Authentication {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Multiple => serializer.serialize_i32(1),
+                Self::Single => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Authentication {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Authentication>::new(
+                ".grafeas.v1.CVSS.Authentication",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PrivilegesRequired {
+        Unspecified,
+        None,
+        Low,
+        High,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PrivilegesRequired::value] or
+        /// [PrivilegesRequired::name].
+        UnknownValue(privileges_required::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod privileges_required {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PrivilegesRequired {
-        pub const PRIVILEGES_REQUIRED_UNSPECIFIED: PrivilegesRequired = PrivilegesRequired::new(0);
-
-        pub const PRIVILEGES_REQUIRED_NONE: PrivilegesRequired = PrivilegesRequired::new(1);
-
-        pub const PRIVILEGES_REQUIRED_LOW: PrivilegesRequired = PrivilegesRequired::new(2);
-
-        pub const PRIVILEGES_REQUIRED_HIGH: PrivilegesRequired = PrivilegesRequired::new(3);
-
-        /// Creates a new PrivilegesRequired instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::High => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_NONE"),
-                2 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_LOW"),
-                3 => std::borrow::Cow::Borrowed("PRIVILEGES_REQUIRED_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PRIVILEGES_REQUIRED_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("PRIVILEGES_REQUIRED_NONE"),
+                Self::Low => std::option::Option::Some("PRIVILEGES_REQUIRED_LOW"),
+                Self::High => std::option::Option::Some("PRIVILEGES_REQUIRED_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PRIVILEGES_REQUIRED_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_UNSPECIFIED)
-                }
-                "PRIVILEGES_REQUIRED_NONE" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_NONE)
-                }
-                "PRIVILEGES_REQUIRED_LOW" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_LOW)
-                }
-                "PRIVILEGES_REQUIRED_HIGH" => {
-                    std::option::Option::Some(Self::PRIVILEGES_REQUIRED_HIGH)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PrivilegesRequired {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PrivilegesRequired {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct UserInteraction(i32);
+    impl std::fmt::Display for PrivilegesRequired {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PrivilegesRequired {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Low,
+                3 => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PrivilegesRequired {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PRIVILEGES_REQUIRED_UNSPECIFIED" => Self::Unspecified,
+                "PRIVILEGES_REQUIRED_NONE" => Self::None,
+                "PRIVILEGES_REQUIRED_LOW" => Self::Low,
+                "PRIVILEGES_REQUIRED_HIGH" => Self::High,
+                _ => Self::UnknownValue(privileges_required::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PrivilegesRequired {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::High => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PrivilegesRequired {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PrivilegesRequired>::new(
+                ".grafeas.v1.CVSS.PrivilegesRequired",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum UserInteraction {
+        Unspecified,
+        None,
+        Required,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [UserInteraction::value] or
+        /// [UserInteraction::name].
+        UnknownValue(user_interaction::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod user_interaction {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl UserInteraction {
-        pub const USER_INTERACTION_UNSPECIFIED: UserInteraction = UserInteraction::new(0);
-
-        pub const USER_INTERACTION_NONE: UserInteraction = UserInteraction::new(1);
-
-        pub const USER_INTERACTION_REQUIRED: UserInteraction = UserInteraction::new(2);
-
-        /// Creates a new UserInteraction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Required => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("USER_INTERACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER_INTERACTION_NONE"),
-                2 => std::borrow::Cow::Borrowed("USER_INTERACTION_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("USER_INTERACTION_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("USER_INTERACTION_NONE"),
+                Self::Required => std::option::Option::Some("USER_INTERACTION_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "USER_INTERACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_UNSPECIFIED)
-                }
-                "USER_INTERACTION_NONE" => std::option::Option::Some(Self::USER_INTERACTION_NONE),
-                "USER_INTERACTION_REQUIRED" => {
-                    std::option::Option::Some(Self::USER_INTERACTION_REQUIRED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for UserInteraction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for UserInteraction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Scope(i32);
+    impl std::fmt::Display for UserInteraction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for UserInteraction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for UserInteraction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "USER_INTERACTION_UNSPECIFIED" => Self::Unspecified,
+                "USER_INTERACTION_NONE" => Self::None,
+                "USER_INTERACTION_REQUIRED" => Self::Required,
+                _ => Self::UnknownValue(user_interaction::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for UserInteraction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Required => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for UserInteraction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<UserInteraction>::new(
+                ".grafeas.v1.CVSS.UserInteraction",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Scope {
+        Unspecified,
+        Unchanged,
+        Changed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Scope::value] or
+        /// [Scope::name].
+        UnknownValue(scope::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod scope {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Scope {
-        pub const SCOPE_UNSPECIFIED: Scope = Scope::new(0);
-
-        pub const SCOPE_UNCHANGED: Scope = Scope::new(1);
-
-        pub const SCOPE_CHANGED: Scope = Scope::new(2);
-
-        /// Creates a new Scope instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unchanged => std::option::Option::Some(1),
+                Self::Changed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SCOPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SCOPE_UNCHANGED"),
-                2 => std::borrow::Cow::Borrowed("SCOPE_CHANGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SCOPE_UNSPECIFIED"),
+                Self::Unchanged => std::option::Option::Some("SCOPE_UNCHANGED"),
+                Self::Changed => std::option::Option::Some("SCOPE_CHANGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SCOPE_UNSPECIFIED" => std::option::Option::Some(Self::SCOPE_UNSPECIFIED),
-                "SCOPE_UNCHANGED" => std::option::Option::Some(Self::SCOPE_UNCHANGED),
-                "SCOPE_CHANGED" => std::option::Option::Some(Self::SCOPE_CHANGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Scope {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Scope {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Impact(i32);
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Scope {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unchanged,
+                2 => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Scope {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SCOPE_UNSPECIFIED" => Self::Unspecified,
+                "SCOPE_UNCHANGED" => Self::Unchanged,
+                "SCOPE_CHANGED" => Self::Changed,
+                _ => Self::UnknownValue(scope::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Scope {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unchanged => serializer.serialize_i32(1),
+                Self::Changed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Scope {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Scope>::new(
+                ".grafeas.v1.CVSS.Scope",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Impact {
+        Unspecified,
+        High,
+        Low,
+        None,
+        Partial,
+        Complete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Impact::value] or
+        /// [Impact::name].
+        UnknownValue(impact::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod impact {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Impact {
-        pub const IMPACT_UNSPECIFIED: Impact = Impact::new(0);
-
-        pub const IMPACT_HIGH: Impact = Impact::new(1);
-
-        pub const IMPACT_LOW: Impact = Impact::new(2);
-
-        pub const IMPACT_NONE: Impact = Impact::new(3);
-
-        pub const IMPACT_PARTIAL: Impact = Impact::new(4);
-
-        pub const IMPACT_COMPLETE: Impact = Impact::new(5);
-
-        /// Creates a new Impact instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::Low => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::Partial => std::option::Option::Some(4),
+                Self::Complete => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IMPACT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMPACT_HIGH"),
-                2 => std::borrow::Cow::Borrowed("IMPACT_LOW"),
-                3 => std::borrow::Cow::Borrowed("IMPACT_NONE"),
-                4 => std::borrow::Cow::Borrowed("IMPACT_PARTIAL"),
-                5 => std::borrow::Cow::Borrowed("IMPACT_COMPLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IMPACT_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("IMPACT_HIGH"),
+                Self::Low => std::option::Option::Some("IMPACT_LOW"),
+                Self::None => std::option::Option::Some("IMPACT_NONE"),
+                Self::Partial => std::option::Option::Some("IMPACT_PARTIAL"),
+                Self::Complete => std::option::Option::Some("IMPACT_COMPLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IMPACT_UNSPECIFIED" => std::option::Option::Some(Self::IMPACT_UNSPECIFIED),
-                "IMPACT_HIGH" => std::option::Option::Some(Self::IMPACT_HIGH),
-                "IMPACT_LOW" => std::option::Option::Some(Self::IMPACT_LOW),
-                "IMPACT_NONE" => std::option::Option::Some(Self::IMPACT_NONE),
-                "IMPACT_PARTIAL" => std::option::Option::Some(Self::IMPACT_PARTIAL),
-                "IMPACT_COMPLETE" => std::option::Option::Some(Self::IMPACT_COMPLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Impact {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Impact {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Impact {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Impact {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::Low,
+                3 => Self::None,
+                4 => Self::Partial,
+                5 => Self::Complete,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Impact {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IMPACT_UNSPECIFIED" => Self::Unspecified,
+                "IMPACT_HIGH" => Self::High,
+                "IMPACT_LOW" => Self::Low,
+                "IMPACT_NONE" => Self::None,
+                "IMPACT_PARTIAL" => Self::Partial,
+                "IMPACT_COMPLETE" => Self::Complete,
+                _ => Self::UnknownValue(impact::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Impact {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::Low => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::Partial => serializer.serialize_i32(4),
+                Self::Complete => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Impact {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Impact>::new(
+                ".grafeas.v1.CVSS.Impact",
+            ))
         }
     }
 }
@@ -2380,64 +3159,127 @@ pub mod deployment_occurrence {
     use super::*;
 
     /// Types of platforms.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Platform(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Platform {
+        /// Unknown.
+        Unspecified,
+        /// Google Container Engine.
+        Gke,
+        /// Google App Engine: Flexible Environment.
+        Flex,
+        /// Custom user-defined platform.
+        Custom,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Platform::value] or
+        /// [Platform::name].
+        UnknownValue(platform::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod platform {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Platform {
-        /// Unknown.
-        pub const PLATFORM_UNSPECIFIED: Platform = Platform::new(0);
-
-        /// Google Container Engine.
-        pub const GKE: Platform = Platform::new(1);
-
-        /// Google App Engine: Flexible Environment.
-        pub const FLEX: Platform = Platform::new(2);
-
-        /// Custom user-defined platform.
-        pub const CUSTOM: Platform = Platform::new(3);
-
-        /// Creates a new Platform instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Gke => std::option::Option::Some(1),
+                Self::Flex => std::option::Option::Some(2),
+                Self::Custom => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PLATFORM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GKE"),
-                2 => std::borrow::Cow::Borrowed("FLEX"),
-                3 => std::borrow::Cow::Borrowed("CUSTOM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PLATFORM_UNSPECIFIED"),
+                Self::Gke => std::option::Option::Some("GKE"),
+                Self::Flex => std::option::Option::Some("FLEX"),
+                Self::Custom => std::option::Option::Some("CUSTOM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PLATFORM_UNSPECIFIED" => std::option::Option::Some(Self::PLATFORM_UNSPECIFIED),
-                "GKE" => std::option::Option::Some(Self::GKE),
-                "FLEX" => std::option::Option::Some(Self::FLEX),
-                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Platform {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Platform {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Platform {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Platform {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Gke,
+                2 => Self::Flex,
+                3 => Self::Custom,
+                _ => Self::UnknownValue(platform::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Platform {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PLATFORM_UNSPECIFIED" => Self::Unspecified,
+                "GKE" => Self::Gke,
+                "FLEX" => Self::Flex,
+                "CUSTOM" => Self::Custom,
+                _ => Self::UnknownValue(platform::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Platform {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Gke => serializer.serialize_i32(1),
+                Self::Flex => serializer.serialize_i32(2),
+                Self::Custom => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Platform {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Platform>::new(
+                ".grafeas.v1.DeploymentOccurrence.Platform",
+            ))
         }
     }
 }
@@ -2743,61 +3585,123 @@ pub mod discovery_occurrence {
         use super::*;
 
         /// An enum indicating the progress of the SBOM generation.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct SBOMState(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum SBOMState {
+            /// Default unknown state.
+            Unspecified,
+            /// SBOM scanning is pending.
+            Pending,
+            /// SBOM scanning has completed.
+            Complete,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [SBOMState::value] or
+            /// [SBOMState::name].
+            UnknownValue(sbom_state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod sbom_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl SBOMState {
-            /// Default unknown state.
-            pub const SBOM_STATE_UNSPECIFIED: SBOMState = SBOMState::new(0);
-
-            /// SBOM scanning is pending.
-            pub const PENDING: SBOMState = SBOMState::new(1);
-
-            /// SBOM scanning has completed.
-            pub const COMPLETE: SBOMState = SBOMState::new(2);
-
-            /// Creates a new SBOMState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Pending => std::option::Option::Some(1),
+                    Self::Complete => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SBOM_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("PENDING"),
-                    2 => std::borrow::Cow::Borrowed("COMPLETE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("SBOM_STATE_UNSPECIFIED"),
+                    Self::Pending => std::option::Option::Some("PENDING"),
+                    Self::Complete => std::option::Option::Some("COMPLETE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SBOM_STATE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SBOM_STATE_UNSPECIFIED)
-                    }
-                    "PENDING" => std::option::Option::Some(Self::PENDING),
-                    "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for SBOMState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for SBOMState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for SBOMState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for SBOMState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Pending,
+                    2 => Self::Complete,
+                    _ => Self::UnknownValue(sbom_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for SBOMState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SBOM_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "PENDING" => Self::Pending,
+                    "COMPLETE" => Self::Complete,
+                    _ => Self::UnknownValue(sbom_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for SBOMState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Pending => serializer.serialize_i32(1),
+                    Self::Complete => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for SBOMState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<SBOMState>::new(
+                    ".grafeas.v1.DiscoveryOccurrence.SBOMStatus.SBOMState",
+                ))
             }
         }
     }
@@ -2863,204 +3767,390 @@ pub mod discovery_occurrence {
         use super::*;
 
         /// An enum indicating the state of the attestation generation.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct VulnerabilityAttestationState(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum VulnerabilityAttestationState {
+            /// Default unknown state.
+            Unspecified,
+            /// Attestation was successfully generated and stored.
+            Success,
+            /// Attestation was unsuccessfully generated and stored.
+            Failure,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [VulnerabilityAttestationState::value] or
+            /// [VulnerabilityAttestationState::name].
+            UnknownValue(vulnerability_attestation_state::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod vulnerability_attestation_state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl VulnerabilityAttestationState {
-            /// Default unknown state.
-            pub const VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED: VulnerabilityAttestationState =
-                VulnerabilityAttestationState::new(0);
-
-            /// Attestation was successfully generated and stored.
-            pub const SUCCESS: VulnerabilityAttestationState =
-                VulnerabilityAttestationState::new(1);
-
-            /// Attestation was unsuccessfully generated and stored.
-            pub const FAILURE: VulnerabilityAttestationState =
-                VulnerabilityAttestationState::new(2);
-
-            /// Creates a new VulnerabilityAttestationState instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Success => std::option::Option::Some(1),
+                    Self::Failure => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("SUCCESS"),
-                    2 => std::borrow::Cow::Borrowed("FAILURE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED")
                     }
-                    "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-                    "FAILURE" => std::option::Option::Some(Self::FAILURE),
-                    _ => std::option::Option::None,
+                    Self::Success => std::option::Option::Some("SUCCESS"),
+                    Self::Failure => std::option::Option::Some("FAILURE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for VulnerabilityAttestationState {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for VulnerabilityAttestationState {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for VulnerabilityAttestationState {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for VulnerabilityAttestationState {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Success,
+                    2 => Self::Failure,
+                    _ => Self::UnknownValue(vulnerability_attestation_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for VulnerabilityAttestationState {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "VULNERABILITY_ATTESTATION_STATE_UNSPECIFIED" => Self::Unspecified,
+                    "SUCCESS" => Self::Success,
+                    "FAILURE" => Self::Failure,
+                    _ => Self::UnknownValue(vulnerability_attestation_state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for VulnerabilityAttestationState {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Success => serializer.serialize_i32(1),
+                    Self::Failure => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for VulnerabilityAttestationState {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<VulnerabilityAttestationState>::new(
+                    ".grafeas.v1.DiscoveryOccurrence.VulnerabilityAttestation.VulnerabilityAttestationState"))
             }
         }
     }
 
     /// Whether the resource is continuously analyzed.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ContinuousAnalysis(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ContinuousAnalysis {
+        /// Unknown.
+        Unspecified,
+        /// The resource is continuously analyzed.
+        Active,
+        /// The resource is ignored for continuous analysis.
+        Inactive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ContinuousAnalysis::value] or
+        /// [ContinuousAnalysis::name].
+        UnknownValue(continuous_analysis::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod continuous_analysis {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ContinuousAnalysis {
-        /// Unknown.
-        pub const CONTINUOUS_ANALYSIS_UNSPECIFIED: ContinuousAnalysis = ContinuousAnalysis::new(0);
-
-        /// The resource is continuously analyzed.
-        pub const ACTIVE: ContinuousAnalysis = ContinuousAnalysis::new(1);
-
-        /// The resource is ignored for continuous analysis.
-        pub const INACTIVE: ContinuousAnalysis = ContinuousAnalysis::new(2);
-
-        /// Creates a new ContinuousAnalysis instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Active => std::option::Option::Some(1),
+                Self::Inactive => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CONTINUOUS_ANALYSIS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACTIVE"),
-                2 => std::borrow::Cow::Borrowed("INACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CONTINUOUS_ANALYSIS_UNSPECIFIED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::Inactive => std::option::Option::Some("INACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CONTINUOUS_ANALYSIS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CONTINUOUS_ANALYSIS_UNSPECIFIED)
-                }
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                "INACTIVE" => std::option::Option::Some(Self::INACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ContinuousAnalysis {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ContinuousAnalysis {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ContinuousAnalysis {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ContinuousAnalysis {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Active,
+                2 => Self::Inactive,
+                _ => Self::UnknownValue(continuous_analysis::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ContinuousAnalysis {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CONTINUOUS_ANALYSIS_UNSPECIFIED" => Self::Unspecified,
+                "ACTIVE" => Self::Active,
+                "INACTIVE" => Self::Inactive,
+                _ => Self::UnknownValue(continuous_analysis::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ContinuousAnalysis {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Active => serializer.serialize_i32(1),
+                Self::Inactive => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ContinuousAnalysis {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContinuousAnalysis>::new(
+                ".grafeas.v1.DiscoveryOccurrence.ContinuousAnalysis",
+            ))
         }
     }
 
     /// Analysis status for a resource. Currently for initial analysis only (not
     /// updated in continuous analysis).
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AnalysisStatus(i32);
-
-    impl AnalysisStatus {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AnalysisStatus {
         /// Unknown.
-        pub const ANALYSIS_STATUS_UNSPECIFIED: AnalysisStatus = AnalysisStatus::new(0);
-
+        Unspecified,
         /// Resource is known but no action has been taken yet.
-        pub const PENDING: AnalysisStatus = AnalysisStatus::new(1);
-
+        Pending,
         /// Resource is being analyzed.
-        pub const SCANNING: AnalysisStatus = AnalysisStatus::new(2);
-
+        Scanning,
         /// Analysis has finished successfully.
-        pub const FINISHED_SUCCESS: AnalysisStatus = AnalysisStatus::new(3);
-
+        FinishedSuccess,
         /// Analysis has completed.
-        pub const COMPLETE: AnalysisStatus = AnalysisStatus::new(3);
-
+        Complete,
         /// Analysis has finished unsuccessfully, the analysis itself is in a bad
         /// state.
-        pub const FINISHED_FAILED: AnalysisStatus = AnalysisStatus::new(4);
-
+        FinishedFailed,
         /// The resource is known not to be supported.
-        pub const FINISHED_UNSUPPORTED: AnalysisStatus = AnalysisStatus::new(5);
+        FinishedUnsupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AnalysisStatus::value] or
+        /// [AnalysisStatus::name].
+        UnknownValue(analysis_status::UnknownValue),
+    }
 
-        /// Creates a new AnalysisStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod analysis_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl AnalysisStatus {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Scanning => std::option::Option::Some(2),
+                Self::FinishedSuccess => std::option::Option::Some(3),
+                Self::Complete => std::option::Option::Some(3),
+                Self::FinishedFailed => std::option::Option::Some(4),
+                Self::FinishedUnsupported => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ANALYSIS_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("SCANNING"),
-                3 => std::borrow::Cow::Borrowed("COMPLETE"),
-                4 => std::borrow::Cow::Borrowed("FINISHED_FAILED"),
-                5 => std::borrow::Cow::Borrowed("FINISHED_UNSUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ANALYSIS_STATUS_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Scanning => std::option::Option::Some("SCANNING"),
+                Self::FinishedSuccess => std::option::Option::Some("FINISHED_SUCCESS"),
+                Self::Complete => std::option::Option::Some("COMPLETE"),
+                Self::FinishedFailed => std::option::Option::Some("FINISHED_FAILED"),
+                Self::FinishedUnsupported => std::option::Option::Some("FINISHED_UNSUPPORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ANALYSIS_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ANALYSIS_STATUS_UNSPECIFIED)
-                }
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "SCANNING" => std::option::Option::Some(Self::SCANNING),
-                "FINISHED_SUCCESS" => std::option::Option::Some(Self::FINISHED_SUCCESS),
-                "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-                "FINISHED_FAILED" => std::option::Option::Some(Self::FINISHED_FAILED),
-                "FINISHED_UNSUPPORTED" => std::option::Option::Some(Self::FINISHED_UNSUPPORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AnalysisStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AnalysisStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AnalysisStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AnalysisStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Scanning,
+                3 => Self::Complete,
+                4 => Self::FinishedFailed,
+                5 => Self::FinishedUnsupported,
+                _ => Self::UnknownValue(analysis_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AnalysisStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ANALYSIS_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "SCANNING" => Self::Scanning,
+                "FINISHED_SUCCESS" => Self::FinishedSuccess,
+                "COMPLETE" => Self::Complete,
+                "FINISHED_FAILED" => Self::FinishedFailed,
+                "FINISHED_UNSUPPORTED" => Self::FinishedUnsupported,
+                _ => Self::UnknownValue(analysis_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AnalysisStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Scanning => serializer.serialize_i32(2),
+                Self::FinishedSuccess => serializer.serialize_i32(3),
+                Self::Complete => serializer.serialize_i32(3),
+                Self::FinishedFailed => serializer.serialize_i32(4),
+                Self::FinishedUnsupported => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AnalysisStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AnalysisStatus>::new(
+                ".grafeas.v1.DiscoveryOccurrence.AnalysisStatus",
+            ))
         }
     }
 }
@@ -7007,66 +8097,127 @@ pub mod version {
     use super::*;
 
     /// Whether this is an ordinary package version or a sentinel MIN/MAX version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionKind(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VersionKind {
+        /// Unknown.
+        Unspecified,
+        /// A standard package version.
+        Normal,
+        /// A special version representing negative infinity.
+        Minimum,
+        /// A special version representing positive infinity.
+        Maximum,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VersionKind::value] or
+        /// [VersionKind::name].
+        UnknownValue(version_kind::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod version_kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VersionKind {
-        /// Unknown.
-        pub const VERSION_KIND_UNSPECIFIED: VersionKind = VersionKind::new(0);
-
-        /// A standard package version.
-        pub const NORMAL: VersionKind = VersionKind::new(1);
-
-        /// A special version representing negative infinity.
-        pub const MINIMUM: VersionKind = VersionKind::new(2);
-
-        /// A special version representing positive infinity.
-        pub const MAXIMUM: VersionKind = VersionKind::new(3);
-
-        /// Creates a new VersionKind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Normal => std::option::Option::Some(1),
+                Self::Minimum => std::option::Option::Some(2),
+                Self::Maximum => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VERSION_KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NORMAL"),
-                2 => std::borrow::Cow::Borrowed("MINIMUM"),
-                3 => std::borrow::Cow::Borrowed("MAXIMUM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VERSION_KIND_UNSPECIFIED"),
+                Self::Normal => std::option::Option::Some("NORMAL"),
+                Self::Minimum => std::option::Option::Some("MINIMUM"),
+                Self::Maximum => std::option::Option::Some("MAXIMUM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VERSION_KIND_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VERSION_KIND_UNSPECIFIED)
-                }
-                "NORMAL" => std::option::Option::Some(Self::NORMAL),
-                "MINIMUM" => std::option::Option::Some(Self::MINIMUM),
-                "MAXIMUM" => std::option::Option::Some(Self::MAXIMUM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VersionKind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionKind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VersionKind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VersionKind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Normal,
+                2 => Self::Minimum,
+                3 => Self::Maximum,
+                _ => Self::UnknownValue(version_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VersionKind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VERSION_KIND_UNSPECIFIED" => Self::Unspecified,
+                "NORMAL" => Self::Normal,
+                "MINIMUM" => Self::Minimum,
+                "MAXIMUM" => Self::Maximum,
+                _ => Self::UnknownValue(version_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VersionKind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Normal => serializer.serialize_i32(1),
+                Self::Minimum => serializer.serialize_i32(2),
+                Self::Maximum => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VersionKind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionKind>::new(
+                ".grafeas.v1.Version.VersionKind",
+            ))
         }
     }
 }
@@ -7799,65 +8950,128 @@ pub mod alias_context {
     use super::*;
 
     /// The type of an alias.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(i32);
-
-    impl Kind {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kind {
         /// Unknown.
-        pub const KIND_UNSPECIFIED: Kind = Kind::new(0);
-
+        Unspecified,
         /// Git tag.
-        pub const FIXED: Kind = Kind::new(1);
-
+        Fixed,
         /// Git branch.
-        pub const MOVABLE: Kind = Kind::new(2);
-
+        Movable,
         /// Used to specify non-standard aliases. For example, if a Git repo has a
         /// ref named "refs/foo/bar".
-        pub const OTHER: Kind = Kind::new(4);
+        Other,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kind::value] or
+        /// [Kind::name].
+        UnknownValue(kind::UnknownValue),
+    }
 
-        /// Creates a new Kind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Kind {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Fixed => std::option::Option::Some(1),
+                Self::Movable => std::option::Option::Some(2),
+                Self::Other => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIXED"),
-                2 => std::borrow::Cow::Borrowed("MOVABLE"),
-                4 => std::borrow::Cow::Borrowed("OTHER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KIND_UNSPECIFIED"),
+                Self::Fixed => std::option::Option::Some("FIXED"),
+                Self::Movable => std::option::Option::Some("MOVABLE"),
+                Self::Other => std::option::Option::Some("OTHER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KIND_UNSPECIFIED" => std::option::Option::Some(Self::KIND_UNSPECIFIED),
-                "FIXED" => std::option::Option::Some(Self::FIXED),
-                "MOVABLE" => std::option::Option::Some(Self::MOVABLE),
-                "OTHER" => std::option::Option::Some(Self::OTHER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Fixed,
+                2 => Self::Movable,
+                4 => Self::Other,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KIND_UNSPECIFIED" => Self::Unspecified,
+                "FIXED" => Self::Fixed,
+                "MOVABLE" => Self::Movable,
+                "OTHER" => Self::Other,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Fixed => serializer.serialize_i32(1),
+                Self::Movable => serializer.serialize_i32(2),
+                Self::Other => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                ".grafeas.v1.AliasContext.Kind",
+            ))
         }
     }
 }
@@ -10390,104 +11604,174 @@ pub mod vulnerability_assessment_note {
             use super::*;
 
             /// Provides the type of justification.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct JustificationType(i32);
-
-            impl JustificationType {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum JustificationType {
                 /// JUSTIFICATION_TYPE_UNSPECIFIED.
-                pub const JUSTIFICATION_TYPE_UNSPECIFIED: JustificationType =
-                    JustificationType::new(0);
-
+                Unspecified,
                 /// The vulnerable component is not present in the product.
-                pub const COMPONENT_NOT_PRESENT: JustificationType = JustificationType::new(1);
-
+                ComponentNotPresent,
                 /// The vulnerable code is not present. Typically this case
                 /// occurs when source code is configured or built in a way that excludes
                 /// the vulnerable code.
-                pub const VULNERABLE_CODE_NOT_PRESENT: JustificationType =
-                    JustificationType::new(2);
-
+                VulnerableCodeNotPresent,
                 /// The vulnerable code can not be executed.
                 /// Typically this case occurs when the product includes the vulnerable
                 /// code but does not call or use the vulnerable code.
-                pub const VULNERABLE_CODE_NOT_IN_EXECUTE_PATH: JustificationType =
-                    JustificationType::new(3);
-
+                VulnerableCodeNotInExecutePath,
                 /// The vulnerable code cannot be controlled by an attacker to exploit
                 /// the vulnerability.
-                pub const VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY: JustificationType =
-                    JustificationType::new(4);
-
+                VulnerableCodeCannotBeControlledByAdversary,
                 /// The product includes built-in protections or features that prevent
                 /// exploitation of the vulnerability. These built-in protections cannot
                 /// be subverted by the attacker and cannot be configured or disabled by
                 /// the user. These mitigations completely prevent exploitation based on
                 /// known attack vectors.
-                pub const INLINE_MITIGATIONS_ALREADY_EXIST: JustificationType =
-                    JustificationType::new(5);
+                InlineMitigationsAlreadyExist,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [JustificationType::value] or
+                /// [JustificationType::name].
+                UnknownValue(justification_type::UnknownValue),
+            }
 
-                /// Creates a new JustificationType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod justification_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl JustificationType {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::ComponentNotPresent => std::option::Option::Some(1),
+                        Self::VulnerableCodeNotPresent => std::option::Option::Some(2),
+                        Self::VulnerableCodeNotInExecutePath => std::option::Option::Some(3),
+                        Self::VulnerableCodeCannotBeControlledByAdversary => {
+                            std::option::Option::Some(4)
+                        }
+                        Self::InlineMitigationsAlreadyExist => std::option::Option::Some(5),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("JUSTIFICATION_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("COMPONENT_NOT_PRESENT"),
-                        2 => std::borrow::Cow::Borrowed("VULNERABLE_CODE_NOT_PRESENT"),
-                        3 => std::borrow::Cow::Borrowed("VULNERABLE_CODE_NOT_IN_EXECUTE_PATH"),
-                        4 => std::borrow::Cow::Borrowed(
-                            "VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY",
-                        ),
-                        5 => std::borrow::Cow::Borrowed("INLINE_MITIGATIONS_ALREADY_EXIST"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "JUSTIFICATION_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::JUSTIFICATION_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("JUSTIFICATION_TYPE_UNSPECIFIED")
                         }
-                        "COMPONENT_NOT_PRESENT" => {
-                            std::option::Option::Some(Self::COMPONENT_NOT_PRESENT)
+                        Self::ComponentNotPresent => {
+                            std::option::Option::Some("COMPONENT_NOT_PRESENT")
                         }
-                        "VULNERABLE_CODE_NOT_PRESENT" => {
-                            std::option::Option::Some(Self::VULNERABLE_CODE_NOT_PRESENT)
+                        Self::VulnerableCodeNotPresent => {
+                            std::option::Option::Some("VULNERABLE_CODE_NOT_PRESENT")
                         }
-                        "VULNERABLE_CODE_NOT_IN_EXECUTE_PATH" => {
-                            std::option::Option::Some(Self::VULNERABLE_CODE_NOT_IN_EXECUTE_PATH)
+                        Self::VulnerableCodeNotInExecutePath => {
+                            std::option::Option::Some("VULNERABLE_CODE_NOT_IN_EXECUTE_PATH")
                         }
-                        "VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY" => {
+                        Self::VulnerableCodeCannotBeControlledByAdversary => {
                             std::option::Option::Some(
-                                Self::VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY,
+                                "VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY",
                             )
                         }
-                        "INLINE_MITIGATIONS_ALREADY_EXIST" => {
-                            std::option::Option::Some(Self::INLINE_MITIGATIONS_ALREADY_EXIST)
+                        Self::InlineMitigationsAlreadyExist => {
+                            std::option::Option::Some("INLINE_MITIGATIONS_ALREADY_EXIST")
                         }
-                        _ => std::option::Option::None,
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for JustificationType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for JustificationType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for JustificationType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for JustificationType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::ComponentNotPresent,
+                        2 => Self::VulnerableCodeNotPresent,
+                        3 => Self::VulnerableCodeNotInExecutePath,
+                        4 => Self::VulnerableCodeCannotBeControlledByAdversary,
+                        5 => Self::InlineMitigationsAlreadyExist,
+                        _ => Self::UnknownValue(justification_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for JustificationType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "JUSTIFICATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "COMPONENT_NOT_PRESENT" => Self::ComponentNotPresent,
+                        "VULNERABLE_CODE_NOT_PRESENT" => Self::VulnerableCodeNotPresent,
+                        "VULNERABLE_CODE_NOT_IN_EXECUTE_PATH" => {
+                            Self::VulnerableCodeNotInExecutePath
+                        }
+                        "VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY" => {
+                            Self::VulnerableCodeCannotBeControlledByAdversary
+                        }
+                        "INLINE_MITIGATIONS_ALREADY_EXIST" => Self::InlineMitigationsAlreadyExist,
+                        _ => Self::UnknownValue(justification_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for JustificationType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::ComponentNotPresent => serializer.serialize_i32(1),
+                        Self::VulnerableCodeNotPresent => serializer.serialize_i32(2),
+                        Self::VulnerableCodeNotInExecutePath => serializer.serialize_i32(3),
+                        Self::VulnerableCodeCannotBeControlledByAdversary => {
+                            serializer.serialize_i32(4)
+                        }
+                        Self::InlineMitigationsAlreadyExist => serializer.serialize_i32(5),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for JustificationType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<JustificationType>::new(
+                        ".grafeas.v1.VulnerabilityAssessmentNote.Assessment.Justification.JustificationType"))
                 }
             }
         }
@@ -10555,145 +11839,282 @@ pub mod vulnerability_assessment_note {
             use super::*;
 
             /// The type of remediation that can be applied.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct RemediationType(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum RemediationType {
+                /// No remediation type specified.
+                Unspecified,
+                /// A MITIGATION is available.
+                Mitigation,
+                /// No fix is planned.
+                NoFixPlanned,
+                /// Not available.
+                NoneAvailable,
+                /// A vendor fix is available.
+                VendorFix,
+                /// A workaround is available.
+                Workaround,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [RemediationType::value] or
+                /// [RemediationType::name].
+                UnknownValue(remediation_type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod remediation_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl RemediationType {
-                /// No remediation type specified.
-                pub const REMEDIATION_TYPE_UNSPECIFIED: RemediationType = RemediationType::new(0);
-
-                /// A MITIGATION is available.
-                pub const MITIGATION: RemediationType = RemediationType::new(1);
-
-                /// No fix is planned.
-                pub const NO_FIX_PLANNED: RemediationType = RemediationType::new(2);
-
-                /// Not available.
-                pub const NONE_AVAILABLE: RemediationType = RemediationType::new(3);
-
-                /// A vendor fix is available.
-                pub const VENDOR_FIX: RemediationType = RemediationType::new(4);
-
-                /// A workaround is available.
-                pub const WORKAROUND: RemediationType = RemediationType::new(5);
-
-                /// Creates a new RemediationType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::Mitigation => std::option::Option::Some(1),
+                        Self::NoFixPlanned => std::option::Option::Some(2),
+                        Self::NoneAvailable => std::option::Option::Some(3),
+                        Self::VendorFix => std::option::Option::Some(4),
+                        Self::Workaround => std::option::Option::Some(5),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("REMEDIATION_TYPE_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("MITIGATION"),
-                        2 => std::borrow::Cow::Borrowed("NO_FIX_PLANNED"),
-                        3 => std::borrow::Cow::Borrowed("NONE_AVAILABLE"),
-                        4 => std::borrow::Cow::Borrowed("VENDOR_FIX"),
-                        5 => std::borrow::Cow::Borrowed("WORKAROUND"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "REMEDIATION_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::REMEDIATION_TYPE_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("REMEDIATION_TYPE_UNSPECIFIED")
                         }
-                        "MITIGATION" => std::option::Option::Some(Self::MITIGATION),
-                        "NO_FIX_PLANNED" => std::option::Option::Some(Self::NO_FIX_PLANNED),
-                        "NONE_AVAILABLE" => std::option::Option::Some(Self::NONE_AVAILABLE),
-                        "VENDOR_FIX" => std::option::Option::Some(Self::VENDOR_FIX),
-                        "WORKAROUND" => std::option::Option::Some(Self::WORKAROUND),
-                        _ => std::option::Option::None,
+                        Self::Mitigation => std::option::Option::Some("MITIGATION"),
+                        Self::NoFixPlanned => std::option::Option::Some("NO_FIX_PLANNED"),
+                        Self::NoneAvailable => std::option::Option::Some("NONE_AVAILABLE"),
+                        Self::VendorFix => std::option::Option::Some("VENDOR_FIX"),
+                        Self::Workaround => std::option::Option::Some("WORKAROUND"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for RemediationType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for RemediationType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for RemediationType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for RemediationType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::Mitigation,
+                        2 => Self::NoFixPlanned,
+                        3 => Self::NoneAvailable,
+                        4 => Self::VendorFix,
+                        5 => Self::Workaround,
+                        _ => Self::UnknownValue(remediation_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for RemediationType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "REMEDIATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "MITIGATION" => Self::Mitigation,
+                        "NO_FIX_PLANNED" => Self::NoFixPlanned,
+                        "NONE_AVAILABLE" => Self::NoneAvailable,
+                        "VENDOR_FIX" => Self::VendorFix,
+                        "WORKAROUND" => Self::Workaround,
+                        _ => Self::UnknownValue(remediation_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for RemediationType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::Mitigation => serializer.serialize_i32(1),
+                        Self::NoFixPlanned => serializer.serialize_i32(2),
+                        Self::NoneAvailable => serializer.serialize_i32(3),
+                        Self::VendorFix => serializer.serialize_i32(4),
+                        Self::Workaround => serializer.serialize_i32(5),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for RemediationType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<RemediationType>::new(
+                        ".grafeas.v1.VulnerabilityAssessmentNote.Assessment.Remediation.RemediationType"))
                 }
             }
         }
 
         /// Provides the state of this Vulnerability assessment.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct State(i32);
-
-        impl State {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum State {
             /// No state is specified.
-            pub const STATE_UNSPECIFIED: State = State::new(0);
-
+            Unspecified,
             /// This product is known to be affected by this vulnerability.
-            pub const AFFECTED: State = State::new(1);
-
+            Affected,
             /// This product is known to be not affected by this vulnerability.
-            pub const NOT_AFFECTED: State = State::new(2);
-
+            NotAffected,
             /// This product contains a fix for this vulnerability.
-            pub const FIXED: State = State::new(3);
-
+            Fixed,
             /// It is not known yet whether these versions are or are not affected
             /// by the vulnerability. However, it is still under investigation.
-            pub const UNDER_INVESTIGATION: State = State::new(4);
+            UnderInvestigation,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [State::value] or
+            /// [State::name].
+            UnknownValue(state::UnknownValue),
+        }
 
-            /// Creates a new State instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod state {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl State {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Affected => std::option::Option::Some(1),
+                    Self::NotAffected => std::option::Option::Some(2),
+                    Self::Fixed => std::option::Option::Some(3),
+                    Self::UnderInvestigation => std::option::Option::Some(4),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AFFECTED"),
-                    2 => std::borrow::Cow::Borrowed("NOT_AFFECTED"),
-                    3 => std::borrow::Cow::Borrowed("FIXED"),
-                    4 => std::borrow::Cow::Borrowed("UNDER_INVESTIGATION"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                    Self::Affected => std::option::Option::Some("AFFECTED"),
+                    Self::NotAffected => std::option::Option::Some("NOT_AFFECTED"),
+                    Self::Fixed => std::option::Option::Some("FIXED"),
+                    Self::UnderInvestigation => std::option::Option::Some("UNDER_INVESTIGATION"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                    "AFFECTED" => std::option::Option::Some(Self::AFFECTED),
-                    "NOT_AFFECTED" => std::option::Option::Some(Self::NOT_AFFECTED),
-                    "FIXED" => std::option::Option::Some(Self::FIXED),
-                    "UNDER_INVESTIGATION" => std::option::Option::Some(Self::UNDER_INVESTIGATION),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for State {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for State {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for State {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for State {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Affected,
+                    2 => Self::NotAffected,
+                    3 => Self::Fixed,
+                    4 => Self::UnderInvestigation,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for State {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "STATE_UNSPECIFIED" => Self::Unspecified,
+                    "AFFECTED" => Self::Affected,
+                    "NOT_AFFECTED" => Self::NotAffected,
+                    "FIXED" => Self::Fixed,
+                    "UNDER_INVESTIGATION" => Self::UnderInvestigation,
+                    _ => Self::UnknownValue(state::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for State {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Affected => serializer.serialize_i32(1),
+                    Self::NotAffected => serializer.serialize_i32(2),
+                    Self::Fixed => serializer.serialize_i32(3),
+                    Self::UnderInvestigation => serializer.serialize_i32(4),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for State {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                    ".grafeas.v1.VulnerabilityAssessmentNote.Assessment.State",
+                ))
             }
         }
     }
@@ -11703,291 +13124,561 @@ pub mod vulnerability_occurrence {
 }
 
 /// Kind represents the kinds of notes supported.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NoteKind(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NoteKind {
+    /// Default value. This value is unused.
+    Unspecified,
+    /// The note and occurrence represent a package vulnerability.
+    Vulnerability,
+    /// The note and occurrence assert build provenance.
+    Build,
+    /// This represents an image basis relationship.
+    Image,
+    /// This represents a package installed via a package manager.
+    Package,
+    /// The note and occurrence track deployment events.
+    Deployment,
+    /// The note and occurrence track the initial discovery status of a resource.
+    Discovery,
+    /// This represents a logical "role" that can attest to artifacts.
+    Attestation,
+    /// This represents an available package upgrade.
+    Upgrade,
+    /// This represents a Compliance Note
+    Compliance,
+    /// This represents a DSSE attestation Note
+    DsseAttestation,
+    /// This represents a Vulnerability Assessment.
+    VulnerabilityAssessment,
+    /// This represents an SBOM Reference.
+    SbomReference,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NoteKind::value] or
+    /// [NoteKind::name].
+    UnknownValue(note_kind::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod note_kind {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl NoteKind {
-    /// Default value. This value is unused.
-    pub const NOTE_KIND_UNSPECIFIED: NoteKind = NoteKind::new(0);
-
-    /// The note and occurrence represent a package vulnerability.
-    pub const VULNERABILITY: NoteKind = NoteKind::new(1);
-
-    /// The note and occurrence assert build provenance.
-    pub const BUILD: NoteKind = NoteKind::new(2);
-
-    /// This represents an image basis relationship.
-    pub const IMAGE: NoteKind = NoteKind::new(3);
-
-    /// This represents a package installed via a package manager.
-    pub const PACKAGE: NoteKind = NoteKind::new(4);
-
-    /// The note and occurrence track deployment events.
-    pub const DEPLOYMENT: NoteKind = NoteKind::new(5);
-
-    /// The note and occurrence track the initial discovery status of a resource.
-    pub const DISCOVERY: NoteKind = NoteKind::new(6);
-
-    /// This represents a logical "role" that can attest to artifacts.
-    pub const ATTESTATION: NoteKind = NoteKind::new(7);
-
-    /// This represents an available package upgrade.
-    pub const UPGRADE: NoteKind = NoteKind::new(8);
-
-    /// This represents a Compliance Note
-    pub const COMPLIANCE: NoteKind = NoteKind::new(9);
-
-    /// This represents a DSSE attestation Note
-    pub const DSSE_ATTESTATION: NoteKind = NoteKind::new(10);
-
-    /// This represents a Vulnerability Assessment.
-    pub const VULNERABILITY_ASSESSMENT: NoteKind = NoteKind::new(11);
-
-    /// This represents an SBOM Reference.
-    pub const SBOM_REFERENCE: NoteKind = NoteKind::new(12);
-
-    /// Creates a new NoteKind instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Vulnerability => std::option::Option::Some(1),
+            Self::Build => std::option::Option::Some(2),
+            Self::Image => std::option::Option::Some(3),
+            Self::Package => std::option::Option::Some(4),
+            Self::Deployment => std::option::Option::Some(5),
+            Self::Discovery => std::option::Option::Some(6),
+            Self::Attestation => std::option::Option::Some(7),
+            Self::Upgrade => std::option::Option::Some(8),
+            Self::Compliance => std::option::Option::Some(9),
+            Self::DsseAttestation => std::option::Option::Some(10),
+            Self::VulnerabilityAssessment => std::option::Option::Some(11),
+            Self::SbomReference => std::option::Option::Some(12),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NOTE_KIND_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VULNERABILITY"),
-            2 => std::borrow::Cow::Borrowed("BUILD"),
-            3 => std::borrow::Cow::Borrowed("IMAGE"),
-            4 => std::borrow::Cow::Borrowed("PACKAGE"),
-            5 => std::borrow::Cow::Borrowed("DEPLOYMENT"),
-            6 => std::borrow::Cow::Borrowed("DISCOVERY"),
-            7 => std::borrow::Cow::Borrowed("ATTESTATION"),
-            8 => std::borrow::Cow::Borrowed("UPGRADE"),
-            9 => std::borrow::Cow::Borrowed("COMPLIANCE"),
-            10 => std::borrow::Cow::Borrowed("DSSE_ATTESTATION"),
-            11 => std::borrow::Cow::Borrowed("VULNERABILITY_ASSESSMENT"),
-            12 => std::borrow::Cow::Borrowed("SBOM_REFERENCE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NOTE_KIND_UNSPECIFIED"),
+            Self::Vulnerability => std::option::Option::Some("VULNERABILITY"),
+            Self::Build => std::option::Option::Some("BUILD"),
+            Self::Image => std::option::Option::Some("IMAGE"),
+            Self::Package => std::option::Option::Some("PACKAGE"),
+            Self::Deployment => std::option::Option::Some("DEPLOYMENT"),
+            Self::Discovery => std::option::Option::Some("DISCOVERY"),
+            Self::Attestation => std::option::Option::Some("ATTESTATION"),
+            Self::Upgrade => std::option::Option::Some("UPGRADE"),
+            Self::Compliance => std::option::Option::Some("COMPLIANCE"),
+            Self::DsseAttestation => std::option::Option::Some("DSSE_ATTESTATION"),
+            Self::VulnerabilityAssessment => std::option::Option::Some("VULNERABILITY_ASSESSMENT"),
+            Self::SbomReference => std::option::Option::Some("SBOM_REFERENCE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NOTE_KIND_UNSPECIFIED" => std::option::Option::Some(Self::NOTE_KIND_UNSPECIFIED),
-            "VULNERABILITY" => std::option::Option::Some(Self::VULNERABILITY),
-            "BUILD" => std::option::Option::Some(Self::BUILD),
-            "IMAGE" => std::option::Option::Some(Self::IMAGE),
-            "PACKAGE" => std::option::Option::Some(Self::PACKAGE),
-            "DEPLOYMENT" => std::option::Option::Some(Self::DEPLOYMENT),
-            "DISCOVERY" => std::option::Option::Some(Self::DISCOVERY),
-            "ATTESTATION" => std::option::Option::Some(Self::ATTESTATION),
-            "UPGRADE" => std::option::Option::Some(Self::UPGRADE),
-            "COMPLIANCE" => std::option::Option::Some(Self::COMPLIANCE),
-            "DSSE_ATTESTATION" => std::option::Option::Some(Self::DSSE_ATTESTATION),
-            "VULNERABILITY_ASSESSMENT" => std::option::Option::Some(Self::VULNERABILITY_ASSESSMENT),
-            "SBOM_REFERENCE" => std::option::Option::Some(Self::SBOM_REFERENCE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NoteKind {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NoteKind {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NoteKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NoteKind {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Vulnerability,
+            2 => Self::Build,
+            3 => Self::Image,
+            4 => Self::Package,
+            5 => Self::Deployment,
+            6 => Self::Discovery,
+            7 => Self::Attestation,
+            8 => Self::Upgrade,
+            9 => Self::Compliance,
+            10 => Self::DsseAttestation,
+            11 => Self::VulnerabilityAssessment,
+            12 => Self::SbomReference,
+            _ => Self::UnknownValue(note_kind::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NoteKind {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NOTE_KIND_UNSPECIFIED" => Self::Unspecified,
+            "VULNERABILITY" => Self::Vulnerability,
+            "BUILD" => Self::Build,
+            "IMAGE" => Self::Image,
+            "PACKAGE" => Self::Package,
+            "DEPLOYMENT" => Self::Deployment,
+            "DISCOVERY" => Self::Discovery,
+            "ATTESTATION" => Self::Attestation,
+            "UPGRADE" => Self::Upgrade,
+            "COMPLIANCE" => Self::Compliance,
+            "DSSE_ATTESTATION" => Self::DsseAttestation,
+            "VULNERABILITY_ASSESSMENT" => Self::VulnerabilityAssessment,
+            "SBOM_REFERENCE" => Self::SbomReference,
+            _ => Self::UnknownValue(note_kind::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NoteKind {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Vulnerability => serializer.serialize_i32(1),
+            Self::Build => serializer.serialize_i32(2),
+            Self::Image => serializer.serialize_i32(3),
+            Self::Package => serializer.serialize_i32(4),
+            Self::Deployment => serializer.serialize_i32(5),
+            Self::Discovery => serializer.serialize_i32(6),
+            Self::Attestation => serializer.serialize_i32(7),
+            Self::Upgrade => serializer.serialize_i32(8),
+            Self::Compliance => serializer.serialize_i32(9),
+            Self::DsseAttestation => serializer.serialize_i32(10),
+            Self::VulnerabilityAssessment => serializer.serialize_i32(11),
+            Self::SbomReference => serializer.serialize_i32(12),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NoteKind {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NoteKind>::new(
+            ".grafeas.v1.NoteKind",
+        ))
     }
 }
 
 /// CVSS Version.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CVSSVersion(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CVSSVersion {
+    Unspecified,
+    _2,
+    _3,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CVSSVersion::value] or
+    /// [CVSSVersion::name].
+    UnknownValue(cvss_version::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod cvss_version {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl CVSSVersion {
-    pub const CVSS_VERSION_UNSPECIFIED: CVSSVersion = CVSSVersion::new(0);
-
-    pub const CVSS_VERSION_2: CVSSVersion = CVSSVersion::new(1);
-
-    pub const CVSS_VERSION_3: CVSSVersion = CVSSVersion::new(2);
-
-    /// Creates a new CVSSVersion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::_2 => std::option::Option::Some(1),
+            Self::_3 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CVSS_VERSION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CVSS_VERSION_2"),
-            2 => std::borrow::Cow::Borrowed("CVSS_VERSION_3"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CVSS_VERSION_UNSPECIFIED"),
+            Self::_2 => std::option::Option::Some("CVSS_VERSION_2"),
+            Self::_3 => std::option::Option::Some("CVSS_VERSION_3"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CVSS_VERSION_UNSPECIFIED" => std::option::Option::Some(Self::CVSS_VERSION_UNSPECIFIED),
-            "CVSS_VERSION_2" => std::option::Option::Some(Self::CVSS_VERSION_2),
-            "CVSS_VERSION_3" => std::option::Option::Some(Self::CVSS_VERSION_3),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CVSSVersion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CVSSVersion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CVSSVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CVSSVersion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::_2,
+            2 => Self::_3,
+            _ => Self::UnknownValue(cvss_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CVSSVersion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CVSS_VERSION_UNSPECIFIED" => Self::Unspecified,
+            "CVSS_VERSION_2" => Self::_2,
+            "CVSS_VERSION_3" => Self::_3,
+            _ => Self::UnknownValue(cvss_version::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CVSSVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::_2 => serializer.serialize_i32(1),
+            Self::_3 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CVSSVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CVSSVersion>::new(
+            ".grafeas.v1.CVSSVersion",
+        ))
     }
 }
 
 /// Instruction set architectures supported by various package managers.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Architecture(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Architecture {
+    /// Unknown architecture.
+    Unspecified,
+    /// X86 architecture.
+    X86,
+    /// X64 architecture.
+    X64,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Architecture::value] or
+    /// [Architecture::name].
+    UnknownValue(architecture::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod architecture {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Architecture {
-    /// Unknown architecture.
-    pub const ARCHITECTURE_UNSPECIFIED: Architecture = Architecture::new(0);
-
-    /// X86 architecture.
-    pub const X86: Architecture = Architecture::new(1);
-
-    /// X64 architecture.
-    pub const X64: Architecture = Architecture::new(2);
-
-    /// Creates a new Architecture instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::X86 => std::option::Option::Some(1),
+            Self::X64 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ARCHITECTURE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("X86"),
-            2 => std::borrow::Cow::Borrowed("X64"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ARCHITECTURE_UNSPECIFIED"),
+            Self::X86 => std::option::Option::Some("X86"),
+            Self::X64 => std::option::Option::Some("X64"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ARCHITECTURE_UNSPECIFIED" => std::option::Option::Some(Self::ARCHITECTURE_UNSPECIFIED),
-            "X86" => std::option::Option::Some(Self::X86),
-            "X64" => std::option::Option::Some(Self::X64),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Architecture {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Architecture {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Architecture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Architecture {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::X86,
+            2 => Self::X64,
+            _ => Self::UnknownValue(architecture::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Architecture {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ARCHITECTURE_UNSPECIFIED" => Self::Unspecified,
+            "X86" => Self::X86,
+            "X64" => Self::X64,
+            _ => Self::UnknownValue(architecture::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Architecture {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::X86 => serializer.serialize_i32(1),
+            Self::X64 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Architecture {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Architecture>::new(
+            ".grafeas.v1.Architecture",
+        ))
     }
 }
 
 /// Note provider assigned severity/impact ranking.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Severity(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Severity {
+    /// Unknown.
+    Unspecified,
+    /// Minimal severity.
+    Minimal,
+    /// Low severity.
+    Low,
+    /// Medium severity.
+    Medium,
+    /// High severity.
+    High,
+    /// Critical severity.
+    Critical,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Severity::value] or
+    /// [Severity::name].
+    UnknownValue(severity::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod severity {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Severity {
-    /// Unknown.
-    pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-    /// Minimal severity.
-    pub const MINIMAL: Severity = Severity::new(1);
-
-    /// Low severity.
-    pub const LOW: Severity = Severity::new(2);
-
-    /// Medium severity.
-    pub const MEDIUM: Severity = Severity::new(3);
-
-    /// High severity.
-    pub const HIGH: Severity = Severity::new(4);
-
-    /// Critical severity.
-    pub const CRITICAL: Severity = Severity::new(5);
-
-    /// Creates a new Severity instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Minimal => std::option::Option::Some(1),
+            Self::Low => std::option::Option::Some(2),
+            Self::Medium => std::option::Option::Some(3),
+            Self::High => std::option::Option::Some(4),
+            Self::Critical => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MINIMAL"),
-            2 => std::borrow::Cow::Borrowed("LOW"),
-            3 => std::borrow::Cow::Borrowed("MEDIUM"),
-            4 => std::borrow::Cow::Borrowed("HIGH"),
-            5 => std::borrow::Cow::Borrowed("CRITICAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+            Self::Minimal => std::option::Option::Some("MINIMAL"),
+            Self::Low => std::option::Option::Some("LOW"),
+            Self::Medium => std::option::Option::Some("MEDIUM"),
+            Self::High => std::option::Option::Some("HIGH"),
+            Self::Critical => std::option::Option::Some("CRITICAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-            "MINIMAL" => std::option::Option::Some(Self::MINIMAL),
-            "LOW" => std::option::Option::Some(Self::LOW),
-            "MEDIUM" => std::option::Option::Some(Self::MEDIUM),
-            "HIGH" => std::option::Option::Some(Self::HIGH),
-            "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Severity {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Severity {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Severity {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Minimal,
+            2 => Self::Low,
+            3 => Self::Medium,
+            4 => Self::High,
+            5 => Self::Critical,
+            _ => Self::UnknownValue(severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Severity {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+            "MINIMAL" => Self::Minimal,
+            "LOW" => Self::Low,
+            "MEDIUM" => Self::Medium,
+            "HIGH" => Self::High,
+            "CRITICAL" => Self::Critical,
+            _ => Self::UnknownValue(severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Severity {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Minimal => serializer.serialize_i32(1),
+            Self::Low => serializer.serialize_i32(2),
+            Self::Medium => serializer.serialize_i32(3),
+            Self::High => serializer.serialize_i32(4),
+            Self::Critical => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Severity {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+            ".grafeas.v1.Severity",
+        ))
     }
 }

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -804,60 +804,121 @@ pub mod list_service_account_keys_request {
 
     /// `KeyType` filters to selectively retrieve certain varieties
     /// of keys.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KeyType(i32);
-
-    impl KeyType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KeyType {
         /// Unspecified key type. The presence of this in the
         /// message will immediately result in an error.
-        pub const KEY_TYPE_UNSPECIFIED: KeyType = KeyType::new(0);
-
+        Unspecified,
         /// User-managed keys (managed and rotated by the user).
-        pub const USER_MANAGED: KeyType = KeyType::new(1);
-
+        UserManaged,
         /// System-managed keys (managed and rotated by Google).
-        pub const SYSTEM_MANAGED: KeyType = KeyType::new(2);
+        SystemManaged,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KeyType::value] or
+        /// [KeyType::name].
+        UnknownValue(key_type::UnknownValue),
+    }
 
-        /// Creates a new KeyType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod key_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KeyType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UserManaged => std::option::Option::Some(1),
+                Self::SystemManaged => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KEY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USER_MANAGED"),
-                2 => std::borrow::Cow::Borrowed("SYSTEM_MANAGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KEY_TYPE_UNSPECIFIED"),
+                Self::UserManaged => std::option::Option::Some("USER_MANAGED"),
+                Self::SystemManaged => std::option::Option::Some("SYSTEM_MANAGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KEY_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::KEY_TYPE_UNSPECIFIED),
-                "USER_MANAGED" => std::option::Option::Some(Self::USER_MANAGED),
-                "SYSTEM_MANAGED" => std::option::Option::Some(Self::SYSTEM_MANAGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for KeyType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KeyType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KeyType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KeyType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UserManaged,
+                2 => Self::SystemManaged,
+                _ => Self::UnknownValue(key_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KeyType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KEY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "USER_MANAGED" => Self::UserManaged,
+                "SYSTEM_MANAGED" => Self::SystemManaged,
+                _ => Self::UnknownValue(key_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KeyType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UserManaged => serializer.serialize_i32(1),
+                Self::SystemManaged => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KeyType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KeyType>::new(
+                ".google.iam.admin.v1.ListServiceAccountKeysRequest.KeyType",
+            ))
         }
     }
 }
@@ -1694,77 +1755,144 @@ pub mod role {
     use super::*;
 
     /// A stage representing a role's lifecycle phase.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RoleLaunchStage(i32);
-
-    impl RoleLaunchStage {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RoleLaunchStage {
         /// The user has indicated this role is currently in an Alpha phase. If this
         /// launch stage is selected, the `stage` field will not be included when
         /// requesting the definition for a given role.
-        pub const ALPHA: RoleLaunchStage = RoleLaunchStage::new(0);
-
+        Alpha,
         /// The user has indicated this role is currently in a Beta phase.
-        pub const BETA: RoleLaunchStage = RoleLaunchStage::new(1);
-
+        Beta,
         /// The user has indicated this role is generally available.
-        pub const GA: RoleLaunchStage = RoleLaunchStage::new(2);
-
+        Ga,
         /// The user has indicated this role is being deprecated.
-        pub const DEPRECATED: RoleLaunchStage = RoleLaunchStage::new(4);
-
+        Deprecated,
         /// This role is disabled and will not contribute permissions to any
         /// principals it is granted to in policies.
-        pub const DISABLED: RoleLaunchStage = RoleLaunchStage::new(5);
-
+        Disabled,
         /// The user has indicated this role is currently in an EAP phase.
-        pub const EAP: RoleLaunchStage = RoleLaunchStage::new(6);
+        Eap,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RoleLaunchStage::value] or
+        /// [RoleLaunchStage::name].
+        UnknownValue(role_launch_stage::UnknownValue),
+    }
 
-        /// Creates a new RoleLaunchStage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod role_launch_stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RoleLaunchStage {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Alpha => std::option::Option::Some(0),
+                Self::Beta => std::option::Option::Some(1),
+                Self::Ga => std::option::Option::Some(2),
+                Self::Deprecated => std::option::Option::Some(4),
+                Self::Disabled => std::option::Option::Some(5),
+                Self::Eap => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ALPHA"),
-                1 => std::borrow::Cow::Borrowed("BETA"),
-                2 => std::borrow::Cow::Borrowed("GA"),
-                4 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                5 => std::borrow::Cow::Borrowed("DISABLED"),
-                6 => std::borrow::Cow::Borrowed("EAP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Alpha => std::option::Option::Some("ALPHA"),
+                Self::Beta => std::option::Option::Some("BETA"),
+                Self::Ga => std::option::Option::Some("GA"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Eap => std::option::Option::Some("EAP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ALPHA" => std::option::Option::Some(Self::ALPHA),
-                "BETA" => std::option::Option::Some(Self::BETA),
-                "GA" => std::option::Option::Some(Self::GA),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "EAP" => std::option::Option::Some(Self::EAP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RoleLaunchStage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RoleLaunchStage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RoleLaunchStage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RoleLaunchStage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Alpha,
+                1 => Self::Beta,
+                2 => Self::Ga,
+                4 => Self::Deprecated,
+                5 => Self::Disabled,
+                6 => Self::Eap,
+                _ => Self::UnknownValue(role_launch_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RoleLaunchStage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ALPHA" => Self::Alpha,
+                "BETA" => Self::Beta,
+                "GA" => Self::Ga,
+                "DEPRECATED" => Self::Deprecated,
+                "DISABLED" => Self::Disabled,
+                "EAP" => Self::Eap,
+                _ => Self::UnknownValue(role_launch_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RoleLaunchStage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Alpha => serializer.serialize_i32(0),
+                Self::Beta => serializer.serialize_i32(1),
+                Self::Ga => serializer.serialize_i32(2),
+                Self::Deprecated => serializer.serialize_i32(4),
+                Self::Disabled => serializer.serialize_i32(5),
+                Self::Eap => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RoleLaunchStage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoleLaunchStage>::new(
+                ".google.iam.admin.v1.Role.RoleLaunchStage",
+            ))
         }
     }
 }
@@ -2545,121 +2673,247 @@ pub mod permission {
     use super::*;
 
     /// A stage representing a permission's lifecycle phase.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PermissionLaunchStage(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PermissionLaunchStage {
+        /// The permission is currently in an alpha phase.
+        Alpha,
+        /// The permission is currently in a beta phase.
+        Beta,
+        /// The permission is generally available.
+        Ga,
+        /// The permission is being deprecated.
+        Deprecated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PermissionLaunchStage::value] or
+        /// [PermissionLaunchStage::name].
+        UnknownValue(permission_launch_stage::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod permission_launch_stage {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PermissionLaunchStage {
-        /// The permission is currently in an alpha phase.
-        pub const ALPHA: PermissionLaunchStage = PermissionLaunchStage::new(0);
-
-        /// The permission is currently in a beta phase.
-        pub const BETA: PermissionLaunchStage = PermissionLaunchStage::new(1);
-
-        /// The permission is generally available.
-        pub const GA: PermissionLaunchStage = PermissionLaunchStage::new(2);
-
-        /// The permission is being deprecated.
-        pub const DEPRECATED: PermissionLaunchStage = PermissionLaunchStage::new(3);
-
-        /// Creates a new PermissionLaunchStage instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Alpha => std::option::Option::Some(0),
+                Self::Beta => std::option::Option::Some(1),
+                Self::Ga => std::option::Option::Some(2),
+                Self::Deprecated => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ALPHA"),
-                1 => std::borrow::Cow::Borrowed("BETA"),
-                2 => std::borrow::Cow::Borrowed("GA"),
-                3 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Alpha => std::option::Option::Some("ALPHA"),
+                Self::Beta => std::option::Option::Some("BETA"),
+                Self::Ga => std::option::Option::Some("GA"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ALPHA" => std::option::Option::Some(Self::ALPHA),
-                "BETA" => std::option::Option::Some(Self::BETA),
-                "GA" => std::option::Option::Some(Self::GA),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PermissionLaunchStage {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PermissionLaunchStage {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PermissionLaunchStage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PermissionLaunchStage {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Alpha,
+                1 => Self::Beta,
+                2 => Self::Ga,
+                3 => Self::Deprecated,
+                _ => Self::UnknownValue(permission_launch_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PermissionLaunchStage {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ALPHA" => Self::Alpha,
+                "BETA" => Self::Beta,
+                "GA" => Self::Ga,
+                "DEPRECATED" => Self::Deprecated,
+                _ => Self::UnknownValue(permission_launch_stage::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PermissionLaunchStage {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Alpha => serializer.serialize_i32(0),
+                Self::Beta => serializer.serialize_i32(1),
+                Self::Ga => serializer.serialize_i32(2),
+                Self::Deprecated => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PermissionLaunchStage {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PermissionLaunchStage>::new(
+                ".google.iam.admin.v1.Permission.PermissionLaunchStage",
+            ))
         }
     }
 
     /// The state of the permission with regards to custom roles.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CustomRolesSupportLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CustomRolesSupportLevel {
+        /// Default state. Permission is fully supported for custom role use.
+        Supported,
+        /// Permission is being tested to check custom role compatibility.
+        Testing,
+        /// Permission is not supported for custom role use.
+        NotSupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CustomRolesSupportLevel::value] or
+        /// [CustomRolesSupportLevel::name].
+        UnknownValue(custom_roles_support_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod custom_roles_support_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CustomRolesSupportLevel {
-        /// Default state. Permission is fully supported for custom role use.
-        pub const SUPPORTED: CustomRolesSupportLevel = CustomRolesSupportLevel::new(0);
-
-        /// Permission is being tested to check custom role compatibility.
-        pub const TESTING: CustomRolesSupportLevel = CustomRolesSupportLevel::new(1);
-
-        /// Permission is not supported for custom role use.
-        pub const NOT_SUPPORTED: CustomRolesSupportLevel = CustomRolesSupportLevel::new(2);
-
-        /// Creates a new CustomRolesSupportLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Supported => std::option::Option::Some(0),
+                Self::Testing => std::option::Option::Some(1),
+                Self::NotSupported => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SUPPORTED"),
-                1 => std::borrow::Cow::Borrowed("TESTING"),
-                2 => std::borrow::Cow::Borrowed("NOT_SUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Supported => std::option::Option::Some("SUPPORTED"),
+                Self::Testing => std::option::Option::Some("TESTING"),
+                Self::NotSupported => std::option::Option::Some("NOT_SUPPORTED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SUPPORTED" => std::option::Option::Some(Self::SUPPORTED),
-                "TESTING" => std::option::Option::Some(Self::TESTING),
-                "NOT_SUPPORTED" => std::option::Option::Some(Self::NOT_SUPPORTED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CustomRolesSupportLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CustomRolesSupportLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CustomRolesSupportLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CustomRolesSupportLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Supported,
+                1 => Self::Testing,
+                2 => Self::NotSupported,
+                _ => Self::UnknownValue(custom_roles_support_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CustomRolesSupportLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SUPPORTED" => Self::Supported,
+                "TESTING" => Self::Testing,
+                "NOT_SUPPORTED" => Self::NotSupported,
+                _ => Self::UnknownValue(custom_roles_support_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CustomRolesSupportLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Supported => serializer.serialize_i32(0),
+                Self::Testing => serializer.serialize_i32(1),
+                Self::NotSupported => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CustomRolesSupportLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<CustomRolesSupportLevel>::new(
+                    ".google.iam.admin.v1.Permission.CustomRolesSupportLevel",
+                ),
+            )
         }
     }
 }
@@ -3114,71 +3368,127 @@ pub mod lint_result {
 
     /// Possible Level values of a validation unit corresponding to its domain
     /// of discourse.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Level(i32);
-
-    impl Level {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Level {
         /// Level is unspecified.
-        pub const LEVEL_UNSPECIFIED: Level = Level::new(0);
-
+        Unspecified,
         /// A validation unit which operates on an individual condition within a
         /// binding.
-        pub const CONDITION: Level = Level::new(3);
+        Condition,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Level::value] or
+        /// [Level::name].
+        UnknownValue(level::UnknownValue),
+    }
 
-        /// Creates a new Level instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Level {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Condition => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LEVEL_UNSPECIFIED"),
-                3 => std::borrow::Cow::Borrowed("CONDITION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LEVEL_UNSPECIFIED"),
+                Self::Condition => std::option::Option::Some("CONDITION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LEVEL_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_UNSPECIFIED),
-                "CONDITION" => std::option::Option::Some(Self::CONDITION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Level {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Level {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Level {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Level {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                3 => Self::Condition,
+                _ => Self::UnknownValue(level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Level {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "CONDITION" => Self::Condition,
+                _ => Self::UnknownValue(level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Level {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Condition => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Level {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Level>::new(
+                ".google.iam.admin.v1.LintResult.Level",
+            ))
         }
     }
 
     /// Possible Severity values of an issued result.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
-
-    impl Severity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
         /// Severity is unspecified.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
+        Unspecified,
         /// A validation unit returns an error only for critical issues. If an
         /// attempt is made to set the problematic policy without rectifying the
         /// critical issue, it causes the `setPolicy` operation to fail.
-        pub const ERROR: Severity = Severity::new(1);
-
+        Error,
         /// Any issue which is severe enough but does not cause an error.
         /// For example, suspicious constructs in the input object will not
         /// necessarily fail `setPolicy`, but there is a high likelihood that they
@@ -3188,68 +3498,138 @@ pub mod lint_result {
         /// - Unsatisfiable condition: Expired timestamp in date/time condition.
         /// - Ineffective condition: Condition on a <principal, role> pair which is
         ///   granted unconditionally in another binding of the same policy.
-        pub const WARNING: Severity = Severity::new(2);
-
+        Warning,
         /// Reserved for the issues that are not severe as `ERROR`/`WARNING`, but
         /// need special handling. For instance, messages about skipped validation
         /// units are issued as `NOTICE`.
-        pub const NOTICE: Severity = Severity::new(3);
-
+        Notice,
         /// Any informative statement which is not severe enough to raise
         /// `ERROR`/`WARNING`/`NOTICE`, like auto-correction recommendations on the
         /// input content. Note that current version of the linter does not utilize
         /// `INFO`.
-        pub const INFO: Severity = Severity::new(4);
-
+        Info,
         /// Deprecated severity level.
-        pub const DEPRECATED: Severity = Severity::new(5);
+        Deprecated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
 
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Severity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Error => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::Notice => std::option::Option::Some(3),
+                Self::Info => std::option::Option::Some(4),
+                Self::Deprecated => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ERROR"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                3 => std::borrow::Cow::Borrowed("NOTICE"),
-                4 => std::borrow::Cow::Borrowed("INFO"),
-                5 => std::borrow::Cow::Borrowed("DEPRECATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::Notice => std::option::Option::Some("NOTICE"),
+                Self::Info => std::option::Option::Some("INFO"),
+                Self::Deprecated => std::option::Option::Some("DEPRECATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                "NOTICE" => std::option::Option::Some(Self::NOTICE),
-                "INFO" => std::option::Option::Some(Self::INFO),
-                "DEPRECATED" => std::option::Option::Some(Self::DEPRECATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Error,
+                2 => Self::Warning,
+                3 => Self::Notice,
+                4 => Self::Info,
+                5 => Self::Deprecated,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "ERROR" => Self::Error,
+                "WARNING" => Self::Warning,
+                "NOTICE" => Self::Notice,
+                "INFO" => Self::Info,
+                "DEPRECATED" => Self::Deprecated,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Error => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::Notice => serializer.serialize_i32(3),
+                Self::Info => serializer.serialize_i32(4),
+                Self::Deprecated => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.iam.admin.v1.LintResult.Severity",
+            ))
         }
     }
 }
@@ -3293,288 +3673,595 @@ impl wkt::message::Message for LintPolicyResponse {
 }
 
 /// Supported key algorithms.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountKeyAlgorithm(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceAccountKeyAlgorithm {
+    /// An unspecified key algorithm.
+    KeyAlgUnspecified,
+    /// 1k RSA Key.
+    KeyAlgRsa1024,
+    /// 2k RSA Key.
+    KeyAlgRsa2048,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServiceAccountKeyAlgorithm::value] or
+    /// [ServiceAccountKeyAlgorithm::name].
+    UnknownValue(service_account_key_algorithm::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod service_account_key_algorithm {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ServiceAccountKeyAlgorithm {
-    /// An unspecified key algorithm.
-    pub const KEY_ALG_UNSPECIFIED: ServiceAccountKeyAlgorithm = ServiceAccountKeyAlgorithm::new(0);
-
-    /// 1k RSA Key.
-    pub const KEY_ALG_RSA_1024: ServiceAccountKeyAlgorithm = ServiceAccountKeyAlgorithm::new(1);
-
-    /// 2k RSA Key.
-    pub const KEY_ALG_RSA_2048: ServiceAccountKeyAlgorithm = ServiceAccountKeyAlgorithm::new(2);
-
-    /// Creates a new ServiceAccountKeyAlgorithm instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::KeyAlgUnspecified => std::option::Option::Some(0),
+            Self::KeyAlgRsa1024 => std::option::Option::Some(1),
+            Self::KeyAlgRsa2048 => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("KEY_ALG_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("KEY_ALG_RSA_1024"),
-            2 => std::borrow::Cow::Borrowed("KEY_ALG_RSA_2048"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::KeyAlgUnspecified => std::option::Option::Some("KEY_ALG_UNSPECIFIED"),
+            Self::KeyAlgRsa1024 => std::option::Option::Some("KEY_ALG_RSA_1024"),
+            Self::KeyAlgRsa2048 => std::option::Option::Some("KEY_ALG_RSA_2048"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "KEY_ALG_UNSPECIFIED" => std::option::Option::Some(Self::KEY_ALG_UNSPECIFIED),
-            "KEY_ALG_RSA_1024" => std::option::Option::Some(Self::KEY_ALG_RSA_1024),
-            "KEY_ALG_RSA_2048" => std::option::Option::Some(Self::KEY_ALG_RSA_2048),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServiceAccountKeyAlgorithm {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountKeyAlgorithm {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServiceAccountKeyAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServiceAccountKeyAlgorithm {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::KeyAlgUnspecified,
+            1 => Self::KeyAlgRsa1024,
+            2 => Self::KeyAlgRsa2048,
+            _ => Self::UnknownValue(service_account_key_algorithm::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServiceAccountKeyAlgorithm {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "KEY_ALG_UNSPECIFIED" => Self::KeyAlgUnspecified,
+            "KEY_ALG_RSA_1024" => Self::KeyAlgRsa1024,
+            "KEY_ALG_RSA_2048" => Self::KeyAlgRsa2048,
+            _ => Self::UnknownValue(service_account_key_algorithm::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServiceAccountKeyAlgorithm {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::KeyAlgUnspecified => serializer.serialize_i32(0),
+            Self::KeyAlgRsa1024 => serializer.serialize_i32(1),
+            Self::KeyAlgRsa2048 => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServiceAccountKeyAlgorithm {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<ServiceAccountKeyAlgorithm>::new(
+                ".google.iam.admin.v1.ServiceAccountKeyAlgorithm",
+            ),
+        )
     }
 }
 
 /// Supported private key output formats.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountPrivateKeyType(i32);
-
-impl ServiceAccountPrivateKeyType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceAccountPrivateKeyType {
     /// Unspecified. Equivalent to `TYPE_GOOGLE_CREDENTIALS_FILE`.
-    pub const TYPE_UNSPECIFIED: ServiceAccountPrivateKeyType = ServiceAccountPrivateKeyType::new(0);
-
+    TypeUnspecified,
     /// PKCS12 format.
     /// The password for the PKCS12 file is `notasecret`.
     /// For more information, see <https://tools.ietf.org/html/rfc7292>.
-    pub const TYPE_PKCS12_FILE: ServiceAccountPrivateKeyType = ServiceAccountPrivateKeyType::new(1);
-
+    TypePkcs12File,
     /// Google Credentials File format.
-    pub const TYPE_GOOGLE_CREDENTIALS_FILE: ServiceAccountPrivateKeyType =
-        ServiceAccountPrivateKeyType::new(2);
+    TypeGoogleCredentialsFile,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServiceAccountPrivateKeyType::value] or
+    /// [ServiceAccountPrivateKeyType::name].
+    UnknownValue(service_account_private_key_type::UnknownValue),
+}
 
-    /// Creates a new ServiceAccountPrivateKeyType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod service_account_private_key_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ServiceAccountPrivateKeyType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::TypeUnspecified => std::option::Option::Some(0),
+            Self::TypePkcs12File => std::option::Option::Some(1),
+            Self::TypeGoogleCredentialsFile => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TYPE_PKCS12_FILE"),
-            2 => std::borrow::Cow::Borrowed("TYPE_GOOGLE_CREDENTIALS_FILE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-            "TYPE_PKCS12_FILE" => std::option::Option::Some(Self::TYPE_PKCS12_FILE),
-            "TYPE_GOOGLE_CREDENTIALS_FILE" => {
-                std::option::Option::Some(Self::TYPE_GOOGLE_CREDENTIALS_FILE)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::TypeUnspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+            Self::TypePkcs12File => std::option::Option::Some("TYPE_PKCS12_FILE"),
+            Self::TypeGoogleCredentialsFile => {
+                std::option::Option::Some("TYPE_GOOGLE_CREDENTIALS_FILE")
             }
-            _ => std::option::Option::None,
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for ServiceAccountPrivateKeyType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountPrivateKeyType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServiceAccountPrivateKeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServiceAccountPrivateKeyType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::TypeUnspecified,
+            1 => Self::TypePkcs12File,
+            2 => Self::TypeGoogleCredentialsFile,
+            _ => Self::UnknownValue(service_account_private_key_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServiceAccountPrivateKeyType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TYPE_UNSPECIFIED" => Self::TypeUnspecified,
+            "TYPE_PKCS12_FILE" => Self::TypePkcs12File,
+            "TYPE_GOOGLE_CREDENTIALS_FILE" => Self::TypeGoogleCredentialsFile,
+            _ => Self::UnknownValue(service_account_private_key_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServiceAccountPrivateKeyType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::TypeUnspecified => serializer.serialize_i32(0),
+            Self::TypePkcs12File => serializer.serialize_i32(1),
+            Self::TypeGoogleCredentialsFile => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServiceAccountPrivateKeyType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<ServiceAccountPrivateKeyType>::new(
+                ".google.iam.admin.v1.ServiceAccountPrivateKeyType",
+            ),
+        )
     }
 }
 
 /// Supported public key output formats.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountPublicKeyType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceAccountPublicKeyType {
+    /// Do not return the public key.
+    TypeNone,
+    /// X509 PEM format.
+    TypeX509PemFile,
+    /// Raw public key.
+    TypeRawPublicKey,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServiceAccountPublicKeyType::value] or
+    /// [ServiceAccountPublicKeyType::name].
+    UnknownValue(service_account_public_key_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod service_account_public_key_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ServiceAccountPublicKeyType {
-    /// Do not return the public key.
-    pub const TYPE_NONE: ServiceAccountPublicKeyType = ServiceAccountPublicKeyType::new(0);
-
-    /// X509 PEM format.
-    pub const TYPE_X509_PEM_FILE: ServiceAccountPublicKeyType = ServiceAccountPublicKeyType::new(1);
-
-    /// Raw public key.
-    pub const TYPE_RAW_PUBLIC_KEY: ServiceAccountPublicKeyType =
-        ServiceAccountPublicKeyType::new(2);
-
-    /// Creates a new ServiceAccountPublicKeyType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::TypeNone => std::option::Option::Some(0),
+            Self::TypeX509PemFile => std::option::Option::Some(1),
+            Self::TypeRawPublicKey => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TYPE_NONE"),
-            1 => std::borrow::Cow::Borrowed("TYPE_X509_PEM_FILE"),
-            2 => std::borrow::Cow::Borrowed("TYPE_RAW_PUBLIC_KEY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::TypeNone => std::option::Option::Some("TYPE_NONE"),
+            Self::TypeX509PemFile => std::option::Option::Some("TYPE_X509_PEM_FILE"),
+            Self::TypeRawPublicKey => std::option::Option::Some("TYPE_RAW_PUBLIC_KEY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TYPE_NONE" => std::option::Option::Some(Self::TYPE_NONE),
-            "TYPE_X509_PEM_FILE" => std::option::Option::Some(Self::TYPE_X509_PEM_FILE),
-            "TYPE_RAW_PUBLIC_KEY" => std::option::Option::Some(Self::TYPE_RAW_PUBLIC_KEY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServiceAccountPublicKeyType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountPublicKeyType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServiceAccountPublicKeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServiceAccountPublicKeyType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::TypeNone,
+            1 => Self::TypeX509PemFile,
+            2 => Self::TypeRawPublicKey,
+            _ => Self::UnknownValue(service_account_public_key_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServiceAccountPublicKeyType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TYPE_NONE" => Self::TypeNone,
+            "TYPE_X509_PEM_FILE" => Self::TypeX509PemFile,
+            "TYPE_RAW_PUBLIC_KEY" => Self::TypeRawPublicKey,
+            _ => Self::UnknownValue(service_account_public_key_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServiceAccountPublicKeyType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::TypeNone => serializer.serialize_i32(0),
+            Self::TypeX509PemFile => serializer.serialize_i32(1),
+            Self::TypeRawPublicKey => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServiceAccountPublicKeyType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<ServiceAccountPublicKeyType>::new(
+                ".google.iam.admin.v1.ServiceAccountPublicKeyType",
+            ),
+        )
     }
 }
 
 /// Service Account Key Origin.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceAccountKeyOrigin(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceAccountKeyOrigin {
+    /// Unspecified key origin.
+    OriginUnspecified,
+    /// Key is provided by user.
+    UserProvided,
+    /// Key is provided by Google.
+    GoogleProvided,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServiceAccountKeyOrigin::value] or
+    /// [ServiceAccountKeyOrigin::name].
+    UnknownValue(service_account_key_origin::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod service_account_key_origin {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ServiceAccountKeyOrigin {
-    /// Unspecified key origin.
-    pub const ORIGIN_UNSPECIFIED: ServiceAccountKeyOrigin = ServiceAccountKeyOrigin::new(0);
-
-    /// Key is provided by user.
-    pub const USER_PROVIDED: ServiceAccountKeyOrigin = ServiceAccountKeyOrigin::new(1);
-
-    /// Key is provided by Google.
-    pub const GOOGLE_PROVIDED: ServiceAccountKeyOrigin = ServiceAccountKeyOrigin::new(2);
-
-    /// Creates a new ServiceAccountKeyOrigin instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::OriginUnspecified => std::option::Option::Some(0),
+            Self::UserProvided => std::option::Option::Some(1),
+            Self::GoogleProvided => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ORIGIN_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("USER_PROVIDED"),
-            2 => std::borrow::Cow::Borrowed("GOOGLE_PROVIDED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::OriginUnspecified => std::option::Option::Some("ORIGIN_UNSPECIFIED"),
+            Self::UserProvided => std::option::Option::Some("USER_PROVIDED"),
+            Self::GoogleProvided => std::option::Option::Some("GOOGLE_PROVIDED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ORIGIN_UNSPECIFIED" => std::option::Option::Some(Self::ORIGIN_UNSPECIFIED),
-            "USER_PROVIDED" => std::option::Option::Some(Self::USER_PROVIDED),
-            "GOOGLE_PROVIDED" => std::option::Option::Some(Self::GOOGLE_PROVIDED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServiceAccountKeyOrigin {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceAccountKeyOrigin {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServiceAccountKeyOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServiceAccountKeyOrigin {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::OriginUnspecified,
+            1 => Self::UserProvided,
+            2 => Self::GoogleProvided,
+            _ => Self::UnknownValue(service_account_key_origin::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServiceAccountKeyOrigin {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ORIGIN_UNSPECIFIED" => Self::OriginUnspecified,
+            "USER_PROVIDED" => Self::UserProvided,
+            "GOOGLE_PROVIDED" => Self::GoogleProvided,
+            _ => Self::UnknownValue(service_account_key_origin::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServiceAccountKeyOrigin {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::OriginUnspecified => serializer.serialize_i32(0),
+            Self::UserProvided => serializer.serialize_i32(1),
+            Self::GoogleProvided => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServiceAccountKeyOrigin {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceAccountKeyOrigin>::new(
+            ".google.iam.admin.v1.ServiceAccountKeyOrigin",
+        ))
     }
 }
 
 /// A view for Role objects.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RoleView(i32);
-
-impl RoleView {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RoleView {
     /// Omits the `included_permissions` field.
     /// This is the default value.
-    pub const BASIC: RoleView = RoleView::new(0);
-
+    Basic,
     /// Returns all fields.
-    pub const FULL: RoleView = RoleView::new(1);
+    Full,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RoleView::value] or
+    /// [RoleView::name].
+    UnknownValue(role_view::UnknownValue),
+}
 
-    /// Creates a new RoleView instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod role_view {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl RoleView {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Basic => std::option::Option::Some(0),
+            Self::Full => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BASIC"),
-            1 => std::borrow::Cow::Borrowed("FULL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Full => std::option::Option::Some("FULL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "FULL" => std::option::Option::Some(Self::FULL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RoleView {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RoleView {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RoleView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RoleView {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Basic,
+            1 => Self::Full,
+            _ => Self::UnknownValue(role_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RoleView {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BASIC" => Self::Basic,
+            "FULL" => Self::Full,
+            _ => Self::UnknownValue(role_view::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RoleView {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Basic => serializer.serialize_i32(0),
+            Self::Full => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RoleView {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RoleView>::new(
+            ".google.iam.admin.v1.RoleView",
+        ))
     }
 }

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -242,9 +242,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = req.key_types.iter().fold(builder, |builder, p| {
-            builder.query(&[("keyTypes", p.value())])
-        });
+        let builder = req
+            .key_types
+            .iter()
+            .fold(builder, |builder, p| builder.query(&[("keyTypes", p)]));
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -264,7 +265,7 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("publicKeyType", &req.public_key_type.value())]);
+        let builder = builder.query(&[("publicKeyType", &req.public_key_type)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -517,7 +518,7 @@ impl super::stub::Iam for Iam {
         let builder = builder.query(&[("parent", &req.parent)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("showDeleted", &req.show_deleted)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -766,64 +766,127 @@ pub mod audit_log_config {
 
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LogType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LogType {
+        /// Default case. Should never be this.
+        Unspecified,
+        /// Admin reads. Example: CloudIAM getIamPolicy
+        AdminRead,
+        /// Data writes. Example: CloudSQL Users create
+        DataWrite,
+        /// Data reads. Example: CloudSQL Users list
+        DataRead,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LogType::value] or
+        /// [LogType::name].
+        UnknownValue(log_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod log_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LogType {
-        /// Default case. Should never be this.
-        pub const LOG_TYPE_UNSPECIFIED: LogType = LogType::new(0);
-
-        /// Admin reads. Example: CloudIAM getIamPolicy
-        pub const ADMIN_READ: LogType = LogType::new(1);
-
-        /// Data writes. Example: CloudSQL Users create
-        pub const DATA_WRITE: LogType = LogType::new(2);
-
-        /// Data reads. Example: CloudSQL Users list
-        pub const DATA_READ: LogType = LogType::new(3);
-
-        /// Creates a new LogType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AdminRead => std::option::Option::Some(1),
+                Self::DataWrite => std::option::Option::Some(2),
+                Self::DataRead => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOG_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADMIN_READ"),
-                2 => std::borrow::Cow::Borrowed("DATA_WRITE"),
-                3 => std::borrow::Cow::Borrowed("DATA_READ"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOG_TYPE_UNSPECIFIED"),
+                Self::AdminRead => std::option::Option::Some("ADMIN_READ"),
+                Self::DataWrite => std::option::Option::Some("DATA_WRITE"),
+                Self::DataRead => std::option::Option::Some("DATA_READ"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOG_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::LOG_TYPE_UNSPECIFIED),
-                "ADMIN_READ" => std::option::Option::Some(Self::ADMIN_READ),
-                "DATA_WRITE" => std::option::Option::Some(Self::DATA_WRITE),
-                "DATA_READ" => std::option::Option::Some(Self::DATA_READ),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LogType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LogType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LogType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LogType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AdminRead,
+                2 => Self::DataWrite,
+                3 => Self::DataRead,
+                _ => Self::UnknownValue(log_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LogType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOG_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ADMIN_READ" => Self::AdminRead,
+                "DATA_WRITE" => Self::DataWrite,
+                "DATA_READ" => Self::DataRead,
+                _ => Self::UnknownValue(log_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LogType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AdminRead => serializer.serialize_i32(1),
+                Self::DataWrite => serializer.serialize_i32(2),
+                Self::DataRead => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LogType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogType>::new(
+                ".google.iam.v1.AuditLogConfig.LogType",
+            ))
         }
     }
 }
@@ -959,59 +1022,120 @@ pub mod binding_delta {
     use super::*;
 
     /// The type of action performed on a Binding in a policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Unspecified.
+        Unspecified,
+        /// Addition of a Binding.
+        Add,
+        /// Removal of a Binding.
+        Remove,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Addition of a Binding.
-        pub const ADD: Action = Action::new(1);
-
-        /// Removal of a Binding.
-        pub const REMOVE: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Add => std::option::Option::Some(1),
+                Self::Remove => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADD"),
-                2 => std::borrow::Cow::Borrowed("REMOVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Add => std::option::Option::Some("ADD"),
+                Self::Remove => std::option::Option::Some("REMOVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "ADD" => std::option::Option::Some(Self::ADD),
-                "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Add,
+                2 => Self::Remove,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ADD" => Self::Add,
+                "REMOVE" => Self::Remove,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Add => serializer.serialize_i32(1),
+                Self::Remove => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.iam.v1.BindingDelta.Action",
+            ))
         }
     }
 }
@@ -1095,59 +1219,120 @@ pub mod audit_config_delta {
     use super::*;
 
     /// The type of action performed on an audit configuration in a policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        /// Unspecified.
+        Unspecified,
+        /// Addition of an audit configuration.
+        Add,
+        /// Removal of an audit configuration.
+        Remove,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        /// Unspecified.
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Addition of an audit configuration.
-        pub const ADD: Action = Action::new(1);
-
-        /// Removal of an audit configuration.
-        pub const REMOVE: Action = Action::new(2);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Add => std::option::Option::Some(1),
+                Self::Remove => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ADD"),
-                2 => std::borrow::Cow::Borrowed("REMOVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Add => std::option::Option::Some("ADD"),
+                Self::Remove => std::option::Option::Some("REMOVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "ADD" => std::option::Option::Some(Self::ADD),
-                "REMOVE" => std::option::Option::Some(Self::REMOVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Add,
+                2 => Self::Remove,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "ADD" => Self::Add,
+                "REMOVE" => Self::Remove,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Add => serializer.serialize_i32(1),
+                Self::Remove => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.iam.v1.AuditConfigDelta.Action",
+            ))
         }
     }
 }

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -469,58 +469,115 @@ pub mod policy_binding {
     }
 
     /// Different policy kinds supported in this binding.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PolicyKind(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PolicyKind {
+        /// Unspecified policy kind; Not a valid state
+        Unspecified,
+        /// Principal access boundary policy kind
+        PrincipalAccessBoundary,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PolicyKind::value] or
+        /// [PolicyKind::name].
+        UnknownValue(policy_kind::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod policy_kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PolicyKind {
-        /// Unspecified policy kind; Not a valid state
-        pub const POLICY_KIND_UNSPECIFIED: PolicyKind = PolicyKind::new(0);
-
-        /// Principal access boundary policy kind
-        pub const PRINCIPAL_ACCESS_BOUNDARY: PolicyKind = PolicyKind::new(1);
-
-        /// Creates a new PolicyKind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::PrincipalAccessBoundary => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("POLICY_KIND_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PRINCIPAL_ACCESS_BOUNDARY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "POLICY_KIND_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::POLICY_KIND_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("POLICY_KIND_UNSPECIFIED"),
+                Self::PrincipalAccessBoundary => {
+                    std::option::Option::Some("PRINCIPAL_ACCESS_BOUNDARY")
                 }
-                "PRINCIPAL_ACCESS_BOUNDARY" => {
-                    std::option::Option::Some(Self::PRINCIPAL_ACCESS_BOUNDARY)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for PolicyKind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PolicyKind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PolicyKind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PolicyKind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::PrincipalAccessBoundary,
+                _ => Self::UnknownValue(policy_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PolicyKind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "POLICY_KIND_UNSPECIFIED" => Self::Unspecified,
+                "PRINCIPAL_ACCESS_BOUNDARY" => Self::PrincipalAccessBoundary,
+                _ => Self::UnknownValue(policy_kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PolicyKind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::PrincipalAccessBoundary => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PolicyKind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PolicyKind>::new(
+                ".google.iam.v3.PolicyBinding.PolicyKind",
+            ))
         }
     }
 }
@@ -1848,54 +1905,113 @@ pub mod principal_access_boundary_policy_rule {
     use super::*;
 
     /// An effect to describe the access relationship.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Effect(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Effect {
+        /// Effect unspecified.
+        Unspecified,
+        /// Allows access to the resources in this rule.
+        Allow,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Effect::value] or
+        /// [Effect::name].
+        UnknownValue(effect::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod effect {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Effect {
-        /// Effect unspecified.
-        pub const EFFECT_UNSPECIFIED: Effect = Effect::new(0);
-
-        /// Allows access to the resources in this rule.
-        pub const ALLOW: Effect = Effect::new(1);
-
-        /// Creates a new Effect instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EFFECT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EFFECT_UNSPECIFIED"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EFFECT_UNSPECIFIED" => std::option::Option::Some(Self::EFFECT_UNSPECIFIED),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Effect {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Effect {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Effect {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Effect {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Allow,
+                _ => Self::UnknownValue(effect::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Effect {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EFFECT_UNSPECIFIED" => Self::Unspecified,
+                "ALLOW" => Self::Allow,
+                _ => Self::UnknownValue(effect::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Effect {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Effect {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Effect>::new(
+                ".google.iam.v3.PrincipalAccessBoundaryPolicyRule.Effect",
+            ))
         }
     }
 }

--- a/src/generated/identity/accesscontextmanager/type/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/type/src/model.rs
@@ -25,206 +25,401 @@ extern crate std;
 extern crate wkt;
 
 /// The encryption state of the device.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeviceEncryptionStatus(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DeviceEncryptionStatus {
+    /// The encryption status of the device is not specified or not known.
+    EncryptionUnspecified,
+    /// The device does not support encryption.
+    EncryptionUnsupported,
+    /// The device supports encryption, but is currently unencrypted.
+    Unencrypted,
+    /// The device is encrypted.
+    Encrypted,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DeviceEncryptionStatus::value] or
+    /// [DeviceEncryptionStatus::name].
+    UnknownValue(device_encryption_status::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod device_encryption_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DeviceEncryptionStatus {
-    /// The encryption status of the device is not specified or not known.
-    pub const ENCRYPTION_UNSPECIFIED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(0);
-
-    /// The device does not support encryption.
-    pub const ENCRYPTION_UNSUPPORTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(1);
-
-    /// The device supports encryption, but is currently unencrypted.
-    pub const UNENCRYPTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(2);
-
-    /// The device is encrypted.
-    pub const ENCRYPTED: DeviceEncryptionStatus = DeviceEncryptionStatus::new(3);
-
-    /// Creates a new DeviceEncryptionStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::EncryptionUnspecified => std::option::Option::Some(0),
+            Self::EncryptionUnsupported => std::option::Option::Some(1),
+            Self::Unencrypted => std::option::Option::Some(2),
+            Self::Encrypted => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENCRYPTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENCRYPTION_UNSUPPORTED"),
-            2 => std::borrow::Cow::Borrowed("UNENCRYPTED"),
-            3 => std::borrow::Cow::Borrowed("ENCRYPTED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::EncryptionUnspecified => std::option::Option::Some("ENCRYPTION_UNSPECIFIED"),
+            Self::EncryptionUnsupported => std::option::Option::Some("ENCRYPTION_UNSUPPORTED"),
+            Self::Unencrypted => std::option::Option::Some("UNENCRYPTED"),
+            Self::Encrypted => std::option::Option::Some("ENCRYPTED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENCRYPTION_UNSPECIFIED" => std::option::Option::Some(Self::ENCRYPTION_UNSPECIFIED),
-            "ENCRYPTION_UNSUPPORTED" => std::option::Option::Some(Self::ENCRYPTION_UNSUPPORTED),
-            "UNENCRYPTED" => std::option::Option::Some(Self::UNENCRYPTED),
-            "ENCRYPTED" => std::option::Option::Some(Self::ENCRYPTED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DeviceEncryptionStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DeviceEncryptionStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DeviceEncryptionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DeviceEncryptionStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::EncryptionUnspecified,
+            1 => Self::EncryptionUnsupported,
+            2 => Self::Unencrypted,
+            3 => Self::Encrypted,
+            _ => Self::UnknownValue(device_encryption_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DeviceEncryptionStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENCRYPTION_UNSPECIFIED" => Self::EncryptionUnspecified,
+            "ENCRYPTION_UNSUPPORTED" => Self::EncryptionUnsupported,
+            "UNENCRYPTED" => Self::Unencrypted,
+            "ENCRYPTED" => Self::Encrypted,
+            _ => Self::UnknownValue(device_encryption_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DeviceEncryptionStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::EncryptionUnspecified => serializer.serialize_i32(0),
+            Self::EncryptionUnsupported => serializer.serialize_i32(1),
+            Self::Unencrypted => serializer.serialize_i32(2),
+            Self::Encrypted => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DeviceEncryptionStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeviceEncryptionStatus>::new(
+            ".google.identity.accesscontextmanager.type.DeviceEncryptionStatus",
+        ))
     }
 }
 
 /// The operating system type of the device.
 /// Next id: 7
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OsType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OsType {
+    /// The operating system of the device is not specified or not known.
+    OsUnspecified,
+    /// A desktop Mac operating system.
+    DesktopMac,
+    /// A desktop Windows operating system.
+    DesktopWindows,
+    /// A desktop Linux operating system.
+    DesktopLinux,
+    /// A desktop ChromeOS operating system.
+    DesktopChromeOs,
+    /// An Android operating system.
+    Android,
+    /// An iOS operating system.
+    Ios,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OsType::value] or
+    /// [OsType::name].
+    UnknownValue(os_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod os_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl OsType {
-    /// The operating system of the device is not specified or not known.
-    pub const OS_UNSPECIFIED: OsType = OsType::new(0);
-
-    /// A desktop Mac operating system.
-    pub const DESKTOP_MAC: OsType = OsType::new(1);
-
-    /// A desktop Windows operating system.
-    pub const DESKTOP_WINDOWS: OsType = OsType::new(2);
-
-    /// A desktop Linux operating system.
-    pub const DESKTOP_LINUX: OsType = OsType::new(3);
-
-    /// A desktop ChromeOS operating system.
-    pub const DESKTOP_CHROME_OS: OsType = OsType::new(6);
-
-    /// An Android operating system.
-    pub const ANDROID: OsType = OsType::new(4);
-
-    /// An iOS operating system.
-    pub const IOS: OsType = OsType::new(5);
-
-    /// Creates a new OsType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::OsUnspecified => std::option::Option::Some(0),
+            Self::DesktopMac => std::option::Option::Some(1),
+            Self::DesktopWindows => std::option::Option::Some(2),
+            Self::DesktopLinux => std::option::Option::Some(3),
+            Self::DesktopChromeOs => std::option::Option::Some(6),
+            Self::Android => std::option::Option::Some(4),
+            Self::Ios => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DESKTOP_MAC"),
-            2 => std::borrow::Cow::Borrowed("DESKTOP_WINDOWS"),
-            3 => std::borrow::Cow::Borrowed("DESKTOP_LINUX"),
-            4 => std::borrow::Cow::Borrowed("ANDROID"),
-            5 => std::borrow::Cow::Borrowed("IOS"),
-            6 => std::borrow::Cow::Borrowed("DESKTOP_CHROME_OS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::OsUnspecified => std::option::Option::Some("OS_UNSPECIFIED"),
+            Self::DesktopMac => std::option::Option::Some("DESKTOP_MAC"),
+            Self::DesktopWindows => std::option::Option::Some("DESKTOP_WINDOWS"),
+            Self::DesktopLinux => std::option::Option::Some("DESKTOP_LINUX"),
+            Self::DesktopChromeOs => std::option::Option::Some("DESKTOP_CHROME_OS"),
+            Self::Android => std::option::Option::Some("ANDROID"),
+            Self::Ios => std::option::Option::Some("IOS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OS_UNSPECIFIED" => std::option::Option::Some(Self::OS_UNSPECIFIED),
-            "DESKTOP_MAC" => std::option::Option::Some(Self::DESKTOP_MAC),
-            "DESKTOP_WINDOWS" => std::option::Option::Some(Self::DESKTOP_WINDOWS),
-            "DESKTOP_LINUX" => std::option::Option::Some(Self::DESKTOP_LINUX),
-            "DESKTOP_CHROME_OS" => std::option::Option::Some(Self::DESKTOP_CHROME_OS),
-            "ANDROID" => std::option::Option::Some(Self::ANDROID),
-            "IOS" => std::option::Option::Some(Self::IOS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OsType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OsType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OsType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OsType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::OsUnspecified,
+            1 => Self::DesktopMac,
+            2 => Self::DesktopWindows,
+            3 => Self::DesktopLinux,
+            4 => Self::Android,
+            5 => Self::Ios,
+            6 => Self::DesktopChromeOs,
+            _ => Self::UnknownValue(os_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OsType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OS_UNSPECIFIED" => Self::OsUnspecified,
+            "DESKTOP_MAC" => Self::DesktopMac,
+            "DESKTOP_WINDOWS" => Self::DesktopWindows,
+            "DESKTOP_LINUX" => Self::DesktopLinux,
+            "DESKTOP_CHROME_OS" => Self::DesktopChromeOs,
+            "ANDROID" => Self::Android,
+            "IOS" => Self::Ios,
+            _ => Self::UnknownValue(os_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OsType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::OsUnspecified => serializer.serialize_i32(0),
+            Self::DesktopMac => serializer.serialize_i32(1),
+            Self::DesktopWindows => serializer.serialize_i32(2),
+            Self::DesktopLinux => serializer.serialize_i32(3),
+            Self::DesktopChromeOs => serializer.serialize_i32(6),
+            Self::Android => serializer.serialize_i32(4),
+            Self::Ios => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OsType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OsType>::new(
+            ".google.identity.accesscontextmanager.type.OsType",
+        ))
     }
 }
 
 /// The degree to which the device is managed by the Cloud organization.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DeviceManagementLevel(i32);
-
-impl DeviceManagementLevel {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DeviceManagementLevel {
     /// The device's management level is not specified or not known.
-    pub const MANAGEMENT_UNSPECIFIED: DeviceManagementLevel = DeviceManagementLevel::new(0);
-
+    ManagementUnspecified,
     /// The device is not managed.
-    pub const NONE: DeviceManagementLevel = DeviceManagementLevel::new(1);
-
+    None,
     /// Basic management is enabled, which is generally limited to monitoring and
     /// wiping the corporate account.
-    pub const BASIC: DeviceManagementLevel = DeviceManagementLevel::new(2);
-
+    Basic,
     /// Complete device management. This includes more thorough monitoring and the
     /// ability to directly manage the device (such as remote wiping). This can be
     /// enabled through the Android Enterprise Platform.
-    pub const COMPLETE: DeviceManagementLevel = DeviceManagementLevel::new(3);
+    Complete,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DeviceManagementLevel::value] or
+    /// [DeviceManagementLevel::name].
+    UnknownValue(device_management_level::UnknownValue),
+}
 
-    /// Creates a new DeviceManagementLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod device_management_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DeviceManagementLevel {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::ManagementUnspecified => std::option::Option::Some(0),
+            Self::None => std::option::Option::Some(1),
+            Self::Basic => std::option::Option::Some(2),
+            Self::Complete => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MANAGEMENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NONE"),
-            2 => std::borrow::Cow::Borrowed("BASIC"),
-            3 => std::borrow::Cow::Borrowed("COMPLETE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::ManagementUnspecified => std::option::Option::Some("MANAGEMENT_UNSPECIFIED"),
+            Self::None => std::option::Option::Some("NONE"),
+            Self::Basic => std::option::Option::Some("BASIC"),
+            Self::Complete => std::option::Option::Some("COMPLETE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MANAGEMENT_UNSPECIFIED" => std::option::Option::Some(Self::MANAGEMENT_UNSPECIFIED),
-            "NONE" => std::option::Option::Some(Self::NONE),
-            "BASIC" => std::option::Option::Some(Self::BASIC),
-            "COMPLETE" => std::option::Option::Some(Self::COMPLETE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DeviceManagementLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DeviceManagementLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DeviceManagementLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DeviceManagementLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::ManagementUnspecified,
+            1 => Self::None,
+            2 => Self::Basic,
+            3 => Self::Complete,
+            _ => Self::UnknownValue(device_management_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DeviceManagementLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MANAGEMENT_UNSPECIFIED" => Self::ManagementUnspecified,
+            "NONE" => Self::None,
+            "BASIC" => Self::Basic,
+            "COMPLETE" => Self::Complete,
+            _ => Self::UnknownValue(device_management_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DeviceManagementLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::ManagementUnspecified => serializer.serialize_i32(0),
+            Self::None => serializer.serialize_i32(1),
+            Self::Basic => serializer.serialize_i32(2),
+            Self::Complete => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DeviceManagementLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DeviceManagementLevel>::new(
+            ".google.identity.accesscontextmanager.type.DeviceManagementLevel",
+        ))
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -1795,54 +1795,112 @@ pub mod basic_level {
 
     /// Options for how the `conditions` list should be combined to determine if
     /// this `AccessLevel` is applied. Default is AND.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConditionCombiningFunction(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConditionCombiningFunction {
+        /// All `Conditions` must be true for the `BasicLevel` to be true.
+        And,
+        /// If at least one `Condition` is true, then the `BasicLevel` is true.
+        Or,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConditionCombiningFunction::value] or
+        /// [ConditionCombiningFunction::name].
+        UnknownValue(condition_combining_function::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod condition_combining_function {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ConditionCombiningFunction {
-        /// All `Conditions` must be true for the `BasicLevel` to be true.
-        pub const AND: ConditionCombiningFunction = ConditionCombiningFunction::new(0);
-
-        /// If at least one `Condition` is true, then the `BasicLevel` is true.
-        pub const OR: ConditionCombiningFunction = ConditionCombiningFunction::new(1);
-
-        /// Creates a new ConditionCombiningFunction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::And => std::option::Option::Some(0),
+                Self::Or => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AND"),
-                1 => std::borrow::Cow::Borrowed("OR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::And => std::option::Option::Some("AND"),
+                Self::Or => std::option::Option::Some("OR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AND" => std::option::Option::Some(Self::AND),
-                "OR" => std::option::Option::Some(Self::OR),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ConditionCombiningFunction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConditionCombiningFunction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConditionCombiningFunction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConditionCombiningFunction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::And,
+                1 => Self::Or,
+                _ => Self::UnknownValue(condition_combining_function::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConditionCombiningFunction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AND" => Self::And,
+                "OR" => Self::Or,
+                _ => Self::UnknownValue(condition_combining_function::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConditionCombiningFunction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::And => serializer.serialize_i32(0),
+                Self::Or => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConditionCombiningFunction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConditionCombiningFunction>::new(
+                ".google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction"))
         }
     }
 }
@@ -2565,54 +2623,113 @@ pub mod service_perimeter {
     /// Perimeter Bridges are typically useful when building more complex toplogies
     /// with many independent perimeters that need to share some data with a common
     /// perimeter, but should not be able to share data among themselves.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PerimeterType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PerimeterType {
+        /// Regular Perimeter.
+        Regular,
+        /// Perimeter Bridge.
+        Bridge,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PerimeterType::value] or
+        /// [PerimeterType::name].
+        UnknownValue(perimeter_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod perimeter_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl PerimeterType {
-        /// Regular Perimeter.
-        pub const PERIMETER_TYPE_REGULAR: PerimeterType = PerimeterType::new(0);
-
-        /// Perimeter Bridge.
-        pub const PERIMETER_TYPE_BRIDGE: PerimeterType = PerimeterType::new(1);
-
-        /// Creates a new PerimeterType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Regular => std::option::Option::Some(0),
+                Self::Bridge => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PERIMETER_TYPE_REGULAR"),
-                1 => std::borrow::Cow::Borrowed("PERIMETER_TYPE_BRIDGE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Regular => std::option::Option::Some("PERIMETER_TYPE_REGULAR"),
+                Self::Bridge => std::option::Option::Some("PERIMETER_TYPE_BRIDGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PERIMETER_TYPE_REGULAR" => std::option::Option::Some(Self::PERIMETER_TYPE_REGULAR),
-                "PERIMETER_TYPE_BRIDGE" => std::option::Option::Some(Self::PERIMETER_TYPE_BRIDGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PerimeterType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PerimeterType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PerimeterType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PerimeterType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Regular,
+                1 => Self::Bridge,
+                _ => Self::UnknownValue(perimeter_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PerimeterType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PERIMETER_TYPE_REGULAR" => Self::Regular,
+                "PERIMETER_TYPE_BRIDGE" => Self::Bridge,
+                _ => Self::UnknownValue(perimeter_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PerimeterType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Regular => serializer.serialize_i32(0),
+                Self::Bridge => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PerimeterType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PerimeterType>::new(
+                ".google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType",
+            ))
         }
     }
 }
@@ -3629,125 +3746,247 @@ pub mod service_perimeter_config {
     /// or [EgressFrom]
     /// [google.identity.accesscontextmanager.v1.ServicePerimeterConfig.EgressFrom]
     /// rules.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IdentityType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IdentityType {
+        /// No blanket identity group specified.
+        Unspecified,
+        /// Authorize access from all identities outside the perimeter.
+        AnyIdentity,
+        /// Authorize access from all human users outside the perimeter.
+        AnyUserAccount,
+        /// Authorize access from all service accounts outside the perimeter.
+        AnyServiceAccount,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IdentityType::value] or
+        /// [IdentityType::name].
+        UnknownValue(identity_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod identity_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IdentityType {
-        /// No blanket identity group specified.
-        pub const IDENTITY_TYPE_UNSPECIFIED: IdentityType = IdentityType::new(0);
-
-        /// Authorize access from all identities outside the perimeter.
-        pub const ANY_IDENTITY: IdentityType = IdentityType::new(1);
-
-        /// Authorize access from all human users outside the perimeter.
-        pub const ANY_USER_ACCOUNT: IdentityType = IdentityType::new(2);
-
-        /// Authorize access from all service accounts outside the perimeter.
-        pub const ANY_SERVICE_ACCOUNT: IdentityType = IdentityType::new(3);
-
-        /// Creates a new IdentityType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AnyIdentity => std::option::Option::Some(1),
+                Self::AnyUserAccount => std::option::Option::Some(2),
+                Self::AnyServiceAccount => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IDENTITY_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ANY_IDENTITY"),
-                2 => std::borrow::Cow::Borrowed("ANY_USER_ACCOUNT"),
-                3 => std::borrow::Cow::Borrowed("ANY_SERVICE_ACCOUNT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("IDENTITY_TYPE_UNSPECIFIED"),
+                Self::AnyIdentity => std::option::Option::Some("ANY_IDENTITY"),
+                Self::AnyUserAccount => std::option::Option::Some("ANY_USER_ACCOUNT"),
+                Self::AnyServiceAccount => std::option::Option::Some("ANY_SERVICE_ACCOUNT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IDENTITY_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::IDENTITY_TYPE_UNSPECIFIED)
-                }
-                "ANY_IDENTITY" => std::option::Option::Some(Self::ANY_IDENTITY),
-                "ANY_USER_ACCOUNT" => std::option::Option::Some(Self::ANY_USER_ACCOUNT),
-                "ANY_SERVICE_ACCOUNT" => std::option::Option::Some(Self::ANY_SERVICE_ACCOUNT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IdentityType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IdentityType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IdentityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IdentityType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AnyIdentity,
+                2 => Self::AnyUserAccount,
+                3 => Self::AnyServiceAccount,
+                _ => Self::UnknownValue(identity_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IdentityType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IDENTITY_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "ANY_IDENTITY" => Self::AnyIdentity,
+                "ANY_USER_ACCOUNT" => Self::AnyUserAccount,
+                "ANY_SERVICE_ACCOUNT" => Self::AnyServiceAccount,
+                _ => Self::UnknownValue(identity_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IdentityType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AnyIdentity => serializer.serialize_i32(1),
+                Self::AnyUserAccount => serializer.serialize_i32(2),
+                Self::AnyServiceAccount => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IdentityType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IdentityType>::new(
+                ".google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IdentityType",
+            ))
         }
     }
 }
 
 /// The format used in an `AccessLevel`.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LevelFormat(i32);
-
-impl LevelFormat {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LevelFormat {
     /// The format was not specified.
-    pub const LEVEL_FORMAT_UNSPECIFIED: LevelFormat = LevelFormat::new(0);
-
+    Unspecified,
     /// Uses the format the resource was defined in. BasicLevels are returned as
     /// BasicLevels, CustomLevels are returned as CustomLevels.
-    pub const AS_DEFINED: LevelFormat = LevelFormat::new(1);
-
+    AsDefined,
     /// Use Cloud Common Expression Language when returning the resource.  Both
     /// BasicLevels and CustomLevels are returned as CustomLevels.
-    pub const CEL: LevelFormat = LevelFormat::new(2);
+    Cel,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LevelFormat::value] or
+    /// [LevelFormat::name].
+    UnknownValue(level_format::UnknownValue),
+}
 
-    /// Creates a new LevelFormat instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod level_format {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LevelFormat {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::AsDefined => std::option::Option::Some(1),
+            Self::Cel => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LEVEL_FORMAT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AS_DEFINED"),
-            2 => std::borrow::Cow::Borrowed("CEL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LEVEL_FORMAT_UNSPECIFIED"),
+            Self::AsDefined => std::option::Option::Some("AS_DEFINED"),
+            Self::Cel => std::option::Option::Some("CEL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LEVEL_FORMAT_UNSPECIFIED" => std::option::Option::Some(Self::LEVEL_FORMAT_UNSPECIFIED),
-            "AS_DEFINED" => std::option::Option::Some(Self::AS_DEFINED),
-            "CEL" => std::option::Option::Some(Self::CEL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LevelFormat {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LevelFormat {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LevelFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LevelFormat {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::AsDefined,
+            2 => Self::Cel,
+            _ => Self::UnknownValue(level_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LevelFormat {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LEVEL_FORMAT_UNSPECIFIED" => Self::Unspecified,
+            "AS_DEFINED" => Self::AsDefined,
+            "CEL" => Self::Cel,
+            _ => Self::UnknownValue(level_format::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LevelFormat {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::AsDefined => serializer.serialize_i32(1),
+            Self::Cel => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LevelFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LevelFormat>::new(
+            ".google.identity.accesscontextmanager.v1.LevelFormat",
+        ))
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -168,7 +168,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
             );
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("accessLevelFormat", &req.access_level_format.value())]);
+        let builder = builder.query(&[("accessLevelFormat", &req.access_level_format)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -188,7 +188,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("accessLevelFormat", &req.access_level_format.value())]);
+        let builder = builder.query(&[("accessLevelFormat", &req.access_level_format)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/logging/type/src/model.rs
+++ b/src/generated/logging/type/src/model.rs
@@ -242,89 +242,162 @@ impl wkt::message::Message for HttpRequest {
 /// one of these standard levels. For example, you might map all of Java's FINE,
 /// FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
 /// original severity level in the log entry payload if you wish.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LogSeverity(i32);
-
-impl LogSeverity {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LogSeverity {
     /// (0) The log entry has no assigned severity level.
-    pub const DEFAULT: LogSeverity = LogSeverity::new(0);
-
+    Default,
     /// (100) Debug or trace information.
-    pub const DEBUG: LogSeverity = LogSeverity::new(100);
-
+    Debug,
     /// (200) Routine information, such as ongoing status or performance.
-    pub const INFO: LogSeverity = LogSeverity::new(200);
-
+    Info,
     /// (300) Normal but significant events, such as start up, shut down, or
     /// a configuration change.
-    pub const NOTICE: LogSeverity = LogSeverity::new(300);
-
+    Notice,
     /// (400) Warning events might cause problems.
-    pub const WARNING: LogSeverity = LogSeverity::new(400);
-
+    Warning,
     /// (500) Error events are likely to cause problems.
-    pub const ERROR: LogSeverity = LogSeverity::new(500);
-
+    Error,
     /// (600) Critical events cause more severe problems or outages.
-    pub const CRITICAL: LogSeverity = LogSeverity::new(600);
-
+    Critical,
     /// (700) A person must take an action immediately.
-    pub const ALERT: LogSeverity = LogSeverity::new(700);
-
+    Alert,
     /// (800) One or more systems are unusable.
-    pub const EMERGENCY: LogSeverity = LogSeverity::new(800);
+    Emergency,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LogSeverity::value] or
+    /// [LogSeverity::name].
+    UnknownValue(log_severity::UnknownValue),
+}
 
-    /// Creates a new LogSeverity instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod log_severity {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LogSeverity {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Default => std::option::Option::Some(0),
+            Self::Debug => std::option::Option::Some(100),
+            Self::Info => std::option::Option::Some(200),
+            Self::Notice => std::option::Option::Some(300),
+            Self::Warning => std::option::Option::Some(400),
+            Self::Error => std::option::Option::Some(500),
+            Self::Critical => std::option::Option::Some(600),
+            Self::Alert => std::option::Option::Some(700),
+            Self::Emergency => std::option::Option::Some(800),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DEFAULT"),
-            100 => std::borrow::Cow::Borrowed("DEBUG"),
-            200 => std::borrow::Cow::Borrowed("INFO"),
-            300 => std::borrow::Cow::Borrowed("NOTICE"),
-            400 => std::borrow::Cow::Borrowed("WARNING"),
-            500 => std::borrow::Cow::Borrowed("ERROR"),
-            600 => std::borrow::Cow::Borrowed("CRITICAL"),
-            700 => std::borrow::Cow::Borrowed("ALERT"),
-            800 => std::borrow::Cow::Borrowed("EMERGENCY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Default => std::option::Option::Some("DEFAULT"),
+            Self::Debug => std::option::Option::Some("DEBUG"),
+            Self::Info => std::option::Option::Some("INFO"),
+            Self::Notice => std::option::Option::Some("NOTICE"),
+            Self::Warning => std::option::Option::Some("WARNING"),
+            Self::Error => std::option::Option::Some("ERROR"),
+            Self::Critical => std::option::Option::Some("CRITICAL"),
+            Self::Alert => std::option::Option::Some("ALERT"),
+            Self::Emergency => std::option::Option::Some("EMERGENCY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DEFAULT" => std::option::Option::Some(Self::DEFAULT),
-            "DEBUG" => std::option::Option::Some(Self::DEBUG),
-            "INFO" => std::option::Option::Some(Self::INFO),
-            "NOTICE" => std::option::Option::Some(Self::NOTICE),
-            "WARNING" => std::option::Option::Some(Self::WARNING),
-            "ERROR" => std::option::Option::Some(Self::ERROR),
-            "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-            "ALERT" => std::option::Option::Some(Self::ALERT),
-            "EMERGENCY" => std::option::Option::Some(Self::EMERGENCY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LogSeverity {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LogSeverity {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LogSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LogSeverity {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Default,
+            100 => Self::Debug,
+            200 => Self::Info,
+            300 => Self::Notice,
+            400 => Self::Warning,
+            500 => Self::Error,
+            600 => Self::Critical,
+            700 => Self::Alert,
+            800 => Self::Emergency,
+            _ => Self::UnknownValue(log_severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LogSeverity {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DEFAULT" => Self::Default,
+            "DEBUG" => Self::Debug,
+            "INFO" => Self::Info,
+            "NOTICE" => Self::Notice,
+            "WARNING" => Self::Warning,
+            "ERROR" => Self::Error,
+            "CRITICAL" => Self::Critical,
+            "ALERT" => Self::Alert,
+            "EMERGENCY" => Self::Emergency,
+            _ => Self::UnknownValue(log_severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LogSeverity {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Default => serializer.serialize_i32(0),
+            Self::Debug => serializer.serialize_i32(100),
+            Self::Info => serializer.serialize_i32(200),
+            Self::Notice => serializer.serialize_i32(300),
+            Self::Warning => serializer.serialize_i32(400),
+            Self::Error => serializer.serialize_i32(500),
+            Self::Critical => serializer.serialize_i32(600),
+            Self::Alert => serializer.serialize_i32(700),
+            Self::Emergency => serializer.serialize_i32(800),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LogSeverity {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogSeverity>::new(
+            ".google.logging.type.LogSeverity",
+        ))
     }
 }

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -1548,63 +1548,127 @@ pub mod tail_log_entries_response {
         use super::*;
 
         /// An indicator of why entries were omitted.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Reason(i32);
-
-        impl Reason {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Reason {
             /// Unexpected default.
-            pub const REASON_UNSPECIFIED: Reason = Reason::new(0);
-
+            Unspecified,
             /// Indicates suppression occurred due to relevant entries being
             /// received in excess of rate limits. For quotas and limits, see
             /// [Logging API quotas and
             /// limits](https://cloud.google.com/logging/quotas#api-limits).
-            pub const RATE_LIMIT: Reason = Reason::new(1);
-
+            RateLimit,
             /// Indicates suppression occurred due to the client not consuming
             /// responses quickly enough.
-            pub const NOT_CONSUMED: Reason = Reason::new(2);
+            NotConsumed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Reason::value] or
+            /// [Reason::name].
+            UnknownValue(reason::UnknownValue),
+        }
 
-            /// Creates a new Reason instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod reason {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl Reason {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::RateLimit => std::option::Option::Some(1),
+                    Self::NotConsumed => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("REASON_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("RATE_LIMIT"),
-                    2 => std::borrow::Cow::Borrowed("NOT_CONSUMED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("REASON_UNSPECIFIED"),
+                    Self::RateLimit => std::option::Option::Some("RATE_LIMIT"),
+                    Self::NotConsumed => std::option::Option::Some("NOT_CONSUMED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "REASON_UNSPECIFIED" => std::option::Option::Some(Self::REASON_UNSPECIFIED),
-                    "RATE_LIMIT" => std::option::Option::Some(Self::RATE_LIMIT),
-                    "NOT_CONSUMED" => std::option::Option::Some(Self::NOT_CONSUMED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Reason {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Reason {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Reason {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Reason {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::RateLimit,
+                    2 => Self::NotConsumed,
+                    _ => Self::UnknownValue(reason::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Reason {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "REASON_UNSPECIFIED" => Self::Unspecified,
+                    "RATE_LIMIT" => Self::RateLimit,
+                    "NOT_CONSUMED" => Self::NotConsumed,
+                    _ => Self::UnknownValue(reason::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Reason {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::RateLimit => serializer.serialize_i32(1),
+                    Self::NotConsumed => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Reason {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Reason>::new(
+                    ".google.logging.v2.TailLogEntriesResponse.SuppressionInfo.Reason",
+                ))
             }
         }
     }
@@ -2231,61 +2295,120 @@ pub mod log_sink {
     use super::*;
 
     /// Deprecated. This is unused.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VersionFormat(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VersionFormat {
+        /// An unspecified format version that will default to V2.
+        Unspecified,
+        /// `LogEntry` version 2 format.
+        V2,
+        /// `LogEntry` version 1 format.
+        V1,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VersionFormat::value] or
+        /// [VersionFormat::name].
+        UnknownValue(version_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod version_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VersionFormat {
-        /// An unspecified format version that will default to V2.
-        pub const VERSION_FORMAT_UNSPECIFIED: VersionFormat = VersionFormat::new(0);
-
-        /// `LogEntry` version 2 format.
-        pub const V2: VersionFormat = VersionFormat::new(1);
-
-        /// `LogEntry` version 1 format.
-        pub const V1: VersionFormat = VersionFormat::new(2);
-
-        /// Creates a new VersionFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V2 => std::option::Option::Some(1),
+                Self::V1 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VERSION_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("V2"),
-                2 => std::borrow::Cow::Borrowed("V1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VERSION_FORMAT_UNSPECIFIED"),
+                Self::V2 => std::option::Option::Some("V2"),
+                Self::V1 => std::option::Option::Some("V1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VERSION_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VERSION_FORMAT_UNSPECIFIED)
-                }
-                "V2" => std::option::Option::Some(Self::V2),
-                "V1" => std::option::Option::Some(Self::V1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VersionFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VersionFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VersionFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VersionFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::V2,
+                2 => Self::V1,
+                _ => Self::UnknownValue(version_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VersionFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VERSION_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "V2" => Self::V2,
+                "V1" => Self::V1,
+                _ => Self::UnknownValue(version_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VersionFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V2 => serializer.serialize_i32(1),
+                Self::V1 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VersionFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VersionFormat>::new(
+                ".google.logging.v2.LogSink.VersionFormat",
+            ))
         }
     }
 
@@ -5724,54 +5847,113 @@ pub mod log_metric {
     use super::*;
 
     /// Logging API version.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ApiVersion(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ApiVersion {
+        /// Logging API v2.
+        V2,
+        /// Logging API v1.
+        V1,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ApiVersion::value] or
+        /// [ApiVersion::name].
+        UnknownValue(api_version::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod api_version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ApiVersion {
-        /// Logging API v2.
-        pub const V2: ApiVersion = ApiVersion::new(0);
-
-        /// Logging API v1.
-        pub const V1: ApiVersion = ApiVersion::new(1);
-
-        /// Creates a new ApiVersion instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::V2 => std::option::Option::Some(0),
+                Self::V1 => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("V2"),
-                1 => std::borrow::Cow::Borrowed("V1"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::V2 => std::option::Option::Some("V2"),
+                Self::V1 => std::option::Option::Some("V1"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "V2" => std::option::Option::Some(Self::V2),
-                "V1" => std::option::Option::Some(Self::V1),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ApiVersion {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ApiVersion {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ApiVersion {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ApiVersion {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::V2,
+                1 => Self::V1,
+                _ => Self::UnknownValue(api_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ApiVersion {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "V2" => Self::V2,
+                "V1" => Self::V1,
+                _ => Self::UnknownValue(api_version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ApiVersion {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::V2 => serializer.serialize_i32(0),
+                Self::V1 => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ApiVersion {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ApiVersion>::new(
+                ".google.logging.v2.LogMetric.ApiVersion",
+            ))
         }
     }
 }
@@ -6082,224 +6264,411 @@ impl wkt::message::Message for DeleteLogMetricRequest {
 /// current state to the user. Once a long running operation is created,
 /// the current state of the operation can be queried even before the
 /// operation is finished and the final result is available.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperationState(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperationState {
+    /// Should not be used.
+    Unspecified,
+    /// The operation is scheduled.
+    Scheduled,
+    /// Waiting for necessary permissions.
+    WaitingForPermissions,
+    /// The operation is running.
+    Running,
+    /// The operation was completed successfully.
+    Succeeded,
+    /// The operation failed.
+    Failed,
+    /// The operation was cancelled by the user.
+    Cancelled,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperationState::value] or
+    /// [OperationState::name].
+    UnknownValue(operation_state::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod operation_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl OperationState {
-    /// Should not be used.
-    pub const OPERATION_STATE_UNSPECIFIED: OperationState = OperationState::new(0);
-
-    /// The operation is scheduled.
-    pub const OPERATION_STATE_SCHEDULED: OperationState = OperationState::new(1);
-
-    /// Waiting for necessary permissions.
-    pub const OPERATION_STATE_WAITING_FOR_PERMISSIONS: OperationState = OperationState::new(2);
-
-    /// The operation is running.
-    pub const OPERATION_STATE_RUNNING: OperationState = OperationState::new(3);
-
-    /// The operation was completed successfully.
-    pub const OPERATION_STATE_SUCCEEDED: OperationState = OperationState::new(4);
-
-    /// The operation failed.
-    pub const OPERATION_STATE_FAILED: OperationState = OperationState::new(5);
-
-    /// The operation was cancelled by the user.
-    pub const OPERATION_STATE_CANCELLED: OperationState = OperationState::new(6);
-
-    /// Creates a new OperationState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Scheduled => std::option::Option::Some(1),
+            Self::WaitingForPermissions => std::option::Option::Some(2),
+            Self::Running => std::option::Option::Some(3),
+            Self::Succeeded => std::option::Option::Some(4),
+            Self::Failed => std::option::Option::Some(5),
+            Self::Cancelled => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("OPERATION_STATE_SCHEDULED"),
-            2 => std::borrow::Cow::Borrowed("OPERATION_STATE_WAITING_FOR_PERMISSIONS"),
-            3 => std::borrow::Cow::Borrowed("OPERATION_STATE_RUNNING"),
-            4 => std::borrow::Cow::Borrowed("OPERATION_STATE_SUCCEEDED"),
-            5 => std::borrow::Cow::Borrowed("OPERATION_STATE_FAILED"),
-            6 => std::borrow::Cow::Borrowed("OPERATION_STATE_CANCELLED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OPERATION_STATE_UNSPECIFIED"),
+            Self::Scheduled => std::option::Option::Some("OPERATION_STATE_SCHEDULED"),
+            Self::WaitingForPermissions => {
+                std::option::Option::Some("OPERATION_STATE_WAITING_FOR_PERMISSIONS")
+            }
+            Self::Running => std::option::Option::Some("OPERATION_STATE_RUNNING"),
+            Self::Succeeded => std::option::Option::Some("OPERATION_STATE_SUCCEEDED"),
+            Self::Failed => std::option::Option::Some("OPERATION_STATE_FAILED"),
+            Self::Cancelled => std::option::Option::Some("OPERATION_STATE_CANCELLED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_UNSPECIFIED)
-            }
-            "OPERATION_STATE_SCHEDULED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_SCHEDULED)
-            }
-            "OPERATION_STATE_WAITING_FOR_PERMISSIONS" => {
-                std::option::Option::Some(Self::OPERATION_STATE_WAITING_FOR_PERMISSIONS)
-            }
-            "OPERATION_STATE_RUNNING" => std::option::Option::Some(Self::OPERATION_STATE_RUNNING),
-            "OPERATION_STATE_SUCCEEDED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_SUCCEEDED)
-            }
-            "OPERATION_STATE_FAILED" => std::option::Option::Some(Self::OPERATION_STATE_FAILED),
-            "OPERATION_STATE_CANCELLED" => {
-                std::option::Option::Some(Self::OPERATION_STATE_CANCELLED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperationState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperationState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperationState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Scheduled,
+            2 => Self::WaitingForPermissions,
+            3 => Self::Running,
+            4 => Self::Succeeded,
+            5 => Self::Failed,
+            6 => Self::Cancelled,
+            _ => Self::UnknownValue(operation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperationState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "OPERATION_STATE_SCHEDULED" => Self::Scheduled,
+            "OPERATION_STATE_WAITING_FOR_PERMISSIONS" => Self::WaitingForPermissions,
+            "OPERATION_STATE_RUNNING" => Self::Running,
+            "OPERATION_STATE_SUCCEEDED" => Self::Succeeded,
+            "OPERATION_STATE_FAILED" => Self::Failed,
+            "OPERATION_STATE_CANCELLED" => Self::Cancelled,
+            _ => Self::UnknownValue(operation_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperationState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Scheduled => serializer.serialize_i32(1),
+            Self::WaitingForPermissions => serializer.serialize_i32(2),
+            Self::Running => serializer.serialize_i32(3),
+            Self::Succeeded => serializer.serialize_i32(4),
+            Self::Failed => serializer.serialize_i32(5),
+            Self::Cancelled => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperationState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperationState>::new(
+            ".google.logging.v2.OperationState",
+        ))
     }
 }
 
 /// LogBucket lifecycle states.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct LifecycleState(i32);
-
-impl LifecycleState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum LifecycleState {
     /// Unspecified state. This is only used/useful for distinguishing unset
     /// values.
-    pub const LIFECYCLE_STATE_UNSPECIFIED: LifecycleState = LifecycleState::new(0);
-
+    Unspecified,
     /// The normal and active state.
-    pub const ACTIVE: LifecycleState = LifecycleState::new(1);
-
+    Active,
     /// The resource has been marked for deletion by the user. For some resources
     /// (e.g. buckets), this can be reversed by an un-delete operation.
-    pub const DELETE_REQUESTED: LifecycleState = LifecycleState::new(2);
-
+    DeleteRequested,
     /// The resource has been marked for an update by the user. It will remain in
     /// this state until the update is complete.
-    pub const UPDATING: LifecycleState = LifecycleState::new(3);
-
+    Updating,
     /// The resource has been marked for creation by the user. It will remain in
     /// this state until the creation is complete.
-    pub const CREATING: LifecycleState = LifecycleState::new(4);
-
+    Creating,
     /// The resource is in an INTERNAL error state.
-    pub const FAILED: LifecycleState = LifecycleState::new(5);
+    Failed,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [LifecycleState::value] or
+    /// [LifecycleState::name].
+    UnknownValue(lifecycle_state::UnknownValue),
+}
 
-    /// Creates a new LifecycleState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod lifecycle_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl LifecycleState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Active => std::option::Option::Some(1),
+            Self::DeleteRequested => std::option::Option::Some(2),
+            Self::Updating => std::option::Option::Some(3),
+            Self::Creating => std::option::Option::Some(4),
+            Self::Failed => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LIFECYCLE_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ACTIVE"),
-            2 => std::borrow::Cow::Borrowed("DELETE_REQUESTED"),
-            3 => std::borrow::Cow::Borrowed("UPDATING"),
-            4 => std::borrow::Cow::Borrowed("CREATING"),
-            5 => std::borrow::Cow::Borrowed("FAILED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LIFECYCLE_STATE_UNSPECIFIED"),
+            Self::Active => std::option::Option::Some("ACTIVE"),
+            Self::DeleteRequested => std::option::Option::Some("DELETE_REQUESTED"),
+            Self::Updating => std::option::Option::Some("UPDATING"),
+            Self::Creating => std::option::Option::Some("CREATING"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LIFECYCLE_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::LIFECYCLE_STATE_UNSPECIFIED)
-            }
-            "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-            "DELETE_REQUESTED" => std::option::Option::Some(Self::DELETE_REQUESTED),
-            "UPDATING" => std::option::Option::Some(Self::UPDATING),
-            "CREATING" => std::option::Option::Some(Self::CREATING),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for LifecycleState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for LifecycleState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for LifecycleState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for LifecycleState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Active,
+            2 => Self::DeleteRequested,
+            3 => Self::Updating,
+            4 => Self::Creating,
+            5 => Self::Failed,
+            _ => Self::UnknownValue(lifecycle_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for LifecycleState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LIFECYCLE_STATE_UNSPECIFIED" => Self::Unspecified,
+            "ACTIVE" => Self::Active,
+            "DELETE_REQUESTED" => Self::DeleteRequested,
+            "UPDATING" => Self::Updating,
+            "CREATING" => Self::Creating,
+            "FAILED" => Self::Failed,
+            _ => Self::UnknownValue(lifecycle_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for LifecycleState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Active => serializer.serialize_i32(1),
+            Self::DeleteRequested => serializer.serialize_i32(2),
+            Self::Updating => serializer.serialize_i32(3),
+            Self::Creating => serializer.serialize_i32(4),
+            Self::Failed => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for LifecycleState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<LifecycleState>::new(
+            ".google.logging.v2.LifecycleState",
+        ))
     }
 }
 
 /// IndexType is used for custom indexing. It describes the type of an indexed
 /// field.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct IndexType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum IndexType {
+    /// The index's type is unspecified.
+    Unspecified,
+    /// The index is a string-type index.
+    String,
+    /// The index is a integer-type index.
+    Integer,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [IndexType::value] or
+    /// [IndexType::name].
+    UnknownValue(index_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod index_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl IndexType {
-    /// The index's type is unspecified.
-    pub const INDEX_TYPE_UNSPECIFIED: IndexType = IndexType::new(0);
-
-    /// The index is a string-type index.
-    pub const INDEX_TYPE_STRING: IndexType = IndexType::new(1);
-
-    /// The index is a integer-type index.
-    pub const INDEX_TYPE_INTEGER: IndexType = IndexType::new(2);
-
-    /// Creates a new IndexType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::String => std::option::Option::Some(1),
+            Self::Integer => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("INDEX_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INDEX_TYPE_STRING"),
-            2 => std::borrow::Cow::Borrowed("INDEX_TYPE_INTEGER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("INDEX_TYPE_UNSPECIFIED"),
+            Self::String => std::option::Option::Some("INDEX_TYPE_STRING"),
+            Self::Integer => std::option::Option::Some("INDEX_TYPE_INTEGER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "INDEX_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::INDEX_TYPE_UNSPECIFIED),
-            "INDEX_TYPE_STRING" => std::option::Option::Some(Self::INDEX_TYPE_STRING),
-            "INDEX_TYPE_INTEGER" => std::option::Option::Some(Self::INDEX_TYPE_INTEGER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for IndexType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for IndexType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for IndexType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for IndexType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::String,
+            2 => Self::Integer,
+            _ => Self::UnknownValue(index_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for IndexType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "INDEX_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "INDEX_TYPE_STRING" => Self::String,
+            "INDEX_TYPE_INTEGER" => Self::Integer,
+            _ => Self::UnknownValue(index_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for IndexType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::String => serializer.serialize_i32(1),
+            Self::Integer => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for IndexType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndexType>::new(
+            ".google.logging.v2.IndexType",
+        ))
     }
 }

--- a/src/generated/monitoring/metricsscope/v1/src/model.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/model.rs
@@ -431,69 +431,134 @@ pub mod operation_metadata {
     use super::*;
 
     /// Batch operation states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
+        /// Invalid.
+        Unspecified,
+        /// Request has been received.
+        Created,
+        /// Request is actively being processed.
+        Running,
+        /// The batch processing is done.
+        Done,
+        /// The batch processing was cancelled.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl State {
-        /// Invalid.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
-        /// Request has been received.
-        pub const CREATED: State = State::new(1);
-
-        /// Request is actively being processed.
-        pub const RUNNING: State = State::new(2);
-
-        /// The batch processing is done.
-        pub const DONE: State = State::new(3);
-
-        /// The batch processing was cancelled.
-        pub const CANCELLED: State = State::new(4);
-
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Created => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::Cancelled => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATED"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                4 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Created,
+                2 => Self::Running,
+                3 => Self::Done,
+                4 => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATED" => Self::Created,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Created => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::Cancelled => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.monitoring.metricsscope.v1.OperationMetadata.State",
+            ))
         }
     }
 }

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -2176,79 +2176,137 @@ pub mod alert_policy {
         /// A condition control that determines how metric-threshold conditions
         /// are evaluated when data stops arriving.
         /// This control doesn't affect metric-absence policies.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct EvaluationMissingData(i32);
-
-        impl EvaluationMissingData {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum EvaluationMissingData {
             /// An unspecified evaluation missing data option.  Equivalent to
             /// EVALUATION_MISSING_DATA_NO_OP.
-            pub const EVALUATION_MISSING_DATA_UNSPECIFIED: EvaluationMissingData =
-                EvaluationMissingData::new(0);
-
+            Unspecified,
             /// If there is no data to evaluate the condition, then evaluate the
             /// condition as false.
-            pub const EVALUATION_MISSING_DATA_INACTIVE: EvaluationMissingData =
-                EvaluationMissingData::new(1);
-
+            Inactive,
             /// If there is no data to evaluate the condition, then evaluate the
             /// condition as true.
-            pub const EVALUATION_MISSING_DATA_ACTIVE: EvaluationMissingData =
-                EvaluationMissingData::new(2);
-
+            Active,
             /// Do not evaluate the condition to any value if there is no data.
-            pub const EVALUATION_MISSING_DATA_NO_OP: EvaluationMissingData =
-                EvaluationMissingData::new(3);
+            NoOp,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [EvaluationMissingData::value] or
+            /// [EvaluationMissingData::name].
+            UnknownValue(evaluation_missing_data::UnknownValue),
+        }
 
-            /// Creates a new EvaluationMissingData instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod evaluation_missing_data {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl EvaluationMissingData {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Inactive => std::option::Option::Some(1),
+                    Self::Active => std::option::Option::Some(2),
+                    Self::NoOp => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_INACTIVE"),
-                    2 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_ACTIVE"),
-                    3 => std::borrow::Cow::Borrowed("EVALUATION_MISSING_DATA_NO_OP"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("EVALUATION_MISSING_DATA_UNSPECIFIED")
+                    }
+                    Self::Inactive => std::option::Option::Some("EVALUATION_MISSING_DATA_INACTIVE"),
+                    Self::Active => std::option::Option::Some("EVALUATION_MISSING_DATA_ACTIVE"),
+                    Self::NoOp => std::option::Option::Some("EVALUATION_MISSING_DATA_NO_OP"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "EVALUATION_MISSING_DATA_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_UNSPECIFIED)
-                    }
-                    "EVALUATION_MISSING_DATA_INACTIVE" => {
-                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_INACTIVE)
-                    }
-                    "EVALUATION_MISSING_DATA_ACTIVE" => {
-                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_ACTIVE)
-                    }
-                    "EVALUATION_MISSING_DATA_NO_OP" => {
-                        std::option::Option::Some(Self::EVALUATION_MISSING_DATA_NO_OP)
-                    }
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for EvaluationMissingData {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for EvaluationMissingData {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for EvaluationMissingData {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for EvaluationMissingData {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Inactive,
+                    2 => Self::Active,
+                    3 => Self::NoOp,
+                    _ => Self::UnknownValue(evaluation_missing_data::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for EvaluationMissingData {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "EVALUATION_MISSING_DATA_UNSPECIFIED" => Self::Unspecified,
+                    "EVALUATION_MISSING_DATA_INACTIVE" => Self::Inactive,
+                    "EVALUATION_MISSING_DATA_ACTIVE" => Self::Active,
+                    "EVALUATION_MISSING_DATA_NO_OP" => Self::NoOp,
+                    _ => Self::UnknownValue(evaluation_missing_data::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for EvaluationMissingData {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Inactive => serializer.serialize_i32(1),
+                    Self::Active => serializer.serialize_i32(2),
+                    Self::NoOp => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for EvaluationMissingData {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(
+                    wkt::internal::EnumVisitor::<EvaluationMissingData>::new(
+                        ".google.monitoring.v3.AlertPolicy.Condition.EvaluationMissingData",
+                    ),
+                )
             }
         }
 
@@ -2486,199 +2544,388 @@ pub mod alert_policy {
         }
 
         /// Control when notifications will be sent out.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct NotificationPrompt(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum NotificationPrompt {
+            /// No strategy specified. Treated as error.
+            Unspecified,
+            /// Notify when an incident is opened.
+            Opened,
+            /// Notify when an incident is closed.
+            Closed,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [NotificationPrompt::value] or
+            /// [NotificationPrompt::name].
+            UnknownValue(notification_prompt::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod notification_prompt {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl NotificationPrompt {
-            /// No strategy specified. Treated as error.
-            pub const NOTIFICATION_PROMPT_UNSPECIFIED: NotificationPrompt =
-                NotificationPrompt::new(0);
-
-            /// Notify when an incident is opened.
-            pub const OPENED: NotificationPrompt = NotificationPrompt::new(1);
-
-            /// Notify when an incident is closed.
-            pub const CLOSED: NotificationPrompt = NotificationPrompt::new(3);
-
-            /// Creates a new NotificationPrompt instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::Opened => std::option::Option::Some(1),
+                    Self::Closed => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("NOTIFICATION_PROMPT_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("OPENED"),
-                    3 => std::borrow::Cow::Borrowed("CLOSED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "NOTIFICATION_PROMPT_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::NOTIFICATION_PROMPT_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("NOTIFICATION_PROMPT_UNSPECIFIED")
                     }
-                    "OPENED" => std::option::Option::Some(Self::OPENED),
-                    "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                    _ => std::option::Option::None,
+                    Self::Opened => std::option::Option::Some("OPENED"),
+                    Self::Closed => std::option::Option::Some("CLOSED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for NotificationPrompt {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for NotificationPrompt {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for NotificationPrompt {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for NotificationPrompt {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::Opened,
+                    3 => Self::Closed,
+                    _ => Self::UnknownValue(notification_prompt::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for NotificationPrompt {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "NOTIFICATION_PROMPT_UNSPECIFIED" => Self::Unspecified,
+                    "OPENED" => Self::Opened,
+                    "CLOSED" => Self::Closed,
+                    _ => Self::UnknownValue(notification_prompt::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for NotificationPrompt {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::Opened => serializer.serialize_i32(1),
+                    Self::Closed => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for NotificationPrompt {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<NotificationPrompt>::new(
+                    ".google.monitoring.v3.AlertPolicy.AlertStrategy.NotificationPrompt",
+                ))
             }
         }
     }
 
     /// Operators for combining conditions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ConditionCombinerType(i32);
-
-    impl ConditionCombinerType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ConditionCombinerType {
         /// An unspecified combiner.
-        pub const COMBINE_UNSPECIFIED: ConditionCombinerType = ConditionCombinerType::new(0);
-
+        CombineUnspecified,
         /// Combine conditions using the logical `AND` operator. An
         /// incident is created only if all the conditions are met
         /// simultaneously. This combiner is satisfied if all conditions are
         /// met, even if they are met on completely different resources.
-        pub const AND: ConditionCombinerType = ConditionCombinerType::new(1);
-
+        And,
         /// Combine conditions using the logical `OR` operator. An incident
         /// is created if any of the listed conditions is met.
-        pub const OR: ConditionCombinerType = ConditionCombinerType::new(2);
-
+        Or,
         /// Combine conditions using logical `AND` operator, but unlike the regular
         /// `AND` option, an incident is created only if all conditions are met
         /// simultaneously on at least one resource.
-        pub const AND_WITH_MATCHING_RESOURCE: ConditionCombinerType = ConditionCombinerType::new(3);
+        AndWithMatchingResource,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ConditionCombinerType::value] or
+        /// [ConditionCombinerType::name].
+        UnknownValue(condition_combiner_type::UnknownValue),
+    }
 
-        /// Creates a new ConditionCombinerType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod condition_combiner_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ConditionCombinerType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::CombineUnspecified => std::option::Option::Some(0),
+                Self::And => std::option::Option::Some(1),
+                Self::Or => std::option::Option::Some(2),
+                Self::AndWithMatchingResource => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMBINE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AND"),
-                2 => std::borrow::Cow::Borrowed("OR"),
-                3 => std::borrow::Cow::Borrowed("AND_WITH_MATCHING_RESOURCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMBINE_UNSPECIFIED" => std::option::Option::Some(Self::COMBINE_UNSPECIFIED),
-                "AND" => std::option::Option::Some(Self::AND),
-                "OR" => std::option::Option::Some(Self::OR),
-                "AND_WITH_MATCHING_RESOURCE" => {
-                    std::option::Option::Some(Self::AND_WITH_MATCHING_RESOURCE)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::CombineUnspecified => std::option::Option::Some("COMBINE_UNSPECIFIED"),
+                Self::And => std::option::Option::Some("AND"),
+                Self::Or => std::option::Option::Some("OR"),
+                Self::AndWithMatchingResource => {
+                    std::option::Option::Some("AND_WITH_MATCHING_RESOURCE")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ConditionCombinerType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ConditionCombinerType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ConditionCombinerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ConditionCombinerType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::CombineUnspecified,
+                1 => Self::And,
+                2 => Self::Or,
+                3 => Self::AndWithMatchingResource,
+                _ => Self::UnknownValue(condition_combiner_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ConditionCombinerType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMBINE_UNSPECIFIED" => Self::CombineUnspecified,
+                "AND" => Self::And,
+                "OR" => Self::Or,
+                "AND_WITH_MATCHING_RESOURCE" => Self::AndWithMatchingResource,
+                _ => Self::UnknownValue(condition_combiner_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ConditionCombinerType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::CombineUnspecified => serializer.serialize_i32(0),
+                Self::And => serializer.serialize_i32(1),
+                Self::Or => serializer.serialize_i32(2),
+                Self::AndWithMatchingResource => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ConditionCombinerType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConditionCombinerType>::new(
+                ".google.monitoring.v3.AlertPolicy.ConditionCombinerType",
+            ))
         }
     }
 
     /// An enumeration of possible severity level for an alerting policy.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
-
-    impl Severity {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
         /// No severity is specified. This is the default value.
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
+        Unspecified,
         /// This is the highest severity level. Use this if the problem could
         /// cause significant damage or downtime.
-        pub const CRITICAL: Severity = Severity::new(1);
-
+        Critical,
         /// This is the medium severity level. Use this if the problem could
         /// cause minor damage or downtime.
-        pub const ERROR: Severity = Severity::new(2);
-
+        Error,
         /// This is the lowest severity level. Use this if the problem is not causing
         /// any damage or downtime, but could potentially lead to a problem in the
         /// future.
-        pub const WARNING: Severity = Severity::new(3);
+        Warning,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
 
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Severity {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Critical => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::Warning => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CRITICAL"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                3 => std::borrow::Cow::Borrowed("WARNING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Critical => std::option::Option::Some("CRITICAL"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Critical,
+                2 => Self::Error,
+                3 => Self::Warning,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "CRITICAL" => Self::Critical,
+                "ERROR" => Self::Error,
+                "WARNING" => Self::Warning,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Critical => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::Warning => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.monitoring.v3.AlertPolicy.Severity",
+            ))
         }
     }
 }
@@ -3508,15 +3755,13 @@ pub mod aggregation {
     /// example, if you apply a counting operation to boolean values, the data
     /// `value_type` in the original time series is `BOOLEAN`, but the `value_type`
     /// in the aligned result is `INT64`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Aligner(i32);
-
-    impl Aligner {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Aligner {
         /// No alignment. Raw data is returned. Not valid if cross-series reduction
         /// is requested. The `value_type` of the result is the same as the
         /// `value_type` of the input.
-        pub const ALIGN_NONE: Aligner = Aligner::new(0);
-
+        AlignNone,
         /// Align and convert to
         /// [DELTA][google.api.MetricDescriptor.MetricKind.DELTA].
         /// The output is `delta = y1 - y0`.
@@ -3528,10 +3773,9 @@ pub mod aggregation {
         /// interpolation. The `value_type`  of the aligned result is the same as
         /// the `value_type` of the input.
         ///
-        /// [google.api.MetricDescriptor.MetricKind.CUMULATIVE]: api::model::metric_descriptor::metric_kind::CUMULATIVE
-        /// [google.api.MetricDescriptor.MetricKind.DELTA]: api::model::metric_descriptor::metric_kind::DELTA
-        pub const ALIGN_DELTA: Aligner = Aligner::new(1);
-
+        /// [google.api.MetricDescriptor.MetricKind.CUMULATIVE]: api::model::metric_descriptor::MetricKind::Cumulative
+        /// [google.api.MetricDescriptor.MetricKind.DELTA]: api::model::metric_descriptor::MetricKind::Delta
+        AlignDelta,
         /// Align and convert to a rate. The result is computed as
         /// `rate = (y1 - y0)/(t1 - t0)`, or "delta over time".
         /// Think of this aligner as providing the slope of the line that passes
@@ -3545,103 +3789,87 @@ pub mod aggregation {
         ///
         /// If, by "rate", you mean "percentage change", see the
         /// `ALIGN_PERCENT_CHANGE` aligner instead.
-        pub const ALIGN_RATE: Aligner = Aligner::new(2);
-
+        AlignRate,
         /// Align by interpolating between adjacent points around the alignment
         /// period boundary. This aligner is valid for `GAUGE` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as the
         /// `value_type` of the input.
-        pub const ALIGN_INTERPOLATE: Aligner = Aligner::new(3);
-
+        AlignInterpolate,
         /// Align by moving the most recent data point before the end of the
         /// alignment period to the boundary at the end of the alignment
         /// period. This aligner is valid for `GAUGE` metrics. The `value_type` of
         /// the aligned result is the same as the `value_type` of the input.
-        pub const ALIGN_NEXT_OLDER: Aligner = Aligner::new(4);
-
+        AlignNextOlder,
         /// Align the time series by returning the minimum value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_MIN: Aligner = Aligner::new(10);
-
+        AlignMin,
         /// Align the time series by returning the maximum value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is the same as
         /// the `value_type` of the input.
-        pub const ALIGN_MAX: Aligner = Aligner::new(11);
-
+        AlignMax,
         /// Align the time series by returning the mean value in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric values. The `value_type` of the aligned result is `DOUBLE`.
-        pub const ALIGN_MEAN: Aligner = Aligner::new(12);
-
+        AlignMean,
         /// Align the time series by returning the number of values in each alignment
         /// period. This aligner is valid for `GAUGE` and `DELTA` metrics with
         /// numeric or Boolean values. The `value_type` of the aligned result is
         /// `INT64`.
-        pub const ALIGN_COUNT: Aligner = Aligner::new(13);
-
+        AlignCount,
         /// Align the time series by returning the sum of the values in each
         /// alignment period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with numeric and distribution values. The `value_type` of the
         /// aligned result is the same as the `value_type` of the input.
-        pub const ALIGN_SUM: Aligner = Aligner::new(14);
-
+        AlignSum,
         /// Align the time series by returning the standard deviation of the values
         /// in each alignment period. This aligner is valid for `GAUGE` and
         /// `DELTA` metrics with numeric values. The `value_type` of the output is
         /// `DOUBLE`.
-        pub const ALIGN_STDDEV: Aligner = Aligner::new(15);
-
+        AlignStddev,
         /// Align the time series by returning the number of `True` values in
         /// each alignment period. This aligner is valid for `GAUGE` metrics with
         /// Boolean values. The `value_type` of the output is `INT64`.
-        pub const ALIGN_COUNT_TRUE: Aligner = Aligner::new(16);
-
+        AlignCountTrue,
         /// Align the time series by returning the number of `False` values in
         /// each alignment period. This aligner is valid for `GAUGE` metrics with
         /// Boolean values. The `value_type` of the output is `INT64`.
-        pub const ALIGN_COUNT_FALSE: Aligner = Aligner::new(24);
-
+        AlignCountFalse,
         /// Align the time series by returning the ratio of the number of `True`
         /// values to the total number of values in each alignment period. This
         /// aligner is valid for `GAUGE` metrics with Boolean values. The output
         /// value is in the range [0.0, 1.0] and has `value_type` `DOUBLE`.
-        pub const ALIGN_FRACTION_TRUE: Aligner = Aligner::new(17);
-
+        AlignFractionTrue,
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
         /// data point in each alignment period is the 99th percentile of all data
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_99: Aligner = Aligner::new(18);
-
+        AlignPercentile99,
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
         /// data point in each alignment period is the 95th percentile of all data
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_95: Aligner = Aligner::new(19);
-
+        AlignPercentile95,
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
         /// data point in each alignment period is the 50th percentile of all data
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_50: Aligner = Aligner::new(20);
-
+        AlignPercentile50,
         /// Align the time series by using [percentile
         /// aggregation](https://en.wikipedia.org/wiki/Percentile). The resulting
         /// data point in each alignment period is the 5th percentile of all data
         /// points in the period. This aligner is valid for `GAUGE` and `DELTA`
         /// metrics with distribution values. The output is a `GAUGE` metric with
         /// `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENTILE_05: Aligner = Aligner::new(21);
-
+        AlignPercentile05,
         /// Align and convert to a percentage change. This aligner is valid for
         /// `GAUGE` and `DELTA` metrics with numeric values. This alignment returns
         /// `((current - previous)/previous) * 100`, where the value of `previous` is
@@ -3658,80 +3886,192 @@ pub mod aggregation {
         /// metrics are accepted by this alignment, special care should be taken that
         /// the values for the metric will always be positive. The output is a
         /// `GAUGE` metric with `value_type` `DOUBLE`.
-        pub const ALIGN_PERCENT_CHANGE: Aligner = Aligner::new(23);
+        AlignPercentChange,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Aligner::value] or
+        /// [Aligner::name].
+        UnknownValue(aligner::UnknownValue),
+    }
 
-        /// Creates a new Aligner instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod aligner {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Aligner {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::AlignNone => std::option::Option::Some(0),
+                Self::AlignDelta => std::option::Option::Some(1),
+                Self::AlignRate => std::option::Option::Some(2),
+                Self::AlignInterpolate => std::option::Option::Some(3),
+                Self::AlignNextOlder => std::option::Option::Some(4),
+                Self::AlignMin => std::option::Option::Some(10),
+                Self::AlignMax => std::option::Option::Some(11),
+                Self::AlignMean => std::option::Option::Some(12),
+                Self::AlignCount => std::option::Option::Some(13),
+                Self::AlignSum => std::option::Option::Some(14),
+                Self::AlignStddev => std::option::Option::Some(15),
+                Self::AlignCountTrue => std::option::Option::Some(16),
+                Self::AlignCountFalse => std::option::Option::Some(24),
+                Self::AlignFractionTrue => std::option::Option::Some(17),
+                Self::AlignPercentile99 => std::option::Option::Some(18),
+                Self::AlignPercentile95 => std::option::Option::Some(19),
+                Self::AlignPercentile50 => std::option::Option::Some(20),
+                Self::AlignPercentile05 => std::option::Option::Some(21),
+                Self::AlignPercentChange => std::option::Option::Some(23),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ALIGN_NONE"),
-                1 => std::borrow::Cow::Borrowed("ALIGN_DELTA"),
-                2 => std::borrow::Cow::Borrowed("ALIGN_RATE"),
-                3 => std::borrow::Cow::Borrowed("ALIGN_INTERPOLATE"),
-                4 => std::borrow::Cow::Borrowed("ALIGN_NEXT_OLDER"),
-                10 => std::borrow::Cow::Borrowed("ALIGN_MIN"),
-                11 => std::borrow::Cow::Borrowed("ALIGN_MAX"),
-                12 => std::borrow::Cow::Borrowed("ALIGN_MEAN"),
-                13 => std::borrow::Cow::Borrowed("ALIGN_COUNT"),
-                14 => std::borrow::Cow::Borrowed("ALIGN_SUM"),
-                15 => std::borrow::Cow::Borrowed("ALIGN_STDDEV"),
-                16 => std::borrow::Cow::Borrowed("ALIGN_COUNT_TRUE"),
-                17 => std::borrow::Cow::Borrowed("ALIGN_FRACTION_TRUE"),
-                18 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_99"),
-                19 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_95"),
-                20 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_50"),
-                21 => std::borrow::Cow::Borrowed("ALIGN_PERCENTILE_05"),
-                23 => std::borrow::Cow::Borrowed("ALIGN_PERCENT_CHANGE"),
-                24 => std::borrow::Cow::Borrowed("ALIGN_COUNT_FALSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::AlignNone => std::option::Option::Some("ALIGN_NONE"),
+                Self::AlignDelta => std::option::Option::Some("ALIGN_DELTA"),
+                Self::AlignRate => std::option::Option::Some("ALIGN_RATE"),
+                Self::AlignInterpolate => std::option::Option::Some("ALIGN_INTERPOLATE"),
+                Self::AlignNextOlder => std::option::Option::Some("ALIGN_NEXT_OLDER"),
+                Self::AlignMin => std::option::Option::Some("ALIGN_MIN"),
+                Self::AlignMax => std::option::Option::Some("ALIGN_MAX"),
+                Self::AlignMean => std::option::Option::Some("ALIGN_MEAN"),
+                Self::AlignCount => std::option::Option::Some("ALIGN_COUNT"),
+                Self::AlignSum => std::option::Option::Some("ALIGN_SUM"),
+                Self::AlignStddev => std::option::Option::Some("ALIGN_STDDEV"),
+                Self::AlignCountTrue => std::option::Option::Some("ALIGN_COUNT_TRUE"),
+                Self::AlignCountFalse => std::option::Option::Some("ALIGN_COUNT_FALSE"),
+                Self::AlignFractionTrue => std::option::Option::Some("ALIGN_FRACTION_TRUE"),
+                Self::AlignPercentile99 => std::option::Option::Some("ALIGN_PERCENTILE_99"),
+                Self::AlignPercentile95 => std::option::Option::Some("ALIGN_PERCENTILE_95"),
+                Self::AlignPercentile50 => std::option::Option::Some("ALIGN_PERCENTILE_50"),
+                Self::AlignPercentile05 => std::option::Option::Some("ALIGN_PERCENTILE_05"),
+                Self::AlignPercentChange => std::option::Option::Some("ALIGN_PERCENT_CHANGE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ALIGN_NONE" => std::option::Option::Some(Self::ALIGN_NONE),
-                "ALIGN_DELTA" => std::option::Option::Some(Self::ALIGN_DELTA),
-                "ALIGN_RATE" => std::option::Option::Some(Self::ALIGN_RATE),
-                "ALIGN_INTERPOLATE" => std::option::Option::Some(Self::ALIGN_INTERPOLATE),
-                "ALIGN_NEXT_OLDER" => std::option::Option::Some(Self::ALIGN_NEXT_OLDER),
-                "ALIGN_MIN" => std::option::Option::Some(Self::ALIGN_MIN),
-                "ALIGN_MAX" => std::option::Option::Some(Self::ALIGN_MAX),
-                "ALIGN_MEAN" => std::option::Option::Some(Self::ALIGN_MEAN),
-                "ALIGN_COUNT" => std::option::Option::Some(Self::ALIGN_COUNT),
-                "ALIGN_SUM" => std::option::Option::Some(Self::ALIGN_SUM),
-                "ALIGN_STDDEV" => std::option::Option::Some(Self::ALIGN_STDDEV),
-                "ALIGN_COUNT_TRUE" => std::option::Option::Some(Self::ALIGN_COUNT_TRUE),
-                "ALIGN_COUNT_FALSE" => std::option::Option::Some(Self::ALIGN_COUNT_FALSE),
-                "ALIGN_FRACTION_TRUE" => std::option::Option::Some(Self::ALIGN_FRACTION_TRUE),
-                "ALIGN_PERCENTILE_99" => std::option::Option::Some(Self::ALIGN_PERCENTILE_99),
-                "ALIGN_PERCENTILE_95" => std::option::Option::Some(Self::ALIGN_PERCENTILE_95),
-                "ALIGN_PERCENTILE_50" => std::option::Option::Some(Self::ALIGN_PERCENTILE_50),
-                "ALIGN_PERCENTILE_05" => std::option::Option::Some(Self::ALIGN_PERCENTILE_05),
-                "ALIGN_PERCENT_CHANGE" => std::option::Option::Some(Self::ALIGN_PERCENT_CHANGE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Aligner {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Aligner {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Aligner {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Aligner {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::AlignNone,
+                1 => Self::AlignDelta,
+                2 => Self::AlignRate,
+                3 => Self::AlignInterpolate,
+                4 => Self::AlignNextOlder,
+                10 => Self::AlignMin,
+                11 => Self::AlignMax,
+                12 => Self::AlignMean,
+                13 => Self::AlignCount,
+                14 => Self::AlignSum,
+                15 => Self::AlignStddev,
+                16 => Self::AlignCountTrue,
+                17 => Self::AlignFractionTrue,
+                18 => Self::AlignPercentile99,
+                19 => Self::AlignPercentile95,
+                20 => Self::AlignPercentile50,
+                21 => Self::AlignPercentile05,
+                23 => Self::AlignPercentChange,
+                24 => Self::AlignCountFalse,
+                _ => Self::UnknownValue(aligner::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Aligner {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ALIGN_NONE" => Self::AlignNone,
+                "ALIGN_DELTA" => Self::AlignDelta,
+                "ALIGN_RATE" => Self::AlignRate,
+                "ALIGN_INTERPOLATE" => Self::AlignInterpolate,
+                "ALIGN_NEXT_OLDER" => Self::AlignNextOlder,
+                "ALIGN_MIN" => Self::AlignMin,
+                "ALIGN_MAX" => Self::AlignMax,
+                "ALIGN_MEAN" => Self::AlignMean,
+                "ALIGN_COUNT" => Self::AlignCount,
+                "ALIGN_SUM" => Self::AlignSum,
+                "ALIGN_STDDEV" => Self::AlignStddev,
+                "ALIGN_COUNT_TRUE" => Self::AlignCountTrue,
+                "ALIGN_COUNT_FALSE" => Self::AlignCountFalse,
+                "ALIGN_FRACTION_TRUE" => Self::AlignFractionTrue,
+                "ALIGN_PERCENTILE_99" => Self::AlignPercentile99,
+                "ALIGN_PERCENTILE_95" => Self::AlignPercentile95,
+                "ALIGN_PERCENTILE_50" => Self::AlignPercentile50,
+                "ALIGN_PERCENTILE_05" => Self::AlignPercentile05,
+                "ALIGN_PERCENT_CHANGE" => Self::AlignPercentChange,
+                _ => Self::UnknownValue(aligner::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Aligner {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::AlignNone => serializer.serialize_i32(0),
+                Self::AlignDelta => serializer.serialize_i32(1),
+                Self::AlignRate => serializer.serialize_i32(2),
+                Self::AlignInterpolate => serializer.serialize_i32(3),
+                Self::AlignNextOlder => serializer.serialize_i32(4),
+                Self::AlignMin => serializer.serialize_i32(10),
+                Self::AlignMax => serializer.serialize_i32(11),
+                Self::AlignMean => serializer.serialize_i32(12),
+                Self::AlignCount => serializer.serialize_i32(13),
+                Self::AlignSum => serializer.serialize_i32(14),
+                Self::AlignStddev => serializer.serialize_i32(15),
+                Self::AlignCountTrue => serializer.serialize_i32(16),
+                Self::AlignCountFalse => serializer.serialize_i32(24),
+                Self::AlignFractionTrue => serializer.serialize_i32(17),
+                Self::AlignPercentile99 => serializer.serialize_i32(18),
+                Self::AlignPercentile95 => serializer.serialize_i32(19),
+                Self::AlignPercentile50 => serializer.serialize_i32(20),
+                Self::AlignPercentile05 => serializer.serialize_i32(21),
+                Self::AlignPercentChange => serializer.serialize_i32(23),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Aligner {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Aligner>::new(
+                ".google.monitoring.v3.Aggregation.Aligner",
+            ))
         }
     }
 
@@ -3739,14 +4079,12 @@ pub mod aggregation {
     /// time series into a single time series, where the value of each data point
     /// in the resulting series is a function of all the already aligned values in
     /// the input time series.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Reducer(i32);
-
-    impl Reducer {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Reducer {
         /// No cross-time series reduction. The output of the `Aligner` is
         /// returned.
-        pub const REDUCE_NONE: Reducer = Reducer::new(0);
-
+        ReduceNone,
         /// Reduce by computing the mean value across time series for each
         /// alignment period. This reducer is valid for
         /// [DELTA][google.api.MetricDescriptor.MetricKind.DELTA] and
@@ -3754,150 +4092,235 @@ pub mod aggregation {
         /// numeric or distribution values. The `value_type` of the output is
         /// [DOUBLE][google.api.MetricDescriptor.ValueType.DOUBLE].
         ///
-        /// [google.api.MetricDescriptor.MetricKind.DELTA]: api::model::metric_descriptor::metric_kind::DELTA
-        /// [google.api.MetricDescriptor.MetricKind.GAUGE]: api::model::metric_descriptor::metric_kind::GAUGE
-        /// [google.api.MetricDescriptor.ValueType.DOUBLE]: api::model::metric_descriptor::value_type::DOUBLE
-        pub const REDUCE_MEAN: Reducer = Reducer::new(1);
-
+        /// [google.api.MetricDescriptor.MetricKind.DELTA]: api::model::metric_descriptor::MetricKind::Delta
+        /// [google.api.MetricDescriptor.MetricKind.GAUGE]: api::model::metric_descriptor::MetricKind::Gauge
+        /// [google.api.MetricDescriptor.ValueType.DOUBLE]: api::model::metric_descriptor::ValueType::Double
+        ReduceMean,
         /// Reduce by computing the minimum value across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric values. The `value_type` of the output is the same as the
         /// `value_type` of the input.
-        pub const REDUCE_MIN: Reducer = Reducer::new(2);
-
+        ReduceMin,
         /// Reduce by computing the maximum value across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric values. The `value_type` of the output is the same as the
         /// `value_type` of the input.
-        pub const REDUCE_MAX: Reducer = Reducer::new(3);
-
+        ReduceMax,
         /// Reduce by computing the sum across time series for each
         /// alignment period. This reducer is valid for `DELTA` and `GAUGE` metrics
         /// with numeric and distribution values. The `value_type` of the output is
         /// the same as the `value_type` of the input.
-        pub const REDUCE_SUM: Reducer = Reducer::new(4);
-
+        ReduceSum,
         /// Reduce by computing the standard deviation across time series
         /// for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics with numeric or distribution values. The `value_type`
         /// of the output is `DOUBLE`.
-        pub const REDUCE_STDDEV: Reducer = Reducer::new(5);
-
+        ReduceStddev,
         /// Reduce by computing the number of data points across time series
         /// for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of numeric, Boolean, distribution, and string
         /// `value_type`. The `value_type` of the output is `INT64`.
-        pub const REDUCE_COUNT: Reducer = Reducer::new(6);
-
+        ReduceCount,
         /// Reduce by computing the number of `True`-valued data points across time
         /// series for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of Boolean `value_type`. The `value_type` of the output
         /// is `INT64`.
-        pub const REDUCE_COUNT_TRUE: Reducer = Reducer::new(7);
-
+        ReduceCountTrue,
         /// Reduce by computing the number of `False`-valued data points across time
         /// series for each alignment period. This reducer is valid for `DELTA` and
         /// `GAUGE` metrics of Boolean `value_type`. The `value_type` of the output
         /// is `INT64`.
-        pub const REDUCE_COUNT_FALSE: Reducer = Reducer::new(15);
-
+        ReduceCountFalse,
         /// Reduce by computing the ratio of the number of `True`-valued data points
         /// to the total number of data points for each alignment period. This
         /// reducer is valid for `DELTA` and `GAUGE` metrics of Boolean `value_type`.
         /// The output value is in the range [0.0, 1.0] and has `value_type`
         /// `DOUBLE`.
-        pub const REDUCE_FRACTION_TRUE: Reducer = Reducer::new(8);
-
+        ReduceFractionTrue,
         /// Reduce by computing the [99th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_99: Reducer = Reducer::new(9);
-
+        ReducePercentile99,
         /// Reduce by computing the [95th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_95: Reducer = Reducer::new(10);
-
+        ReducePercentile95,
         /// Reduce by computing the [50th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_50: Reducer = Reducer::new(11);
-
+        ReducePercentile50,
         /// Reduce by computing the [5th
         /// percentile](https://en.wikipedia.org/wiki/Percentile) of data points
         /// across time series for each alignment period. This reducer is valid for
         /// `GAUGE` and `DELTA` metrics of numeric and distribution type. The value
         /// of the output is `DOUBLE`.
-        pub const REDUCE_PERCENTILE_05: Reducer = Reducer::new(12);
+        ReducePercentile05,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Reducer::value] or
+        /// [Reducer::name].
+        UnknownValue(reducer::UnknownValue),
+    }
 
-        /// Creates a new Reducer instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod reducer {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Reducer {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::ReduceNone => std::option::Option::Some(0),
+                Self::ReduceMean => std::option::Option::Some(1),
+                Self::ReduceMin => std::option::Option::Some(2),
+                Self::ReduceMax => std::option::Option::Some(3),
+                Self::ReduceSum => std::option::Option::Some(4),
+                Self::ReduceStddev => std::option::Option::Some(5),
+                Self::ReduceCount => std::option::Option::Some(6),
+                Self::ReduceCountTrue => std::option::Option::Some(7),
+                Self::ReduceCountFalse => std::option::Option::Some(15),
+                Self::ReduceFractionTrue => std::option::Option::Some(8),
+                Self::ReducePercentile99 => std::option::Option::Some(9),
+                Self::ReducePercentile95 => std::option::Option::Some(10),
+                Self::ReducePercentile50 => std::option::Option::Some(11),
+                Self::ReducePercentile05 => std::option::Option::Some(12),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REDUCE_NONE"),
-                1 => std::borrow::Cow::Borrowed("REDUCE_MEAN"),
-                2 => std::borrow::Cow::Borrowed("REDUCE_MIN"),
-                3 => std::borrow::Cow::Borrowed("REDUCE_MAX"),
-                4 => std::borrow::Cow::Borrowed("REDUCE_SUM"),
-                5 => std::borrow::Cow::Borrowed("REDUCE_STDDEV"),
-                6 => std::borrow::Cow::Borrowed("REDUCE_COUNT"),
-                7 => std::borrow::Cow::Borrowed("REDUCE_COUNT_TRUE"),
-                8 => std::borrow::Cow::Borrowed("REDUCE_FRACTION_TRUE"),
-                9 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_99"),
-                10 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_95"),
-                11 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_50"),
-                12 => std::borrow::Cow::Borrowed("REDUCE_PERCENTILE_05"),
-                15 => std::borrow::Cow::Borrowed("REDUCE_COUNT_FALSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::ReduceNone => std::option::Option::Some("REDUCE_NONE"),
+                Self::ReduceMean => std::option::Option::Some("REDUCE_MEAN"),
+                Self::ReduceMin => std::option::Option::Some("REDUCE_MIN"),
+                Self::ReduceMax => std::option::Option::Some("REDUCE_MAX"),
+                Self::ReduceSum => std::option::Option::Some("REDUCE_SUM"),
+                Self::ReduceStddev => std::option::Option::Some("REDUCE_STDDEV"),
+                Self::ReduceCount => std::option::Option::Some("REDUCE_COUNT"),
+                Self::ReduceCountTrue => std::option::Option::Some("REDUCE_COUNT_TRUE"),
+                Self::ReduceCountFalse => std::option::Option::Some("REDUCE_COUNT_FALSE"),
+                Self::ReduceFractionTrue => std::option::Option::Some("REDUCE_FRACTION_TRUE"),
+                Self::ReducePercentile99 => std::option::Option::Some("REDUCE_PERCENTILE_99"),
+                Self::ReducePercentile95 => std::option::Option::Some("REDUCE_PERCENTILE_95"),
+                Self::ReducePercentile50 => std::option::Option::Some("REDUCE_PERCENTILE_50"),
+                Self::ReducePercentile05 => std::option::Option::Some("REDUCE_PERCENTILE_05"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REDUCE_NONE" => std::option::Option::Some(Self::REDUCE_NONE),
-                "REDUCE_MEAN" => std::option::Option::Some(Self::REDUCE_MEAN),
-                "REDUCE_MIN" => std::option::Option::Some(Self::REDUCE_MIN),
-                "REDUCE_MAX" => std::option::Option::Some(Self::REDUCE_MAX),
-                "REDUCE_SUM" => std::option::Option::Some(Self::REDUCE_SUM),
-                "REDUCE_STDDEV" => std::option::Option::Some(Self::REDUCE_STDDEV),
-                "REDUCE_COUNT" => std::option::Option::Some(Self::REDUCE_COUNT),
-                "REDUCE_COUNT_TRUE" => std::option::Option::Some(Self::REDUCE_COUNT_TRUE),
-                "REDUCE_COUNT_FALSE" => std::option::Option::Some(Self::REDUCE_COUNT_FALSE),
-                "REDUCE_FRACTION_TRUE" => std::option::Option::Some(Self::REDUCE_FRACTION_TRUE),
-                "REDUCE_PERCENTILE_99" => std::option::Option::Some(Self::REDUCE_PERCENTILE_99),
-                "REDUCE_PERCENTILE_95" => std::option::Option::Some(Self::REDUCE_PERCENTILE_95),
-                "REDUCE_PERCENTILE_50" => std::option::Option::Some(Self::REDUCE_PERCENTILE_50),
-                "REDUCE_PERCENTILE_05" => std::option::Option::Some(Self::REDUCE_PERCENTILE_05),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Reducer {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Reducer {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Reducer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Reducer {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::ReduceNone,
+                1 => Self::ReduceMean,
+                2 => Self::ReduceMin,
+                3 => Self::ReduceMax,
+                4 => Self::ReduceSum,
+                5 => Self::ReduceStddev,
+                6 => Self::ReduceCount,
+                7 => Self::ReduceCountTrue,
+                8 => Self::ReduceFractionTrue,
+                9 => Self::ReducePercentile99,
+                10 => Self::ReducePercentile95,
+                11 => Self::ReducePercentile50,
+                12 => Self::ReducePercentile05,
+                15 => Self::ReduceCountFalse,
+                _ => Self::UnknownValue(reducer::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Reducer {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REDUCE_NONE" => Self::ReduceNone,
+                "REDUCE_MEAN" => Self::ReduceMean,
+                "REDUCE_MIN" => Self::ReduceMin,
+                "REDUCE_MAX" => Self::ReduceMax,
+                "REDUCE_SUM" => Self::ReduceSum,
+                "REDUCE_STDDEV" => Self::ReduceStddev,
+                "REDUCE_COUNT" => Self::ReduceCount,
+                "REDUCE_COUNT_TRUE" => Self::ReduceCountTrue,
+                "REDUCE_COUNT_FALSE" => Self::ReduceCountFalse,
+                "REDUCE_FRACTION_TRUE" => Self::ReduceFractionTrue,
+                "REDUCE_PERCENTILE_99" => Self::ReducePercentile99,
+                "REDUCE_PERCENTILE_95" => Self::ReducePercentile95,
+                "REDUCE_PERCENTILE_50" => Self::ReducePercentile50,
+                "REDUCE_PERCENTILE_05" => Self::ReducePercentile05,
+                _ => Self::UnknownValue(reducer::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Reducer {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::ReduceNone => serializer.serialize_i32(0),
+                Self::ReduceMean => serializer.serialize_i32(1),
+                Self::ReduceMin => serializer.serialize_i32(2),
+                Self::ReduceMax => serializer.serialize_i32(3),
+                Self::ReduceSum => serializer.serialize_i32(4),
+                Self::ReduceStddev => serializer.serialize_i32(5),
+                Self::ReduceCount => serializer.serialize_i32(6),
+                Self::ReduceCountTrue => serializer.serialize_i32(7),
+                Self::ReduceCountFalse => serializer.serialize_i32(15),
+                Self::ReduceFractionTrue => serializer.serialize_i32(8),
+                Self::ReducePercentile99 => serializer.serialize_i32(9),
+                Self::ReducePercentile95 => serializer.serialize_i32(10),
+                Self::ReducePercentile50 => serializer.serialize_i32(11),
+                Self::ReducePercentile05 => serializer.serialize_i32(12),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Reducer {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Reducer>::new(
+                ".google.monitoring.v3.Aggregation.Reducer",
+            ))
         }
     }
 }
@@ -6144,56 +6567,115 @@ pub mod list_time_series_request {
     use super::*;
 
     /// Controls which fields are returned by `ListTimeSeries*`.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeSeriesView(i32);
-
-    impl TimeSeriesView {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimeSeriesView {
         /// Returns the identity of the metric(s), the time series,
         /// and the time series data.
-        pub const FULL: TimeSeriesView = TimeSeriesView::new(0);
-
+        Full,
         /// Returns the identity of the metric and the time series resource,
         /// but not the time series data.
-        pub const HEADERS: TimeSeriesView = TimeSeriesView::new(1);
+        Headers,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimeSeriesView::value] or
+        /// [TimeSeriesView::name].
+        UnknownValue(time_series_view::UnknownValue),
+    }
 
-        /// Creates a new TimeSeriesView instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod time_series_view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TimeSeriesView {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Full => std::option::Option::Some(0),
+                Self::Headers => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FULL"),
-                1 => std::borrow::Cow::Borrowed("HEADERS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::Headers => std::option::Option::Some("HEADERS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FULL" => std::option::Option::Some(Self::FULL),
-                "HEADERS" => std::option::Option::Some(Self::HEADERS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TimeSeriesView {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeSeriesView {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimeSeriesView {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimeSeriesView {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Full,
+                1 => Self::Headers,
+                _ => Self::UnknownValue(time_series_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimeSeriesView {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FULL" => Self::Full,
+                "HEADERS" => Self::Headers,
+                _ => Self::UnknownValue(time_series_view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimeSeriesView {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Full => serializer.serialize_i32(0),
+                Self::Headers => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimeSeriesView {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimeSeriesView>::new(
+                ".google.monitoring.v3.ListTimeSeriesRequest.TimeSeriesView",
+            ))
         }
     }
 }
@@ -7121,68 +7603,127 @@ pub mod notification_channel {
     ///
     /// [google.monitoring.v3.NotificationChannelService.CreateNotificationChannel]: crate::client::NotificationChannelService::create_notification_channel
     /// [google.monitoring.v3.NotificationChannelService.UpdateNotificationChannel]: crate::client::NotificationChannelService::update_notification_channel
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VerificationStatus(i32);
-
-    impl VerificationStatus {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VerificationStatus {
         /// Sentinel value used to indicate that the state is unknown, omitted, or
         /// is not applicable (as in the case of channels that neither support
         /// nor require verification in order to function).
-        pub const VERIFICATION_STATUS_UNSPECIFIED: VerificationStatus = VerificationStatus::new(0);
-
+        Unspecified,
         /// The channel has yet to be verified and requires verification to function.
         /// Note that this state also applies to the case where the verification
         /// process has been initiated by sending a verification code but where
         /// the verification code has not been submitted to complete the process.
-        pub const UNVERIFIED: VerificationStatus = VerificationStatus::new(1);
-
+        Unverified,
         /// It has been proven that notifications can be received on this
         /// notification channel and that someone on the project has access
         /// to messages that are delivered to that channel.
-        pub const VERIFIED: VerificationStatus = VerificationStatus::new(2);
+        Verified,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VerificationStatus::value] or
+        /// [VerificationStatus::name].
+        UnknownValue(verification_status::UnknownValue),
+    }
 
-        /// Creates a new VerificationStatus instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod verification_status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl VerificationStatus {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unverified => std::option::Option::Some(1),
+                Self::Verified => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VERIFICATION_STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UNVERIFIED"),
-                2 => std::borrow::Cow::Borrowed("VERIFIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VERIFICATION_STATUS_UNSPECIFIED"),
+                Self::Unverified => std::option::Option::Some("UNVERIFIED"),
+                Self::Verified => std::option::Option::Some("VERIFIED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VERIFICATION_STATUS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::VERIFICATION_STATUS_UNSPECIFIED)
-                }
-                "UNVERIFIED" => std::option::Option::Some(Self::UNVERIFIED),
-                "VERIFIED" => std::option::Option::Some(Self::VERIFIED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VerificationStatus {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VerificationStatus {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VerificationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VerificationStatus {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unverified,
+                2 => Self::Verified,
+                _ => Self::UnknownValue(verification_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VerificationStatus {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VERIFICATION_STATUS_UNSPECIFIED" => Self::Unspecified,
+                "UNVERIFIED" => Self::Unverified,
+                "VERIFIED" => Self::Verified,
+                _ => Self::UnknownValue(verification_status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VerificationStatus {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unverified => serializer.serialize_i32(1),
+                Self::Verified => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VerificationStatus {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VerificationStatus>::new(
+                ".google.monitoring.v3.NotificationChannel.VerificationStatus",
+            ))
         }
     }
 }
@@ -9244,64 +9785,125 @@ pub mod service_level_objective {
     /// `ServiceLevelObjective.View` determines what form of
     /// `ServiceLevelObjective` is returned from `GetServiceLevelObjective`,
     /// `ListServiceLevelObjectives`, and `ListServiceLevelObjectiveVersions` RPCs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct View(i32);
-
-    impl View {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum View {
         /// Same as FULL.
-        pub const VIEW_UNSPECIFIED: View = View::new(0);
-
+        Unspecified,
         /// Return the embedded `ServiceLevelIndicator` in the form in which it was
         /// defined. If it was defined using a `BasicSli`, return that `BasicSli`.
-        pub const FULL: View = View::new(2);
-
+        Full,
         /// For `ServiceLevelIndicator`s using `BasicSli` articulation, instead
         /// return the `ServiceLevelIndicator` with its mode of computation fully
         /// spelled out as a `RequestBasedSli`. For `ServiceLevelIndicator`s using
         /// `RequestBasedSli` or `WindowsBasedSli`, return the
         /// `ServiceLevelIndicator` as it was provided.
-        pub const EXPLICIT: View = View::new(1);
+        Explicit,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [View::value] or
+        /// [View::name].
+        UnknownValue(view::UnknownValue),
+    }
 
-        /// Creates a new View instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod view {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl View {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Full => std::option::Option::Some(2),
+                Self::Explicit => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VIEW_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXPLICIT"),
-                2 => std::borrow::Cow::Borrowed("FULL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VIEW_UNSPECIFIED"),
+                Self::Full => std::option::Option::Some("FULL"),
+                Self::Explicit => std::option::Option::Some("EXPLICIT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VIEW_UNSPECIFIED" => std::option::Option::Some(Self::VIEW_UNSPECIFIED),
-                "FULL" => std::option::Option::Some(Self::FULL),
-                "EXPLICIT" => std::option::Option::Some(Self::EXPLICIT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for View {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for View {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for View {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for View {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Explicit,
+                2 => Self::Full,
+                _ => Self::UnknownValue(view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for View {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VIEW_UNSPECIFIED" => Self::Unspecified,
+                "FULL" => Self::Full,
+                "EXPLICIT" => Self::Explicit,
+                _ => Self::UnknownValue(view::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for View {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Full => serializer.serialize_i32(2),
+                Self::Explicit => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for View {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<View>::new(
+                ".google.monitoring.v3.ServiceLevelObjective.View",
+            ))
         }
     }
 
@@ -11752,20 +12354,17 @@ pub mod internal_checker {
     use super::*;
 
     /// Operational states for an internal checker.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// An internal checker should never be in the unspecified state.
-        pub const UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The checker is being created, provisioned, and configured. A checker in
         /// this state can be returned by `ListInternalCheckers` or
         /// `GetInternalChecker`, as well as by examining the [long running
         /// Operation](https://cloud.google.com/apis/design/design_patterns#long_running_operations)
         /// that created it.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The checker is running and available for use. A checker in this state
         /// can be returned by `ListInternalCheckers` or `GetInternalChecker` as
         /// well as by examining the [long running
@@ -11773,48 +12372,112 @@ pub mod internal_checker {
         /// that created it.
         /// If a checker is being torn down, it is neither visible nor usable, so
         /// there is no "deleting" or "down" state.
-        pub const RUNNING: State = State::new(2);
+        Running,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Running,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "RUNNING" => Self::Running,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.monitoring.v3.InternalChecker.State",
+            ))
         }
     }
 }
@@ -12902,81 +13565,150 @@ pub mod uptime_check_config {
             use super::*;
 
             /// An HTTP status code class.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct StatusClass(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum StatusClass {
+                /// Default value that matches no status codes.
+                Unspecified,
+                /// The class of status codes between 100 and 199.
+                _1Xx,
+                /// The class of status codes between 200 and 299.
+                _2Xx,
+                /// The class of status codes between 300 and 399.
+                _3Xx,
+                /// The class of status codes between 400 and 499.
+                _4Xx,
+                /// The class of status codes between 500 and 599.
+                _5Xx,
+                /// The class of all status codes.
+                Any,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [StatusClass::value] or
+                /// [StatusClass::name].
+                UnknownValue(status_class::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod status_class {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl StatusClass {
-                /// Default value that matches no status codes.
-                pub const STATUS_CLASS_UNSPECIFIED: StatusClass = StatusClass::new(0);
-
-                /// The class of status codes between 100 and 199.
-                pub const STATUS_CLASS_1XX: StatusClass = StatusClass::new(100);
-
-                /// The class of status codes between 200 and 299.
-                pub const STATUS_CLASS_2XX: StatusClass = StatusClass::new(200);
-
-                /// The class of status codes between 300 and 399.
-                pub const STATUS_CLASS_3XX: StatusClass = StatusClass::new(300);
-
-                /// The class of status codes between 400 and 499.
-                pub const STATUS_CLASS_4XX: StatusClass = StatusClass::new(400);
-
-                /// The class of status codes between 500 and 599.
-                pub const STATUS_CLASS_5XX: StatusClass = StatusClass::new(500);
-
-                /// The class of all status codes.
-                pub const STATUS_CLASS_ANY: StatusClass = StatusClass::new(1000);
-
-                /// Creates a new StatusClass instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::_1Xx => std::option::Option::Some(100),
+                        Self::_2Xx => std::option::Option::Some(200),
+                        Self::_3Xx => std::option::Option::Some(300),
+                        Self::_4Xx => std::option::Option::Some(400),
+                        Self::_5Xx => std::option::Option::Some(500),
+                        Self::Any => std::option::Option::Some(1000),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("STATUS_CLASS_UNSPECIFIED"),
-                        100 => std::borrow::Cow::Borrowed("STATUS_CLASS_1XX"),
-                        200 => std::borrow::Cow::Borrowed("STATUS_CLASS_2XX"),
-                        300 => std::borrow::Cow::Borrowed("STATUS_CLASS_3XX"),
-                        400 => std::borrow::Cow::Borrowed("STATUS_CLASS_4XX"),
-                        500 => std::borrow::Cow::Borrowed("STATUS_CLASS_5XX"),
-                        1000 => std::borrow::Cow::Borrowed("STATUS_CLASS_ANY"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some("STATUS_CLASS_UNSPECIFIED"),
+                        Self::_1Xx => std::option::Option::Some("STATUS_CLASS_1XX"),
+                        Self::_2Xx => std::option::Option::Some("STATUS_CLASS_2XX"),
+                        Self::_3Xx => std::option::Option::Some("STATUS_CLASS_3XX"),
+                        Self::_4Xx => std::option::Option::Some("STATUS_CLASS_4XX"),
+                        Self::_5Xx => std::option::Option::Some("STATUS_CLASS_5XX"),
+                        Self::Any => std::option::Option::Some("STATUS_CLASS_ANY"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "STATUS_CLASS_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::STATUS_CLASS_UNSPECIFIED)
-                        }
-                        "STATUS_CLASS_1XX" => std::option::Option::Some(Self::STATUS_CLASS_1XX),
-                        "STATUS_CLASS_2XX" => std::option::Option::Some(Self::STATUS_CLASS_2XX),
-                        "STATUS_CLASS_3XX" => std::option::Option::Some(Self::STATUS_CLASS_3XX),
-                        "STATUS_CLASS_4XX" => std::option::Option::Some(Self::STATUS_CLASS_4XX),
-                        "STATUS_CLASS_5XX" => std::option::Option::Some(Self::STATUS_CLASS_5XX),
-                        "STATUS_CLASS_ANY" => std::option::Option::Some(Self::STATUS_CLASS_ANY),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for StatusClass {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for StatusClass {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for StatusClass {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for StatusClass {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        100 => Self::_1Xx,
+                        200 => Self::_2Xx,
+                        300 => Self::_3Xx,
+                        400 => Self::_4Xx,
+                        500 => Self::_5Xx,
+                        1000 => Self::Any,
+                        _ => Self::UnknownValue(status_class::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for StatusClass {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "STATUS_CLASS_UNSPECIFIED" => Self::Unspecified,
+                        "STATUS_CLASS_1XX" => Self::_1Xx,
+                        "STATUS_CLASS_2XX" => Self::_2Xx,
+                        "STATUS_CLASS_3XX" => Self::_3Xx,
+                        "STATUS_CLASS_4XX" => Self::_4Xx,
+                        "STATUS_CLASS_5XX" => Self::_5Xx,
+                        "STATUS_CLASS_ANY" => Self::Any,
+                        _ => Self::UnknownValue(status_class::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for StatusClass {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::_1Xx => serializer.serialize_i32(100),
+                        Self::_2Xx => serializer.serialize_i32(200),
+                        Self::_3Xx => serializer.serialize_i32(300),
+                        Self::_4Xx => serializer.serialize_i32(400),
+                        Self::_5Xx => serializer.serialize_i32(500),
+                        Self::Any => serializer.serialize_i32(1000),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for StatusClass {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<StatusClass>::new(
+                        ".google.monitoring.v3.UptimeCheckConfig.HttpCheck.ResponseStatusCode.StatusClass"))
                 }
             }
 
@@ -13036,180 +13768,363 @@ pub mod uptime_check_config {
             use super::*;
 
             /// Type of authentication.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct ServiceAgentAuthenticationType(i32);
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum ServiceAgentAuthenticationType {
+                /// Default value, will result in OIDC Authentication.
+                Unspecified,
+                /// OIDC Authentication
+                OidcToken,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [ServiceAgentAuthenticationType::value] or
+                /// [ServiceAgentAuthenticationType::name].
+                UnknownValue(service_agent_authentication_type::UnknownValue),
+            }
+
+            #[doc(hidden)]
+            pub mod service_agent_authentication_type {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
             impl ServiceAgentAuthenticationType {
-                /// Default value, will result in OIDC Authentication.
-                pub const SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED:
-                    ServiceAgentAuthenticationType = ServiceAgentAuthenticationType::new(0);
-
-                /// OIDC Authentication
-                pub const OIDC_TOKEN: ServiceAgentAuthenticationType =
-                    ServiceAgentAuthenticationType::new(1);
-
-                /// Creates a new ServiceAgentAuthenticationType instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
-
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::OidcToken => std::option::Option::Some(1),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed(
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(
                             "SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED",
                         ),
-                        1 => std::borrow::Cow::Borrowed("OIDC_TOKEN"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+                        Self::OidcToken => std::option::Option::Some("OIDC_TOKEN"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED" => {
-                            std::option::Option::Some(
-                                Self::SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED,
-                            )
-                        }
-                        "OIDC_TOKEN" => std::option::Option::Some(Self::OIDC_TOKEN),
-                        _ => std::option::Option::None,
-                    }
-                }
-            }
-
-            impl std::convert::From<i32> for ServiceAgentAuthenticationType {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for ServiceAgentAuthenticationType {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for ServiceAgentAuthenticationType {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for ServiceAgentAuthenticationType {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::OidcToken,
+                        _ => Self::UnknownValue(service_agent_authentication_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for ServiceAgentAuthenticationType {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                        "OIDC_TOKEN" => Self::OidcToken,
+                        _ => Self::UnknownValue(service_agent_authentication_type::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for ServiceAgentAuthenticationType {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::OidcToken => serializer.serialize_i32(1),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for ServiceAgentAuthenticationType {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceAgentAuthenticationType>::new(
+                        ".google.monitoring.v3.UptimeCheckConfig.HttpCheck.ServiceAgentAuthentication.ServiceAgentAuthenticationType"))
                 }
             }
         }
 
         /// The HTTP request method options.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct RequestMethod(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum RequestMethod {
+            /// No request method specified.
+            MethodUnspecified,
+            /// GET request.
+            Get,
+            /// POST request.
+            Post,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [RequestMethod::value] or
+            /// [RequestMethod::name].
+            UnknownValue(request_method::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod request_method {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl RequestMethod {
-            /// No request method specified.
-            pub const METHOD_UNSPECIFIED: RequestMethod = RequestMethod::new(0);
-
-            /// GET request.
-            pub const GET: RequestMethod = RequestMethod::new(1);
-
-            /// POST request.
-            pub const POST: RequestMethod = RequestMethod::new(2);
-
-            /// Creates a new RequestMethod instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::MethodUnspecified => std::option::Option::Some(0),
+                    Self::Get => std::option::Option::Some(1),
+                    Self::Post => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("METHOD_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("GET"),
-                    2 => std::borrow::Cow::Borrowed("POST"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::MethodUnspecified => std::option::Option::Some("METHOD_UNSPECIFIED"),
+                    Self::Get => std::option::Option::Some("GET"),
+                    Self::Post => std::option::Option::Some("POST"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "METHOD_UNSPECIFIED" => std::option::Option::Some(Self::METHOD_UNSPECIFIED),
-                    "GET" => std::option::Option::Some(Self::GET),
-                    "POST" => std::option::Option::Some(Self::POST),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for RequestMethod {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for RequestMethod {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for RequestMethod {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for RequestMethod {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::MethodUnspecified,
+                    1 => Self::Get,
+                    2 => Self::Post,
+                    _ => Self::UnknownValue(request_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for RequestMethod {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "METHOD_UNSPECIFIED" => Self::MethodUnspecified,
+                    "GET" => Self::Get,
+                    "POST" => Self::Post,
+                    _ => Self::UnknownValue(request_method::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for RequestMethod {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::MethodUnspecified => serializer.serialize_i32(0),
+                    Self::Get => serializer.serialize_i32(1),
+                    Self::Post => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for RequestMethod {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<RequestMethod>::new(
+                    ".google.monitoring.v3.UptimeCheckConfig.HttpCheck.RequestMethod",
+                ))
             }
         }
 
         /// Header options corresponding to the content type of a HTTP request body.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ContentType(i32);
-
-        impl ContentType {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ContentType {
             /// No content type specified.
-            pub const TYPE_UNSPECIFIED: ContentType = ContentType::new(0);
-
+            TypeUnspecified,
             /// `body` is in URL-encoded form. Equivalent to setting the `Content-Type`
             /// to `application/x-www-form-urlencoded` in the HTTP request.
-            pub const URL_ENCODED: ContentType = ContentType::new(1);
-
+            UrlEncoded,
             /// `body` is in `custom_content_type` form. Equivalent to setting the
             /// `Content-Type` to the contents of `custom_content_type` in the HTTP
             /// request.
-            pub const USER_PROVIDED: ContentType = ContentType::new(2);
+            UserProvided,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ContentType::value] or
+            /// [ContentType::name].
+            UnknownValue(content_type::UnknownValue),
+        }
 
-            /// Creates a new ContentType instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod content_type {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ContentType {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::TypeUnspecified => std::option::Option::Some(0),
+                    Self::UrlEncoded => std::option::Option::Some(1),
+                    Self::UserProvided => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("URL_ENCODED"),
-                    2 => std::borrow::Cow::Borrowed("USER_PROVIDED"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::TypeUnspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                    Self::UrlEncoded => std::option::Option::Some("URL_ENCODED"),
+                    Self::UserProvided => std::option::Option::Some("USER_PROVIDED"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                    "URL_ENCODED" => std::option::Option::Some(Self::URL_ENCODED),
-                    "USER_PROVIDED" => std::option::Option::Some(Self::USER_PROVIDED),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for ContentType {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ContentType {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ContentType {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ContentType {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::TypeUnspecified,
+                    1 => Self::UrlEncoded,
+                    2 => Self::UserProvided,
+                    _ => Self::UnknownValue(content_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ContentType {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "TYPE_UNSPECIFIED" => Self::TypeUnspecified,
+                    "URL_ENCODED" => Self::UrlEncoded,
+                    "USER_PROVIDED" => Self::UserProvided,
+                    _ => Self::UnknownValue(content_type::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ContentType {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::TypeUnspecified => serializer.serialize_i32(0),
+                    Self::UrlEncoded => serializer.serialize_i32(1),
+                    Self::UserProvided => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ContentType {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentType>::new(
+                    ".google.monitoring.v3.UptimeCheckConfig.HttpCheck.ContentType",
+                ))
             }
         }
 
@@ -13458,164 +14373,294 @@ pub mod uptime_check_config {
             use super::*;
 
             /// Options to perform JSONPath content matching.
-            #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-            pub struct JsonPathMatcherOption(i32);
-
-            impl JsonPathMatcherOption {
+            #[derive(Clone, Debug, PartialEq)]
+            #[non_exhaustive]
+            pub enum JsonPathMatcherOption {
                 /// No JSONPath matcher type specified (not valid).
-                pub const JSON_PATH_MATCHER_OPTION_UNSPECIFIED: JsonPathMatcherOption =
-                    JsonPathMatcherOption::new(0);
-
+                Unspecified,
                 /// Selects 'exact string' matching. The match succeeds if the content at
                 /// the `json_path` within the output is exactly the same as the
                 /// `content` string.
-                pub const EXACT_MATCH: JsonPathMatcherOption = JsonPathMatcherOption::new(1);
-
+                ExactMatch,
                 /// Selects regular-expression matching. The match succeeds if the
                 /// content at the `json_path` within the output matches the regular
                 /// expression specified in the `content` string.
-                pub const REGEX_MATCH: JsonPathMatcherOption = JsonPathMatcherOption::new(2);
+                RegexMatch,
+                /// If set, the enum was initialized with an unknown value.
+                ///
+                /// Applications can examine the value using [JsonPathMatcherOption::value] or
+                /// [JsonPathMatcherOption::name].
+                UnknownValue(json_path_matcher_option::UnknownValue),
+            }
 
-                /// Creates a new JsonPathMatcherOption instance.
-                pub(crate) const fn new(value: i32) -> Self {
-                    Self(value)
-                }
+            #[doc(hidden)]
+            pub mod json_path_matcher_option {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug, PartialEq)]
+                pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+            }
 
+            impl JsonPathMatcherOption {
                 /// Gets the enum value.
-                pub fn value(&self) -> i32 {
-                    self.0
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the string representation of enums.
+                pub fn value(&self) -> std::option::Option<i32> {
+                    match self {
+                        Self::Unspecified => std::option::Option::Some(0),
+                        Self::ExactMatch => std::option::Option::Some(1),
+                        Self::RegexMatch => std::option::Option::Some(2),
+                        Self::UnknownValue(u) => u.0.value(),
+                    }
                 }
 
                 /// Gets the enum value as a string.
-                pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                    match self.0 {
-                        0 => std::borrow::Cow::Borrowed("JSON_PATH_MATCHER_OPTION_UNSPECIFIED"),
-                        1 => std::borrow::Cow::Borrowed("EXACT_MATCH"),
-                        2 => std::borrow::Cow::Borrowed("REGEX_MATCH"),
-                        _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                    }
-                }
-
-                /// Creates an enum value from the value name.
-                pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                    match name {
-                        "JSON_PATH_MATCHER_OPTION_UNSPECIFIED" => {
-                            std::option::Option::Some(Self::JSON_PATH_MATCHER_OPTION_UNSPECIFIED)
+                ///
+                /// Returns `None` if the enum contains an unknown value deserialized from
+                /// the integer representation of enums.
+                pub fn name(&self) -> std::option::Option<&str> {
+                    match self {
+                        Self::Unspecified => {
+                            std::option::Option::Some("JSON_PATH_MATCHER_OPTION_UNSPECIFIED")
                         }
-                        "EXACT_MATCH" => std::option::Option::Some(Self::EXACT_MATCH),
-                        "REGEX_MATCH" => std::option::Option::Some(Self::REGEX_MATCH),
-                        _ => std::option::Option::None,
+                        Self::ExactMatch => std::option::Option::Some("EXACT_MATCH"),
+                        Self::RegexMatch => std::option::Option::Some("REGEX_MATCH"),
+                        Self::UnknownValue(u) => u.0.name(),
                     }
-                }
-            }
-
-            impl std::convert::From<i32> for JsonPathMatcherOption {
-                fn from(value: i32) -> Self {
-                    Self::new(value)
                 }
             }
 
             impl std::default::Default for JsonPathMatcherOption {
                 fn default() -> Self {
-                    Self::new(0)
+                    use std::convert::From;
+                    Self::from(0)
+                }
+            }
+
+            impl std::fmt::Display for JsonPathMatcherOption {
+                fn fmt(
+                    &self,
+                    f: &mut std::fmt::Formatter<'_>,
+                ) -> std::result::Result<(), std::fmt::Error> {
+                    wkt::internal::display_enum(f, self.name(), self.value())
+                }
+            }
+
+            impl std::convert::From<i32> for JsonPathMatcherOption {
+                fn from(value: i32) -> Self {
+                    match value {
+                        0 => Self::Unspecified,
+                        1 => Self::ExactMatch,
+                        2 => Self::RegexMatch,
+                        _ => Self::UnknownValue(json_path_matcher_option::UnknownValue(
+                            wkt::internal::UnknownEnumValue::Integer(value),
+                        )),
+                    }
+                }
+            }
+
+            impl std::convert::From<&str> for JsonPathMatcherOption {
+                fn from(value: &str) -> Self {
+                    use std::string::ToString;
+                    match value {
+                        "JSON_PATH_MATCHER_OPTION_UNSPECIFIED" => Self::Unspecified,
+                        "EXACT_MATCH" => Self::ExactMatch,
+                        "REGEX_MATCH" => Self::RegexMatch,
+                        _ => Self::UnknownValue(json_path_matcher_option::UnknownValue(
+                            wkt::internal::UnknownEnumValue::String(value.to_string()),
+                        )),
+                    }
+                }
+            }
+
+            impl serde::ser::Serialize for JsonPathMatcherOption {
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
+                    match self {
+                        Self::Unspecified => serializer.serialize_i32(0),
+                        Self::ExactMatch => serializer.serialize_i32(1),
+                        Self::RegexMatch => serializer.serialize_i32(2),
+                        Self::UnknownValue(u) => u.0.serialize(serializer),
+                    }
+                }
+            }
+
+            impl<'de> serde::de::Deserialize<'de> for JsonPathMatcherOption {
+                fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    deserializer.deserialize_any(wkt::internal::EnumVisitor::<JsonPathMatcherOption>::new(
+                        ".google.monitoring.v3.UptimeCheckConfig.ContentMatcher.JsonPathMatcher.JsonPathMatcherOption"))
                 }
             }
         }
 
         /// Options to perform content matching.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct ContentMatcherOption(i32);
-
-        impl ContentMatcherOption {
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum ContentMatcherOption {
             /// No content matcher type specified (maintained for backward
             /// compatibility, but deprecated for future use).
             /// Treated as `CONTAINS_STRING`.
-            pub const CONTENT_MATCHER_OPTION_UNSPECIFIED: ContentMatcherOption =
-                ContentMatcherOption::new(0);
-
+            Unspecified,
             /// Selects substring matching. The match succeeds if the output contains
             /// the `content` string.  This is the default value for checks without
             /// a `matcher` option, or where the value of `matcher` is
             /// `CONTENT_MATCHER_OPTION_UNSPECIFIED`.
-            pub const CONTAINS_STRING: ContentMatcherOption = ContentMatcherOption::new(1);
-
+            ContainsString,
             /// Selects negation of substring matching. The match succeeds if the
             /// output does _NOT_ contain the `content` string.
-            pub const NOT_CONTAINS_STRING: ContentMatcherOption = ContentMatcherOption::new(2);
-
+            NotContainsString,
             /// Selects regular-expression matching. The match succeeds if the output
             /// matches the regular expression specified in the `content` string.
             /// Regex matching is only supported for HTTP/HTTPS checks.
-            pub const MATCHES_REGEX: ContentMatcherOption = ContentMatcherOption::new(3);
-
+            MatchesRegex,
             /// Selects negation of regular-expression matching. The match succeeds if
             /// the output does _NOT_ match the regular expression specified in the
             /// `content` string. Regex matching is only supported for HTTP/HTTPS
             /// checks.
-            pub const NOT_MATCHES_REGEX: ContentMatcherOption = ContentMatcherOption::new(4);
-
+            NotMatchesRegex,
             /// Selects JSONPath matching. See `JsonPathMatcher` for details on when
             /// the match succeeds. JSONPath matching is only supported for HTTP/HTTPS
             /// checks.
-            pub const MATCHES_JSON_PATH: ContentMatcherOption = ContentMatcherOption::new(5);
-
+            MatchesJsonPath,
             /// Selects JSONPath matching. See `JsonPathMatcher` for details on when
             /// the match succeeds. Succeeds when output does _NOT_ match as specified.
             /// JSONPath is only supported for HTTP/HTTPS checks.
-            pub const NOT_MATCHES_JSON_PATH: ContentMatcherOption = ContentMatcherOption::new(6);
+            NotMatchesJsonPath,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [ContentMatcherOption::value] or
+            /// [ContentMatcherOption::name].
+            UnknownValue(content_matcher_option::UnknownValue),
+        }
 
-            /// Creates a new ContentMatcherOption instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
+        #[doc(hidden)]
+        pub mod content_matcher_option {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
+        impl ContentMatcherOption {
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::ContainsString => std::option::Option::Some(1),
+                    Self::NotContainsString => std::option::Option::Some(2),
+                    Self::MatchesRegex => std::option::Option::Some(3),
+                    Self::NotMatchesRegex => std::option::Option::Some(4),
+                    Self::MatchesJsonPath => std::option::Option::Some(5),
+                    Self::NotMatchesJsonPath => std::option::Option::Some(6),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("CONTENT_MATCHER_OPTION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("CONTAINS_STRING"),
-                    2 => std::borrow::Cow::Borrowed("NOT_CONTAINS_STRING"),
-                    3 => std::borrow::Cow::Borrowed("MATCHES_REGEX"),
-                    4 => std::borrow::Cow::Borrowed("NOT_MATCHES_REGEX"),
-                    5 => std::borrow::Cow::Borrowed("MATCHES_JSON_PATH"),
-                    6 => std::borrow::Cow::Borrowed("NOT_MATCHES_JSON_PATH"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "CONTENT_MATCHER_OPTION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::CONTENT_MATCHER_OPTION_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => {
+                        std::option::Option::Some("CONTENT_MATCHER_OPTION_UNSPECIFIED")
                     }
-                    "CONTAINS_STRING" => std::option::Option::Some(Self::CONTAINS_STRING),
-                    "NOT_CONTAINS_STRING" => std::option::Option::Some(Self::NOT_CONTAINS_STRING),
-                    "MATCHES_REGEX" => std::option::Option::Some(Self::MATCHES_REGEX),
-                    "NOT_MATCHES_REGEX" => std::option::Option::Some(Self::NOT_MATCHES_REGEX),
-                    "MATCHES_JSON_PATH" => std::option::Option::Some(Self::MATCHES_JSON_PATH),
-                    "NOT_MATCHES_JSON_PATH" => {
-                        std::option::Option::Some(Self::NOT_MATCHES_JSON_PATH)
-                    }
-                    _ => std::option::Option::None,
+                    Self::ContainsString => std::option::Option::Some("CONTAINS_STRING"),
+                    Self::NotContainsString => std::option::Option::Some("NOT_CONTAINS_STRING"),
+                    Self::MatchesRegex => std::option::Option::Some("MATCHES_REGEX"),
+                    Self::NotMatchesRegex => std::option::Option::Some("NOT_MATCHES_REGEX"),
+                    Self::MatchesJsonPath => std::option::Option::Some("MATCHES_JSON_PATH"),
+                    Self::NotMatchesJsonPath => std::option::Option::Some("NOT_MATCHES_JSON_PATH"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for ContentMatcherOption {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for ContentMatcherOption {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for ContentMatcherOption {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for ContentMatcherOption {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::ContainsString,
+                    2 => Self::NotContainsString,
+                    3 => Self::MatchesRegex,
+                    4 => Self::NotMatchesRegex,
+                    5 => Self::MatchesJsonPath,
+                    6 => Self::NotMatchesJsonPath,
+                    _ => Self::UnknownValue(content_matcher_option::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for ContentMatcherOption {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "CONTENT_MATCHER_OPTION_UNSPECIFIED" => Self::Unspecified,
+                    "CONTAINS_STRING" => Self::ContainsString,
+                    "NOT_CONTAINS_STRING" => Self::NotContainsString,
+                    "MATCHES_REGEX" => Self::MatchesRegex,
+                    "NOT_MATCHES_REGEX" => Self::NotMatchesRegex,
+                    "MATCHES_JSON_PATH" => Self::MatchesJsonPath,
+                    "NOT_MATCHES_JSON_PATH" => Self::NotMatchesJsonPath,
+                    _ => Self::UnknownValue(content_matcher_option::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for ContentMatcherOption {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::ContainsString => serializer.serialize_i32(1),
+                    Self::NotContainsString => serializer.serialize_i32(2),
+                    Self::MatchesRegex => serializer.serialize_i32(3),
+                    Self::NotMatchesRegex => serializer.serialize_i32(4),
+                    Self::MatchesJsonPath => serializer.serialize_i32(5),
+                    Self::NotMatchesJsonPath => serializer.serialize_i32(6),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for ContentMatcherOption {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentMatcherOption>::new(
+                    ".google.monitoring.v3.UptimeCheckConfig.ContentMatcher.ContentMatcherOption"))
             }
         }
 
@@ -13636,66 +14681,125 @@ pub mod uptime_check_config {
     }
 
     /// What kind of checkers are available to be used by the check.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CheckerType(i32);
-
-    impl CheckerType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CheckerType {
         /// The default checker type. Currently converted to `STATIC_IP_CHECKERS`
         /// on creation, the default conversion behavior may change in the future.
-        pub const CHECKER_TYPE_UNSPECIFIED: CheckerType = CheckerType::new(0);
-
+        Unspecified,
         /// `STATIC_IP_CHECKERS` are used for uptime checks that perform egress
         /// across the public internet. `STATIC_IP_CHECKERS` use the static IP
         /// addresses returned by `ListUptimeCheckIps`.
-        pub const STATIC_IP_CHECKERS: CheckerType = CheckerType::new(1);
-
+        StaticIpCheckers,
         /// `VPC_CHECKERS` are used for uptime checks that perform egress using
         /// Service Directory and private network access. When using `VPC_CHECKERS`,
         /// the monitored resource type must be `servicedirectory_service`.
-        pub const VPC_CHECKERS: CheckerType = CheckerType::new(3);
+        VpcCheckers,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CheckerType::value] or
+        /// [CheckerType::name].
+        UnknownValue(checker_type::UnknownValue),
+    }
 
-        /// Creates a new CheckerType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod checker_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CheckerType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::StaticIpCheckers => std::option::Option::Some(1),
+                Self::VpcCheckers => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CHECKER_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STATIC_IP_CHECKERS"),
-                3 => std::borrow::Cow::Borrowed("VPC_CHECKERS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CHECKER_TYPE_UNSPECIFIED"),
+                Self::StaticIpCheckers => std::option::Option::Some("STATIC_IP_CHECKERS"),
+                Self::VpcCheckers => std::option::Option::Some("VPC_CHECKERS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CHECKER_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CHECKER_TYPE_UNSPECIFIED)
-                }
-                "STATIC_IP_CHECKERS" => std::option::Option::Some(Self::STATIC_IP_CHECKERS),
-                "VPC_CHECKERS" => std::option::Option::Some(Self::VPC_CHECKERS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CheckerType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CheckerType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CheckerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CheckerType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::StaticIpCheckers,
+                3 => Self::VpcCheckers,
+                _ => Self::UnknownValue(checker_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CheckerType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CHECKER_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "STATIC_IP_CHECKERS" => Self::StaticIpCheckers,
+                "VPC_CHECKERS" => Self::VpcCheckers,
+                _ => Self::UnknownValue(checker_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CheckerType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::StaticIpCheckers => serializer.serialize_i32(1),
+                Self::VpcCheckers => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CheckerType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CheckerType>::new(
+                ".google.monitoring.v3.UptimeCheckConfig.CheckerType",
+            ))
         }
     }
 
@@ -14255,79 +15359,148 @@ impl gax::paginator::internal::PageableResponse for ListUptimeCheckIpsResponse {
 
 /// Specifies an ordering relationship on two arguments, called `left` and
 /// `right`.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ComparisonType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ComparisonType {
+    /// No ordering relationship is specified.
+    ComparisonUnspecified,
+    /// True if the left argument is greater than the right argument.
+    ComparisonGt,
+    /// True if the left argument is greater than or equal to the right argument.
+    ComparisonGe,
+    /// True if the left argument is less than the right argument.
+    ComparisonLt,
+    /// True if the left argument is less than or equal to the right argument.
+    ComparisonLe,
+    /// True if the left argument is equal to the right argument.
+    ComparisonEq,
+    /// True if the left argument is not equal to the right argument.
+    ComparisonNe,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ComparisonType::value] or
+    /// [ComparisonType::name].
+    UnknownValue(comparison_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod comparison_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ComparisonType {
-    /// No ordering relationship is specified.
-    pub const COMPARISON_UNSPECIFIED: ComparisonType = ComparisonType::new(0);
-
-    /// True if the left argument is greater than the right argument.
-    pub const COMPARISON_GT: ComparisonType = ComparisonType::new(1);
-
-    /// True if the left argument is greater than or equal to the right argument.
-    pub const COMPARISON_GE: ComparisonType = ComparisonType::new(2);
-
-    /// True if the left argument is less than the right argument.
-    pub const COMPARISON_LT: ComparisonType = ComparisonType::new(3);
-
-    /// True if the left argument is less than or equal to the right argument.
-    pub const COMPARISON_LE: ComparisonType = ComparisonType::new(4);
-
-    /// True if the left argument is equal to the right argument.
-    pub const COMPARISON_EQ: ComparisonType = ComparisonType::new(5);
-
-    /// True if the left argument is not equal to the right argument.
-    pub const COMPARISON_NE: ComparisonType = ComparisonType::new(6);
-
-    /// Creates a new ComparisonType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::ComparisonUnspecified => std::option::Option::Some(0),
+            Self::ComparisonGt => std::option::Option::Some(1),
+            Self::ComparisonGe => std::option::Option::Some(2),
+            Self::ComparisonLt => std::option::Option::Some(3),
+            Self::ComparisonLe => std::option::Option::Some(4),
+            Self::ComparisonEq => std::option::Option::Some(5),
+            Self::ComparisonNe => std::option::Option::Some(6),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("COMPARISON_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("COMPARISON_GT"),
-            2 => std::borrow::Cow::Borrowed("COMPARISON_GE"),
-            3 => std::borrow::Cow::Borrowed("COMPARISON_LT"),
-            4 => std::borrow::Cow::Borrowed("COMPARISON_LE"),
-            5 => std::borrow::Cow::Borrowed("COMPARISON_EQ"),
-            6 => std::borrow::Cow::Borrowed("COMPARISON_NE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::ComparisonUnspecified => std::option::Option::Some("COMPARISON_UNSPECIFIED"),
+            Self::ComparisonGt => std::option::Option::Some("COMPARISON_GT"),
+            Self::ComparisonGe => std::option::Option::Some("COMPARISON_GE"),
+            Self::ComparisonLt => std::option::Option::Some("COMPARISON_LT"),
+            Self::ComparisonLe => std::option::Option::Some("COMPARISON_LE"),
+            Self::ComparisonEq => std::option::Option::Some("COMPARISON_EQ"),
+            Self::ComparisonNe => std::option::Option::Some("COMPARISON_NE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "COMPARISON_UNSPECIFIED" => std::option::Option::Some(Self::COMPARISON_UNSPECIFIED),
-            "COMPARISON_GT" => std::option::Option::Some(Self::COMPARISON_GT),
-            "COMPARISON_GE" => std::option::Option::Some(Self::COMPARISON_GE),
-            "COMPARISON_LT" => std::option::Option::Some(Self::COMPARISON_LT),
-            "COMPARISON_LE" => std::option::Option::Some(Self::COMPARISON_LE),
-            "COMPARISON_EQ" => std::option::Option::Some(Self::COMPARISON_EQ),
-            "COMPARISON_NE" => std::option::Option::Some(Self::COMPARISON_NE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ComparisonType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ComparisonType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ComparisonType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ComparisonType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::ComparisonUnspecified,
+            1 => Self::ComparisonGt,
+            2 => Self::ComparisonGe,
+            3 => Self::ComparisonLt,
+            4 => Self::ComparisonLe,
+            5 => Self::ComparisonEq,
+            6 => Self::ComparisonNe,
+            _ => Self::UnknownValue(comparison_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ComparisonType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "COMPARISON_UNSPECIFIED" => Self::ComparisonUnspecified,
+            "COMPARISON_GT" => Self::ComparisonGt,
+            "COMPARISON_GE" => Self::ComparisonGe,
+            "COMPARISON_LT" => Self::ComparisonLt,
+            "COMPARISON_LE" => Self::ComparisonLe,
+            "COMPARISON_EQ" => Self::ComparisonEq,
+            "COMPARISON_NE" => Self::ComparisonNe,
+            _ => Self::UnknownValue(comparison_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ComparisonType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::ComparisonUnspecified => serializer.serialize_i32(0),
+            Self::ComparisonGt => serializer.serialize_i32(1),
+            Self::ComparisonGe => serializer.serialize_i32(2),
+            Self::ComparisonLt => serializer.serialize_i32(3),
+            Self::ComparisonLe => serializer.serialize_i32(4),
+            Self::ComparisonEq => serializer.serialize_i32(5),
+            Self::ComparisonNe => serializer.serialize_i32(6),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ComparisonType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ComparisonType>::new(
+            ".google.monitoring.v3.ComparisonType",
+        ))
     }
 }
 
@@ -14335,156 +15508,288 @@ impl std::default::Default for ComparisonType {
 /// [service tiers
 /// documentation](https://cloud.google.com/monitoring/workspaces/tiers) for more
 /// details.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ServiceTier(i32);
-
-impl ServiceTier {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ServiceTier {
     /// An invalid sentinel value, used to indicate that a tier has not
     /// been provided explicitly.
-    pub const SERVICE_TIER_UNSPECIFIED: ServiceTier = ServiceTier::new(0);
-
+    Unspecified,
     /// The Cloud Monitoring Basic tier, a free tier of service that provides basic
     /// features, a moderate allotment of logs, and access to built-in metrics.
     /// A number of features are not available in this tier. For more details,
     /// see [the service tiers
     /// documentation](https://cloud.google.com/monitoring/workspaces/tiers).
-    pub const SERVICE_TIER_BASIC: ServiceTier = ServiceTier::new(1);
-
+    Basic,
     /// The Cloud Monitoring Premium tier, a higher, more expensive tier of service
     /// that provides access to all Cloud Monitoring features, lets you use Cloud
     /// Monitoring with AWS accounts, and has a larger allotments for logs and
     /// metrics. For more details, see [the service tiers
     /// documentation](https://cloud.google.com/monitoring/workspaces/tiers).
-    pub const SERVICE_TIER_PREMIUM: ServiceTier = ServiceTier::new(2);
+    Premium,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ServiceTier::value] or
+    /// [ServiceTier::name].
+    UnknownValue(service_tier::UnknownValue),
+}
 
-    /// Creates a new ServiceTier instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod service_tier {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ServiceTier {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Basic => std::option::Option::Some(1),
+            Self::Premium => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SERVICE_TIER_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SERVICE_TIER_BASIC"),
-            2 => std::borrow::Cow::Borrowed("SERVICE_TIER_PREMIUM"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("SERVICE_TIER_UNSPECIFIED"),
+            Self::Basic => std::option::Option::Some("SERVICE_TIER_BASIC"),
+            Self::Premium => std::option::Option::Some("SERVICE_TIER_PREMIUM"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SERVICE_TIER_UNSPECIFIED" => std::option::Option::Some(Self::SERVICE_TIER_UNSPECIFIED),
-            "SERVICE_TIER_BASIC" => std::option::Option::Some(Self::SERVICE_TIER_BASIC),
-            "SERVICE_TIER_PREMIUM" => std::option::Option::Some(Self::SERVICE_TIER_PREMIUM),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ServiceTier {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ServiceTier {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ServiceTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ServiceTier {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Basic,
+            2 => Self::Premium,
+            _ => Self::UnknownValue(service_tier::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ServiceTier {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SERVICE_TIER_UNSPECIFIED" => Self::Unspecified,
+            "SERVICE_TIER_BASIC" => Self::Basic,
+            "SERVICE_TIER_PREMIUM" => Self::Premium,
+            _ => Self::UnknownValue(service_tier::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ServiceTier {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Basic => serializer.serialize_i32(1),
+            Self::Premium => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ServiceTier {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ServiceTier>::new(
+            ".google.monitoring.v3.ServiceTier",
+        ))
     }
 }
 
 /// The regions from which an Uptime check can be run.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UptimeCheckRegion(i32);
-
-impl UptimeCheckRegion {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum UptimeCheckRegion {
     /// Default value if no region is specified. Will result in Uptime checks
     /// running from all regions.
-    pub const REGION_UNSPECIFIED: UptimeCheckRegion = UptimeCheckRegion::new(0);
-
+    RegionUnspecified,
     /// Allows checks to run from locations within the United States of America.
-    pub const USA: UptimeCheckRegion = UptimeCheckRegion::new(1);
-
+    Usa,
     /// Allows checks to run from locations within the continent of Europe.
-    pub const EUROPE: UptimeCheckRegion = UptimeCheckRegion::new(2);
-
+    Europe,
     /// Allows checks to run from locations within the continent of South
     /// America.
-    pub const SOUTH_AMERICA: UptimeCheckRegion = UptimeCheckRegion::new(3);
-
+    SouthAmerica,
     /// Allows checks to run from locations within the Asia Pacific area (ex:
     /// Singapore).
-    pub const ASIA_PACIFIC: UptimeCheckRegion = UptimeCheckRegion::new(4);
-
+    AsiaPacific,
     /// Allows checks to run from locations within the western United States of
     /// America
-    pub const USA_OREGON: UptimeCheckRegion = UptimeCheckRegion::new(5);
-
+    UsaOregon,
     /// Allows checks to run from locations within the central United States of
     /// America
-    pub const USA_IOWA: UptimeCheckRegion = UptimeCheckRegion::new(6);
-
+    UsaIowa,
     /// Allows checks to run from locations within the eastern United States of
     /// America
-    pub const USA_VIRGINIA: UptimeCheckRegion = UptimeCheckRegion::new(7);
+    UsaVirginia,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [UptimeCheckRegion::value] or
+    /// [UptimeCheckRegion::name].
+    UnknownValue(uptime_check_region::UnknownValue),
+}
 
-    /// Creates a new UptimeCheckRegion instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod uptime_check_region {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl UptimeCheckRegion {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::RegionUnspecified => std::option::Option::Some(0),
+            Self::Usa => std::option::Option::Some(1),
+            Self::Europe => std::option::Option::Some(2),
+            Self::SouthAmerica => std::option::Option::Some(3),
+            Self::AsiaPacific => std::option::Option::Some(4),
+            Self::UsaOregon => std::option::Option::Some(5),
+            Self::UsaIowa => std::option::Option::Some(6),
+            Self::UsaVirginia => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("REGION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("USA"),
-            2 => std::borrow::Cow::Borrowed("EUROPE"),
-            3 => std::borrow::Cow::Borrowed("SOUTH_AMERICA"),
-            4 => std::borrow::Cow::Borrowed("ASIA_PACIFIC"),
-            5 => std::borrow::Cow::Borrowed("USA_OREGON"),
-            6 => std::borrow::Cow::Borrowed("USA_IOWA"),
-            7 => std::borrow::Cow::Borrowed("USA_VIRGINIA"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::RegionUnspecified => std::option::Option::Some("REGION_UNSPECIFIED"),
+            Self::Usa => std::option::Option::Some("USA"),
+            Self::Europe => std::option::Option::Some("EUROPE"),
+            Self::SouthAmerica => std::option::Option::Some("SOUTH_AMERICA"),
+            Self::AsiaPacific => std::option::Option::Some("ASIA_PACIFIC"),
+            Self::UsaOregon => std::option::Option::Some("USA_OREGON"),
+            Self::UsaIowa => std::option::Option::Some("USA_IOWA"),
+            Self::UsaVirginia => std::option::Option::Some("USA_VIRGINIA"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "REGION_UNSPECIFIED" => std::option::Option::Some(Self::REGION_UNSPECIFIED),
-            "USA" => std::option::Option::Some(Self::USA),
-            "EUROPE" => std::option::Option::Some(Self::EUROPE),
-            "SOUTH_AMERICA" => std::option::Option::Some(Self::SOUTH_AMERICA),
-            "ASIA_PACIFIC" => std::option::Option::Some(Self::ASIA_PACIFIC),
-            "USA_OREGON" => std::option::Option::Some(Self::USA_OREGON),
-            "USA_IOWA" => std::option::Option::Some(Self::USA_IOWA),
-            "USA_VIRGINIA" => std::option::Option::Some(Self::USA_VIRGINIA),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for UptimeCheckRegion {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for UptimeCheckRegion {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for UptimeCheckRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for UptimeCheckRegion {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::RegionUnspecified,
+            1 => Self::Usa,
+            2 => Self::Europe,
+            3 => Self::SouthAmerica,
+            4 => Self::AsiaPacific,
+            5 => Self::UsaOregon,
+            6 => Self::UsaIowa,
+            7 => Self::UsaVirginia,
+            _ => Self::UnknownValue(uptime_check_region::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for UptimeCheckRegion {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "REGION_UNSPECIFIED" => Self::RegionUnspecified,
+            "USA" => Self::Usa,
+            "EUROPE" => Self::Europe,
+            "SOUTH_AMERICA" => Self::SouthAmerica,
+            "ASIA_PACIFIC" => Self::AsiaPacific,
+            "USA_OREGON" => Self::UsaOregon,
+            "USA_IOWA" => Self::UsaIowa,
+            "USA_VIRGINIA" => Self::UsaVirginia,
+            _ => Self::UnknownValue(uptime_check_region::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for UptimeCheckRegion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::RegionUnspecified => serializer.serialize_i32(0),
+            Self::Usa => serializer.serialize_i32(1),
+            Self::Europe => serializer.serialize_i32(2),
+            Self::SouthAmerica => serializer.serialize_i32(3),
+            Self::AsiaPacific => serializer.serialize_i32(4),
+            Self::UsaOregon => serializer.serialize_i32(5),
+            Self::UsaIowa => serializer.serialize_i32(6),
+            Self::UsaVirginia => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for UptimeCheckRegion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<UptimeCheckRegion>::new(
+            ".google.monitoring.v3.UptimeCheckRegion",
+        ))
     }
 }
 
@@ -14493,61 +15798,120 @@ impl std::default::Default for UptimeCheckRegion {
 /// `INSTANCE` includes `gce_instance` and `aws_ec2_instance` resource types.
 /// The resource types `gae_app` and `uptime_url` are not valid here because
 /// group checks on App Engine modules and URLs are not allowed.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct GroupResourceType(i32);
-
-impl GroupResourceType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum GroupResourceType {
     /// Default value (not valid).
-    pub const RESOURCE_TYPE_UNSPECIFIED: GroupResourceType = GroupResourceType::new(0);
-
+    ResourceTypeUnspecified,
     /// A group of instances from Google Cloud Platform (GCP) or
     /// Amazon Web Services (AWS).
-    pub const INSTANCE: GroupResourceType = GroupResourceType::new(1);
-
+    Instance,
     /// A group of Amazon ELB load balancers.
-    pub const AWS_ELB_LOAD_BALANCER: GroupResourceType = GroupResourceType::new(2);
+    AwsElbLoadBalancer,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [GroupResourceType::value] or
+    /// [GroupResourceType::name].
+    UnknownValue(group_resource_type::UnknownValue),
+}
 
-    /// Creates a new GroupResourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod group_resource_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl GroupResourceType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::ResourceTypeUnspecified => std::option::Option::Some(0),
+            Self::Instance => std::option::Option::Some(1),
+            Self::AwsElbLoadBalancer => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESOURCE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INSTANCE"),
-            2 => std::borrow::Cow::Borrowed("AWS_ELB_LOAD_BALANCER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::ResourceTypeUnspecified => std::option::Option::Some("RESOURCE_TYPE_UNSPECIFIED"),
+            Self::Instance => std::option::Option::Some("INSTANCE"),
+            Self::AwsElbLoadBalancer => std::option::Option::Some("AWS_ELB_LOAD_BALANCER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESOURCE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESOURCE_TYPE_UNSPECIFIED)
-            }
-            "INSTANCE" => std::option::Option::Some(Self::INSTANCE),
-            "AWS_ELB_LOAD_BALANCER" => std::option::Option::Some(Self::AWS_ELB_LOAD_BALANCER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for GroupResourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for GroupResourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for GroupResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for GroupResourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::ResourceTypeUnspecified,
+            1 => Self::Instance,
+            2 => Self::AwsElbLoadBalancer,
+            _ => Self::UnknownValue(group_resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for GroupResourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESOURCE_TYPE_UNSPECIFIED" => Self::ResourceTypeUnspecified,
+            "INSTANCE" => Self::Instance,
+            "AWS_ELB_LOAD_BALANCER" => Self::AwsElbLoadBalancer,
+            _ => Self::UnknownValue(group_resource_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for GroupResourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::ResourceTypeUnspecified => serializer.serialize_i32(0),
+            Self::Instance => serializer.serialize_i32(1),
+            Self::AwsElbLoadBalancer => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for GroupResourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<GroupResourceType>::new(
+            ".google.monitoring.v3.GroupResourceType",
+        ))
     }
 }

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -544,7 +544,7 @@ impl super::stub::MetricService for MetricService {
                 v.add(builder, "secondaryAggregation")
             });
         let builder = builder.query(&[("orderBy", &req.order_by)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
         self.inner
@@ -1082,7 +1082,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
@@ -1108,7 +1108,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("view", &req.view.value())]);
+        let builder = builder.query(&[("view", &req.view)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/oslogin/common/src/model.rs
+++ b/src/generated/oslogin/common/src/model.rs
@@ -226,61 +226,120 @@ impl wkt::message::Message for SshPublicKey {
 }
 
 /// The operating system options for account entries.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OperatingSystemType(i32);
-
-impl OperatingSystemType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum OperatingSystemType {
     /// The operating system type associated with the user account information is
     /// unspecified.
-    pub const OPERATING_SYSTEM_TYPE_UNSPECIFIED: OperatingSystemType = OperatingSystemType::new(0);
-
+    Unspecified,
     /// Linux user account information.
-    pub const LINUX: OperatingSystemType = OperatingSystemType::new(1);
-
+    Linux,
     /// Windows user account information.
-    pub const WINDOWS: OperatingSystemType = OperatingSystemType::new(2);
+    Windows,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [OperatingSystemType::value] or
+    /// [OperatingSystemType::name].
+    UnknownValue(operating_system_type::UnknownValue),
+}
 
-    /// Creates a new OperatingSystemType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod operating_system_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl OperatingSystemType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Linux => std::option::Option::Some(1),
+            Self::Windows => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OPERATING_SYSTEM_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("LINUX"),
-            2 => std::borrow::Cow::Borrowed("WINDOWS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("OPERATING_SYSTEM_TYPE_UNSPECIFIED"),
+            Self::Linux => std::option::Option::Some("LINUX"),
+            Self::Windows => std::option::Option::Some("WINDOWS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OPERATING_SYSTEM_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::OPERATING_SYSTEM_TYPE_UNSPECIFIED)
-            }
-            "LINUX" => std::option::Option::Some(Self::LINUX),
-            "WINDOWS" => std::option::Option::Some(Self::WINDOWS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for OperatingSystemType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for OperatingSystemType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for OperatingSystemType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for OperatingSystemType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Linux,
+            2 => Self::Windows,
+            _ => Self::UnknownValue(operating_system_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for OperatingSystemType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OPERATING_SYSTEM_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "LINUX" => Self::Linux,
+            "WINDOWS" => Self::Windows,
+            _ => Self::UnknownValue(operating_system_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for OperatingSystemType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Linux => serializer.serialize_i32(1),
+            Self::Windows => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for OperatingSystemType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<OperatingSystemType>::new(
+            ".google.cloud.oslogin.common.OperatingSystemType",
+        ))
     }
 }

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -959,134 +959,225 @@ pub mod byte_content_item {
     ///
     /// Only the first frame of each multiframe image is inspected. Metadata and
     /// other frames aren't inspected.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BytesType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BytesType {
+        /// Unused
+        Unspecified,
+        /// Any image type.
+        Image,
+        /// jpeg
+        ImageJpeg,
+        /// bmp
+        ImageBmp,
+        /// png
+        ImagePng,
+        /// svg
+        ImageSvg,
+        /// plain text
+        TextUtf8,
+        /// docx, docm, dotx, dotm
+        WordDocument,
+        /// pdf
+        Pdf,
+        /// pptx, pptm, potx, potm, pot
+        PowerpointDocument,
+        /// xlsx, xlsm, xltx, xltm
+        ExcelDocument,
+        /// avro
+        Avro,
+        /// csv
+        Csv,
+        /// tsv
+        Tsv,
+        /// Audio file types. Only used for profiling.
+        Audio,
+        /// Video file types. Only used for profiling.
+        Video,
+        /// Executable file types. Only used for profiling.
+        Executable,
+        /// AI model file types. Only used for profiling.
+        AiModel,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BytesType::value] or
+        /// [BytesType::name].
+        UnknownValue(bytes_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod bytes_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BytesType {
-        /// Unused
-        pub const BYTES_TYPE_UNSPECIFIED: BytesType = BytesType::new(0);
-
-        /// Any image type.
-        pub const IMAGE: BytesType = BytesType::new(6);
-
-        /// jpeg
-        pub const IMAGE_JPEG: BytesType = BytesType::new(1);
-
-        /// bmp
-        pub const IMAGE_BMP: BytesType = BytesType::new(2);
-
-        /// png
-        pub const IMAGE_PNG: BytesType = BytesType::new(3);
-
-        /// svg
-        pub const IMAGE_SVG: BytesType = BytesType::new(4);
-
-        /// plain text
-        pub const TEXT_UTF8: BytesType = BytesType::new(5);
-
-        /// docx, docm, dotx, dotm
-        pub const WORD_DOCUMENT: BytesType = BytesType::new(7);
-
-        /// pdf
-        pub const PDF: BytesType = BytesType::new(8);
-
-        /// pptx, pptm, potx, potm, pot
-        pub const POWERPOINT_DOCUMENT: BytesType = BytesType::new(9);
-
-        /// xlsx, xlsm, xltx, xltm
-        pub const EXCEL_DOCUMENT: BytesType = BytesType::new(10);
-
-        /// avro
-        pub const AVRO: BytesType = BytesType::new(11);
-
-        /// csv
-        pub const CSV: BytesType = BytesType::new(12);
-
-        /// tsv
-        pub const TSV: BytesType = BytesType::new(13);
-
-        /// Audio file types. Only used for profiling.
-        pub const AUDIO: BytesType = BytesType::new(15);
-
-        /// Video file types. Only used for profiling.
-        pub const VIDEO: BytesType = BytesType::new(16);
-
-        /// Executable file types. Only used for profiling.
-        pub const EXECUTABLE: BytesType = BytesType::new(17);
-
-        /// AI model file types. Only used for profiling.
-        pub const AI_MODEL: BytesType = BytesType::new(18);
-
-        /// Creates a new BytesType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Image => std::option::Option::Some(6),
+                Self::ImageJpeg => std::option::Option::Some(1),
+                Self::ImageBmp => std::option::Option::Some(2),
+                Self::ImagePng => std::option::Option::Some(3),
+                Self::ImageSvg => std::option::Option::Some(4),
+                Self::TextUtf8 => std::option::Option::Some(5),
+                Self::WordDocument => std::option::Option::Some(7),
+                Self::Pdf => std::option::Option::Some(8),
+                Self::PowerpointDocument => std::option::Option::Some(9),
+                Self::ExcelDocument => std::option::Option::Some(10),
+                Self::Avro => std::option::Option::Some(11),
+                Self::Csv => std::option::Option::Some(12),
+                Self::Tsv => std::option::Option::Some(13),
+                Self::Audio => std::option::Option::Some(15),
+                Self::Video => std::option::Option::Some(16),
+                Self::Executable => std::option::Option::Some(17),
+                Self::AiModel => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("BYTES_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMAGE_JPEG"),
-                2 => std::borrow::Cow::Borrowed("IMAGE_BMP"),
-                3 => std::borrow::Cow::Borrowed("IMAGE_PNG"),
-                4 => std::borrow::Cow::Borrowed("IMAGE_SVG"),
-                5 => std::borrow::Cow::Borrowed("TEXT_UTF8"),
-                6 => std::borrow::Cow::Borrowed("IMAGE"),
-                7 => std::borrow::Cow::Borrowed("WORD_DOCUMENT"),
-                8 => std::borrow::Cow::Borrowed("PDF"),
-                9 => std::borrow::Cow::Borrowed("POWERPOINT_DOCUMENT"),
-                10 => std::borrow::Cow::Borrowed("EXCEL_DOCUMENT"),
-                11 => std::borrow::Cow::Borrowed("AVRO"),
-                12 => std::borrow::Cow::Borrowed("CSV"),
-                13 => std::borrow::Cow::Borrowed("TSV"),
-                15 => std::borrow::Cow::Borrowed("AUDIO"),
-                16 => std::borrow::Cow::Borrowed("VIDEO"),
-                17 => std::borrow::Cow::Borrowed("EXECUTABLE"),
-                18 => std::borrow::Cow::Borrowed("AI_MODEL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("BYTES_TYPE_UNSPECIFIED"),
+                Self::Image => std::option::Option::Some("IMAGE"),
+                Self::ImageJpeg => std::option::Option::Some("IMAGE_JPEG"),
+                Self::ImageBmp => std::option::Option::Some("IMAGE_BMP"),
+                Self::ImagePng => std::option::Option::Some("IMAGE_PNG"),
+                Self::ImageSvg => std::option::Option::Some("IMAGE_SVG"),
+                Self::TextUtf8 => std::option::Option::Some("TEXT_UTF8"),
+                Self::WordDocument => std::option::Option::Some("WORD_DOCUMENT"),
+                Self::Pdf => std::option::Option::Some("PDF"),
+                Self::PowerpointDocument => std::option::Option::Some("POWERPOINT_DOCUMENT"),
+                Self::ExcelDocument => std::option::Option::Some("EXCEL_DOCUMENT"),
+                Self::Avro => std::option::Option::Some("AVRO"),
+                Self::Csv => std::option::Option::Some("CSV"),
+                Self::Tsv => std::option::Option::Some("TSV"),
+                Self::Audio => std::option::Option::Some("AUDIO"),
+                Self::Video => std::option::Option::Some("VIDEO"),
+                Self::Executable => std::option::Option::Some("EXECUTABLE"),
+                Self::AiModel => std::option::Option::Some("AI_MODEL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "BYTES_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::BYTES_TYPE_UNSPECIFIED),
-                "IMAGE" => std::option::Option::Some(Self::IMAGE),
-                "IMAGE_JPEG" => std::option::Option::Some(Self::IMAGE_JPEG),
-                "IMAGE_BMP" => std::option::Option::Some(Self::IMAGE_BMP),
-                "IMAGE_PNG" => std::option::Option::Some(Self::IMAGE_PNG),
-                "IMAGE_SVG" => std::option::Option::Some(Self::IMAGE_SVG),
-                "TEXT_UTF8" => std::option::Option::Some(Self::TEXT_UTF8),
-                "WORD_DOCUMENT" => std::option::Option::Some(Self::WORD_DOCUMENT),
-                "PDF" => std::option::Option::Some(Self::PDF),
-                "POWERPOINT_DOCUMENT" => std::option::Option::Some(Self::POWERPOINT_DOCUMENT),
-                "EXCEL_DOCUMENT" => std::option::Option::Some(Self::EXCEL_DOCUMENT),
-                "AVRO" => std::option::Option::Some(Self::AVRO),
-                "CSV" => std::option::Option::Some(Self::CSV),
-                "TSV" => std::option::Option::Some(Self::TSV),
-                "AUDIO" => std::option::Option::Some(Self::AUDIO),
-                "VIDEO" => std::option::Option::Some(Self::VIDEO),
-                "EXECUTABLE" => std::option::Option::Some(Self::EXECUTABLE),
-                "AI_MODEL" => std::option::Option::Some(Self::AI_MODEL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BytesType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BytesType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BytesType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BytesType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ImageJpeg,
+                2 => Self::ImageBmp,
+                3 => Self::ImagePng,
+                4 => Self::ImageSvg,
+                5 => Self::TextUtf8,
+                6 => Self::Image,
+                7 => Self::WordDocument,
+                8 => Self::Pdf,
+                9 => Self::PowerpointDocument,
+                10 => Self::ExcelDocument,
+                11 => Self::Avro,
+                12 => Self::Csv,
+                13 => Self::Tsv,
+                15 => Self::Audio,
+                16 => Self::Video,
+                17 => Self::Executable,
+                18 => Self::AiModel,
+                _ => Self::UnknownValue(bytes_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BytesType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "BYTES_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "IMAGE" => Self::Image,
+                "IMAGE_JPEG" => Self::ImageJpeg,
+                "IMAGE_BMP" => Self::ImageBmp,
+                "IMAGE_PNG" => Self::ImagePng,
+                "IMAGE_SVG" => Self::ImageSvg,
+                "TEXT_UTF8" => Self::TextUtf8,
+                "WORD_DOCUMENT" => Self::WordDocument,
+                "PDF" => Self::Pdf,
+                "POWERPOINT_DOCUMENT" => Self::PowerpointDocument,
+                "EXCEL_DOCUMENT" => Self::ExcelDocument,
+                "AVRO" => Self::Avro,
+                "CSV" => Self::Csv,
+                "TSV" => Self::Tsv,
+                "AUDIO" => Self::Audio,
+                "VIDEO" => Self::Video,
+                "EXECUTABLE" => Self::Executable,
+                "AI_MODEL" => Self::AiModel,
+                _ => Self::UnknownValue(bytes_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BytesType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Image => serializer.serialize_i32(6),
+                Self::ImageJpeg => serializer.serialize_i32(1),
+                Self::ImageBmp => serializer.serialize_i32(2),
+                Self::ImagePng => serializer.serialize_i32(3),
+                Self::ImageSvg => serializer.serialize_i32(4),
+                Self::TextUtf8 => serializer.serialize_i32(5),
+                Self::WordDocument => serializer.serialize_i32(7),
+                Self::Pdf => serializer.serialize_i32(8),
+                Self::PowerpointDocument => serializer.serialize_i32(9),
+                Self::ExcelDocument => serializer.serialize_i32(10),
+                Self::Avro => serializer.serialize_i32(11),
+                Self::Csv => serializer.serialize_i32(12),
+                Self::Tsv => serializer.serialize_i32(13),
+                Self::Audio => serializer.serialize_i32(15),
+                Self::Video => serializer.serialize_i32(16),
+                Self::Executable => serializer.serialize_i32(17),
+                Self::AiModel => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BytesType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BytesType>::new(
+                ".google.privacy.dlp.v2.ByteContentItem.BytesType",
+            ))
         }
     }
 }
@@ -3421,77 +3512,142 @@ pub mod output_storage_config {
 
     /// Predefined schemas for storing findings.
     /// Only for use with external storage.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OutputSchema(i32);
-
-    impl OutputSchema {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OutputSchema {
         /// Unused.
-        pub const OUTPUT_SCHEMA_UNSPECIFIED: OutputSchema = OutputSchema::new(0);
-
+        Unspecified,
         /// Basic schema including only `info_type`, `quote`, `certainty`, and
         /// `timestamp`.
-        pub const BASIC_COLUMNS: OutputSchema = OutputSchema::new(1);
-
+        BasicColumns,
         /// Schema tailored to findings from scanning Cloud Storage.
-        pub const GCS_COLUMNS: OutputSchema = OutputSchema::new(2);
-
+        GcsColumns,
         /// Schema tailored to findings from scanning Google Datastore.
-        pub const DATASTORE_COLUMNS: OutputSchema = OutputSchema::new(3);
-
+        DatastoreColumns,
         /// Schema tailored to findings from scanning Google BigQuery.
-        pub const BIG_QUERY_COLUMNS: OutputSchema = OutputSchema::new(4);
-
+        BigQueryColumns,
         /// Schema containing all columns.
-        pub const ALL_COLUMNS: OutputSchema = OutputSchema::new(5);
+        AllColumns,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OutputSchema::value] or
+        /// [OutputSchema::name].
+        UnknownValue(output_schema::UnknownValue),
+    }
 
-        /// Creates a new OutputSchema instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod output_schema {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OutputSchema {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::BasicColumns => std::option::Option::Some(1),
+                Self::GcsColumns => std::option::Option::Some(2),
+                Self::DatastoreColumns => std::option::Option::Some(3),
+                Self::BigQueryColumns => std::option::Option::Some(4),
+                Self::AllColumns => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OUTPUT_SCHEMA_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("BASIC_COLUMNS"),
-                2 => std::borrow::Cow::Borrowed("GCS_COLUMNS"),
-                3 => std::borrow::Cow::Borrowed("DATASTORE_COLUMNS"),
-                4 => std::borrow::Cow::Borrowed("BIG_QUERY_COLUMNS"),
-                5 => std::borrow::Cow::Borrowed("ALL_COLUMNS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OUTPUT_SCHEMA_UNSPECIFIED"),
+                Self::BasicColumns => std::option::Option::Some("BASIC_COLUMNS"),
+                Self::GcsColumns => std::option::Option::Some("GCS_COLUMNS"),
+                Self::DatastoreColumns => std::option::Option::Some("DATASTORE_COLUMNS"),
+                Self::BigQueryColumns => std::option::Option::Some("BIG_QUERY_COLUMNS"),
+                Self::AllColumns => std::option::Option::Some("ALL_COLUMNS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OUTPUT_SCHEMA_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OUTPUT_SCHEMA_UNSPECIFIED)
-                }
-                "BASIC_COLUMNS" => std::option::Option::Some(Self::BASIC_COLUMNS),
-                "GCS_COLUMNS" => std::option::Option::Some(Self::GCS_COLUMNS),
-                "DATASTORE_COLUMNS" => std::option::Option::Some(Self::DATASTORE_COLUMNS),
-                "BIG_QUERY_COLUMNS" => std::option::Option::Some(Self::BIG_QUERY_COLUMNS),
-                "ALL_COLUMNS" => std::option::Option::Some(Self::ALL_COLUMNS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OutputSchema {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OutputSchema {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OutputSchema {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OutputSchema {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::BasicColumns,
+                2 => Self::GcsColumns,
+                3 => Self::DatastoreColumns,
+                4 => Self::BigQueryColumns,
+                5 => Self::AllColumns,
+                _ => Self::UnknownValue(output_schema::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OutputSchema {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OUTPUT_SCHEMA_UNSPECIFIED" => Self::Unspecified,
+                "BASIC_COLUMNS" => Self::BasicColumns,
+                "GCS_COLUMNS" => Self::GcsColumns,
+                "DATASTORE_COLUMNS" => Self::DatastoreColumns,
+                "BIG_QUERY_COLUMNS" => Self::BigQueryColumns,
+                "ALL_COLUMNS" => Self::AllColumns,
+                _ => Self::UnknownValue(output_schema::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OutputSchema {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::BasicColumns => serializer.serialize_i32(1),
+                Self::GcsColumns => serializer.serialize_i32(2),
+                Self::DatastoreColumns => serializer.serialize_i32(3),
+                Self::BigQueryColumns => serializer.serialize_i32(4),
+                Self::AllColumns => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OutputSchema {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OutputSchema>::new(
+                ".google.privacy.dlp.v2.OutputStorageConfig.OutputSchema",
+            ))
         }
     }
 
@@ -4557,460 +4713,755 @@ pub mod info_type_category {
 
     /// Enum of the current locations.
     /// We might add more locations in the future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LocationCategory(i32);
-
-    impl LocationCategory {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LocationCategory {
         /// Unused location
-        pub const LOCATION_UNSPECIFIED: LocationCategory = LocationCategory::new(0);
-
+        LocationUnspecified,
         /// The infoType is not issued by or tied to a specific region, but is used
         /// almost everywhere.
-        pub const GLOBAL: LocationCategory = LocationCategory::new(1);
-
+        Global,
         /// The infoType is typically used in Argentina.
-        pub const ARGENTINA: LocationCategory = LocationCategory::new(2);
-
+        Argentina,
         /// The infoType is typically used in Armenia.
-        pub const ARMENIA: LocationCategory = LocationCategory::new(51);
-
+        Armenia,
         /// The infoType is typically used in Australia.
-        pub const AUSTRALIA: LocationCategory = LocationCategory::new(3);
-
+        Australia,
         /// The infoType is typically used in Azerbaijan.
-        pub const AZERBAIJAN: LocationCategory = LocationCategory::new(48);
-
+        Azerbaijan,
         /// The infoType is typically used in Belarus.
-        pub const BELARUS: LocationCategory = LocationCategory::new(50);
-
+        Belarus,
         /// The infoType is typically used in Belgium.
-        pub const BELGIUM: LocationCategory = LocationCategory::new(4);
-
+        Belgium,
         /// The infoType is typically used in Brazil.
-        pub const BRAZIL: LocationCategory = LocationCategory::new(5);
-
+        Brazil,
         /// The infoType is typically used in Canada.
-        pub const CANADA: LocationCategory = LocationCategory::new(6);
-
+        Canada,
         /// The infoType is typically used in Chile.
-        pub const CHILE: LocationCategory = LocationCategory::new(7);
-
+        Chile,
         /// The infoType is typically used in China.
-        pub const CHINA: LocationCategory = LocationCategory::new(8);
-
+        China,
         /// The infoType is typically used in Colombia.
-        pub const COLOMBIA: LocationCategory = LocationCategory::new(9);
-
+        Colombia,
         /// The infoType is typically used in Croatia.
-        pub const CROATIA: LocationCategory = LocationCategory::new(42);
-
+        Croatia,
         /// The infoType is typically used in Czechia.
-        pub const CZECHIA: LocationCategory = LocationCategory::new(52);
-
+        Czechia,
         /// The infoType is typically used in Denmark.
-        pub const DENMARK: LocationCategory = LocationCategory::new(10);
-
+        Denmark,
         /// The infoType is typically used in France.
-        pub const FRANCE: LocationCategory = LocationCategory::new(11);
-
+        France,
         /// The infoType is typically used in Finland.
-        pub const FINLAND: LocationCategory = LocationCategory::new(12);
-
+        Finland,
         /// The infoType is typically used in Germany.
-        pub const GERMANY: LocationCategory = LocationCategory::new(13);
-
+        Germany,
         /// The infoType is typically used in Hong Kong.
-        pub const HONG_KONG: LocationCategory = LocationCategory::new(14);
-
+        HongKong,
         /// The infoType is typically used in India.
-        pub const INDIA: LocationCategory = LocationCategory::new(15);
-
+        India,
         /// The infoType is typically used in Indonesia.
-        pub const INDONESIA: LocationCategory = LocationCategory::new(16);
-
+        Indonesia,
         /// The infoType is typically used in Ireland.
-        pub const IRELAND: LocationCategory = LocationCategory::new(17);
-
+        Ireland,
         /// The infoType is typically used in Israel.
-        pub const ISRAEL: LocationCategory = LocationCategory::new(18);
-
+        Israel,
         /// The infoType is typically used in Italy.
-        pub const ITALY: LocationCategory = LocationCategory::new(19);
-
+        Italy,
         /// The infoType is typically used in Japan.
-        pub const JAPAN: LocationCategory = LocationCategory::new(20);
-
+        Japan,
         /// The infoType is typically used in Kazakhstan.
-        pub const KAZAKHSTAN: LocationCategory = LocationCategory::new(47);
-
+        Kazakhstan,
         /// The infoType is typically used in Korea.
-        pub const KOREA: LocationCategory = LocationCategory::new(21);
-
+        Korea,
         /// The infoType is typically used in Mexico.
-        pub const MEXICO: LocationCategory = LocationCategory::new(22);
-
+        Mexico,
         /// The infoType is typically used in the Netherlands.
-        pub const THE_NETHERLANDS: LocationCategory = LocationCategory::new(23);
-
+        TheNetherlands,
         /// The infoType is typically used in New Zealand.
-        pub const NEW_ZEALAND: LocationCategory = LocationCategory::new(41);
-
+        NewZealand,
         /// The infoType is typically used in Norway.
-        pub const NORWAY: LocationCategory = LocationCategory::new(24);
-
+        Norway,
         /// The infoType is typically used in Paraguay.
-        pub const PARAGUAY: LocationCategory = LocationCategory::new(25);
-
+        Paraguay,
         /// The infoType is typically used in Peru.
-        pub const PERU: LocationCategory = LocationCategory::new(26);
-
+        Peru,
         /// The infoType is typically used in Poland.
-        pub const POLAND: LocationCategory = LocationCategory::new(27);
-
+        Poland,
         /// The infoType is typically used in Portugal.
-        pub const PORTUGAL: LocationCategory = LocationCategory::new(28);
-
+        Portugal,
         /// The infoType is typically used in Russia.
-        pub const RUSSIA: LocationCategory = LocationCategory::new(44);
-
+        Russia,
         /// The infoType is typically used in Singapore.
-        pub const SINGAPORE: LocationCategory = LocationCategory::new(29);
-
+        Singapore,
         /// The infoType is typically used in South Africa.
-        pub const SOUTH_AFRICA: LocationCategory = LocationCategory::new(30);
-
+        SouthAfrica,
         /// The infoType is typically used in Spain.
-        pub const SPAIN: LocationCategory = LocationCategory::new(31);
-
+        Spain,
         /// The infoType is typically used in Sweden.
-        pub const SWEDEN: LocationCategory = LocationCategory::new(32);
-
+        Sweden,
         /// The infoType is typically used in Switzerland.
-        pub const SWITZERLAND: LocationCategory = LocationCategory::new(43);
-
+        Switzerland,
         /// The infoType is typically used in Taiwan.
-        pub const TAIWAN: LocationCategory = LocationCategory::new(33);
-
+        Taiwan,
         /// The infoType is typically used in Thailand.
-        pub const THAILAND: LocationCategory = LocationCategory::new(34);
-
+        Thailand,
         /// The infoType is typically used in Turkey.
-        pub const TURKEY: LocationCategory = LocationCategory::new(35);
-
+        Turkey,
         /// The infoType is typically used in Ukraine.
-        pub const UKRAINE: LocationCategory = LocationCategory::new(45);
-
+        Ukraine,
         /// The infoType is typically used in the United Kingdom.
-        pub const UNITED_KINGDOM: LocationCategory = LocationCategory::new(36);
-
+        UnitedKingdom,
         /// The infoType is typically used in the United States.
-        pub const UNITED_STATES: LocationCategory = LocationCategory::new(37);
-
+        UnitedStates,
         /// The infoType is typically used in Uruguay.
-        pub const URUGUAY: LocationCategory = LocationCategory::new(38);
-
+        Uruguay,
         /// The infoType is typically used in Uzbekistan.
-        pub const UZBEKISTAN: LocationCategory = LocationCategory::new(46);
-
+        Uzbekistan,
         /// The infoType is typically used in Venezuela.
-        pub const VENEZUELA: LocationCategory = LocationCategory::new(39);
-
+        Venezuela,
         /// The infoType is typically used in Google internally.
-        pub const INTERNAL: LocationCategory = LocationCategory::new(40);
+        Internal,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LocationCategory::value] or
+        /// [LocationCategory::name].
+        UnknownValue(location_category::UnknownValue),
+    }
 
-        /// Creates a new LocationCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod location_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LocationCategory {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::LocationUnspecified => std::option::Option::Some(0),
+                Self::Global => std::option::Option::Some(1),
+                Self::Argentina => std::option::Option::Some(2),
+                Self::Armenia => std::option::Option::Some(51),
+                Self::Australia => std::option::Option::Some(3),
+                Self::Azerbaijan => std::option::Option::Some(48),
+                Self::Belarus => std::option::Option::Some(50),
+                Self::Belgium => std::option::Option::Some(4),
+                Self::Brazil => std::option::Option::Some(5),
+                Self::Canada => std::option::Option::Some(6),
+                Self::Chile => std::option::Option::Some(7),
+                Self::China => std::option::Option::Some(8),
+                Self::Colombia => std::option::Option::Some(9),
+                Self::Croatia => std::option::Option::Some(42),
+                Self::Czechia => std::option::Option::Some(52),
+                Self::Denmark => std::option::Option::Some(10),
+                Self::France => std::option::Option::Some(11),
+                Self::Finland => std::option::Option::Some(12),
+                Self::Germany => std::option::Option::Some(13),
+                Self::HongKong => std::option::Option::Some(14),
+                Self::India => std::option::Option::Some(15),
+                Self::Indonesia => std::option::Option::Some(16),
+                Self::Ireland => std::option::Option::Some(17),
+                Self::Israel => std::option::Option::Some(18),
+                Self::Italy => std::option::Option::Some(19),
+                Self::Japan => std::option::Option::Some(20),
+                Self::Kazakhstan => std::option::Option::Some(47),
+                Self::Korea => std::option::Option::Some(21),
+                Self::Mexico => std::option::Option::Some(22),
+                Self::TheNetherlands => std::option::Option::Some(23),
+                Self::NewZealand => std::option::Option::Some(41),
+                Self::Norway => std::option::Option::Some(24),
+                Self::Paraguay => std::option::Option::Some(25),
+                Self::Peru => std::option::Option::Some(26),
+                Self::Poland => std::option::Option::Some(27),
+                Self::Portugal => std::option::Option::Some(28),
+                Self::Russia => std::option::Option::Some(44),
+                Self::Singapore => std::option::Option::Some(29),
+                Self::SouthAfrica => std::option::Option::Some(30),
+                Self::Spain => std::option::Option::Some(31),
+                Self::Sweden => std::option::Option::Some(32),
+                Self::Switzerland => std::option::Option::Some(43),
+                Self::Taiwan => std::option::Option::Some(33),
+                Self::Thailand => std::option::Option::Some(34),
+                Self::Turkey => std::option::Option::Some(35),
+                Self::Ukraine => std::option::Option::Some(45),
+                Self::UnitedKingdom => std::option::Option::Some(36),
+                Self::UnitedStates => std::option::Option::Some(37),
+                Self::Uruguay => std::option::Option::Some(38),
+                Self::Uzbekistan => std::option::Option::Some(46),
+                Self::Venezuela => std::option::Option::Some(39),
+                Self::Internal => std::option::Option::Some(40),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOCATION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GLOBAL"),
-                2 => std::borrow::Cow::Borrowed("ARGENTINA"),
-                3 => std::borrow::Cow::Borrowed("AUSTRALIA"),
-                4 => std::borrow::Cow::Borrowed("BELGIUM"),
-                5 => std::borrow::Cow::Borrowed("BRAZIL"),
-                6 => std::borrow::Cow::Borrowed("CANADA"),
-                7 => std::borrow::Cow::Borrowed("CHILE"),
-                8 => std::borrow::Cow::Borrowed("CHINA"),
-                9 => std::borrow::Cow::Borrowed("COLOMBIA"),
-                10 => std::borrow::Cow::Borrowed("DENMARK"),
-                11 => std::borrow::Cow::Borrowed("FRANCE"),
-                12 => std::borrow::Cow::Borrowed("FINLAND"),
-                13 => std::borrow::Cow::Borrowed("GERMANY"),
-                14 => std::borrow::Cow::Borrowed("HONG_KONG"),
-                15 => std::borrow::Cow::Borrowed("INDIA"),
-                16 => std::borrow::Cow::Borrowed("INDONESIA"),
-                17 => std::borrow::Cow::Borrowed("IRELAND"),
-                18 => std::borrow::Cow::Borrowed("ISRAEL"),
-                19 => std::borrow::Cow::Borrowed("ITALY"),
-                20 => std::borrow::Cow::Borrowed("JAPAN"),
-                21 => std::borrow::Cow::Borrowed("KOREA"),
-                22 => std::borrow::Cow::Borrowed("MEXICO"),
-                23 => std::borrow::Cow::Borrowed("THE_NETHERLANDS"),
-                24 => std::borrow::Cow::Borrowed("NORWAY"),
-                25 => std::borrow::Cow::Borrowed("PARAGUAY"),
-                26 => std::borrow::Cow::Borrowed("PERU"),
-                27 => std::borrow::Cow::Borrowed("POLAND"),
-                28 => std::borrow::Cow::Borrowed("PORTUGAL"),
-                29 => std::borrow::Cow::Borrowed("SINGAPORE"),
-                30 => std::borrow::Cow::Borrowed("SOUTH_AFRICA"),
-                31 => std::borrow::Cow::Borrowed("SPAIN"),
-                32 => std::borrow::Cow::Borrowed("SWEDEN"),
-                33 => std::borrow::Cow::Borrowed("TAIWAN"),
-                34 => std::borrow::Cow::Borrowed("THAILAND"),
-                35 => std::borrow::Cow::Borrowed("TURKEY"),
-                36 => std::borrow::Cow::Borrowed("UNITED_KINGDOM"),
-                37 => std::borrow::Cow::Borrowed("UNITED_STATES"),
-                38 => std::borrow::Cow::Borrowed("URUGUAY"),
-                39 => std::borrow::Cow::Borrowed("VENEZUELA"),
-                40 => std::borrow::Cow::Borrowed("INTERNAL"),
-                41 => std::borrow::Cow::Borrowed("NEW_ZEALAND"),
-                42 => std::borrow::Cow::Borrowed("CROATIA"),
-                43 => std::borrow::Cow::Borrowed("SWITZERLAND"),
-                44 => std::borrow::Cow::Borrowed("RUSSIA"),
-                45 => std::borrow::Cow::Borrowed("UKRAINE"),
-                46 => std::borrow::Cow::Borrowed("UZBEKISTAN"),
-                47 => std::borrow::Cow::Borrowed("KAZAKHSTAN"),
-                48 => std::borrow::Cow::Borrowed("AZERBAIJAN"),
-                50 => std::borrow::Cow::Borrowed("BELARUS"),
-                51 => std::borrow::Cow::Borrowed("ARMENIA"),
-                52 => std::borrow::Cow::Borrowed("CZECHIA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::LocationUnspecified => std::option::Option::Some("LOCATION_UNSPECIFIED"),
+                Self::Global => std::option::Option::Some("GLOBAL"),
+                Self::Argentina => std::option::Option::Some("ARGENTINA"),
+                Self::Armenia => std::option::Option::Some("ARMENIA"),
+                Self::Australia => std::option::Option::Some("AUSTRALIA"),
+                Self::Azerbaijan => std::option::Option::Some("AZERBAIJAN"),
+                Self::Belarus => std::option::Option::Some("BELARUS"),
+                Self::Belgium => std::option::Option::Some("BELGIUM"),
+                Self::Brazil => std::option::Option::Some("BRAZIL"),
+                Self::Canada => std::option::Option::Some("CANADA"),
+                Self::Chile => std::option::Option::Some("CHILE"),
+                Self::China => std::option::Option::Some("CHINA"),
+                Self::Colombia => std::option::Option::Some("COLOMBIA"),
+                Self::Croatia => std::option::Option::Some("CROATIA"),
+                Self::Czechia => std::option::Option::Some("CZECHIA"),
+                Self::Denmark => std::option::Option::Some("DENMARK"),
+                Self::France => std::option::Option::Some("FRANCE"),
+                Self::Finland => std::option::Option::Some("FINLAND"),
+                Self::Germany => std::option::Option::Some("GERMANY"),
+                Self::HongKong => std::option::Option::Some("HONG_KONG"),
+                Self::India => std::option::Option::Some("INDIA"),
+                Self::Indonesia => std::option::Option::Some("INDONESIA"),
+                Self::Ireland => std::option::Option::Some("IRELAND"),
+                Self::Israel => std::option::Option::Some("ISRAEL"),
+                Self::Italy => std::option::Option::Some("ITALY"),
+                Self::Japan => std::option::Option::Some("JAPAN"),
+                Self::Kazakhstan => std::option::Option::Some("KAZAKHSTAN"),
+                Self::Korea => std::option::Option::Some("KOREA"),
+                Self::Mexico => std::option::Option::Some("MEXICO"),
+                Self::TheNetherlands => std::option::Option::Some("THE_NETHERLANDS"),
+                Self::NewZealand => std::option::Option::Some("NEW_ZEALAND"),
+                Self::Norway => std::option::Option::Some("NORWAY"),
+                Self::Paraguay => std::option::Option::Some("PARAGUAY"),
+                Self::Peru => std::option::Option::Some("PERU"),
+                Self::Poland => std::option::Option::Some("POLAND"),
+                Self::Portugal => std::option::Option::Some("PORTUGAL"),
+                Self::Russia => std::option::Option::Some("RUSSIA"),
+                Self::Singapore => std::option::Option::Some("SINGAPORE"),
+                Self::SouthAfrica => std::option::Option::Some("SOUTH_AFRICA"),
+                Self::Spain => std::option::Option::Some("SPAIN"),
+                Self::Sweden => std::option::Option::Some("SWEDEN"),
+                Self::Switzerland => std::option::Option::Some("SWITZERLAND"),
+                Self::Taiwan => std::option::Option::Some("TAIWAN"),
+                Self::Thailand => std::option::Option::Some("THAILAND"),
+                Self::Turkey => std::option::Option::Some("TURKEY"),
+                Self::Ukraine => std::option::Option::Some("UKRAINE"),
+                Self::UnitedKingdom => std::option::Option::Some("UNITED_KINGDOM"),
+                Self::UnitedStates => std::option::Option::Some("UNITED_STATES"),
+                Self::Uruguay => std::option::Option::Some("URUGUAY"),
+                Self::Uzbekistan => std::option::Option::Some("UZBEKISTAN"),
+                Self::Venezuela => std::option::Option::Some("VENEZUELA"),
+                Self::Internal => std::option::Option::Some("INTERNAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOCATION_UNSPECIFIED" => std::option::Option::Some(Self::LOCATION_UNSPECIFIED),
-                "GLOBAL" => std::option::Option::Some(Self::GLOBAL),
-                "ARGENTINA" => std::option::Option::Some(Self::ARGENTINA),
-                "ARMENIA" => std::option::Option::Some(Self::ARMENIA),
-                "AUSTRALIA" => std::option::Option::Some(Self::AUSTRALIA),
-                "AZERBAIJAN" => std::option::Option::Some(Self::AZERBAIJAN),
-                "BELARUS" => std::option::Option::Some(Self::BELARUS),
-                "BELGIUM" => std::option::Option::Some(Self::BELGIUM),
-                "BRAZIL" => std::option::Option::Some(Self::BRAZIL),
-                "CANADA" => std::option::Option::Some(Self::CANADA),
-                "CHILE" => std::option::Option::Some(Self::CHILE),
-                "CHINA" => std::option::Option::Some(Self::CHINA),
-                "COLOMBIA" => std::option::Option::Some(Self::COLOMBIA),
-                "CROATIA" => std::option::Option::Some(Self::CROATIA),
-                "CZECHIA" => std::option::Option::Some(Self::CZECHIA),
-                "DENMARK" => std::option::Option::Some(Self::DENMARK),
-                "FRANCE" => std::option::Option::Some(Self::FRANCE),
-                "FINLAND" => std::option::Option::Some(Self::FINLAND),
-                "GERMANY" => std::option::Option::Some(Self::GERMANY),
-                "HONG_KONG" => std::option::Option::Some(Self::HONG_KONG),
-                "INDIA" => std::option::Option::Some(Self::INDIA),
-                "INDONESIA" => std::option::Option::Some(Self::INDONESIA),
-                "IRELAND" => std::option::Option::Some(Self::IRELAND),
-                "ISRAEL" => std::option::Option::Some(Self::ISRAEL),
-                "ITALY" => std::option::Option::Some(Self::ITALY),
-                "JAPAN" => std::option::Option::Some(Self::JAPAN),
-                "KAZAKHSTAN" => std::option::Option::Some(Self::KAZAKHSTAN),
-                "KOREA" => std::option::Option::Some(Self::KOREA),
-                "MEXICO" => std::option::Option::Some(Self::MEXICO),
-                "THE_NETHERLANDS" => std::option::Option::Some(Self::THE_NETHERLANDS),
-                "NEW_ZEALAND" => std::option::Option::Some(Self::NEW_ZEALAND),
-                "NORWAY" => std::option::Option::Some(Self::NORWAY),
-                "PARAGUAY" => std::option::Option::Some(Self::PARAGUAY),
-                "PERU" => std::option::Option::Some(Self::PERU),
-                "POLAND" => std::option::Option::Some(Self::POLAND),
-                "PORTUGAL" => std::option::Option::Some(Self::PORTUGAL),
-                "RUSSIA" => std::option::Option::Some(Self::RUSSIA),
-                "SINGAPORE" => std::option::Option::Some(Self::SINGAPORE),
-                "SOUTH_AFRICA" => std::option::Option::Some(Self::SOUTH_AFRICA),
-                "SPAIN" => std::option::Option::Some(Self::SPAIN),
-                "SWEDEN" => std::option::Option::Some(Self::SWEDEN),
-                "SWITZERLAND" => std::option::Option::Some(Self::SWITZERLAND),
-                "TAIWAN" => std::option::Option::Some(Self::TAIWAN),
-                "THAILAND" => std::option::Option::Some(Self::THAILAND),
-                "TURKEY" => std::option::Option::Some(Self::TURKEY),
-                "UKRAINE" => std::option::Option::Some(Self::UKRAINE),
-                "UNITED_KINGDOM" => std::option::Option::Some(Self::UNITED_KINGDOM),
-                "UNITED_STATES" => std::option::Option::Some(Self::UNITED_STATES),
-                "URUGUAY" => std::option::Option::Some(Self::URUGUAY),
-                "UZBEKISTAN" => std::option::Option::Some(Self::UZBEKISTAN),
-                "VENEZUELA" => std::option::Option::Some(Self::VENEZUELA),
-                "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LocationCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LocationCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LocationCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LocationCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::LocationUnspecified,
+                1 => Self::Global,
+                2 => Self::Argentina,
+                3 => Self::Australia,
+                4 => Self::Belgium,
+                5 => Self::Brazil,
+                6 => Self::Canada,
+                7 => Self::Chile,
+                8 => Self::China,
+                9 => Self::Colombia,
+                10 => Self::Denmark,
+                11 => Self::France,
+                12 => Self::Finland,
+                13 => Self::Germany,
+                14 => Self::HongKong,
+                15 => Self::India,
+                16 => Self::Indonesia,
+                17 => Self::Ireland,
+                18 => Self::Israel,
+                19 => Self::Italy,
+                20 => Self::Japan,
+                21 => Self::Korea,
+                22 => Self::Mexico,
+                23 => Self::TheNetherlands,
+                24 => Self::Norway,
+                25 => Self::Paraguay,
+                26 => Self::Peru,
+                27 => Self::Poland,
+                28 => Self::Portugal,
+                29 => Self::Singapore,
+                30 => Self::SouthAfrica,
+                31 => Self::Spain,
+                32 => Self::Sweden,
+                33 => Self::Taiwan,
+                34 => Self::Thailand,
+                35 => Self::Turkey,
+                36 => Self::UnitedKingdom,
+                37 => Self::UnitedStates,
+                38 => Self::Uruguay,
+                39 => Self::Venezuela,
+                40 => Self::Internal,
+                41 => Self::NewZealand,
+                42 => Self::Croatia,
+                43 => Self::Switzerland,
+                44 => Self::Russia,
+                45 => Self::Ukraine,
+                46 => Self::Uzbekistan,
+                47 => Self::Kazakhstan,
+                48 => Self::Azerbaijan,
+                50 => Self::Belarus,
+                51 => Self::Armenia,
+                52 => Self::Czechia,
+                _ => Self::UnknownValue(location_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LocationCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOCATION_UNSPECIFIED" => Self::LocationUnspecified,
+                "GLOBAL" => Self::Global,
+                "ARGENTINA" => Self::Argentina,
+                "ARMENIA" => Self::Armenia,
+                "AUSTRALIA" => Self::Australia,
+                "AZERBAIJAN" => Self::Azerbaijan,
+                "BELARUS" => Self::Belarus,
+                "BELGIUM" => Self::Belgium,
+                "BRAZIL" => Self::Brazil,
+                "CANADA" => Self::Canada,
+                "CHILE" => Self::Chile,
+                "CHINA" => Self::China,
+                "COLOMBIA" => Self::Colombia,
+                "CROATIA" => Self::Croatia,
+                "CZECHIA" => Self::Czechia,
+                "DENMARK" => Self::Denmark,
+                "FRANCE" => Self::France,
+                "FINLAND" => Self::Finland,
+                "GERMANY" => Self::Germany,
+                "HONG_KONG" => Self::HongKong,
+                "INDIA" => Self::India,
+                "INDONESIA" => Self::Indonesia,
+                "IRELAND" => Self::Ireland,
+                "ISRAEL" => Self::Israel,
+                "ITALY" => Self::Italy,
+                "JAPAN" => Self::Japan,
+                "KAZAKHSTAN" => Self::Kazakhstan,
+                "KOREA" => Self::Korea,
+                "MEXICO" => Self::Mexico,
+                "THE_NETHERLANDS" => Self::TheNetherlands,
+                "NEW_ZEALAND" => Self::NewZealand,
+                "NORWAY" => Self::Norway,
+                "PARAGUAY" => Self::Paraguay,
+                "PERU" => Self::Peru,
+                "POLAND" => Self::Poland,
+                "PORTUGAL" => Self::Portugal,
+                "RUSSIA" => Self::Russia,
+                "SINGAPORE" => Self::Singapore,
+                "SOUTH_AFRICA" => Self::SouthAfrica,
+                "SPAIN" => Self::Spain,
+                "SWEDEN" => Self::Sweden,
+                "SWITZERLAND" => Self::Switzerland,
+                "TAIWAN" => Self::Taiwan,
+                "THAILAND" => Self::Thailand,
+                "TURKEY" => Self::Turkey,
+                "UKRAINE" => Self::Ukraine,
+                "UNITED_KINGDOM" => Self::UnitedKingdom,
+                "UNITED_STATES" => Self::UnitedStates,
+                "URUGUAY" => Self::Uruguay,
+                "UZBEKISTAN" => Self::Uzbekistan,
+                "VENEZUELA" => Self::Venezuela,
+                "INTERNAL" => Self::Internal,
+                _ => Self::UnknownValue(location_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LocationCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::LocationUnspecified => serializer.serialize_i32(0),
+                Self::Global => serializer.serialize_i32(1),
+                Self::Argentina => serializer.serialize_i32(2),
+                Self::Armenia => serializer.serialize_i32(51),
+                Self::Australia => serializer.serialize_i32(3),
+                Self::Azerbaijan => serializer.serialize_i32(48),
+                Self::Belarus => serializer.serialize_i32(50),
+                Self::Belgium => serializer.serialize_i32(4),
+                Self::Brazil => serializer.serialize_i32(5),
+                Self::Canada => serializer.serialize_i32(6),
+                Self::Chile => serializer.serialize_i32(7),
+                Self::China => serializer.serialize_i32(8),
+                Self::Colombia => serializer.serialize_i32(9),
+                Self::Croatia => serializer.serialize_i32(42),
+                Self::Czechia => serializer.serialize_i32(52),
+                Self::Denmark => serializer.serialize_i32(10),
+                Self::France => serializer.serialize_i32(11),
+                Self::Finland => serializer.serialize_i32(12),
+                Self::Germany => serializer.serialize_i32(13),
+                Self::HongKong => serializer.serialize_i32(14),
+                Self::India => serializer.serialize_i32(15),
+                Self::Indonesia => serializer.serialize_i32(16),
+                Self::Ireland => serializer.serialize_i32(17),
+                Self::Israel => serializer.serialize_i32(18),
+                Self::Italy => serializer.serialize_i32(19),
+                Self::Japan => serializer.serialize_i32(20),
+                Self::Kazakhstan => serializer.serialize_i32(47),
+                Self::Korea => serializer.serialize_i32(21),
+                Self::Mexico => serializer.serialize_i32(22),
+                Self::TheNetherlands => serializer.serialize_i32(23),
+                Self::NewZealand => serializer.serialize_i32(41),
+                Self::Norway => serializer.serialize_i32(24),
+                Self::Paraguay => serializer.serialize_i32(25),
+                Self::Peru => serializer.serialize_i32(26),
+                Self::Poland => serializer.serialize_i32(27),
+                Self::Portugal => serializer.serialize_i32(28),
+                Self::Russia => serializer.serialize_i32(44),
+                Self::Singapore => serializer.serialize_i32(29),
+                Self::SouthAfrica => serializer.serialize_i32(30),
+                Self::Spain => serializer.serialize_i32(31),
+                Self::Sweden => serializer.serialize_i32(32),
+                Self::Switzerland => serializer.serialize_i32(43),
+                Self::Taiwan => serializer.serialize_i32(33),
+                Self::Thailand => serializer.serialize_i32(34),
+                Self::Turkey => serializer.serialize_i32(35),
+                Self::Ukraine => serializer.serialize_i32(45),
+                Self::UnitedKingdom => serializer.serialize_i32(36),
+                Self::UnitedStates => serializer.serialize_i32(37),
+                Self::Uruguay => serializer.serialize_i32(38),
+                Self::Uzbekistan => serializer.serialize_i32(46),
+                Self::Venezuela => serializer.serialize_i32(39),
+                Self::Internal => serializer.serialize_i32(40),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LocationCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LocationCategory>::new(
+                ".google.privacy.dlp.v2.InfoTypeCategory.LocationCategory",
+            ))
         }
     }
 
     /// Enum of the current industries in the category.
     /// We might add more industries in the future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IndustryCategory(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IndustryCategory {
+        /// Unused industry
+        IndustryUnspecified,
+        /// The infoType is typically used in the finance industry.
+        Finance,
+        /// The infoType is typically used in the health industry.
+        Health,
+        /// The infoType is typically used in the telecommunications industry.
+        Telecommunications,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IndustryCategory::value] or
+        /// [IndustryCategory::name].
+        UnknownValue(industry_category::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod industry_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IndustryCategory {
-        /// Unused industry
-        pub const INDUSTRY_UNSPECIFIED: IndustryCategory = IndustryCategory::new(0);
-
-        /// The infoType is typically used in the finance industry.
-        pub const FINANCE: IndustryCategory = IndustryCategory::new(1);
-
-        /// The infoType is typically used in the health industry.
-        pub const HEALTH: IndustryCategory = IndustryCategory::new(2);
-
-        /// The infoType is typically used in the telecommunications industry.
-        pub const TELECOMMUNICATIONS: IndustryCategory = IndustryCategory::new(3);
-
-        /// Creates a new IndustryCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::IndustryUnspecified => std::option::Option::Some(0),
+                Self::Finance => std::option::Option::Some(1),
+                Self::Health => std::option::Option::Some(2),
+                Self::Telecommunications => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INDUSTRY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FINANCE"),
-                2 => std::borrow::Cow::Borrowed("HEALTH"),
-                3 => std::borrow::Cow::Borrowed("TELECOMMUNICATIONS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::IndustryUnspecified => std::option::Option::Some("INDUSTRY_UNSPECIFIED"),
+                Self::Finance => std::option::Option::Some("FINANCE"),
+                Self::Health => std::option::Option::Some("HEALTH"),
+                Self::Telecommunications => std::option::Option::Some("TELECOMMUNICATIONS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INDUSTRY_UNSPECIFIED" => std::option::Option::Some(Self::INDUSTRY_UNSPECIFIED),
-                "FINANCE" => std::option::Option::Some(Self::FINANCE),
-                "HEALTH" => std::option::Option::Some(Self::HEALTH),
-                "TELECOMMUNICATIONS" => std::option::Option::Some(Self::TELECOMMUNICATIONS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IndustryCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IndustryCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IndustryCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IndustryCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::IndustryUnspecified,
+                1 => Self::Finance,
+                2 => Self::Health,
+                3 => Self::Telecommunications,
+                _ => Self::UnknownValue(industry_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IndustryCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INDUSTRY_UNSPECIFIED" => Self::IndustryUnspecified,
+                "FINANCE" => Self::Finance,
+                "HEALTH" => Self::Health,
+                "TELECOMMUNICATIONS" => Self::Telecommunications,
+                _ => Self::UnknownValue(industry_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IndustryCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::IndustryUnspecified => serializer.serialize_i32(0),
+                Self::Finance => serializer.serialize_i32(1),
+                Self::Health => serializer.serialize_i32(2),
+                Self::Telecommunications => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IndustryCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IndustryCategory>::new(
+                ".google.privacy.dlp.v2.InfoTypeCategory.IndustryCategory",
+            ))
         }
     }
 
     /// Enum of the current types in the category.
     /// We might add more types in the future.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TypeCategory(i32);
-
-    impl TypeCategory {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TypeCategory {
         /// Unused type
-        pub const TYPE_UNSPECIFIED: TypeCategory = TypeCategory::new(0);
-
+        TypeUnspecified,
         /// Personally identifiable information, for example, a
         /// name or phone number
-        pub const PII: TypeCategory = TypeCategory::new(1);
-
+        Pii,
         /// Personally identifiable information that is especially sensitive, for
         /// example, a passport number.
-        pub const SPII: TypeCategory = TypeCategory::new(2);
-
+        Spii,
         /// Attributes that can partially identify someone, especially in
         /// combination with other attributes, like age, height, and gender.
-        pub const DEMOGRAPHIC: TypeCategory = TypeCategory::new(3);
-
+        Demographic,
         /// Confidential or secret information, for example, a password.
-        pub const CREDENTIAL: TypeCategory = TypeCategory::new(4);
-
+        Credential,
         /// An identification document issued by a government.
-        pub const GOVERNMENT_ID: TypeCategory = TypeCategory::new(5);
-
+        GovernmentId,
         /// A document, for example, a resume or source code.
-        pub const DOCUMENT: TypeCategory = TypeCategory::new(6);
-
+        Document,
         /// Information that is not sensitive on its own, but provides details about
         /// the circumstances surrounding an entity or an event.
-        pub const CONTEXTUAL_INFORMATION: TypeCategory = TypeCategory::new(7);
-
+        ContextualInformation,
         /// Category for `CustomInfoType` types.
-        pub const CUSTOM: TypeCategory = TypeCategory::new(8);
+        Custom,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TypeCategory::value] or
+        /// [TypeCategory::name].
+        UnknownValue(type_category::UnknownValue),
+    }
 
-        /// Creates a new TypeCategory instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod type_category {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TypeCategory {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::TypeUnspecified => std::option::Option::Some(0),
+                Self::Pii => std::option::Option::Some(1),
+                Self::Spii => std::option::Option::Some(2),
+                Self::Demographic => std::option::Option::Some(3),
+                Self::Credential => std::option::Option::Some(4),
+                Self::GovernmentId => std::option::Option::Some(5),
+                Self::Document => std::option::Option::Some(6),
+                Self::ContextualInformation => std::option::Option::Some(7),
+                Self::Custom => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PII"),
-                2 => std::borrow::Cow::Borrowed("SPII"),
-                3 => std::borrow::Cow::Borrowed("DEMOGRAPHIC"),
-                4 => std::borrow::Cow::Borrowed("CREDENTIAL"),
-                5 => std::borrow::Cow::Borrowed("GOVERNMENT_ID"),
-                6 => std::borrow::Cow::Borrowed("DOCUMENT"),
-                7 => std::borrow::Cow::Borrowed("CONTEXTUAL_INFORMATION"),
-                8 => std::borrow::Cow::Borrowed("CUSTOM"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::TypeUnspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Pii => std::option::Option::Some("PII"),
+                Self::Spii => std::option::Option::Some("SPII"),
+                Self::Demographic => std::option::Option::Some("DEMOGRAPHIC"),
+                Self::Credential => std::option::Option::Some("CREDENTIAL"),
+                Self::GovernmentId => std::option::Option::Some("GOVERNMENT_ID"),
+                Self::Document => std::option::Option::Some("DOCUMENT"),
+                Self::ContextualInformation => std::option::Option::Some("CONTEXTUAL_INFORMATION"),
+                Self::Custom => std::option::Option::Some("CUSTOM"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "PII" => std::option::Option::Some(Self::PII),
-                "SPII" => std::option::Option::Some(Self::SPII),
-                "DEMOGRAPHIC" => std::option::Option::Some(Self::DEMOGRAPHIC),
-                "CREDENTIAL" => std::option::Option::Some(Self::CREDENTIAL),
-                "GOVERNMENT_ID" => std::option::Option::Some(Self::GOVERNMENT_ID),
-                "DOCUMENT" => std::option::Option::Some(Self::DOCUMENT),
-                "CONTEXTUAL_INFORMATION" => std::option::Option::Some(Self::CONTEXTUAL_INFORMATION),
-                "CUSTOM" => std::option::Option::Some(Self::CUSTOM),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TypeCategory {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TypeCategory {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TypeCategory {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TypeCategory {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::TypeUnspecified,
+                1 => Self::Pii,
+                2 => Self::Spii,
+                3 => Self::Demographic,
+                4 => Self::Credential,
+                5 => Self::GovernmentId,
+                6 => Self::Document,
+                7 => Self::ContextualInformation,
+                8 => Self::Custom,
+                _ => Self::UnknownValue(type_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TypeCategory {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::TypeUnspecified,
+                "PII" => Self::Pii,
+                "SPII" => Self::Spii,
+                "DEMOGRAPHIC" => Self::Demographic,
+                "CREDENTIAL" => Self::Credential,
+                "GOVERNMENT_ID" => Self::GovernmentId,
+                "DOCUMENT" => Self::Document,
+                "CONTEXTUAL_INFORMATION" => Self::ContextualInformation,
+                "CUSTOM" => Self::Custom,
+                _ => Self::UnknownValue(type_category::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TypeCategory {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::TypeUnspecified => serializer.serialize_i32(0),
+                Self::Pii => serializer.serialize_i32(1),
+                Self::Spii => serializer.serialize_i32(2),
+                Self::Demographic => serializer.serialize_i32(3),
+                Self::Credential => serializer.serialize_i32(4),
+                Self::GovernmentId => serializer.serialize_i32(5),
+                Self::Document => serializer.serialize_i32(6),
+                Self::ContextualInformation => serializer.serialize_i32(7),
+                Self::Custom => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TypeCategory {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TypeCategory>::new(
+                ".google.privacy.dlp.v2.InfoTypeCategory.TypeCategory",
+            ))
         }
     }
 
@@ -9508,79 +9959,148 @@ pub mod time_part_config {
     use super::*;
 
     /// Components that make up time.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimePart(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimePart {
+        /// Unused
+        Unspecified,
+        /// [0-9999]
+        Year,
+        /// [1-12]
+        Month,
+        /// [1-31]
+        DayOfMonth,
+        /// [1-7]
+        DayOfWeek,
+        /// [1-53]
+        WeekOfYear,
+        /// [0-23]
+        HourOfDay,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimePart::value] or
+        /// [TimePart::name].
+        UnknownValue(time_part::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod time_part {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TimePart {
-        /// Unused
-        pub const TIME_PART_UNSPECIFIED: TimePart = TimePart::new(0);
-
-        /// [0-9999]
-        pub const YEAR: TimePart = TimePart::new(1);
-
-        /// [1-12]
-        pub const MONTH: TimePart = TimePart::new(2);
-
-        /// [1-31]
-        pub const DAY_OF_MONTH: TimePart = TimePart::new(3);
-
-        /// [1-7]
-        pub const DAY_OF_WEEK: TimePart = TimePart::new(4);
-
-        /// [1-53]
-        pub const WEEK_OF_YEAR: TimePart = TimePart::new(5);
-
-        /// [0-23]
-        pub const HOUR_OF_DAY: TimePart = TimePart::new(6);
-
-        /// Creates a new TimePart instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Year => std::option::Option::Some(1),
+                Self::Month => std::option::Option::Some(2),
+                Self::DayOfMonth => std::option::Option::Some(3),
+                Self::DayOfWeek => std::option::Option::Some(4),
+                Self::WeekOfYear => std::option::Option::Some(5),
+                Self::HourOfDay => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIME_PART_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("YEAR"),
-                2 => std::borrow::Cow::Borrowed("MONTH"),
-                3 => std::borrow::Cow::Borrowed("DAY_OF_MONTH"),
-                4 => std::borrow::Cow::Borrowed("DAY_OF_WEEK"),
-                5 => std::borrow::Cow::Borrowed("WEEK_OF_YEAR"),
-                6 => std::borrow::Cow::Borrowed("HOUR_OF_DAY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIME_PART_UNSPECIFIED"),
+                Self::Year => std::option::Option::Some("YEAR"),
+                Self::Month => std::option::Option::Some("MONTH"),
+                Self::DayOfMonth => std::option::Option::Some("DAY_OF_MONTH"),
+                Self::DayOfWeek => std::option::Option::Some("DAY_OF_WEEK"),
+                Self::WeekOfYear => std::option::Option::Some("WEEK_OF_YEAR"),
+                Self::HourOfDay => std::option::Option::Some("HOUR_OF_DAY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIME_PART_UNSPECIFIED" => std::option::Option::Some(Self::TIME_PART_UNSPECIFIED),
-                "YEAR" => std::option::Option::Some(Self::YEAR),
-                "MONTH" => std::option::Option::Some(Self::MONTH),
-                "DAY_OF_MONTH" => std::option::Option::Some(Self::DAY_OF_MONTH),
-                "DAY_OF_WEEK" => std::option::Option::Some(Self::DAY_OF_WEEK),
-                "WEEK_OF_YEAR" => std::option::Option::Some(Self::WEEK_OF_YEAR),
-                "HOUR_OF_DAY" => std::option::Option::Some(Self::HOUR_OF_DAY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TimePart {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimePart {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimePart {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimePart {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Year,
+                2 => Self::Month,
+                3 => Self::DayOfMonth,
+                4 => Self::DayOfWeek,
+                5 => Self::WeekOfYear,
+                6 => Self::HourOfDay,
+                _ => Self::UnknownValue(time_part::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimePart {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIME_PART_UNSPECIFIED" => Self::Unspecified,
+                "YEAR" => Self::Year,
+                "MONTH" => Self::Month,
+                "DAY_OF_MONTH" => Self::DayOfMonth,
+                "DAY_OF_WEEK" => Self::DayOfWeek,
+                "WEEK_OF_YEAR" => Self::WeekOfYear,
+                "HOUR_OF_DAY" => Self::HourOfDay,
+                _ => Self::UnknownValue(time_part::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimePart {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Year => serializer.serialize_i32(1),
+                Self::Month => serializer.serialize_i32(2),
+                Self::DayOfMonth => serializer.serialize_i32(3),
+                Self::DayOfWeek => serializer.serialize_i32(4),
+                Self::WeekOfYear => serializer.serialize_i32(5),
+                Self::HourOfDay => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimePart {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimePart>::new(
+                ".google.privacy.dlp.v2.TimePartConfig.TimePart",
+            ))
         }
     }
 }
@@ -10020,77 +10540,143 @@ pub mod chars_to_ignore {
     use super::*;
 
     /// Convenience enum for indicating common characters to not transform.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CommonCharsToIgnore(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CommonCharsToIgnore {
+        /// Unused.
+        Unspecified,
+        /// 0-9
+        Numeric,
+        /// A-Z
+        AlphaUpperCase,
+        /// a-z
+        AlphaLowerCase,
+        /// US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+        Punctuation,
+        /// Whitespace character, one of [ \t\n\x0B\f\r]
+        Whitespace,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CommonCharsToIgnore::value] or
+        /// [CommonCharsToIgnore::name].
+        UnknownValue(common_chars_to_ignore::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod common_chars_to_ignore {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl CommonCharsToIgnore {
-        /// Unused.
-        pub const COMMON_CHARS_TO_IGNORE_UNSPECIFIED: CommonCharsToIgnore =
-            CommonCharsToIgnore::new(0);
-
-        /// 0-9
-        pub const NUMERIC: CommonCharsToIgnore = CommonCharsToIgnore::new(1);
-
-        /// A-Z
-        pub const ALPHA_UPPER_CASE: CommonCharsToIgnore = CommonCharsToIgnore::new(2);
-
-        /// a-z
-        pub const ALPHA_LOWER_CASE: CommonCharsToIgnore = CommonCharsToIgnore::new(3);
-
-        /// US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
-        pub const PUNCTUATION: CommonCharsToIgnore = CommonCharsToIgnore::new(4);
-
-        /// Whitespace character, one of [ \t\n\x0B\f\r]
-        pub const WHITESPACE: CommonCharsToIgnore = CommonCharsToIgnore::new(5);
-
-        /// Creates a new CommonCharsToIgnore instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Numeric => std::option::Option::Some(1),
+                Self::AlphaUpperCase => std::option::Option::Some(2),
+                Self::AlphaLowerCase => std::option::Option::Some(3),
+                Self::Punctuation => std::option::Option::Some(4),
+                Self::Whitespace => std::option::Option::Some(5),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COMMON_CHARS_TO_IGNORE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NUMERIC"),
-                2 => std::borrow::Cow::Borrowed("ALPHA_UPPER_CASE"),
-                3 => std::borrow::Cow::Borrowed("ALPHA_LOWER_CASE"),
-                4 => std::borrow::Cow::Borrowed("PUNCTUATION"),
-                5 => std::borrow::Cow::Borrowed("WHITESPACE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COMMON_CHARS_TO_IGNORE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COMMON_CHARS_TO_IGNORE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("COMMON_CHARS_TO_IGNORE_UNSPECIFIED")
                 }
-                "NUMERIC" => std::option::Option::Some(Self::NUMERIC),
-                "ALPHA_UPPER_CASE" => std::option::Option::Some(Self::ALPHA_UPPER_CASE),
-                "ALPHA_LOWER_CASE" => std::option::Option::Some(Self::ALPHA_LOWER_CASE),
-                "PUNCTUATION" => std::option::Option::Some(Self::PUNCTUATION),
-                "WHITESPACE" => std::option::Option::Some(Self::WHITESPACE),
-                _ => std::option::Option::None,
+                Self::Numeric => std::option::Option::Some("NUMERIC"),
+                Self::AlphaUpperCase => std::option::Option::Some("ALPHA_UPPER_CASE"),
+                Self::AlphaLowerCase => std::option::Option::Some("ALPHA_LOWER_CASE"),
+                Self::Punctuation => std::option::Option::Some("PUNCTUATION"),
+                Self::Whitespace => std::option::Option::Some("WHITESPACE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CommonCharsToIgnore {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CommonCharsToIgnore {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CommonCharsToIgnore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CommonCharsToIgnore {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Numeric,
+                2 => Self::AlphaUpperCase,
+                3 => Self::AlphaLowerCase,
+                4 => Self::Punctuation,
+                5 => Self::Whitespace,
+                _ => Self::UnknownValue(common_chars_to_ignore::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CommonCharsToIgnore {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COMMON_CHARS_TO_IGNORE_UNSPECIFIED" => Self::Unspecified,
+                "NUMERIC" => Self::Numeric,
+                "ALPHA_UPPER_CASE" => Self::AlphaUpperCase,
+                "ALPHA_LOWER_CASE" => Self::AlphaLowerCase,
+                "PUNCTUATION" => Self::Punctuation,
+                "WHITESPACE" => Self::Whitespace,
+                _ => Self::UnknownValue(common_chars_to_ignore::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CommonCharsToIgnore {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Numeric => serializer.serialize_i32(1),
+                Self::AlphaUpperCase => serializer.serialize_i32(2),
+                Self::AlphaLowerCase => serializer.serialize_i32(3),
+                Self::Punctuation => serializer.serialize_i32(4),
+                Self::Whitespace => serializer.serialize_i32(5),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CommonCharsToIgnore {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CommonCharsToIgnore>::new(
+                ".google.privacy.dlp.v2.CharsToIgnore.CommonCharsToIgnore",
+            ))
         }
     }
 
@@ -10638,75 +11224,140 @@ pub mod crypto_replace_ffx_fpe_config {
     /// These are commonly used subsets of the alphabet that the FFX mode
     /// natively supports. In the algorithm, the alphabet is selected using
     /// the "radix". Therefore each corresponds to a particular radix.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FfxCommonNativeAlphabet(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FfxCommonNativeAlphabet {
+        /// Unused.
+        Unspecified,
+        /// `[0-9]` (radix of 10)
+        Numeric,
+        /// `[0-9A-F]` (radix of 16)
+        Hexadecimal,
+        /// `[0-9A-Z]` (radix of 36)
+        UpperCaseAlphaNumeric,
+        /// `[0-9A-Za-z]` (radix of 62)
+        AlphaNumeric,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FfxCommonNativeAlphabet::value] or
+        /// [FfxCommonNativeAlphabet::name].
+        UnknownValue(ffx_common_native_alphabet::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod ffx_common_native_alphabet {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FfxCommonNativeAlphabet {
-        /// Unused.
-        pub const FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED: FfxCommonNativeAlphabet =
-            FfxCommonNativeAlphabet::new(0);
-
-        /// `[0-9]` (radix of 10)
-        pub const NUMERIC: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new(1);
-
-        /// `[0-9A-F]` (radix of 16)
-        pub const HEXADECIMAL: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new(2);
-
-        /// `[0-9A-Z]` (radix of 36)
-        pub const UPPER_CASE_ALPHA_NUMERIC: FfxCommonNativeAlphabet =
-            FfxCommonNativeAlphabet::new(3);
-
-        /// `[0-9A-Za-z]` (radix of 62)
-        pub const ALPHA_NUMERIC: FfxCommonNativeAlphabet = FfxCommonNativeAlphabet::new(4);
-
-        /// Creates a new FfxCommonNativeAlphabet instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Numeric => std::option::Option::Some(1),
+                Self::Hexadecimal => std::option::Option::Some(2),
+                Self::UpperCaseAlphaNumeric => std::option::Option::Some(3),
+                Self::AlphaNumeric => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NUMERIC"),
-                2 => std::borrow::Cow::Borrowed("HEXADECIMAL"),
-                3 => std::borrow::Cow::Borrowed("UPPER_CASE_ALPHA_NUMERIC"),
-                4 => std::borrow::Cow::Borrowed("ALPHA_NUMERIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED")
                 }
-                "NUMERIC" => std::option::Option::Some(Self::NUMERIC),
-                "HEXADECIMAL" => std::option::Option::Some(Self::HEXADECIMAL),
-                "UPPER_CASE_ALPHA_NUMERIC" => {
-                    std::option::Option::Some(Self::UPPER_CASE_ALPHA_NUMERIC)
+                Self::Numeric => std::option::Option::Some("NUMERIC"),
+                Self::Hexadecimal => std::option::Option::Some("HEXADECIMAL"),
+                Self::UpperCaseAlphaNumeric => {
+                    std::option::Option::Some("UPPER_CASE_ALPHA_NUMERIC")
                 }
-                "ALPHA_NUMERIC" => std::option::Option::Some(Self::ALPHA_NUMERIC),
-                _ => std::option::Option::None,
+                Self::AlphaNumeric => std::option::Option::Some("ALPHA_NUMERIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for FfxCommonNativeAlphabet {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FfxCommonNativeAlphabet {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FfxCommonNativeAlphabet {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FfxCommonNativeAlphabet {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Numeric,
+                2 => Self::Hexadecimal,
+                3 => Self::UpperCaseAlphaNumeric,
+                4 => Self::AlphaNumeric,
+                _ => Self::UnknownValue(ffx_common_native_alphabet::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FfxCommonNativeAlphabet {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED" => Self::Unspecified,
+                "NUMERIC" => Self::Numeric,
+                "HEXADECIMAL" => Self::Hexadecimal,
+                "UPPER_CASE_ALPHA_NUMERIC" => Self::UpperCaseAlphaNumeric,
+                "ALPHA_NUMERIC" => Self::AlphaNumeric,
+                _ => Self::UnknownValue(ffx_common_native_alphabet::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FfxCommonNativeAlphabet {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Numeric => serializer.serialize_i32(1),
+                Self::Hexadecimal => serializer.serialize_i32(2),
+                Self::UpperCaseAlphaNumeric => serializer.serialize_i32(3),
+                Self::AlphaNumeric => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FfxCommonNativeAlphabet {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<FfxCommonNativeAlphabet>::new(
+                    ".google.privacy.dlp.v2.CryptoReplaceFfxFpeConfig.FfxCommonNativeAlphabet",
+                ),
+            )
         }
     }
 
@@ -11748,56 +12399,116 @@ pub mod record_condition {
         use super::*;
 
         /// Logical operators for conditional checks.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct LogicalOperator(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum LogicalOperator {
+            /// Unused
+            Unspecified,
+            /// Conditional AND
+            And,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [LogicalOperator::value] or
+            /// [LogicalOperator::name].
+            UnknownValue(logical_operator::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod logical_operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl LogicalOperator {
-            /// Unused
-            pub const LOGICAL_OPERATOR_UNSPECIFIED: LogicalOperator = LogicalOperator::new(0);
-
-            /// Conditional AND
-            pub const AND: LogicalOperator = LogicalOperator::new(1);
-
-            /// Creates a new LogicalOperator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::And => std::option::Option::Some(1),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("LOGICAL_OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("AND"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("LOGICAL_OPERATOR_UNSPECIFIED"),
+                    Self::And => std::option::Option::Some("AND"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "LOGICAL_OPERATOR_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::LOGICAL_OPERATOR_UNSPECIFIED)
-                    }
-                    "AND" => std::option::Option::Some(Self::AND),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for LogicalOperator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for LogicalOperator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for LogicalOperator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for LogicalOperator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::And,
+                    _ => Self::UnknownValue(logical_operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for LogicalOperator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "LOGICAL_OPERATOR_UNSPECIFIED" => Self::Unspecified,
+                    "AND" => Self::And,
+                    _ => Self::UnknownValue(logical_operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for LogicalOperator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::And => serializer.serialize_i32(1),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for LogicalOperator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<LogicalOperator>::new(
+                    ".google.privacy.dlp.v2.RecordCondition.Expressions.LogicalOperator",
+                ))
             }
         }
 
@@ -12048,62 +12759,124 @@ pub mod transformation_summary {
     }
 
     /// Possible outcomes of transformations.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TransformationResultCode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TransformationResultCode {
+        /// Unused
+        Unspecified,
+        /// Transformation completed without an error.
+        Success,
+        /// Transformation had an error.
+        Error,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TransformationResultCode::value] or
+        /// [TransformationResultCode::name].
+        UnknownValue(transformation_result_code::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod transformation_result_code {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TransformationResultCode {
-        /// Unused
-        pub const TRANSFORMATION_RESULT_CODE_UNSPECIFIED: TransformationResultCode =
-            TransformationResultCode::new(0);
-
-        /// Transformation completed without an error.
-        pub const SUCCESS: TransformationResultCode = TransformationResultCode::new(1);
-
-        /// Transformation had an error.
-        pub const ERROR: TransformationResultCode = TransformationResultCode::new(2);
-
-        /// Creates a new TransformationResultCode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Success => std::option::Option::Some(1),
+                Self::Error => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TRANSFORMATION_RESULT_CODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCESS"),
-                2 => std::borrow::Cow::Borrowed("ERROR"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TRANSFORMATION_RESULT_CODE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TRANSFORMATION_RESULT_CODE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("TRANSFORMATION_RESULT_CODE_UNSPECIFIED")
                 }
-                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                _ => std::option::Option::None,
+                Self::Success => std::option::Option::Some("SUCCESS"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TransformationResultCode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TransformationResultCode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TransformationResultCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TransformationResultCode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Success,
+                2 => Self::Error,
+                _ => Self::UnknownValue(transformation_result_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TransformationResultCode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TRANSFORMATION_RESULT_CODE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCESS" => Self::Success,
+                "ERROR" => Self::Error,
+                _ => Self::UnknownValue(transformation_result_code::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TransformationResultCode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Success => serializer.serialize_i32(1),
+                Self::Error => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TransformationResultCode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<TransformationResultCode>::new(
+                    ".google.privacy.dlp.v2.TransformationSummary.TransformationResultCode",
+                ),
+            )
         }
     }
 }
@@ -13019,63 +13792,124 @@ pub mod error {
     use super::*;
 
     /// Additional information about the error.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ErrorExtraInfo(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ErrorExtraInfo {
+        /// Unused.
+        ErrorInfoUnspecified,
+        /// Image scan is not available in the region.
+        ImageScanUnavailableInRegion,
+        /// File store cluster is not supported for profile generation.
+        FileStoreClusterUnsupported,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ErrorExtraInfo::value] or
+        /// [ErrorExtraInfo::name].
+        UnknownValue(error_extra_info::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod error_extra_info {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ErrorExtraInfo {
-        /// Unused.
-        pub const ERROR_INFO_UNSPECIFIED: ErrorExtraInfo = ErrorExtraInfo::new(0);
-
-        /// Image scan is not available in the region.
-        pub const IMAGE_SCAN_UNAVAILABLE_IN_REGION: ErrorExtraInfo = ErrorExtraInfo::new(1);
-
-        /// File store cluster is not supported for profile generation.
-        pub const FILE_STORE_CLUSTER_UNSUPPORTED: ErrorExtraInfo = ErrorExtraInfo::new(2);
-
-        /// Creates a new ErrorExtraInfo instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::ErrorInfoUnspecified => std::option::Option::Some(0),
+                Self::ImageScanUnavailableInRegion => std::option::Option::Some(1),
+                Self::FileStoreClusterUnsupported => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ERROR_INFO_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IMAGE_SCAN_UNAVAILABLE_IN_REGION"),
-                2 => std::borrow::Cow::Borrowed("FILE_STORE_CLUSTER_UNSUPPORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ERROR_INFO_UNSPECIFIED" => std::option::Option::Some(Self::ERROR_INFO_UNSPECIFIED),
-                "IMAGE_SCAN_UNAVAILABLE_IN_REGION" => {
-                    std::option::Option::Some(Self::IMAGE_SCAN_UNAVAILABLE_IN_REGION)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::ErrorInfoUnspecified => std::option::Option::Some("ERROR_INFO_UNSPECIFIED"),
+                Self::ImageScanUnavailableInRegion => {
+                    std::option::Option::Some("IMAGE_SCAN_UNAVAILABLE_IN_REGION")
                 }
-                "FILE_STORE_CLUSTER_UNSUPPORTED" => {
-                    std::option::Option::Some(Self::FILE_STORE_CLUSTER_UNSUPPORTED)
+                Self::FileStoreClusterUnsupported => {
+                    std::option::Option::Some("FILE_STORE_CLUSTER_UNSUPPORTED")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ErrorExtraInfo {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ErrorExtraInfo {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ErrorExtraInfo {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ErrorExtraInfo {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::ErrorInfoUnspecified,
+                1 => Self::ImageScanUnavailableInRegion,
+                2 => Self::FileStoreClusterUnsupported,
+                _ => Self::UnknownValue(error_extra_info::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ErrorExtraInfo {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ERROR_INFO_UNSPECIFIED" => Self::ErrorInfoUnspecified,
+                "IMAGE_SCAN_UNAVAILABLE_IN_REGION" => Self::ImageScanUnavailableInRegion,
+                "FILE_STORE_CLUSTER_UNSUPPORTED" => Self::FileStoreClusterUnsupported,
+                _ => Self::UnknownValue(error_extra_info::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ErrorExtraInfo {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::ErrorInfoUnspecified => serializer.serialize_i32(0),
+                Self::ImageScanUnavailableInRegion => serializer.serialize_i32(1),
+                Self::FileStoreClusterUnsupported => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ErrorExtraInfo {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ErrorExtraInfo>::new(
+                ".google.privacy.dlp.v2.Error.ErrorExtraInfo",
+            ))
         }
     }
 }
@@ -13389,64 +14223,127 @@ pub mod job_trigger {
     /// will be created with this configuration. The service may automatically
     /// pause triggers experiencing frequent errors. To restart a job, set the
     /// status to HEALTHY after correcting user errors.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
+        /// Unused.
+        Unspecified,
+        /// Trigger is healthy.
+        Healthy,
+        /// Trigger is temporarily paused.
+        Paused,
+        /// Trigger is cancelled and can not be resumed.
+        Cancelled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Status {
-        /// Unused.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
-        /// Trigger is healthy.
-        pub const HEALTHY: Status = Status::new(1);
-
-        /// Trigger is temporarily paused.
-        pub const PAUSED: Status = Status::new(2);
-
-        /// Trigger is cancelled and can not be resumed.
-        pub const CANCELLED: Status = Status::new(3);
-
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Healthy => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Cancelled => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HEALTHY"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("CANCELLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Healthy => std::option::Option::Some("HEALTHY"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Cancelled => std::option::Option::Some("CANCELLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "HEALTHY" => std::option::Option::Some(Self::HEALTHY),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Healthy,
+                2 => Self::Paused,
+                3 => Self::Cancelled,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "HEALTHY" => Self::Healthy,
+                "PAUSED" => Self::Paused,
+                "CANCELLED" => Self::Cancelled,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Healthy => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Cancelled => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.privacy.dlp.v2.JobTrigger.Status",
+            ))
         }
     }
 
@@ -16013,66 +16910,130 @@ pub mod data_profile_action {
         use super::*;
 
         /// The levels of detail that can be included in the Pub/Sub message.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct DetailLevel(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum DetailLevel {
+            /// Unused.
+            Unspecified,
+            /// The full table data profile.
+            TableProfile,
+            /// The name of the profiled resource.
+            ResourceName,
+            /// The full file store data profile.
+            FileStoreProfile,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [DetailLevel::value] or
+            /// [DetailLevel::name].
+            UnknownValue(detail_level::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod detail_level {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl DetailLevel {
-            /// Unused.
-            pub const DETAIL_LEVEL_UNSPECIFIED: DetailLevel = DetailLevel::new(0);
-
-            /// The full table data profile.
-            pub const TABLE_PROFILE: DetailLevel = DetailLevel::new(1);
-
-            /// The name of the profiled resource.
-            pub const RESOURCE_NAME: DetailLevel = DetailLevel::new(2);
-
-            /// The full file store data profile.
-            pub const FILE_STORE_PROFILE: DetailLevel = DetailLevel::new(3);
-
-            /// Creates a new DetailLevel instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some(0),
+                    Self::TableProfile => std::option::Option::Some(1),
+                    Self::ResourceName => std::option::Option::Some(2),
+                    Self::FileStoreProfile => std::option::Option::Some(3),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("DETAIL_LEVEL_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("TABLE_PROFILE"),
-                    2 => std::borrow::Cow::Borrowed("RESOURCE_NAME"),
-                    3 => std::borrow::Cow::Borrowed("FILE_STORE_PROFILE"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::Unspecified => std::option::Option::Some("DETAIL_LEVEL_UNSPECIFIED"),
+                    Self::TableProfile => std::option::Option::Some("TABLE_PROFILE"),
+                    Self::ResourceName => std::option::Option::Some("RESOURCE_NAME"),
+                    Self::FileStoreProfile => std::option::Option::Some("FILE_STORE_PROFILE"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "DETAIL_LEVEL_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::DETAIL_LEVEL_UNSPECIFIED)
-                    }
-                    "TABLE_PROFILE" => std::option::Option::Some(Self::TABLE_PROFILE),
-                    "RESOURCE_NAME" => std::option::Option::Some(Self::RESOURCE_NAME),
-                    "FILE_STORE_PROFILE" => std::option::Option::Some(Self::FILE_STORE_PROFILE),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for DetailLevel {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for DetailLevel {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for DetailLevel {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for DetailLevel {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::Unspecified,
+                    1 => Self::TableProfile,
+                    2 => Self::ResourceName,
+                    3 => Self::FileStoreProfile,
+                    _ => Self::UnknownValue(detail_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for DetailLevel {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "DETAIL_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                    "TABLE_PROFILE" => Self::TableProfile,
+                    "RESOURCE_NAME" => Self::ResourceName,
+                    "FILE_STORE_PROFILE" => Self::FileStoreProfile,
+                    _ => Self::UnknownValue(detail_level::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for DetailLevel {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::Unspecified => serializer.serialize_i32(0),
+                    Self::TableProfile => serializer.serialize_i32(1),
+                    Self::ResourceName => serializer.serialize_i32(2),
+                    Self::FileStoreProfile => serializer.serialize_i32(3),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for DetailLevel {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<DetailLevel>::new(
+                    ".google.privacy.dlp.v2.DataProfileAction.PubSubNotification.DetailLevel",
+                ))
             }
         }
     }
@@ -16415,71 +17376,136 @@ pub mod data_profile_action {
     }
 
     /// Types of event that can trigger an action.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
-
-    impl EventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
         /// Unused.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
+        Unspecified,
         /// New profile (not a re-profile).
-        pub const NEW_PROFILE: EventType = EventType::new(1);
-
+        NewProfile,
         /// One of the following profile metrics changed: Data risk score,
         /// Sensitivity score, Resource visibility, Encryption type, Predicted
         /// infoTypes, Other infoTypes
-        pub const CHANGED_PROFILE: EventType = EventType::new(2);
-
+        ChangedProfile,
         /// Table data risk score or sensitivity score increased.
-        pub const SCORE_INCREASED: EventType = EventType::new(3);
-
+        ScoreIncreased,
         /// A user (non-internal) error occurred.
-        pub const ERROR_CHANGED: EventType = EventType::new(4);
+        ErrorChanged,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
 
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::NewProfile => std::option::Option::Some(1),
+                Self::ChangedProfile => std::option::Option::Some(2),
+                Self::ScoreIncreased => std::option::Option::Some(3),
+                Self::ErrorChanged => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NEW_PROFILE"),
-                2 => std::borrow::Cow::Borrowed("CHANGED_PROFILE"),
-                3 => std::borrow::Cow::Borrowed("SCORE_INCREASED"),
-                4 => std::borrow::Cow::Borrowed("ERROR_CHANGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::NewProfile => std::option::Option::Some("NEW_PROFILE"),
+                Self::ChangedProfile => std::option::Option::Some("CHANGED_PROFILE"),
+                Self::ScoreIncreased => std::option::Option::Some("SCORE_INCREASED"),
+                Self::ErrorChanged => std::option::Option::Some("ERROR_CHANGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "NEW_PROFILE" => std::option::Option::Some(Self::NEW_PROFILE),
-                "CHANGED_PROFILE" => std::option::Option::Some(Self::CHANGED_PROFILE),
-                "SCORE_INCREASED" => std::option::Option::Some(Self::SCORE_INCREASED),
-                "ERROR_CHANGED" => std::option::Option::Some(Self::ERROR_CHANGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::NewProfile,
+                2 => Self::ChangedProfile,
+                3 => Self::ScoreIncreased,
+                4 => Self::ErrorChanged,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NEW_PROFILE" => Self::NewProfile,
+                "CHANGED_PROFILE" => Self::ChangedProfile,
+                "SCORE_INCREASED" => Self::ScoreIncreased,
+                "ERROR_CHANGED" => Self::ErrorChanged,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::NewProfile => serializer.serialize_i32(1),
+                Self::ChangedProfile => serializer.serialize_i32(2),
+                Self::ScoreIncreased => serializer.serialize_i32(3),
+                Self::ErrorChanged => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.privacy.dlp.v2.DataProfileAction.EventType",
+            ))
         }
     }
 
@@ -17449,59 +18475,120 @@ pub mod discovery_config {
 
     /// Whether the discovery config is currently active. New options may be added
     /// at a later time.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
+        /// Unused
+        Unspecified,
+        /// The discovery config is currently active.
+        Running,
+        /// The discovery config is paused temporarily.
+        Paused,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Status {
-        /// Unused
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
-        /// The discovery config is currently active.
-        pub const RUNNING: Status = Status::new(1);
-
-        /// The discovery config is paused temporarily.
-        pub const PAUSED: Status = Status::new(2);
-
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Paused,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "PAUSED" => Self::Paused,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.privacy.dlp.v2.DiscoveryConfig.Status",
+            ))
         }
     }
 }
@@ -19339,133 +20426,251 @@ pub mod discovery_cloud_sql_conditions {
     use super::*;
 
     /// The database engines that should be profiled.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEngine(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseEngine {
+        /// Unused.
+        Unspecified,
+        /// Include all supported database engines.
+        AllSupportedDatabaseEngines,
+        /// MySQL database.
+        Mysql,
+        /// PostgreSQL database.
+        Postgres,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseEngine::value] or
+        /// [DatabaseEngine::name].
+        UnknownValue(database_engine::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_engine {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseEngine {
-        /// Unused.
-        pub const DATABASE_ENGINE_UNSPECIFIED: DatabaseEngine = DatabaseEngine::new(0);
-
-        /// Include all supported database engines.
-        pub const ALL_SUPPORTED_DATABASE_ENGINES: DatabaseEngine = DatabaseEngine::new(1);
-
-        /// MySQL database.
-        pub const MYSQL: DatabaseEngine = DatabaseEngine::new(2);
-
-        /// PostgreSQL database.
-        pub const POSTGRES: DatabaseEngine = DatabaseEngine::new(3);
-
-        /// Creates a new DatabaseEngine instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllSupportedDatabaseEngines => std::option::Option::Some(1),
+                Self::Mysql => std::option::Option::Some(2),
+                Self::Postgres => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_DATABASE_ENGINES"),
-                2 => std::borrow::Cow::Borrowed("MYSQL"),
-                3 => std::borrow::Cow::Borrowed("POSTGRES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_ENGINE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_ENGINE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("DATABASE_ENGINE_UNSPECIFIED"),
+                Self::AllSupportedDatabaseEngines => {
+                    std::option::Option::Some("ALL_SUPPORTED_DATABASE_ENGINES")
                 }
-                "ALL_SUPPORTED_DATABASE_ENGINES" => {
-                    std::option::Option::Some(Self::ALL_SUPPORTED_DATABASE_ENGINES)
-                }
-                "MYSQL" => std::option::Option::Some(Self::MYSQL),
-                "POSTGRES" => std::option::Option::Some(Self::POSTGRES),
-                _ => std::option::Option::None,
+                Self::Mysql => std::option::Option::Some("MYSQL"),
+                Self::Postgres => std::option::Option::Some("POSTGRES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseEngine {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEngine {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseEngine {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseEngine {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllSupportedDatabaseEngines,
+                2 => Self::Mysql,
+                3 => Self::Postgres,
+                _ => Self::UnknownValue(database_engine::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseEngine {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_ENGINE_UNSPECIFIED" => Self::Unspecified,
+                "ALL_SUPPORTED_DATABASE_ENGINES" => Self::AllSupportedDatabaseEngines,
+                "MYSQL" => Self::Mysql,
+                "POSTGRES" => Self::Postgres,
+                _ => Self::UnknownValue(database_engine::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseEngine {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllSupportedDatabaseEngines => serializer.serialize_i32(1),
+                Self::Mysql => serializer.serialize_i32(2),
+                Self::Postgres => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseEngine {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEngine>::new(
+                ".google.privacy.dlp.v2.DiscoveryCloudSqlConditions.DatabaseEngine",
+            ))
         }
     }
 
     /// Cloud SQL database resource types. New values can be added at a later time.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseResourceType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseResourceType {
+        /// Unused.
+        Unspecified,
+        /// Includes database resource types that become supported at a later time.
+        AllSupportedTypes,
+        /// Tables.
+        Table,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseResourceType::value] or
+        /// [DatabaseResourceType::name].
+        UnknownValue(database_resource_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_resource_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseResourceType {
-        /// Unused.
-        pub const DATABASE_RESOURCE_TYPE_UNSPECIFIED: DatabaseResourceType =
-            DatabaseResourceType::new(0);
-
-        /// Includes database resource types that become supported at a later time.
-        pub const DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES: DatabaseResourceType =
-            DatabaseResourceType::new(1);
-
-        /// Tables.
-        pub const DATABASE_RESOURCE_TYPE_TABLE: DatabaseResourceType = DatabaseResourceType::new(2);
-
-        /// Creates a new DatabaseResourceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllSupportedTypes => std::option::Option::Some(1),
+                Self::Table => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_RESOURCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES"),
-                2 => std::borrow::Cow::Borrowed("DATABASE_RESOURCE_TYPE_TABLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DATABASE_RESOURCE_TYPE_UNSPECIFIED")
+                }
+                Self::AllSupportedTypes => {
+                    std::option::Option::Some("DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES")
+                }
+                Self::Table => std::option::Option::Some("DATABASE_RESOURCE_TYPE_TABLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_RESOURCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DATABASE_RESOURCE_TYPE_UNSPECIFIED)
-                }
-                "DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES" => {
-                    std::option::Option::Some(Self::DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES)
-                }
-                "DATABASE_RESOURCE_TYPE_TABLE" => {
-                    std::option::Option::Some(Self::DATABASE_RESOURCE_TYPE_TABLE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseResourceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseResourceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseResourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseResourceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllSupportedTypes,
+                2 => Self::Table,
+                _ => Self::UnknownValue(database_resource_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseResourceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_RESOURCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "DATABASE_RESOURCE_TYPE_ALL_SUPPORTED_TYPES" => Self::AllSupportedTypes,
+                "DATABASE_RESOURCE_TYPE_TABLE" => Self::Table,
+                _ => Self::UnknownValue(database_resource_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseResourceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllSupportedTypes => serializer.serialize_i32(1),
+                Self::Table => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseResourceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseResourceType>::new(
+                ".google.privacy.dlp.v2.DiscoveryCloudSqlConditions.DatabaseResourceType",
+            ))
         }
     }
 }
@@ -19615,63 +20820,124 @@ pub mod discovery_cloud_sql_generation_cadence {
         use super::*;
 
         /// The type of modification that causes a profile update.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct CloudSqlSchemaModification(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum CloudSqlSchemaModification {
+            /// Unused.
+            SqlSchemaModificationUnspecified,
+            /// New columns have appeared.
+            NewColumns,
+            /// Columns have been removed from the table.
+            RemovedColumns,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [CloudSqlSchemaModification::value] or
+            /// [CloudSqlSchemaModification::name].
+            UnknownValue(cloud_sql_schema_modification::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod cloud_sql_schema_modification {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl CloudSqlSchemaModification {
-            /// Unused.
-            pub const SQL_SCHEMA_MODIFICATION_UNSPECIFIED: CloudSqlSchemaModification =
-                CloudSqlSchemaModification::new(0);
-
-            /// New columns have appeared.
-            pub const NEW_COLUMNS: CloudSqlSchemaModification = CloudSqlSchemaModification::new(1);
-
-            /// Columns have been removed from the table.
-            pub const REMOVED_COLUMNS: CloudSqlSchemaModification =
-                CloudSqlSchemaModification::new(2);
-
-            /// Creates a new CloudSqlSchemaModification instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::SqlSchemaModificationUnspecified => std::option::Option::Some(0),
+                    Self::NewColumns => std::option::Option::Some(1),
+                    Self::RemovedColumns => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("SQL_SCHEMA_MODIFICATION_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("NEW_COLUMNS"),
-                    2 => std::borrow::Cow::Borrowed("REMOVED_COLUMNS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "SQL_SCHEMA_MODIFICATION_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::SQL_SCHEMA_MODIFICATION_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::SqlSchemaModificationUnspecified => {
+                        std::option::Option::Some("SQL_SCHEMA_MODIFICATION_UNSPECIFIED")
                     }
-                    "NEW_COLUMNS" => std::option::Option::Some(Self::NEW_COLUMNS),
-                    "REMOVED_COLUMNS" => std::option::Option::Some(Self::REMOVED_COLUMNS),
-                    _ => std::option::Option::None,
+                    Self::NewColumns => std::option::Option::Some("NEW_COLUMNS"),
+                    Self::RemovedColumns => std::option::Option::Some("REMOVED_COLUMNS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for CloudSqlSchemaModification {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for CloudSqlSchemaModification {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for CloudSqlSchemaModification {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for CloudSqlSchemaModification {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::SqlSchemaModificationUnspecified,
+                    1 => Self::NewColumns,
+                    2 => Self::RemovedColumns,
+                    _ => Self::UnknownValue(cloud_sql_schema_modification::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for CloudSqlSchemaModification {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "SQL_SCHEMA_MODIFICATION_UNSPECIFIED" => Self::SqlSchemaModificationUnspecified,
+                    "NEW_COLUMNS" => Self::NewColumns,
+                    "REMOVED_COLUMNS" => Self::RemovedColumns,
+                    _ => Self::UnknownValue(cloud_sql_schema_modification::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for CloudSqlSchemaModification {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::SqlSchemaModificationUnspecified => serializer.serialize_i32(0),
+                    Self::NewColumns => serializer.serialize_i32(1),
+                    Self::RemovedColumns => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for CloudSqlSchemaModification {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<CloudSqlSchemaModification>::new(
+                    ".google.privacy.dlp.v2.DiscoveryCloudSqlGenerationCadence.SchemaModifiedCadence.CloudSqlSchemaModification"))
             }
         }
     }
@@ -20481,173 +21747,300 @@ pub mod discovery_cloud_storage_conditions {
     /// The attribute of an object. See
     /// <https://cloud.google.com/storage/docs/storage-classes> for more information
     /// on storage classes.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CloudStorageObjectAttribute(i32);
-
-    impl CloudStorageObjectAttribute {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CloudStorageObjectAttribute {
         /// Unused.
-        pub const CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new(0);
-
+        Unspecified,
         /// Scan objects regardless of the attribute.
-        pub const ALL_SUPPORTED_OBJECTS: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new(1);
-
+        AllSupportedObjects,
         /// Scan objects with the standard storage class.
-        pub const STANDARD: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(2);
-
+        Standard,
         /// Scan objects with the nearline storage class. This will incur retrieval
         /// fees.
-        pub const NEARLINE: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(3);
-
+        Nearline,
         /// Scan objects with the coldline storage class. This will incur retrieval
         /// fees.
-        pub const COLDLINE: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(4);
-
+        Coldline,
         /// Scan objects with the archive storage class. This will incur retrieval
         /// fees.
-        pub const ARCHIVE: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(5);
-
+        Archive,
         /// Scan objects with the regional storage class.
-        pub const REGIONAL: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(6);
-
+        Regional,
         /// Scan objects with the multi-regional storage class.
-        pub const MULTI_REGIONAL: CloudStorageObjectAttribute = CloudStorageObjectAttribute::new(7);
-
+        MultiRegional,
         /// Scan objects with the dual-regional storage class. This will incur
         /// retrieval fees.
-        pub const DURABLE_REDUCED_AVAILABILITY: CloudStorageObjectAttribute =
-            CloudStorageObjectAttribute::new(8);
+        DurableReducedAvailability,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CloudStorageObjectAttribute::value] or
+        /// [CloudStorageObjectAttribute::name].
+        UnknownValue(cloud_storage_object_attribute::UnknownValue),
+    }
 
-        /// Creates a new CloudStorageObjectAttribute instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cloud_storage_object_attribute {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CloudStorageObjectAttribute {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllSupportedObjects => std::option::Option::Some(1),
+                Self::Standard => std::option::Option::Some(2),
+                Self::Nearline => std::option::Option::Some(3),
+                Self::Coldline => std::option::Option::Some(4),
+                Self::Archive => std::option::Option::Some(5),
+                Self::Regional => std::option::Option::Some(6),
+                Self::MultiRegional => std::option::Option::Some(7),
+                Self::DurableReducedAvailability => std::option::Option::Some(8),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_OBJECTS"),
-                2 => std::borrow::Cow::Borrowed("STANDARD"),
-                3 => std::borrow::Cow::Borrowed("NEARLINE"),
-                4 => std::borrow::Cow::Borrowed("COLDLINE"),
-                5 => std::borrow::Cow::Borrowed("ARCHIVE"),
-                6 => std::borrow::Cow::Borrowed("REGIONAL"),
-                7 => std::borrow::Cow::Borrowed("MULTI_REGIONAL"),
-                8 => std::borrow::Cow::Borrowed("DURABLE_REDUCED_AVAILABILITY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED")
                 }
-                "ALL_SUPPORTED_OBJECTS" => std::option::Option::Some(Self::ALL_SUPPORTED_OBJECTS),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "NEARLINE" => std::option::Option::Some(Self::NEARLINE),
-                "COLDLINE" => std::option::Option::Some(Self::COLDLINE),
-                "ARCHIVE" => std::option::Option::Some(Self::ARCHIVE),
-                "REGIONAL" => std::option::Option::Some(Self::REGIONAL),
-                "MULTI_REGIONAL" => std::option::Option::Some(Self::MULTI_REGIONAL),
-                "DURABLE_REDUCED_AVAILABILITY" => {
-                    std::option::Option::Some(Self::DURABLE_REDUCED_AVAILABILITY)
+                Self::AllSupportedObjects => std::option::Option::Some("ALL_SUPPORTED_OBJECTS"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Nearline => std::option::Option::Some("NEARLINE"),
+                Self::Coldline => std::option::Option::Some("COLDLINE"),
+                Self::Archive => std::option::Option::Some("ARCHIVE"),
+                Self::Regional => std::option::Option::Some("REGIONAL"),
+                Self::MultiRegional => std::option::Option::Some("MULTI_REGIONAL"),
+                Self::DurableReducedAvailability => {
+                    std::option::Option::Some("DURABLE_REDUCED_AVAILABILITY")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CloudStorageObjectAttribute {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CloudStorageObjectAttribute {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CloudStorageObjectAttribute {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CloudStorageObjectAttribute {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllSupportedObjects,
+                2 => Self::Standard,
+                3 => Self::Nearline,
+                4 => Self::Coldline,
+                5 => Self::Archive,
+                6 => Self::Regional,
+                7 => Self::MultiRegional,
+                8 => Self::DurableReducedAvailability,
+                _ => Self::UnknownValue(cloud_storage_object_attribute::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CloudStorageObjectAttribute {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLOUD_STORAGE_OBJECT_ATTRIBUTE_UNSPECIFIED" => Self::Unspecified,
+                "ALL_SUPPORTED_OBJECTS" => Self::AllSupportedObjects,
+                "STANDARD" => Self::Standard,
+                "NEARLINE" => Self::Nearline,
+                "COLDLINE" => Self::Coldline,
+                "ARCHIVE" => Self::Archive,
+                "REGIONAL" => Self::Regional,
+                "MULTI_REGIONAL" => Self::MultiRegional,
+                "DURABLE_REDUCED_AVAILABILITY" => Self::DurableReducedAvailability,
+                _ => Self::UnknownValue(cloud_storage_object_attribute::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CloudStorageObjectAttribute {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllSupportedObjects => serializer.serialize_i32(1),
+                Self::Standard => serializer.serialize_i32(2),
+                Self::Nearline => serializer.serialize_i32(3),
+                Self::Coldline => serializer.serialize_i32(4),
+                Self::Archive => serializer.serialize_i32(5),
+                Self::Regional => serializer.serialize_i32(6),
+                Self::MultiRegional => serializer.serialize_i32(7),
+                Self::DurableReducedAvailability => serializer.serialize_i32(8),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CloudStorageObjectAttribute {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CloudStorageObjectAttribute>::new(
+                ".google.privacy.dlp.v2.DiscoveryCloudStorageConditions.CloudStorageObjectAttribute"))
         }
     }
 
     /// The attribute of a bucket.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CloudStorageBucketAttribute(i32);
-
-    impl CloudStorageBucketAttribute {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CloudStorageBucketAttribute {
         /// Unused.
-        pub const CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new(0);
-
+        Unspecified,
         /// Scan buckets regardless of the attribute.
-        pub const ALL_SUPPORTED_BUCKETS: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new(1);
-
+        AllSupportedBuckets,
         /// Buckets with [Autoclass](https://cloud.google.com/storage/docs/autoclass)
         /// disabled. Only one of
         /// AUTOCLASS_DISABLED or AUTOCLASS_ENABLED should be set.
-        pub const AUTOCLASS_DISABLED: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new(2);
-
+        AutoclassDisabled,
         /// Buckets with [Autoclass](https://cloud.google.com/storage/docs/autoclass)
         /// enabled. Only one of
         /// AUTOCLASS_DISABLED or AUTOCLASS_ENABLED should be set. Scanning
         /// Autoclass-enabled buckets can affect object storage classes.
-        pub const AUTOCLASS_ENABLED: CloudStorageBucketAttribute =
-            CloudStorageBucketAttribute::new(3);
+        AutoclassEnabled,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CloudStorageBucketAttribute::value] or
+        /// [CloudStorageBucketAttribute::name].
+        UnknownValue(cloud_storage_bucket_attribute::UnknownValue),
+    }
 
-        /// Creates a new CloudStorageBucketAttribute instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod cloud_storage_bucket_attribute {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl CloudStorageBucketAttribute {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllSupportedBuckets => std::option::Option::Some(1),
+                Self::AutoclassDisabled => std::option::Option::Some(2),
+                Self::AutoclassEnabled => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_BUCKETS"),
-                2 => std::borrow::Cow::Borrowed("AUTOCLASS_DISABLED"),
-                3 => std::borrow::Cow::Borrowed("AUTOCLASS_ENABLED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED")
                 }
-                "ALL_SUPPORTED_BUCKETS" => std::option::Option::Some(Self::ALL_SUPPORTED_BUCKETS),
-                "AUTOCLASS_DISABLED" => std::option::Option::Some(Self::AUTOCLASS_DISABLED),
-                "AUTOCLASS_ENABLED" => std::option::Option::Some(Self::AUTOCLASS_ENABLED),
-                _ => std::option::Option::None,
+                Self::AllSupportedBuckets => std::option::Option::Some("ALL_SUPPORTED_BUCKETS"),
+                Self::AutoclassDisabled => std::option::Option::Some("AUTOCLASS_DISABLED"),
+                Self::AutoclassEnabled => std::option::Option::Some("AUTOCLASS_ENABLED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for CloudStorageBucketAttribute {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CloudStorageBucketAttribute {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for CloudStorageBucketAttribute {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CloudStorageBucketAttribute {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllSupportedBuckets,
+                2 => Self::AutoclassDisabled,
+                3 => Self::AutoclassEnabled,
+                _ => Self::UnknownValue(cloud_storage_bucket_attribute::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CloudStorageBucketAttribute {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLOUD_STORAGE_BUCKET_ATTRIBUTE_UNSPECIFIED" => Self::Unspecified,
+                "ALL_SUPPORTED_BUCKETS" => Self::AllSupportedBuckets,
+                "AUTOCLASS_DISABLED" => Self::AutoclassDisabled,
+                "AUTOCLASS_ENABLED" => Self::AutoclassEnabled,
+                _ => Self::UnknownValue(cloud_storage_bucket_attribute::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CloudStorageBucketAttribute {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllSupportedBuckets => serializer.serialize_i32(1),
+                Self::AutoclassDisabled => serializer.serialize_i32(2),
+                Self::AutoclassEnabled => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CloudStorageBucketAttribute {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CloudStorageBucketAttribute>::new(
+                ".google.privacy.dlp.v2.DiscoveryCloudStorageConditions.CloudStorageBucketAttribute"))
         }
     }
 }
@@ -21752,136 +23145,264 @@ pub mod amazon_s_3_bucket_conditions {
 
     /// Supported Amazon S3 bucket types.
     /// Defaults to TYPE_ALL_SUPPORTED.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct BucketType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum BucketType {
+        /// Unused.
+        TypeUnspecified,
+        /// All supported classes.
+        TypeAllSupported,
+        /// A general purpose Amazon S3 bucket.
+        TypeGeneralPurpose,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [BucketType::value] or
+        /// [BucketType::name].
+        UnknownValue(bucket_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod bucket_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl BucketType {
-        /// Unused.
-        pub const TYPE_UNSPECIFIED: BucketType = BucketType::new(0);
-
-        /// All supported classes.
-        pub const TYPE_ALL_SUPPORTED: BucketType = BucketType::new(1);
-
-        /// A general purpose Amazon S3 bucket.
-        pub const TYPE_GENERAL_PURPOSE: BucketType = BucketType::new(2);
-
-        /// Creates a new BucketType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::TypeUnspecified => std::option::Option::Some(0),
+                Self::TypeAllSupported => std::option::Option::Some(1),
+                Self::TypeGeneralPurpose => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TYPE_ALL_SUPPORTED"),
-                2 => std::borrow::Cow::Borrowed("TYPE_GENERAL_PURPOSE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::TypeUnspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::TypeAllSupported => std::option::Option::Some("TYPE_ALL_SUPPORTED"),
+                Self::TypeGeneralPurpose => std::option::Option::Some("TYPE_GENERAL_PURPOSE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "TYPE_ALL_SUPPORTED" => std::option::Option::Some(Self::TYPE_ALL_SUPPORTED),
-                "TYPE_GENERAL_PURPOSE" => std::option::Option::Some(Self::TYPE_GENERAL_PURPOSE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for BucketType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for BucketType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for BucketType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for BucketType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::TypeUnspecified,
+                1 => Self::TypeAllSupported,
+                2 => Self::TypeGeneralPurpose,
+                _ => Self::UnknownValue(bucket_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for BucketType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::TypeUnspecified,
+                "TYPE_ALL_SUPPORTED" => Self::TypeAllSupported,
+                "TYPE_GENERAL_PURPOSE" => Self::TypeGeneralPurpose,
+                _ => Self::UnknownValue(bucket_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for BucketType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::TypeUnspecified => serializer.serialize_i32(0),
+                Self::TypeAllSupported => serializer.serialize_i32(1),
+                Self::TypeGeneralPurpose => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for BucketType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<BucketType>::new(
+                ".google.privacy.dlp.v2.AmazonS3BucketConditions.BucketType",
+            ))
         }
     }
 
     /// Supported Amazon S3 object storage classes.
     /// Defaults to ALL_SUPPORTED_CLASSES.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ObjectStorageClass(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ObjectStorageClass {
+        /// Unused.
+        Unspecified,
+        /// All supported classes.
+        AllSupportedClasses,
+        /// Standard object class.
+        Standard,
+        /// Standard - infrequent access object class.
+        StandardInfrequentAccess,
+        /// Glacier - instant retrieval object class.
+        GlacierInstantRetrieval,
+        /// Objects in the S3 Intelligent-Tiering access tiers.
+        IntelligentTiering,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ObjectStorageClass::value] or
+        /// [ObjectStorageClass::name].
+        UnknownValue(object_storage_class::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod object_storage_class {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ObjectStorageClass {
-        /// Unused.
-        pub const UNSPECIFIED: ObjectStorageClass = ObjectStorageClass::new(0);
-
-        /// All supported classes.
-        pub const ALL_SUPPORTED_CLASSES: ObjectStorageClass = ObjectStorageClass::new(1);
-
-        /// Standard object class.
-        pub const STANDARD: ObjectStorageClass = ObjectStorageClass::new(2);
-
-        /// Standard - infrequent access object class.
-        pub const STANDARD_INFREQUENT_ACCESS: ObjectStorageClass = ObjectStorageClass::new(4);
-
-        /// Glacier - instant retrieval object class.
-        pub const GLACIER_INSTANT_RETRIEVAL: ObjectStorageClass = ObjectStorageClass::new(6);
-
-        /// Objects in the S3 Intelligent-Tiering access tiers.
-        pub const INTELLIGENT_TIERING: ObjectStorageClass = ObjectStorageClass::new(7);
-
-        /// Creates a new ObjectStorageClass instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AllSupportedClasses => std::option::Option::Some(1),
+                Self::Standard => std::option::Option::Some(2),
+                Self::StandardInfrequentAccess => std::option::Option::Some(4),
+                Self::GlacierInstantRetrieval => std::option::Option::Some(6),
+                Self::IntelligentTiering => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ALL_SUPPORTED_CLASSES"),
-                2 => std::borrow::Cow::Borrowed("STANDARD"),
-                4 => std::borrow::Cow::Borrowed("STANDARD_INFREQUENT_ACCESS"),
-                6 => std::borrow::Cow::Borrowed("GLACIER_INSTANT_RETRIEVAL"),
-                7 => std::borrow::Cow::Borrowed("INTELLIGENT_TIERING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UNSPECIFIED" => std::option::Option::Some(Self::UNSPECIFIED),
-                "ALL_SUPPORTED_CLASSES" => std::option::Option::Some(Self::ALL_SUPPORTED_CLASSES),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "STANDARD_INFREQUENT_ACCESS" => {
-                    std::option::Option::Some(Self::STANDARD_INFREQUENT_ACCESS)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UNSPECIFIED"),
+                Self::AllSupportedClasses => std::option::Option::Some("ALL_SUPPORTED_CLASSES"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::StandardInfrequentAccess => {
+                    std::option::Option::Some("STANDARD_INFREQUENT_ACCESS")
                 }
-                "GLACIER_INSTANT_RETRIEVAL" => {
-                    std::option::Option::Some(Self::GLACIER_INSTANT_RETRIEVAL)
+                Self::GlacierInstantRetrieval => {
+                    std::option::Option::Some("GLACIER_INSTANT_RETRIEVAL")
                 }
-                "INTELLIGENT_TIERING" => std::option::Option::Some(Self::INTELLIGENT_TIERING),
-                _ => std::option::Option::None,
+                Self::IntelligentTiering => std::option::Option::Some("INTELLIGENT_TIERING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ObjectStorageClass {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ObjectStorageClass {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ObjectStorageClass {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ObjectStorageClass {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AllSupportedClasses,
+                2 => Self::Standard,
+                4 => Self::StandardInfrequentAccess,
+                6 => Self::GlacierInstantRetrieval,
+                7 => Self::IntelligentTiering,
+                _ => Self::UnknownValue(object_storage_class::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ObjectStorageClass {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UNSPECIFIED" => Self::Unspecified,
+                "ALL_SUPPORTED_CLASSES" => Self::AllSupportedClasses,
+                "STANDARD" => Self::Standard,
+                "STANDARD_INFREQUENT_ACCESS" => Self::StandardInfrequentAccess,
+                "GLACIER_INSTANT_RETRIEVAL" => Self::GlacierInstantRetrieval,
+                "INTELLIGENT_TIERING" => Self::IntelligentTiering,
+                _ => Self::UnknownValue(object_storage_class::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ObjectStorageClass {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AllSupportedClasses => serializer.serialize_i32(1),
+                Self::Standard => serializer.serialize_i32(2),
+                Self::StandardInfrequentAccess => serializer.serialize_i32(4),
+                Self::GlacierInstantRetrieval => serializer.serialize_i32(6),
+                Self::IntelligentTiering => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ObjectStorageClass {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ObjectStorageClass>::new(
+                ".google.privacy.dlp.v2.AmazonS3BucketConditions.ObjectStorageClass",
+            ))
         }
     }
 }
@@ -23144,83 +24665,152 @@ pub mod dlp_job {
     use super::*;
 
     /// Possible states of a job. New items may be added.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JobState(i32);
-
-    impl JobState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JobState {
         /// Unused.
-        pub const JOB_STATE_UNSPECIFIED: JobState = JobState::new(0);
-
+        Unspecified,
         /// The job has not yet started.
-        pub const PENDING: JobState = JobState::new(1);
-
+        Pending,
         /// The job is currently running. Once a job has finished it will transition
         /// to FAILED or DONE.
-        pub const RUNNING: JobState = JobState::new(2);
-
+        Running,
         /// The job is no longer running.
-        pub const DONE: JobState = JobState::new(3);
-
+        Done,
         /// The job was canceled before it could be completed.
-        pub const CANCELED: JobState = JobState::new(4);
-
+        Canceled,
         /// The job had an error and did not complete.
-        pub const FAILED: JobState = JobState::new(5);
-
+        Failed,
         /// The job is currently accepting findings via hybridInspect.
         /// A hybrid job in ACTIVE state may continue to have findings added to it
         /// through the calling of hybridInspect. After the job has finished no more
         /// calls to hybridInspect may be made. ACTIVE jobs can transition to DONE.
-        pub const ACTIVE: JobState = JobState::new(6);
+        Active,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JobState::value] or
+        /// [JobState::name].
+        UnknownValue(job_state::UnknownValue),
+    }
 
-        /// Creates a new JobState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod job_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl JobState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Pending => std::option::Option::Some(1),
+                Self::Running => std::option::Option::Some(2),
+                Self::Done => std::option::Option::Some(3),
+                Self::Canceled => std::option::Option::Some(4),
+                Self::Failed => std::option::Option::Some(5),
+                Self::Active => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JOB_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PENDING"),
-                2 => std::borrow::Cow::Borrowed("RUNNING"),
-                3 => std::borrow::Cow::Borrowed("DONE"),
-                4 => std::borrow::Cow::Borrowed("CANCELED"),
-                5 => std::borrow::Cow::Borrowed("FAILED"),
-                6 => std::borrow::Cow::Borrowed("ACTIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("JOB_STATE_UNSPECIFIED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::Canceled => std::option::Option::Some("CANCELED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Active => std::option::Option::Some("ACTIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JOB_STATE_UNSPECIFIED" => std::option::Option::Some(Self::JOB_STATE_UNSPECIFIED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                "CANCELED" => std::option::Option::Some(Self::CANCELED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ACTIVE" => std::option::Option::Some(Self::ACTIVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JobState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JobState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JobState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JobState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Pending,
+                2 => Self::Running,
+                3 => Self::Done,
+                4 => Self::Canceled,
+                5 => Self::Failed,
+                6 => Self::Active,
+                _ => Self::UnknownValue(job_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JobState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JOB_STATE_UNSPECIFIED" => Self::Unspecified,
+                "PENDING" => Self::Pending,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                "CANCELED" => Self::Canceled,
+                "FAILED" => Self::Failed,
+                "ACTIVE" => Self::Active,
+                _ => Self::UnknownValue(job_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JobState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Pending => serializer.serialize_i32(1),
+                Self::Running => serializer.serialize_i32(2),
+                Self::Done => serializer.serialize_i32(3),
+                Self::Canceled => serializer.serialize_i32(4),
+                Self::Failed => serializer.serialize_i32(5),
+                Self::Active => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JobState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JobState>::new(
+                ".google.privacy.dlp.v2.DlpJob.JobState",
+            ))
         }
     }
 
@@ -25834,75 +27424,140 @@ pub mod data_risk_level {
     use super::*;
 
     /// Various score levels for resources.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DataRiskLevelScore(i32);
-
-    impl DataRiskLevelScore {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DataRiskLevelScore {
         /// Unused.
-        pub const RISK_SCORE_UNSPECIFIED: DataRiskLevelScore = DataRiskLevelScore::new(0);
-
+        RiskScoreUnspecified,
         /// Low risk - Lower indication of sensitive data that appears to have
         /// additional access restrictions in place or no indication of sensitive
         /// data found.
-        pub const RISK_LOW: DataRiskLevelScore = DataRiskLevelScore::new(10);
-
+        RiskLow,
         /// Unable to determine risk.
-        pub const RISK_UNKNOWN: DataRiskLevelScore = DataRiskLevelScore::new(12);
-
+        RiskUnknown,
         /// Medium risk - Sensitive data may be present but additional access or fine
         /// grain access restrictions appear to be present.  Consider limiting
         /// access even further or transform data to mask.
-        pub const RISK_MODERATE: DataRiskLevelScore = DataRiskLevelScore::new(20);
-
+        RiskModerate,
         /// High risk – SPII may be present. Access controls may include public
         /// ACLs. Exfiltration of data may lead to user data loss. Re-identification
         /// of users may be possible. Consider limiting usage and or removing SPII.
-        pub const RISK_HIGH: DataRiskLevelScore = DataRiskLevelScore::new(30);
+        RiskHigh,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DataRiskLevelScore::value] or
+        /// [DataRiskLevelScore::name].
+        UnknownValue(data_risk_level_score::UnknownValue),
+    }
 
-        /// Creates a new DataRiskLevelScore instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod data_risk_level_score {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DataRiskLevelScore {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::RiskScoreUnspecified => std::option::Option::Some(0),
+                Self::RiskLow => std::option::Option::Some(10),
+                Self::RiskUnknown => std::option::Option::Some(12),
+                Self::RiskModerate => std::option::Option::Some(20),
+                Self::RiskHigh => std::option::Option::Some(30),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RISK_SCORE_UNSPECIFIED"),
-                10 => std::borrow::Cow::Borrowed("RISK_LOW"),
-                12 => std::borrow::Cow::Borrowed("RISK_UNKNOWN"),
-                20 => std::borrow::Cow::Borrowed("RISK_MODERATE"),
-                30 => std::borrow::Cow::Borrowed("RISK_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::RiskScoreUnspecified => std::option::Option::Some("RISK_SCORE_UNSPECIFIED"),
+                Self::RiskLow => std::option::Option::Some("RISK_LOW"),
+                Self::RiskUnknown => std::option::Option::Some("RISK_UNKNOWN"),
+                Self::RiskModerate => std::option::Option::Some("RISK_MODERATE"),
+                Self::RiskHigh => std::option::Option::Some("RISK_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RISK_SCORE_UNSPECIFIED" => std::option::Option::Some(Self::RISK_SCORE_UNSPECIFIED),
-                "RISK_LOW" => std::option::Option::Some(Self::RISK_LOW),
-                "RISK_UNKNOWN" => std::option::Option::Some(Self::RISK_UNKNOWN),
-                "RISK_MODERATE" => std::option::Option::Some(Self::RISK_MODERATE),
-                "RISK_HIGH" => std::option::Option::Some(Self::RISK_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DataRiskLevelScore {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DataRiskLevelScore {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DataRiskLevelScore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DataRiskLevelScore {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::RiskScoreUnspecified,
+                10 => Self::RiskLow,
+                12 => Self::RiskUnknown,
+                20 => Self::RiskModerate,
+                30 => Self::RiskHigh,
+                _ => Self::UnknownValue(data_risk_level_score::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DataRiskLevelScore {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RISK_SCORE_UNSPECIFIED" => Self::RiskScoreUnspecified,
+                "RISK_LOW" => Self::RiskLow,
+                "RISK_UNKNOWN" => Self::RiskUnknown,
+                "RISK_MODERATE" => Self::RiskModerate,
+                "RISK_HIGH" => Self::RiskHigh,
+                _ => Self::UnknownValue(data_risk_level_score::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DataRiskLevelScore {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::RiskScoreUnspecified => serializer.serialize_i32(0),
+                Self::RiskLow => serializer.serialize_i32(10),
+                Self::RiskUnknown => serializer.serialize_i32(12),
+                Self::RiskModerate => serializer.serialize_i32(20),
+                Self::RiskHigh => serializer.serialize_i32(30),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DataRiskLevelScore {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DataRiskLevelScore>::new(
+                ".google.privacy.dlp.v2.DataRiskLevel.DataRiskLevelScore",
+            ))
         }
     }
 }
@@ -26547,62 +28202,123 @@ pub mod table_data_profile {
     use super::*;
 
     /// Possible states of a profile. New items may be added.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The profile is currently running. Once a profile has finished it will
         /// transition to DONE.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The profile is no longer generating.
         /// If profile_status.status.code is 0, the profile succeeded, otherwise, it
         /// failed.
-        pub const DONE: State = State::new(2);
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Done => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Done => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.privacy.dlp.v2.TableDataProfile.State",
+            ))
         }
     }
 }
@@ -27054,256 +28770,465 @@ pub mod column_data_profile {
     use super::*;
 
     /// Possible states of a profile. New items may be added.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The profile is currently running. Once a profile has finished it will
         /// transition to DONE.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The profile is no longer generating.
         /// If profile_status.status.code is 0, the profile succeeded, otherwise, it
         /// failed.
-        pub const DONE: State = State::new(2);
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Done => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Done => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.privacy.dlp.v2.ColumnDataProfile.State",
+            ))
         }
     }
 
     /// Data types of the data in a column. Types may be added over time.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ColumnDataType(i32);
-
-    impl ColumnDataType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ColumnDataType {
         /// Invalid type.
-        pub const COLUMN_DATA_TYPE_UNSPECIFIED: ColumnDataType = ColumnDataType::new(0);
-
+        Unspecified,
         /// Encoded as a string in decimal format.
-        pub const TYPE_INT64: ColumnDataType = ColumnDataType::new(1);
-
+        TypeInt64,
         /// Encoded as a boolean "false" or "true".
-        pub const TYPE_BOOL: ColumnDataType = ColumnDataType::new(2);
-
+        TypeBool,
         /// Encoded as a number, or string "NaN", "Infinity" or "-Infinity".
-        pub const TYPE_FLOAT64: ColumnDataType = ColumnDataType::new(3);
-
+        TypeFloat64,
         /// Encoded as a string value.
-        pub const TYPE_STRING: ColumnDataType = ColumnDataType::new(4);
-
+        TypeString,
         /// Encoded as a base64 string per RFC 4648, section 4.
-        pub const TYPE_BYTES: ColumnDataType = ColumnDataType::new(5);
-
+        TypeBytes,
         /// Encoded as an RFC 3339 timestamp with mandatory "Z" time zone string:
         /// 1985-04-12T23:20:50.52Z
-        pub const TYPE_TIMESTAMP: ColumnDataType = ColumnDataType::new(6);
-
+        TypeTimestamp,
         /// Encoded as RFC 3339 full-date format string: 1985-04-12
-        pub const TYPE_DATE: ColumnDataType = ColumnDataType::new(7);
-
+        TypeDate,
         /// Encoded as RFC 3339 partial-time format string: 23:20:50.52
-        pub const TYPE_TIME: ColumnDataType = ColumnDataType::new(8);
-
+        TypeTime,
         /// Encoded as RFC 3339 full-date "T" partial-time: 1985-04-12T23:20:50.52
-        pub const TYPE_DATETIME: ColumnDataType = ColumnDataType::new(9);
-
+        TypeDatetime,
         /// Encoded as WKT
-        pub const TYPE_GEOGRAPHY: ColumnDataType = ColumnDataType::new(10);
-
+        TypeGeography,
         /// Encoded as a decimal string.
-        pub const TYPE_NUMERIC: ColumnDataType = ColumnDataType::new(11);
-
+        TypeNumeric,
         /// Container of ordered fields, each with a type and field name.
-        pub const TYPE_RECORD: ColumnDataType = ColumnDataType::new(12);
-
+        TypeRecord,
         /// Decimal type.
-        pub const TYPE_BIGNUMERIC: ColumnDataType = ColumnDataType::new(13);
-
+        TypeBignumeric,
         /// Json type.
-        pub const TYPE_JSON: ColumnDataType = ColumnDataType::new(14);
-
+        TypeJson,
         /// Interval type.
-        pub const TYPE_INTERVAL: ColumnDataType = ColumnDataType::new(15);
-
+        TypeInterval,
         /// `Range<Date>` type.
-        pub const TYPE_RANGE_DATE: ColumnDataType = ColumnDataType::new(16);
-
+        TypeRangeDate,
         /// `Range<Datetime>` type.
-        pub const TYPE_RANGE_DATETIME: ColumnDataType = ColumnDataType::new(17);
-
+        TypeRangeDatetime,
         /// `Range<Timestamp>` type.
-        pub const TYPE_RANGE_TIMESTAMP: ColumnDataType = ColumnDataType::new(18);
+        TypeRangeTimestamp,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ColumnDataType::value] or
+        /// [ColumnDataType::name].
+        UnknownValue(column_data_type::UnknownValue),
+    }
 
-        /// Creates a new ColumnDataType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod column_data_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ColumnDataType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TypeInt64 => std::option::Option::Some(1),
+                Self::TypeBool => std::option::Option::Some(2),
+                Self::TypeFloat64 => std::option::Option::Some(3),
+                Self::TypeString => std::option::Option::Some(4),
+                Self::TypeBytes => std::option::Option::Some(5),
+                Self::TypeTimestamp => std::option::Option::Some(6),
+                Self::TypeDate => std::option::Option::Some(7),
+                Self::TypeTime => std::option::Option::Some(8),
+                Self::TypeDatetime => std::option::Option::Some(9),
+                Self::TypeGeography => std::option::Option::Some(10),
+                Self::TypeNumeric => std::option::Option::Some(11),
+                Self::TypeRecord => std::option::Option::Some(12),
+                Self::TypeBignumeric => std::option::Option::Some(13),
+                Self::TypeJson => std::option::Option::Some(14),
+                Self::TypeInterval => std::option::Option::Some(15),
+                Self::TypeRangeDate => std::option::Option::Some(16),
+                Self::TypeRangeDatetime => std::option::Option::Some(17),
+                Self::TypeRangeTimestamp => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COLUMN_DATA_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TYPE_INT64"),
-                2 => std::borrow::Cow::Borrowed("TYPE_BOOL"),
-                3 => std::borrow::Cow::Borrowed("TYPE_FLOAT64"),
-                4 => std::borrow::Cow::Borrowed("TYPE_STRING"),
-                5 => std::borrow::Cow::Borrowed("TYPE_BYTES"),
-                6 => std::borrow::Cow::Borrowed("TYPE_TIMESTAMP"),
-                7 => std::borrow::Cow::Borrowed("TYPE_DATE"),
-                8 => std::borrow::Cow::Borrowed("TYPE_TIME"),
-                9 => std::borrow::Cow::Borrowed("TYPE_DATETIME"),
-                10 => std::borrow::Cow::Borrowed("TYPE_GEOGRAPHY"),
-                11 => std::borrow::Cow::Borrowed("TYPE_NUMERIC"),
-                12 => std::borrow::Cow::Borrowed("TYPE_RECORD"),
-                13 => std::borrow::Cow::Borrowed("TYPE_BIGNUMERIC"),
-                14 => std::borrow::Cow::Borrowed("TYPE_JSON"),
-                15 => std::borrow::Cow::Borrowed("TYPE_INTERVAL"),
-                16 => std::borrow::Cow::Borrowed("TYPE_RANGE_DATE"),
-                17 => std::borrow::Cow::Borrowed("TYPE_RANGE_DATETIME"),
-                18 => std::borrow::Cow::Borrowed("TYPE_RANGE_TIMESTAMP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COLUMN_DATA_TYPE_UNSPECIFIED"),
+                Self::TypeInt64 => std::option::Option::Some("TYPE_INT64"),
+                Self::TypeBool => std::option::Option::Some("TYPE_BOOL"),
+                Self::TypeFloat64 => std::option::Option::Some("TYPE_FLOAT64"),
+                Self::TypeString => std::option::Option::Some("TYPE_STRING"),
+                Self::TypeBytes => std::option::Option::Some("TYPE_BYTES"),
+                Self::TypeTimestamp => std::option::Option::Some("TYPE_TIMESTAMP"),
+                Self::TypeDate => std::option::Option::Some("TYPE_DATE"),
+                Self::TypeTime => std::option::Option::Some("TYPE_TIME"),
+                Self::TypeDatetime => std::option::Option::Some("TYPE_DATETIME"),
+                Self::TypeGeography => std::option::Option::Some("TYPE_GEOGRAPHY"),
+                Self::TypeNumeric => std::option::Option::Some("TYPE_NUMERIC"),
+                Self::TypeRecord => std::option::Option::Some("TYPE_RECORD"),
+                Self::TypeBignumeric => std::option::Option::Some("TYPE_BIGNUMERIC"),
+                Self::TypeJson => std::option::Option::Some("TYPE_JSON"),
+                Self::TypeInterval => std::option::Option::Some("TYPE_INTERVAL"),
+                Self::TypeRangeDate => std::option::Option::Some("TYPE_RANGE_DATE"),
+                Self::TypeRangeDatetime => std::option::Option::Some("TYPE_RANGE_DATETIME"),
+                Self::TypeRangeTimestamp => std::option::Option::Some("TYPE_RANGE_TIMESTAMP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COLUMN_DATA_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COLUMN_DATA_TYPE_UNSPECIFIED)
-                }
-                "TYPE_INT64" => std::option::Option::Some(Self::TYPE_INT64),
-                "TYPE_BOOL" => std::option::Option::Some(Self::TYPE_BOOL),
-                "TYPE_FLOAT64" => std::option::Option::Some(Self::TYPE_FLOAT64),
-                "TYPE_STRING" => std::option::Option::Some(Self::TYPE_STRING),
-                "TYPE_BYTES" => std::option::Option::Some(Self::TYPE_BYTES),
-                "TYPE_TIMESTAMP" => std::option::Option::Some(Self::TYPE_TIMESTAMP),
-                "TYPE_DATE" => std::option::Option::Some(Self::TYPE_DATE),
-                "TYPE_TIME" => std::option::Option::Some(Self::TYPE_TIME),
-                "TYPE_DATETIME" => std::option::Option::Some(Self::TYPE_DATETIME),
-                "TYPE_GEOGRAPHY" => std::option::Option::Some(Self::TYPE_GEOGRAPHY),
-                "TYPE_NUMERIC" => std::option::Option::Some(Self::TYPE_NUMERIC),
-                "TYPE_RECORD" => std::option::Option::Some(Self::TYPE_RECORD),
-                "TYPE_BIGNUMERIC" => std::option::Option::Some(Self::TYPE_BIGNUMERIC),
-                "TYPE_JSON" => std::option::Option::Some(Self::TYPE_JSON),
-                "TYPE_INTERVAL" => std::option::Option::Some(Self::TYPE_INTERVAL),
-                "TYPE_RANGE_DATE" => std::option::Option::Some(Self::TYPE_RANGE_DATE),
-                "TYPE_RANGE_DATETIME" => std::option::Option::Some(Self::TYPE_RANGE_DATETIME),
-                "TYPE_RANGE_TIMESTAMP" => std::option::Option::Some(Self::TYPE_RANGE_TIMESTAMP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ColumnDataType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ColumnDataType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ColumnDataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ColumnDataType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TypeInt64,
+                2 => Self::TypeBool,
+                3 => Self::TypeFloat64,
+                4 => Self::TypeString,
+                5 => Self::TypeBytes,
+                6 => Self::TypeTimestamp,
+                7 => Self::TypeDate,
+                8 => Self::TypeTime,
+                9 => Self::TypeDatetime,
+                10 => Self::TypeGeography,
+                11 => Self::TypeNumeric,
+                12 => Self::TypeRecord,
+                13 => Self::TypeBignumeric,
+                14 => Self::TypeJson,
+                15 => Self::TypeInterval,
+                16 => Self::TypeRangeDate,
+                17 => Self::TypeRangeDatetime,
+                18 => Self::TypeRangeTimestamp,
+                _ => Self::UnknownValue(column_data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ColumnDataType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COLUMN_DATA_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TYPE_INT64" => Self::TypeInt64,
+                "TYPE_BOOL" => Self::TypeBool,
+                "TYPE_FLOAT64" => Self::TypeFloat64,
+                "TYPE_STRING" => Self::TypeString,
+                "TYPE_BYTES" => Self::TypeBytes,
+                "TYPE_TIMESTAMP" => Self::TypeTimestamp,
+                "TYPE_DATE" => Self::TypeDate,
+                "TYPE_TIME" => Self::TypeTime,
+                "TYPE_DATETIME" => Self::TypeDatetime,
+                "TYPE_GEOGRAPHY" => Self::TypeGeography,
+                "TYPE_NUMERIC" => Self::TypeNumeric,
+                "TYPE_RECORD" => Self::TypeRecord,
+                "TYPE_BIGNUMERIC" => Self::TypeBignumeric,
+                "TYPE_JSON" => Self::TypeJson,
+                "TYPE_INTERVAL" => Self::TypeInterval,
+                "TYPE_RANGE_DATE" => Self::TypeRangeDate,
+                "TYPE_RANGE_DATETIME" => Self::TypeRangeDatetime,
+                "TYPE_RANGE_TIMESTAMP" => Self::TypeRangeTimestamp,
+                _ => Self::UnknownValue(column_data_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ColumnDataType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TypeInt64 => serializer.serialize_i32(1),
+                Self::TypeBool => serializer.serialize_i32(2),
+                Self::TypeFloat64 => serializer.serialize_i32(3),
+                Self::TypeString => serializer.serialize_i32(4),
+                Self::TypeBytes => serializer.serialize_i32(5),
+                Self::TypeTimestamp => serializer.serialize_i32(6),
+                Self::TypeDate => serializer.serialize_i32(7),
+                Self::TypeTime => serializer.serialize_i32(8),
+                Self::TypeDatetime => serializer.serialize_i32(9),
+                Self::TypeGeography => serializer.serialize_i32(10),
+                Self::TypeNumeric => serializer.serialize_i32(11),
+                Self::TypeRecord => serializer.serialize_i32(12),
+                Self::TypeBignumeric => serializer.serialize_i32(13),
+                Self::TypeJson => serializer.serialize_i32(14),
+                Self::TypeInterval => serializer.serialize_i32(15),
+                Self::TypeRangeDate => serializer.serialize_i32(16),
+                Self::TypeRangeDatetime => serializer.serialize_i32(17),
+                Self::TypeRangeTimestamp => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ColumnDataType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ColumnDataType>::new(
+                ".google.privacy.dlp.v2.ColumnDataProfile.ColumnDataType",
+            ))
         }
     }
 
     /// The possible policy states for a column.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ColumnPolicyState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ColumnPolicyState {
+        /// No policy tags.
+        Unspecified,
+        /// Column has policy tag applied.
+        ColumnPolicyTagged,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ColumnPolicyState::value] or
+        /// [ColumnPolicyState::name].
+        UnknownValue(column_policy_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod column_policy_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ColumnPolicyState {
-        /// No policy tags.
-        pub const COLUMN_POLICY_STATE_UNSPECIFIED: ColumnPolicyState = ColumnPolicyState::new(0);
-
-        /// Column has policy tag applied.
-        pub const COLUMN_POLICY_TAGGED: ColumnPolicyState = ColumnPolicyState::new(1);
-
-        /// Creates a new ColumnPolicyState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ColumnPolicyTagged => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("COLUMN_POLICY_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("COLUMN_POLICY_TAGGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("COLUMN_POLICY_STATE_UNSPECIFIED"),
+                Self::ColumnPolicyTagged => std::option::Option::Some("COLUMN_POLICY_TAGGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "COLUMN_POLICY_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::COLUMN_POLICY_STATE_UNSPECIFIED)
-                }
-                "COLUMN_POLICY_TAGGED" => std::option::Option::Some(Self::COLUMN_POLICY_TAGGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ColumnPolicyState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ColumnPolicyState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ColumnPolicyState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ColumnPolicyState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ColumnPolicyTagged,
+                _ => Self::UnknownValue(column_policy_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ColumnPolicyState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "COLUMN_POLICY_STATE_UNSPECIFIED" => Self::Unspecified,
+                "COLUMN_POLICY_TAGGED" => Self::ColumnPolicyTagged,
+                _ => Self::UnknownValue(column_policy_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ColumnPolicyState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ColumnPolicyTagged => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ColumnPolicyState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ColumnPolicyState>::new(
+                ".google.privacy.dlp.v2.ColumnDataProfile.ColumnPolicyState",
+            ))
         }
     }
 }
@@ -27715,62 +29640,123 @@ pub mod file_store_data_profile {
     use super::*;
 
     /// Possible states of a profile. New items may be added.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The profile is currently running. Once a profile has finished it will
         /// transition to DONE.
-        pub const RUNNING: State = State::new(1);
-
+        Running,
         /// The profile is no longer generating.
         /// If profile_status.status.code is 0, the profile succeeded, otherwise, it
         /// failed.
-        pub const DONE: State = State::new(2);
+        Done,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Running => std::option::Option::Some(1),
+                Self::Done => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("RUNNING"),
-                2 => std::borrow::Cow::Borrowed("DONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Running => std::option::Option::Some("RUNNING"),
+                Self::Done => std::option::Option::Some("DONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "RUNNING" => std::option::Option::Some(Self::RUNNING),
-                "DONE" => std::option::Option::Some(Self::DONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Running,
+                2 => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "RUNNING" => Self::Running,
+                "DONE" => Self::Done,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Running => serializer.serialize_i32(1),
+                Self::Done => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.privacy.dlp.v2.FileStoreDataProfile.State",
+            ))
         }
     }
 }
@@ -28667,122 +30653,243 @@ pub mod data_profile_pub_sub_condition {
         use super::*;
 
         /// Logical operators for conditional checks.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct PubSubLogicalOperator(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum PubSubLogicalOperator {
+            /// Unused.
+            LogicalOperatorUnspecified,
+            /// Conditional OR.
+            Or,
+            /// Conditional AND.
+            And,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [PubSubLogicalOperator::value] or
+            /// [PubSubLogicalOperator::name].
+            UnknownValue(pub_sub_logical_operator::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod pub_sub_logical_operator {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl PubSubLogicalOperator {
-            /// Unused.
-            pub const LOGICAL_OPERATOR_UNSPECIFIED: PubSubLogicalOperator =
-                PubSubLogicalOperator::new(0);
-
-            /// Conditional OR.
-            pub const OR: PubSubLogicalOperator = PubSubLogicalOperator::new(1);
-
-            /// Conditional AND.
-            pub const AND: PubSubLogicalOperator = PubSubLogicalOperator::new(2);
-
-            /// Creates a new PubSubLogicalOperator instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::LogicalOperatorUnspecified => std::option::Option::Some(0),
+                    Self::Or => std::option::Option::Some(1),
+                    Self::And => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("LOGICAL_OPERATOR_UNSPECIFIED"),
-                    1 => std::borrow::Cow::Borrowed("OR"),
-                    2 => std::borrow::Cow::Borrowed("AND"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-                }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "LOGICAL_OPERATOR_UNSPECIFIED" => {
-                        std::option::Option::Some(Self::LOGICAL_OPERATOR_UNSPECIFIED)
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::LogicalOperatorUnspecified => {
+                        std::option::Option::Some("LOGICAL_OPERATOR_UNSPECIFIED")
                     }
-                    "OR" => std::option::Option::Some(Self::OR),
-                    "AND" => std::option::Option::Some(Self::AND),
-                    _ => std::option::Option::None,
+                    Self::Or => std::option::Option::Some("OR"),
+                    Self::And => std::option::Option::Some("AND"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-        }
-
-        impl std::convert::From<i32> for PubSubLogicalOperator {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for PubSubLogicalOperator {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for PubSubLogicalOperator {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for PubSubLogicalOperator {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::LogicalOperatorUnspecified,
+                    1 => Self::Or,
+                    2 => Self::And,
+                    _ => Self::UnknownValue(pub_sub_logical_operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for PubSubLogicalOperator {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "LOGICAL_OPERATOR_UNSPECIFIED" => Self::LogicalOperatorUnspecified,
+                    "OR" => Self::Or,
+                    "AND" => Self::And,
+                    _ => Self::UnknownValue(pub_sub_logical_operator::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for PubSubLogicalOperator {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::LogicalOperatorUnspecified => serializer.serialize_i32(0),
+                    Self::Or => serializer.serialize_i32(1),
+                    Self::And => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for PubSubLogicalOperator {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<PubSubLogicalOperator>::new(
+                    ".google.privacy.dlp.v2.DataProfilePubSubCondition.PubSubExpressions.PubSubLogicalOperator"))
             }
         }
     }
 
     /// Various score levels for resources.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ProfileScoreBucket(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ProfileScoreBucket {
+        /// Unused.
+        Unspecified,
+        /// High risk/sensitivity detected.
+        High,
+        /// Medium or high risk/sensitivity detected.
+        MediumOrHigh,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ProfileScoreBucket::value] or
+        /// [ProfileScoreBucket::name].
+        UnknownValue(profile_score_bucket::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod profile_score_bucket {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ProfileScoreBucket {
-        /// Unused.
-        pub const PROFILE_SCORE_BUCKET_UNSPECIFIED: ProfileScoreBucket = ProfileScoreBucket::new(0);
-
-        /// High risk/sensitivity detected.
-        pub const HIGH: ProfileScoreBucket = ProfileScoreBucket::new(1);
-
-        /// Medium or high risk/sensitivity detected.
-        pub const MEDIUM_OR_HIGH: ProfileScoreBucket = ProfileScoreBucket::new(2);
-
-        /// Creates a new ProfileScoreBucket instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::High => std::option::Option::Some(1),
+                Self::MediumOrHigh => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PROFILE_SCORE_BUCKET_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("HIGH"),
-                2 => std::borrow::Cow::Borrowed("MEDIUM_OR_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PROFILE_SCORE_BUCKET_UNSPECIFIED"),
+                Self::High => std::option::Option::Some("HIGH"),
+                Self::MediumOrHigh => std::option::Option::Some("MEDIUM_OR_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PROFILE_SCORE_BUCKET_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PROFILE_SCORE_BUCKET_UNSPECIFIED)
-                }
-                "HIGH" => std::option::Option::Some(Self::HIGH),
-                "MEDIUM_OR_HIGH" => std::option::Option::Some(Self::MEDIUM_OR_HIGH),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ProfileScoreBucket {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ProfileScoreBucket {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ProfileScoreBucket {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ProfileScoreBucket {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::High,
+                2 => Self::MediumOrHigh,
+                _ => Self::UnknownValue(profile_score_bucket::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ProfileScoreBucket {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PROFILE_SCORE_BUCKET_UNSPECIFIED" => Self::Unspecified,
+                "HIGH" => Self::High,
+                "MEDIUM_OR_HIGH" => Self::MediumOrHigh,
+                _ => Self::UnknownValue(profile_score_bucket::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ProfileScoreBucket {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::High => serializer.serialize_i32(1),
+                Self::MediumOrHigh => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ProfileScoreBucket {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProfileScoreBucket>::new(
+                ".google.privacy.dlp.v2.DataProfilePubSubCondition.ProfileScoreBucket",
+            ))
         }
     }
 }
@@ -29642,63 +31749,120 @@ pub mod cloud_sql_properties {
 
     /// Database engine of a Cloud SQL instance.
     /// New values may be added over time.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DatabaseEngine(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DatabaseEngine {
+        /// An engine that is not currently supported by Sensitive Data Protection.
+        Unknown,
+        /// Cloud SQL for MySQL instance.
+        Mysql,
+        /// Cloud SQL for PostgreSQL instance.
+        Postgres,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DatabaseEngine::value] or
+        /// [DatabaseEngine::name].
+        UnknownValue(database_engine::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod database_engine {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl DatabaseEngine {
-        /// An engine that is not currently supported by Sensitive Data Protection.
-        pub const DATABASE_ENGINE_UNKNOWN: DatabaseEngine = DatabaseEngine::new(0);
-
-        /// Cloud SQL for MySQL instance.
-        pub const DATABASE_ENGINE_MYSQL: DatabaseEngine = DatabaseEngine::new(1);
-
-        /// Cloud SQL for PostgreSQL instance.
-        pub const DATABASE_ENGINE_POSTGRES: DatabaseEngine = DatabaseEngine::new(2);
-
-        /// Creates a new DatabaseEngine instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Mysql => std::option::Option::Some(1),
+                Self::Postgres => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_MYSQL"),
-                2 => std::borrow::Cow::Borrowed("DATABASE_ENGINE_POSTGRES"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("DATABASE_ENGINE_UNKNOWN"),
+                Self::Mysql => std::option::Option::Some("DATABASE_ENGINE_MYSQL"),
+                Self::Postgres => std::option::Option::Some("DATABASE_ENGINE_POSTGRES"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DATABASE_ENGINE_UNKNOWN" => {
-                    std::option::Option::Some(Self::DATABASE_ENGINE_UNKNOWN)
-                }
-                "DATABASE_ENGINE_MYSQL" => std::option::Option::Some(Self::DATABASE_ENGINE_MYSQL),
-                "DATABASE_ENGINE_POSTGRES" => {
-                    std::option::Option::Some(Self::DATABASE_ENGINE_POSTGRES)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for DatabaseEngine {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DatabaseEngine {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DatabaseEngine {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DatabaseEngine {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Mysql,
+                2 => Self::Postgres,
+                _ => Self::UnknownValue(database_engine::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DatabaseEngine {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DATABASE_ENGINE_UNKNOWN" => Self::Unknown,
+                "DATABASE_ENGINE_MYSQL" => Self::Mysql,
+                "DATABASE_ENGINE_POSTGRES" => Self::Postgres,
+                _ => Self::UnknownValue(database_engine::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DatabaseEngine {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Mysql => serializer.serialize_i32(1),
+                Self::Postgres => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DatabaseEngine {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseEngine>::new(
+                ".google.privacy.dlp.v2.CloudSqlProperties.DatabaseEngine",
+            ))
         }
     }
 
@@ -29859,101 +32023,176 @@ pub mod file_cluster_type {
 
     /// Cluster type. Each cluster corresponds to a set of file types.
     /// Over time, new types may be added and files may move between clusters.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cluster(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Cluster {
+        /// Unused.
+        Unspecified,
+        /// Unsupported files.
+        Unknown,
+        /// Plain text.
+        Text,
+        /// Structured data like CSV, TSV etc.
+        StructuredData,
+        /// Source code.
+        SourceCode,
+        /// Rich document like docx, xlsx etc.
+        RichDocument,
+        /// Images like jpeg, bmp.
+        Image,
+        /// Archives and containers like .zip, .tar etc.
+        Archive,
+        /// Multimedia like .mp4, .avi etc.
+        Multimedia,
+        /// Executable files like .exe, .class, .apk etc.
+        Executable,
+        /// AI models like .tflite etc.
+        AiModel,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Cluster::value] or
+        /// [Cluster::name].
+        UnknownValue(cluster::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod cluster {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Cluster {
-        /// Unused.
-        pub const CLUSTER_UNSPECIFIED: Cluster = Cluster::new(0);
-
-        /// Unsupported files.
-        pub const CLUSTER_UNKNOWN: Cluster = Cluster::new(1);
-
-        /// Plain text.
-        pub const CLUSTER_TEXT: Cluster = Cluster::new(2);
-
-        /// Structured data like CSV, TSV etc.
-        pub const CLUSTER_STRUCTURED_DATA: Cluster = Cluster::new(3);
-
-        /// Source code.
-        pub const CLUSTER_SOURCE_CODE: Cluster = Cluster::new(4);
-
-        /// Rich document like docx, xlsx etc.
-        pub const CLUSTER_RICH_DOCUMENT: Cluster = Cluster::new(5);
-
-        /// Images like jpeg, bmp.
-        pub const CLUSTER_IMAGE: Cluster = Cluster::new(6);
-
-        /// Archives and containers like .zip, .tar etc.
-        pub const CLUSTER_ARCHIVE: Cluster = Cluster::new(7);
-
-        /// Multimedia like .mp4, .avi etc.
-        pub const CLUSTER_MULTIMEDIA: Cluster = Cluster::new(8);
-
-        /// Executable files like .exe, .class, .apk etc.
-        pub const CLUSTER_EXECUTABLE: Cluster = Cluster::new(9);
-
-        /// AI models like .tflite etc.
-        pub const CLUSTER_AI_MODEL: Cluster = Cluster::new(10);
-
-        /// Creates a new Cluster instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Unknown => std::option::Option::Some(1),
+                Self::Text => std::option::Option::Some(2),
+                Self::StructuredData => std::option::Option::Some(3),
+                Self::SourceCode => std::option::Option::Some(4),
+                Self::RichDocument => std::option::Option::Some(5),
+                Self::Image => std::option::Option::Some(6),
+                Self::Archive => std::option::Option::Some(7),
+                Self::Multimedia => std::option::Option::Some(8),
+                Self::Executable => std::option::Option::Some(9),
+                Self::AiModel => std::option::Option::Some(10),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CLUSTER_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CLUSTER_UNKNOWN"),
-                2 => std::borrow::Cow::Borrowed("CLUSTER_TEXT"),
-                3 => std::borrow::Cow::Borrowed("CLUSTER_STRUCTURED_DATA"),
-                4 => std::borrow::Cow::Borrowed("CLUSTER_SOURCE_CODE"),
-                5 => std::borrow::Cow::Borrowed("CLUSTER_RICH_DOCUMENT"),
-                6 => std::borrow::Cow::Borrowed("CLUSTER_IMAGE"),
-                7 => std::borrow::Cow::Borrowed("CLUSTER_ARCHIVE"),
-                8 => std::borrow::Cow::Borrowed("CLUSTER_MULTIMEDIA"),
-                9 => std::borrow::Cow::Borrowed("CLUSTER_EXECUTABLE"),
-                10 => std::borrow::Cow::Borrowed("CLUSTER_AI_MODEL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("CLUSTER_UNSPECIFIED"),
+                Self::Unknown => std::option::Option::Some("CLUSTER_UNKNOWN"),
+                Self::Text => std::option::Option::Some("CLUSTER_TEXT"),
+                Self::StructuredData => std::option::Option::Some("CLUSTER_STRUCTURED_DATA"),
+                Self::SourceCode => std::option::Option::Some("CLUSTER_SOURCE_CODE"),
+                Self::RichDocument => std::option::Option::Some("CLUSTER_RICH_DOCUMENT"),
+                Self::Image => std::option::Option::Some("CLUSTER_IMAGE"),
+                Self::Archive => std::option::Option::Some("CLUSTER_ARCHIVE"),
+                Self::Multimedia => std::option::Option::Some("CLUSTER_MULTIMEDIA"),
+                Self::Executable => std::option::Option::Some("CLUSTER_EXECUTABLE"),
+                Self::AiModel => std::option::Option::Some("CLUSTER_AI_MODEL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CLUSTER_UNSPECIFIED" => std::option::Option::Some(Self::CLUSTER_UNSPECIFIED),
-                "CLUSTER_UNKNOWN" => std::option::Option::Some(Self::CLUSTER_UNKNOWN),
-                "CLUSTER_TEXT" => std::option::Option::Some(Self::CLUSTER_TEXT),
-                "CLUSTER_STRUCTURED_DATA" => {
-                    std::option::Option::Some(Self::CLUSTER_STRUCTURED_DATA)
-                }
-                "CLUSTER_SOURCE_CODE" => std::option::Option::Some(Self::CLUSTER_SOURCE_CODE),
-                "CLUSTER_RICH_DOCUMENT" => std::option::Option::Some(Self::CLUSTER_RICH_DOCUMENT),
-                "CLUSTER_IMAGE" => std::option::Option::Some(Self::CLUSTER_IMAGE),
-                "CLUSTER_ARCHIVE" => std::option::Option::Some(Self::CLUSTER_ARCHIVE),
-                "CLUSTER_MULTIMEDIA" => std::option::Option::Some(Self::CLUSTER_MULTIMEDIA),
-                "CLUSTER_EXECUTABLE" => std::option::Option::Some(Self::CLUSTER_EXECUTABLE),
-                "CLUSTER_AI_MODEL" => std::option::Option::Some(Self::CLUSTER_AI_MODEL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Cluster {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Cluster {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Cluster {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Cluster {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Unknown,
+                2 => Self::Text,
+                3 => Self::StructuredData,
+                4 => Self::SourceCode,
+                5 => Self::RichDocument,
+                6 => Self::Image,
+                7 => Self::Archive,
+                8 => Self::Multimedia,
+                9 => Self::Executable,
+                10 => Self::AiModel,
+                _ => Self::UnknownValue(cluster::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Cluster {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CLUSTER_UNSPECIFIED" => Self::Unspecified,
+                "CLUSTER_UNKNOWN" => Self::Unknown,
+                "CLUSTER_TEXT" => Self::Text,
+                "CLUSTER_STRUCTURED_DATA" => Self::StructuredData,
+                "CLUSTER_SOURCE_CODE" => Self::SourceCode,
+                "CLUSTER_RICH_DOCUMENT" => Self::RichDocument,
+                "CLUSTER_IMAGE" => Self::Image,
+                "CLUSTER_ARCHIVE" => Self::Archive,
+                "CLUSTER_MULTIMEDIA" => Self::Multimedia,
+                "CLUSTER_EXECUTABLE" => Self::Executable,
+                "CLUSTER_AI_MODEL" => Self::AiModel,
+                _ => Self::UnknownValue(cluster::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Cluster {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Unknown => serializer.serialize_i32(1),
+                Self::Text => serializer.serialize_i32(2),
+                Self::StructuredData => serializer.serialize_i32(3),
+                Self::SourceCode => serializer.serialize_i32(4),
+                Self::RichDocument => serializer.serialize_i32(5),
+                Self::Image => serializer.serialize_i32(6),
+                Self::Archive => serializer.serialize_i32(7),
+                Self::Multimedia => serializer.serialize_i32(8),
+                Self::Executable => serializer.serialize_i32(9),
+                Self::AiModel => serializer.serialize_i32(10),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Cluster {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Cluster>::new(
+                ".google.privacy.dlp.v2.FileClusterType.Cluster",
+            ))
         }
     }
 
@@ -30227,79 +32466,143 @@ pub mod sensitivity_score {
     use super::*;
 
     /// Various sensitivity score levels for resources.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SensitivityScoreLevel(i32);
-
-    impl SensitivityScoreLevel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SensitivityScoreLevel {
         /// Unused.
-        pub const SENSITIVITY_SCORE_UNSPECIFIED: SensitivityScoreLevel =
-            SensitivityScoreLevel::new(0);
-
+        SensitivityScoreUnspecified,
         /// No sensitive information detected. The resource isn't publicly
         /// accessible.
-        pub const SENSITIVITY_LOW: SensitivityScoreLevel = SensitivityScoreLevel::new(10);
-
+        SensitivityLow,
         /// Unable to determine sensitivity.
-        pub const SENSITIVITY_UNKNOWN: SensitivityScoreLevel = SensitivityScoreLevel::new(12);
-
+        SensitivityUnknown,
         /// Medium risk. Contains personally identifiable information (PII),
         /// potentially sensitive data, or fields with free-text data that are at a
         /// higher risk of having intermittent sensitive data. Consider limiting
         /// access.
-        pub const SENSITIVITY_MODERATE: SensitivityScoreLevel = SensitivityScoreLevel::new(20);
-
+        SensitivityModerate,
         /// High risk. Sensitive personally identifiable information (SPII) can be
         /// present. Exfiltration of data can lead to user data loss.
         /// Re-identification of users might be possible. Consider limiting usage and
         /// or removing SPII.
-        pub const SENSITIVITY_HIGH: SensitivityScoreLevel = SensitivityScoreLevel::new(30);
+        SensitivityHigh,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SensitivityScoreLevel::value] or
+        /// [SensitivityScoreLevel::name].
+        UnknownValue(sensitivity_score_level::UnknownValue),
+    }
 
-        /// Creates a new SensitivityScoreLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod sensitivity_score_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SensitivityScoreLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::SensitivityScoreUnspecified => std::option::Option::Some(0),
+                Self::SensitivityLow => std::option::Option::Some(10),
+                Self::SensitivityUnknown => std::option::Option::Some(12),
+                Self::SensitivityModerate => std::option::Option::Some(20),
+                Self::SensitivityHigh => std::option::Option::Some(30),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SENSITIVITY_SCORE_UNSPECIFIED"),
-                10 => std::borrow::Cow::Borrowed("SENSITIVITY_LOW"),
-                12 => std::borrow::Cow::Borrowed("SENSITIVITY_UNKNOWN"),
-                20 => std::borrow::Cow::Borrowed("SENSITIVITY_MODERATE"),
-                30 => std::borrow::Cow::Borrowed("SENSITIVITY_HIGH"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SENSITIVITY_SCORE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SENSITIVITY_SCORE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::SensitivityScoreUnspecified => {
+                    std::option::Option::Some("SENSITIVITY_SCORE_UNSPECIFIED")
                 }
-                "SENSITIVITY_LOW" => std::option::Option::Some(Self::SENSITIVITY_LOW),
-                "SENSITIVITY_UNKNOWN" => std::option::Option::Some(Self::SENSITIVITY_UNKNOWN),
-                "SENSITIVITY_MODERATE" => std::option::Option::Some(Self::SENSITIVITY_MODERATE),
-                "SENSITIVITY_HIGH" => std::option::Option::Some(Self::SENSITIVITY_HIGH),
-                _ => std::option::Option::None,
+                Self::SensitivityLow => std::option::Option::Some("SENSITIVITY_LOW"),
+                Self::SensitivityUnknown => std::option::Option::Some("SENSITIVITY_UNKNOWN"),
+                Self::SensitivityModerate => std::option::Option::Some("SENSITIVITY_MODERATE"),
+                Self::SensitivityHigh => std::option::Option::Some("SENSITIVITY_HIGH"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for SensitivityScoreLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SensitivityScoreLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SensitivityScoreLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SensitivityScoreLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::SensitivityScoreUnspecified,
+                10 => Self::SensitivityLow,
+                12 => Self::SensitivityUnknown,
+                20 => Self::SensitivityModerate,
+                30 => Self::SensitivityHigh,
+                _ => Self::UnknownValue(sensitivity_score_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SensitivityScoreLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SENSITIVITY_SCORE_UNSPECIFIED" => Self::SensitivityScoreUnspecified,
+                "SENSITIVITY_LOW" => Self::SensitivityLow,
+                "SENSITIVITY_UNKNOWN" => Self::SensitivityUnknown,
+                "SENSITIVITY_MODERATE" => Self::SensitivityModerate,
+                "SENSITIVITY_HIGH" => Self::SensitivityHigh,
+                _ => Self::UnknownValue(sensitivity_score_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SensitivityScoreLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::SensitivityScoreUnspecified => serializer.serialize_i32(0),
+                Self::SensitivityLow => serializer.serialize_i32(10),
+                Self::SensitivityUnknown => serializer.serialize_i32(12),
+                Self::SensitivityModerate => serializer.serialize_i32(20),
+                Self::SensitivityHigh => serializer.serialize_i32(30),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SensitivityScoreLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SensitivityScoreLevel>::new(
+                ".google.privacy.dlp.v2.SensitivityScore.SensitivityScoreLevel",
+            ))
         }
     }
 }
@@ -31212,57 +33515,114 @@ pub mod custom_info_type {
     }
 
     /// Type of exclusion rule.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExclusionType(i32);
-
-    impl ExclusionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExclusionType {
         /// A finding of this custom info type will not be excluded from results.
-        pub const EXCLUSION_TYPE_UNSPECIFIED: ExclusionType = ExclusionType::new(0);
-
+        Unspecified,
         /// A finding of this custom info type will be excluded from final results,
         /// but can still affect rule execution.
-        pub const EXCLUSION_TYPE_EXCLUDE: ExclusionType = ExclusionType::new(1);
+        Exclude,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExclusionType::value] or
+        /// [ExclusionType::name].
+        UnknownValue(exclusion_type::UnknownValue),
+    }
 
-        /// Creates a new ExclusionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod exclusion_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExclusionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Exclude => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXCLUSION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("EXCLUSION_TYPE_EXCLUDE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXCLUSION_TYPE_UNSPECIFIED"),
+                Self::Exclude => std::option::Option::Some("EXCLUSION_TYPE_EXCLUDE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXCLUSION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXCLUSION_TYPE_UNSPECIFIED)
-                }
-                "EXCLUSION_TYPE_EXCLUDE" => std::option::Option::Some(Self::EXCLUSION_TYPE_EXCLUDE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExclusionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExclusionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExclusionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExclusionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Exclude,
+                _ => Self::UnknownValue(exclusion_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExclusionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXCLUSION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "EXCLUSION_TYPE_EXCLUDE" => Self::Exclude,
+                _ => Self::UnknownValue(exclusion_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExclusionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Exclude => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExclusionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExclusionType>::new(
+                ".google.privacy.dlp.v2.CustomInfoType.ExclusionType",
+            ))
         }
     }
 
@@ -31737,62 +34097,121 @@ pub mod cloud_storage_options {
     /// How to sample bytes if not all bytes are scanned. Meaningful only when used
     /// in conjunction with bytes_limit_per_file. If not specified, scanning would
     /// start from the top.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SampleMethod(i32);
-
-    impl SampleMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SampleMethod {
         /// No sampling.
-        pub const SAMPLE_METHOD_UNSPECIFIED: SampleMethod = SampleMethod::new(0);
-
+        Unspecified,
         /// Scan from the top (default).
-        pub const TOP: SampleMethod = SampleMethod::new(1);
-
+        Top,
         /// For each file larger than bytes_limit_per_file, randomly pick the offset
         /// to start scanning. The scanned bytes are contiguous.
-        pub const RANDOM_START: SampleMethod = SampleMethod::new(2);
+        RandomStart,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SampleMethod::value] or
+        /// [SampleMethod::name].
+        UnknownValue(sample_method::UnknownValue),
+    }
 
-        /// Creates a new SampleMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod sample_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SampleMethod {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Top => std::option::Option::Some(1),
+                Self::RandomStart => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SAMPLE_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TOP"),
-                2 => std::borrow::Cow::Borrowed("RANDOM_START"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SAMPLE_METHOD_UNSPECIFIED"),
+                Self::Top => std::option::Option::Some("TOP"),
+                Self::RandomStart => std::option::Option::Some("RANDOM_START"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SAMPLE_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SAMPLE_METHOD_UNSPECIFIED)
-                }
-                "TOP" => std::option::Option::Some(Self::TOP),
-                "RANDOM_START" => std::option::Option::Some(Self::RANDOM_START),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SampleMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SampleMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SampleMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SampleMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Top,
+                2 => Self::RandomStart,
+                _ => Self::UnknownValue(sample_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SampleMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SAMPLE_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "TOP" => Self::Top,
+                "RANDOM_START" => Self::RandomStart,
+                _ => Self::UnknownValue(sample_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SampleMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Top => serializer.serialize_i32(1),
+                Self::RandomStart => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SampleMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SampleMethod>::new(
+                ".google.privacy.dlp.v2.CloudStorageOptions.SampleMethod",
+            ))
         }
     }
 }
@@ -32011,63 +34430,122 @@ pub mod big_query_options {
     /// How to sample rows if not all rows are scanned. Meaningful only when used
     /// in conjunction with either rows_limit or rows_limit_percent. If not
     /// specified, rows are scanned in the order BigQuery reads them.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct SampleMethod(i32);
-
-    impl SampleMethod {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum SampleMethod {
         /// No sampling.
-        pub const SAMPLE_METHOD_UNSPECIFIED: SampleMethod = SampleMethod::new(0);
-
+        Unspecified,
         /// Scan groups of rows in the order BigQuery provides (default). Multiple
         /// groups of rows may be scanned in parallel, so results may not appear in
         /// the same order the rows are read.
-        pub const TOP: SampleMethod = SampleMethod::new(1);
-
+        Top,
         /// Randomly pick groups of rows to scan.
-        pub const RANDOM_START: SampleMethod = SampleMethod::new(2);
+        RandomStart,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [SampleMethod::value] or
+        /// [SampleMethod::name].
+        UnknownValue(sample_method::UnknownValue),
+    }
 
-        /// Creates a new SampleMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod sample_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl SampleMethod {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Top => std::option::Option::Some(1),
+                Self::RandomStart => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SAMPLE_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TOP"),
-                2 => std::borrow::Cow::Borrowed("RANDOM_START"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SAMPLE_METHOD_UNSPECIFIED"),
+                Self::Top => std::option::Option::Some("TOP"),
+                Self::RandomStart => std::option::Option::Some("RANDOM_START"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SAMPLE_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::SAMPLE_METHOD_UNSPECIFIED)
-                }
-                "TOP" => std::option::Option::Some(Self::TOP),
-                "RANDOM_START" => std::option::Option::Some(Self::RANDOM_START),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for SampleMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for SampleMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for SampleMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for SampleMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Top,
+                2 => Self::RandomStart,
+                _ => Self::UnknownValue(sample_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for SampleMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SAMPLE_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "TOP" => Self::Top,
+                "RANDOM_START" => Self::RandomStart,
+                _ => Self::UnknownValue(sample_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for SampleMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Top => serializer.serialize_i32(1),
+                Self::RandomStart => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for SampleMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<SampleMethod>::new(
+                ".google.privacy.dlp.v2.BigQueryOptions.SampleMethod",
+            ))
         }
     }
 }
@@ -33131,1330 +35609,2503 @@ impl wkt::message::Message for TableOptions {
 /// Enum of possible outcomes of transformations. SUCCESS if transformation and
 /// storing of transformation was successful, otherwise, reason for not
 /// transforming.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransformationResultStatusType(i32);
-
-impl TransformationResultStatusType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransformationResultStatusType {
     /// Unused.
-    pub const STATE_TYPE_UNSPECIFIED: TransformationResultStatusType =
-        TransformationResultStatusType::new(0);
-
+    StateTypeUnspecified,
     /// This will be set when a finding could not be transformed (i.e. outside user
     /// set bucket range).
-    pub const INVALID_TRANSFORM: TransformationResultStatusType =
-        TransformationResultStatusType::new(1);
-
+    InvalidTransform,
     /// This will be set when a BigQuery transformation was successful but could
     /// not be stored back in BigQuery because the transformed row exceeds
     /// BigQuery's max row size.
-    pub const BIGQUERY_MAX_ROW_SIZE_EXCEEDED: TransformationResultStatusType =
-        TransformationResultStatusType::new(2);
-
+    BigqueryMaxRowSizeExceeded,
     /// This will be set when there is a finding in the custom metadata of a file,
     /// but at the write time of the transformed file, this key / value pair is
     /// unretrievable.
-    pub const METADATA_UNRETRIEVABLE: TransformationResultStatusType =
-        TransformationResultStatusType::new(3);
-
+    MetadataUnretrievable,
     /// This will be set when the transformation and storing of it is successful.
-    pub const SUCCESS: TransformationResultStatusType = TransformationResultStatusType::new(4);
+    Success,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransformationResultStatusType::value] or
+    /// [TransformationResultStatusType::name].
+    UnknownValue(transformation_result_status_type::UnknownValue),
+}
 
-    /// Creates a new TransformationResultStatusType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod transformation_result_status_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl TransformationResultStatusType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::StateTypeUnspecified => std::option::Option::Some(0),
+            Self::InvalidTransform => std::option::Option::Some(1),
+            Self::BigqueryMaxRowSizeExceeded => std::option::Option::Some(2),
+            Self::MetadataUnretrievable => std::option::Option::Some(3),
+            Self::Success => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STATE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INVALID_TRANSFORM"),
-            2 => std::borrow::Cow::Borrowed("BIGQUERY_MAX_ROW_SIZE_EXCEEDED"),
-            3 => std::borrow::Cow::Borrowed("METADATA_UNRETRIEVABLE"),
-            4 => std::borrow::Cow::Borrowed("SUCCESS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STATE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_TYPE_UNSPECIFIED),
-            "INVALID_TRANSFORM" => std::option::Option::Some(Self::INVALID_TRANSFORM),
-            "BIGQUERY_MAX_ROW_SIZE_EXCEEDED" => {
-                std::option::Option::Some(Self::BIGQUERY_MAX_ROW_SIZE_EXCEEDED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::StateTypeUnspecified => std::option::Option::Some("STATE_TYPE_UNSPECIFIED"),
+            Self::InvalidTransform => std::option::Option::Some("INVALID_TRANSFORM"),
+            Self::BigqueryMaxRowSizeExceeded => {
+                std::option::Option::Some("BIGQUERY_MAX_ROW_SIZE_EXCEEDED")
             }
-            "METADATA_UNRETRIEVABLE" => std::option::Option::Some(Self::METADATA_UNRETRIEVABLE),
-            "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-            _ => std::option::Option::None,
+            Self::MetadataUnretrievable => std::option::Option::Some("METADATA_UNRETRIEVABLE"),
+            Self::Success => std::option::Option::Some("SUCCESS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for TransformationResultStatusType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransformationResultStatusType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransformationResultStatusType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransformationResultStatusType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::StateTypeUnspecified,
+            1 => Self::InvalidTransform,
+            2 => Self::BigqueryMaxRowSizeExceeded,
+            3 => Self::MetadataUnretrievable,
+            4 => Self::Success,
+            _ => Self::UnknownValue(transformation_result_status_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransformationResultStatusType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STATE_TYPE_UNSPECIFIED" => Self::StateTypeUnspecified,
+            "INVALID_TRANSFORM" => Self::InvalidTransform,
+            "BIGQUERY_MAX_ROW_SIZE_EXCEEDED" => Self::BigqueryMaxRowSizeExceeded,
+            "METADATA_UNRETRIEVABLE" => Self::MetadataUnretrievable,
+            "SUCCESS" => Self::Success,
+            _ => Self::UnknownValue(transformation_result_status_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransformationResultStatusType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::StateTypeUnspecified => serializer.serialize_i32(0),
+            Self::InvalidTransform => serializer.serialize_i32(1),
+            Self::BigqueryMaxRowSizeExceeded => serializer.serialize_i32(2),
+            Self::MetadataUnretrievable => serializer.serialize_i32(3),
+            Self::Success => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransformationResultStatusType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<TransformationResultStatusType>::new(
+                ".google.privacy.dlp.v2.TransformationResultStatusType",
+            ),
+        )
     }
 }
 
 /// Describes functionality of a given container in its original format.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransformationContainerType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransformationContainerType {
+    /// Unused.
+    TransformUnknownContainer,
+    /// Body of a file.
+    TransformBody,
+    /// Metadata for a file.
+    TransformMetadata,
+    /// A table.
+    TransformTable,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransformationContainerType::value] or
+    /// [TransformationContainerType::name].
+    UnknownValue(transformation_container_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod transformation_container_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TransformationContainerType {
-    /// Unused.
-    pub const TRANSFORM_UNKNOWN_CONTAINER: TransformationContainerType =
-        TransformationContainerType::new(0);
-
-    /// Body of a file.
-    pub const TRANSFORM_BODY: TransformationContainerType = TransformationContainerType::new(1);
-
-    /// Metadata for a file.
-    pub const TRANSFORM_METADATA: TransformationContainerType = TransformationContainerType::new(2);
-
-    /// A table.
-    pub const TRANSFORM_TABLE: TransformationContainerType = TransformationContainerType::new(3);
-
-    /// Creates a new TransformationContainerType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::TransformUnknownContainer => std::option::Option::Some(0),
+            Self::TransformBody => std::option::Option::Some(1),
+            Self::TransformMetadata => std::option::Option::Some(2),
+            Self::TransformTable => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFORM_UNKNOWN_CONTAINER"),
-            1 => std::borrow::Cow::Borrowed("TRANSFORM_BODY"),
-            2 => std::borrow::Cow::Borrowed("TRANSFORM_METADATA"),
-            3 => std::borrow::Cow::Borrowed("TRANSFORM_TABLE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFORM_UNKNOWN_CONTAINER" => {
-                std::option::Option::Some(Self::TRANSFORM_UNKNOWN_CONTAINER)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::TransformUnknownContainer => {
+                std::option::Option::Some("TRANSFORM_UNKNOWN_CONTAINER")
             }
-            "TRANSFORM_BODY" => std::option::Option::Some(Self::TRANSFORM_BODY),
-            "TRANSFORM_METADATA" => std::option::Option::Some(Self::TRANSFORM_METADATA),
-            "TRANSFORM_TABLE" => std::option::Option::Some(Self::TRANSFORM_TABLE),
-            _ => std::option::Option::None,
+            Self::TransformBody => std::option::Option::Some("TRANSFORM_BODY"),
+            Self::TransformMetadata => std::option::Option::Some("TRANSFORM_METADATA"),
+            Self::TransformTable => std::option::Option::Some("TRANSFORM_TABLE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for TransformationContainerType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransformationContainerType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransformationContainerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransformationContainerType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::TransformUnknownContainer,
+            1 => Self::TransformBody,
+            2 => Self::TransformMetadata,
+            3 => Self::TransformTable,
+            _ => Self::UnknownValue(transformation_container_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransformationContainerType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFORM_UNKNOWN_CONTAINER" => Self::TransformUnknownContainer,
+            "TRANSFORM_BODY" => Self::TransformBody,
+            "TRANSFORM_METADATA" => Self::TransformMetadata,
+            "TRANSFORM_TABLE" => Self::TransformTable,
+            _ => Self::UnknownValue(transformation_container_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransformationContainerType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::TransformUnknownContainer => serializer.serialize_i32(0),
+            Self::TransformBody => serializer.serialize_i32(1),
+            Self::TransformMetadata => serializer.serialize_i32(2),
+            Self::TransformTable => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransformationContainerType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<TransformationContainerType>::new(
+                ".google.privacy.dlp.v2.TransformationContainerType",
+            ),
+        )
     }
 }
 
 /// An enum of rules that can be used to transform a value. Can be a
 /// record suppression, or one of the transformation rules specified under
 /// `PrimitiveTransformation`.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct TransformationType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum TransformationType {
+    /// Unused
+    Unspecified,
+    /// Record suppression
+    RecordSuppression,
+    /// Replace value
+    ReplaceValue,
+    /// Replace value using a dictionary.
+    ReplaceDictionary,
+    /// Redact
+    Redact,
+    /// Character mask
+    CharacterMask,
+    /// FFX-FPE
+    CryptoReplaceFfxFpe,
+    /// Fixed size bucketing
+    FixedSizeBucketing,
+    /// Bucketing
+    Bucketing,
+    /// Replace with info type
+    ReplaceWithInfoType,
+    /// Time part
+    TimePart,
+    /// Crypto hash
+    CryptoHash,
+    /// Date shift
+    DateShift,
+    /// Deterministic crypto
+    CryptoDeterministicConfig,
+    /// Redact image
+    RedactImage,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [TransformationType::value] or
+    /// [TransformationType::name].
+    UnknownValue(transformation_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod transformation_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl TransformationType {
-    /// Unused
-    pub const TRANSFORMATION_TYPE_UNSPECIFIED: TransformationType = TransformationType::new(0);
-
-    /// Record suppression
-    pub const RECORD_SUPPRESSION: TransformationType = TransformationType::new(1);
-
-    /// Replace value
-    pub const REPLACE_VALUE: TransformationType = TransformationType::new(2);
-
-    /// Replace value using a dictionary.
-    pub const REPLACE_DICTIONARY: TransformationType = TransformationType::new(15);
-
-    /// Redact
-    pub const REDACT: TransformationType = TransformationType::new(3);
-
-    /// Character mask
-    pub const CHARACTER_MASK: TransformationType = TransformationType::new(4);
-
-    /// FFX-FPE
-    pub const CRYPTO_REPLACE_FFX_FPE: TransformationType = TransformationType::new(5);
-
-    /// Fixed size bucketing
-    pub const FIXED_SIZE_BUCKETING: TransformationType = TransformationType::new(6);
-
-    /// Bucketing
-    pub const BUCKETING: TransformationType = TransformationType::new(7);
-
-    /// Replace with info type
-    pub const REPLACE_WITH_INFO_TYPE: TransformationType = TransformationType::new(8);
-
-    /// Time part
-    pub const TIME_PART: TransformationType = TransformationType::new(9);
-
-    /// Crypto hash
-    pub const CRYPTO_HASH: TransformationType = TransformationType::new(10);
-
-    /// Date shift
-    pub const DATE_SHIFT: TransformationType = TransformationType::new(12);
-
-    /// Deterministic crypto
-    pub const CRYPTO_DETERMINISTIC_CONFIG: TransformationType = TransformationType::new(13);
-
-    /// Redact image
-    pub const REDACT_IMAGE: TransformationType = TransformationType::new(14);
-
-    /// Creates a new TransformationType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::RecordSuppression => std::option::Option::Some(1),
+            Self::ReplaceValue => std::option::Option::Some(2),
+            Self::ReplaceDictionary => std::option::Option::Some(15),
+            Self::Redact => std::option::Option::Some(3),
+            Self::CharacterMask => std::option::Option::Some(4),
+            Self::CryptoReplaceFfxFpe => std::option::Option::Some(5),
+            Self::FixedSizeBucketing => std::option::Option::Some(6),
+            Self::Bucketing => std::option::Option::Some(7),
+            Self::ReplaceWithInfoType => std::option::Option::Some(8),
+            Self::TimePart => std::option::Option::Some(9),
+            Self::CryptoHash => std::option::Option::Some(10),
+            Self::DateShift => std::option::Option::Some(12),
+            Self::CryptoDeterministicConfig => std::option::Option::Some(13),
+            Self::RedactImage => std::option::Option::Some(14),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TRANSFORMATION_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("RECORD_SUPPRESSION"),
-            2 => std::borrow::Cow::Borrowed("REPLACE_VALUE"),
-            3 => std::borrow::Cow::Borrowed("REDACT"),
-            4 => std::borrow::Cow::Borrowed("CHARACTER_MASK"),
-            5 => std::borrow::Cow::Borrowed("CRYPTO_REPLACE_FFX_FPE"),
-            6 => std::borrow::Cow::Borrowed("FIXED_SIZE_BUCKETING"),
-            7 => std::borrow::Cow::Borrowed("BUCKETING"),
-            8 => std::borrow::Cow::Borrowed("REPLACE_WITH_INFO_TYPE"),
-            9 => std::borrow::Cow::Borrowed("TIME_PART"),
-            10 => std::borrow::Cow::Borrowed("CRYPTO_HASH"),
-            12 => std::borrow::Cow::Borrowed("DATE_SHIFT"),
-            13 => std::borrow::Cow::Borrowed("CRYPTO_DETERMINISTIC_CONFIG"),
-            14 => std::borrow::Cow::Borrowed("REDACT_IMAGE"),
-            15 => std::borrow::Cow::Borrowed("REPLACE_DICTIONARY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TRANSFORMATION_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TRANSFORMATION_TYPE_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("TRANSFORMATION_TYPE_UNSPECIFIED"),
+            Self::RecordSuppression => std::option::Option::Some("RECORD_SUPPRESSION"),
+            Self::ReplaceValue => std::option::Option::Some("REPLACE_VALUE"),
+            Self::ReplaceDictionary => std::option::Option::Some("REPLACE_DICTIONARY"),
+            Self::Redact => std::option::Option::Some("REDACT"),
+            Self::CharacterMask => std::option::Option::Some("CHARACTER_MASK"),
+            Self::CryptoReplaceFfxFpe => std::option::Option::Some("CRYPTO_REPLACE_FFX_FPE"),
+            Self::FixedSizeBucketing => std::option::Option::Some("FIXED_SIZE_BUCKETING"),
+            Self::Bucketing => std::option::Option::Some("BUCKETING"),
+            Self::ReplaceWithInfoType => std::option::Option::Some("REPLACE_WITH_INFO_TYPE"),
+            Self::TimePart => std::option::Option::Some("TIME_PART"),
+            Self::CryptoHash => std::option::Option::Some("CRYPTO_HASH"),
+            Self::DateShift => std::option::Option::Some("DATE_SHIFT"),
+            Self::CryptoDeterministicConfig => {
+                std::option::Option::Some("CRYPTO_DETERMINISTIC_CONFIG")
             }
-            "RECORD_SUPPRESSION" => std::option::Option::Some(Self::RECORD_SUPPRESSION),
-            "REPLACE_VALUE" => std::option::Option::Some(Self::REPLACE_VALUE),
-            "REPLACE_DICTIONARY" => std::option::Option::Some(Self::REPLACE_DICTIONARY),
-            "REDACT" => std::option::Option::Some(Self::REDACT),
-            "CHARACTER_MASK" => std::option::Option::Some(Self::CHARACTER_MASK),
-            "CRYPTO_REPLACE_FFX_FPE" => std::option::Option::Some(Self::CRYPTO_REPLACE_FFX_FPE),
-            "FIXED_SIZE_BUCKETING" => std::option::Option::Some(Self::FIXED_SIZE_BUCKETING),
-            "BUCKETING" => std::option::Option::Some(Self::BUCKETING),
-            "REPLACE_WITH_INFO_TYPE" => std::option::Option::Some(Self::REPLACE_WITH_INFO_TYPE),
-            "TIME_PART" => std::option::Option::Some(Self::TIME_PART),
-            "CRYPTO_HASH" => std::option::Option::Some(Self::CRYPTO_HASH),
-            "DATE_SHIFT" => std::option::Option::Some(Self::DATE_SHIFT),
-            "CRYPTO_DETERMINISTIC_CONFIG" => {
-                std::option::Option::Some(Self::CRYPTO_DETERMINISTIC_CONFIG)
-            }
-            "REDACT_IMAGE" => std::option::Option::Some(Self::REDACT_IMAGE),
-            _ => std::option::Option::None,
+            Self::RedactImage => std::option::Option::Some("REDACT_IMAGE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for TransformationType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for TransformationType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for TransformationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for TransformationType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::RecordSuppression,
+            2 => Self::ReplaceValue,
+            3 => Self::Redact,
+            4 => Self::CharacterMask,
+            5 => Self::CryptoReplaceFfxFpe,
+            6 => Self::FixedSizeBucketing,
+            7 => Self::Bucketing,
+            8 => Self::ReplaceWithInfoType,
+            9 => Self::TimePart,
+            10 => Self::CryptoHash,
+            12 => Self::DateShift,
+            13 => Self::CryptoDeterministicConfig,
+            14 => Self::RedactImage,
+            15 => Self::ReplaceDictionary,
+            _ => Self::UnknownValue(transformation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for TransformationType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TRANSFORMATION_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "RECORD_SUPPRESSION" => Self::RecordSuppression,
+            "REPLACE_VALUE" => Self::ReplaceValue,
+            "REPLACE_DICTIONARY" => Self::ReplaceDictionary,
+            "REDACT" => Self::Redact,
+            "CHARACTER_MASK" => Self::CharacterMask,
+            "CRYPTO_REPLACE_FFX_FPE" => Self::CryptoReplaceFfxFpe,
+            "FIXED_SIZE_BUCKETING" => Self::FixedSizeBucketing,
+            "BUCKETING" => Self::Bucketing,
+            "REPLACE_WITH_INFO_TYPE" => Self::ReplaceWithInfoType,
+            "TIME_PART" => Self::TimePart,
+            "CRYPTO_HASH" => Self::CryptoHash,
+            "DATE_SHIFT" => Self::DateShift,
+            "CRYPTO_DETERMINISTIC_CONFIG" => Self::CryptoDeterministicConfig,
+            "REDACT_IMAGE" => Self::RedactImage,
+            _ => Self::UnknownValue(transformation_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for TransformationType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::RecordSuppression => serializer.serialize_i32(1),
+            Self::ReplaceValue => serializer.serialize_i32(2),
+            Self::ReplaceDictionary => serializer.serialize_i32(15),
+            Self::Redact => serializer.serialize_i32(3),
+            Self::CharacterMask => serializer.serialize_i32(4),
+            Self::CryptoReplaceFfxFpe => serializer.serialize_i32(5),
+            Self::FixedSizeBucketing => serializer.serialize_i32(6),
+            Self::Bucketing => serializer.serialize_i32(7),
+            Self::ReplaceWithInfoType => serializer.serialize_i32(8),
+            Self::TimePart => serializer.serialize_i32(9),
+            Self::CryptoHash => serializer.serialize_i32(10),
+            Self::DateShift => serializer.serialize_i32(12),
+            Self::CryptoDeterministicConfig => serializer.serialize_i32(13),
+            Self::RedactImage => serializer.serialize_i32(14),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransformationType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<TransformationType>::new(
+            ".google.privacy.dlp.v2.TransformationType",
+        ))
     }
 }
 
 /// Whether a profile being created is the first generation or an update.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ProfileGeneration(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ProfileGeneration {
+    /// Unused.
+    Unspecified,
+    /// The profile is the first profile for the resource.
+    New,
+    /// The profile is an update to a previous profile.
+    Update,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ProfileGeneration::value] or
+    /// [ProfileGeneration::name].
+    UnknownValue(profile_generation::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod profile_generation {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ProfileGeneration {
-    /// Unused.
-    pub const PROFILE_GENERATION_UNSPECIFIED: ProfileGeneration = ProfileGeneration::new(0);
-
-    /// The profile is the first profile for the resource.
-    pub const PROFILE_GENERATION_NEW: ProfileGeneration = ProfileGeneration::new(1);
-
-    /// The profile is an update to a previous profile.
-    pub const PROFILE_GENERATION_UPDATE: ProfileGeneration = ProfileGeneration::new(2);
-
-    /// Creates a new ProfileGeneration instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::New => std::option::Option::Some(1),
+            Self::Update => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("PROFILE_GENERATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PROFILE_GENERATION_NEW"),
-            2 => std::borrow::Cow::Borrowed("PROFILE_GENERATION_UPDATE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("PROFILE_GENERATION_UNSPECIFIED"),
+            Self::New => std::option::Option::Some("PROFILE_GENERATION_NEW"),
+            Self::Update => std::option::Option::Some("PROFILE_GENERATION_UPDATE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "PROFILE_GENERATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::PROFILE_GENERATION_UNSPECIFIED)
-            }
-            "PROFILE_GENERATION_NEW" => std::option::Option::Some(Self::PROFILE_GENERATION_NEW),
-            "PROFILE_GENERATION_UPDATE" => {
-                std::option::Option::Some(Self::PROFILE_GENERATION_UPDATE)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ProfileGeneration {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ProfileGeneration {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ProfileGeneration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ProfileGeneration {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::New,
+            2 => Self::Update,
+            _ => Self::UnknownValue(profile_generation::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ProfileGeneration {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "PROFILE_GENERATION_UNSPECIFIED" => Self::Unspecified,
+            "PROFILE_GENERATION_NEW" => Self::New,
+            "PROFILE_GENERATION_UPDATE" => Self::Update,
+            _ => Self::UnknownValue(profile_generation::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ProfileGeneration {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::New => serializer.serialize_i32(1),
+            Self::Update => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ProfileGeneration {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ProfileGeneration>::new(
+            ".google.privacy.dlp.v2.ProfileGeneration",
+        ))
     }
 }
 
 /// Over time new types may be added. Currently VIEW, MATERIALIZED_VIEW, and
 /// non-BigLake external tables are not supported.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQueryTableTypeCollection(i32);
-
-impl BigQueryTableTypeCollection {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BigQueryTableTypeCollection {
     /// Unused.
-    pub const BIG_QUERY_COLLECTION_UNSPECIFIED: BigQueryTableTypeCollection =
-        BigQueryTableTypeCollection::new(0);
-
+    BigQueryCollectionUnspecified,
     /// Automatically generate profiles for all tables, even if the table type is
     /// not yet fully supported for analysis. Profiles for unsupported tables will
     /// be generated with errors to indicate their partial support. When full
     /// support is added, the tables will automatically be profiled during the next
     /// scheduled run.
-    pub const BIG_QUERY_COLLECTION_ALL_TYPES: BigQueryTableTypeCollection =
-        BigQueryTableTypeCollection::new(1);
-
+    BigQueryCollectionAllTypes,
     /// Only those types fully supported will be profiled. Will expand
     /// automatically as Cloud DLP adds support for new table types. Unsupported
     /// table types will not have partial profiles generated.
-    pub const BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES: BigQueryTableTypeCollection =
-        BigQueryTableTypeCollection::new(2);
+    BigQueryCollectionOnlySupportedTypes,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BigQueryTableTypeCollection::value] or
+    /// [BigQueryTableTypeCollection::name].
+    UnknownValue(big_query_table_type_collection::UnknownValue),
+}
 
-    /// Creates a new BigQueryTableTypeCollection instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod big_query_table_type_collection {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BigQueryTableTypeCollection {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::BigQueryCollectionUnspecified => std::option::Option::Some(0),
+            Self::BigQueryCollectionAllTypes => std::option::Option::Some(1),
+            Self::BigQueryCollectionOnlySupportedTypes => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BIG_QUERY_COLLECTION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BIG_QUERY_COLLECTION_ALL_TYPES"),
-            2 => std::borrow::Cow::Borrowed("BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::BigQueryCollectionUnspecified => {
+                std::option::Option::Some("BIG_QUERY_COLLECTION_UNSPECIFIED")
+            }
+            Self::BigQueryCollectionAllTypes => {
+                std::option::Option::Some("BIG_QUERY_COLLECTION_ALL_TYPES")
+            }
+            Self::BigQueryCollectionOnlySupportedTypes => {
+                std::option::Option::Some("BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BIG_QUERY_COLLECTION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::BIG_QUERY_COLLECTION_UNSPECIFIED)
-            }
-            "BIG_QUERY_COLLECTION_ALL_TYPES" => {
-                std::option::Option::Some(Self::BIG_QUERY_COLLECTION_ALL_TYPES)
-            }
-            "BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES" => {
-                std::option::Option::Some(Self::BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BigQueryTableTypeCollection {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQueryTableTypeCollection {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BigQueryTableTypeCollection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BigQueryTableTypeCollection {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::BigQueryCollectionUnspecified,
+            1 => Self::BigQueryCollectionAllTypes,
+            2 => Self::BigQueryCollectionOnlySupportedTypes,
+            _ => Self::UnknownValue(big_query_table_type_collection::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BigQueryTableTypeCollection {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BIG_QUERY_COLLECTION_UNSPECIFIED" => Self::BigQueryCollectionUnspecified,
+            "BIG_QUERY_COLLECTION_ALL_TYPES" => Self::BigQueryCollectionAllTypes,
+            "BIG_QUERY_COLLECTION_ONLY_SUPPORTED_TYPES" => {
+                Self::BigQueryCollectionOnlySupportedTypes
+            }
+            _ => Self::UnknownValue(big_query_table_type_collection::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BigQueryTableTypeCollection {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::BigQueryCollectionUnspecified => serializer.serialize_i32(0),
+            Self::BigQueryCollectionAllTypes => serializer.serialize_i32(1),
+            Self::BigQueryCollectionOnlySupportedTypes => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BigQueryTableTypeCollection {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<BigQueryTableTypeCollection>::new(
+                ".google.privacy.dlp.v2.BigQueryTableTypeCollection",
+            ),
+        )
     }
 }
 
 /// Over time new types may be added. Currently VIEW, MATERIALIZED_VIEW, and
 /// non-BigLake external tables are not supported.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQueryTableType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BigQueryTableType {
+    /// Unused.
+    Unspecified,
+    /// A normal BigQuery table.
+    Table,
+    /// A table that references data stored in Cloud Storage.
+    ExternalBigLake,
+    /// A snapshot of a BigQuery table.
+    Snapshot,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BigQueryTableType::value] or
+    /// [BigQueryTableType::name].
+    UnknownValue(big_query_table_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod big_query_table_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl BigQueryTableType {
-    /// Unused.
-    pub const BIG_QUERY_TABLE_TYPE_UNSPECIFIED: BigQueryTableType = BigQueryTableType::new(0);
-
-    /// A normal BigQuery table.
-    pub const BIG_QUERY_TABLE_TYPE_TABLE: BigQueryTableType = BigQueryTableType::new(1);
-
-    /// A table that references data stored in Cloud Storage.
-    pub const BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE: BigQueryTableType = BigQueryTableType::new(2);
-
-    /// A snapshot of a BigQuery table.
-    pub const BIG_QUERY_TABLE_TYPE_SNAPSHOT: BigQueryTableType = BigQueryTableType::new(3);
-
-    /// Creates a new BigQueryTableType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Table => std::option::Option::Some(1),
+            Self::ExternalBigLake => std::option::Option::Some(2),
+            Self::Snapshot => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_TABLE"),
-            2 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE"),
-            3 => std::borrow::Cow::Borrowed("BIG_QUERY_TABLE_TYPE_SNAPSHOT"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("BIG_QUERY_TABLE_TYPE_UNSPECIFIED"),
+            Self::Table => std::option::Option::Some("BIG_QUERY_TABLE_TYPE_TABLE"),
+            Self::ExternalBigLake => {
+                std::option::Option::Some("BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE")
+            }
+            Self::Snapshot => std::option::Option::Some("BIG_QUERY_TABLE_TYPE_SNAPSHOT"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "BIG_QUERY_TABLE_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_UNSPECIFIED)
-            }
-            "BIG_QUERY_TABLE_TYPE_TABLE" => {
-                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_TABLE)
-            }
-            "BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE" => {
-                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE)
-            }
-            "BIG_QUERY_TABLE_TYPE_SNAPSHOT" => {
-                std::option::Option::Some(Self::BIG_QUERY_TABLE_TYPE_SNAPSHOT)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for BigQueryTableType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQueryTableType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BigQueryTableType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BigQueryTableType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Table,
+            2 => Self::ExternalBigLake,
+            3 => Self::Snapshot,
+            _ => Self::UnknownValue(big_query_table_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BigQueryTableType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "BIG_QUERY_TABLE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BIG_QUERY_TABLE_TYPE_TABLE" => Self::Table,
+            "BIG_QUERY_TABLE_TYPE_EXTERNAL_BIG_LAKE" => Self::ExternalBigLake,
+            "BIG_QUERY_TABLE_TYPE_SNAPSHOT" => Self::Snapshot,
+            _ => Self::UnknownValue(big_query_table_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BigQueryTableType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Table => serializer.serialize_i32(1),
+            Self::ExternalBigLake => serializer.serialize_i32(2),
+            Self::Snapshot => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BigQueryTableType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<BigQueryTableType>::new(
+            ".google.privacy.dlp.v2.BigQueryTableType",
+        ))
     }
 }
 
 /// How frequently data profiles can be updated. New options can be added at a
 /// later time.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DataProfileUpdateFrequency(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DataProfileUpdateFrequency {
+    /// Unspecified.
+    UpdateFrequencyUnspecified,
+    /// After the data profile is created, it will never be updated.
+    UpdateFrequencyNever,
+    /// The data profile can be updated up to once every 24 hours.
+    UpdateFrequencyDaily,
+    /// The data profile can be updated up to once every 30 days. Default.
+    UpdateFrequencyMonthly,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DataProfileUpdateFrequency::value] or
+    /// [DataProfileUpdateFrequency::name].
+    UnknownValue(data_profile_update_frequency::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod data_profile_update_frequency {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DataProfileUpdateFrequency {
-    /// Unspecified.
-    pub const UPDATE_FREQUENCY_UNSPECIFIED: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new(0);
-
-    /// After the data profile is created, it will never be updated.
-    pub const UPDATE_FREQUENCY_NEVER: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new(1);
-
-    /// The data profile can be updated up to once every 24 hours.
-    pub const UPDATE_FREQUENCY_DAILY: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new(2);
-
-    /// The data profile can be updated up to once every 30 days. Default.
-    pub const UPDATE_FREQUENCY_MONTHLY: DataProfileUpdateFrequency =
-        DataProfileUpdateFrequency::new(4);
-
-    /// Creates a new DataProfileUpdateFrequency instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::UpdateFrequencyUnspecified => std::option::Option::Some(0),
+            Self::UpdateFrequencyNever => std::option::Option::Some(1),
+            Self::UpdateFrequencyDaily => std::option::Option::Some(2),
+            Self::UpdateFrequencyMonthly => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_NEVER"),
-            2 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_DAILY"),
-            4 => std::borrow::Cow::Borrowed("UPDATE_FREQUENCY_MONTHLY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UPDATE_FREQUENCY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::UPDATE_FREQUENCY_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::UpdateFrequencyUnspecified => {
+                std::option::Option::Some("UPDATE_FREQUENCY_UNSPECIFIED")
             }
-            "UPDATE_FREQUENCY_NEVER" => std::option::Option::Some(Self::UPDATE_FREQUENCY_NEVER),
-            "UPDATE_FREQUENCY_DAILY" => std::option::Option::Some(Self::UPDATE_FREQUENCY_DAILY),
-            "UPDATE_FREQUENCY_MONTHLY" => std::option::Option::Some(Self::UPDATE_FREQUENCY_MONTHLY),
-            _ => std::option::Option::None,
+            Self::UpdateFrequencyNever => std::option::Option::Some("UPDATE_FREQUENCY_NEVER"),
+            Self::UpdateFrequencyDaily => std::option::Option::Some("UPDATE_FREQUENCY_DAILY"),
+            Self::UpdateFrequencyMonthly => std::option::Option::Some("UPDATE_FREQUENCY_MONTHLY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for DataProfileUpdateFrequency {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DataProfileUpdateFrequency {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DataProfileUpdateFrequency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DataProfileUpdateFrequency {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::UpdateFrequencyUnspecified,
+            1 => Self::UpdateFrequencyNever,
+            2 => Self::UpdateFrequencyDaily,
+            4 => Self::UpdateFrequencyMonthly,
+            _ => Self::UnknownValue(data_profile_update_frequency::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DataProfileUpdateFrequency {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UPDATE_FREQUENCY_UNSPECIFIED" => Self::UpdateFrequencyUnspecified,
+            "UPDATE_FREQUENCY_NEVER" => Self::UpdateFrequencyNever,
+            "UPDATE_FREQUENCY_DAILY" => Self::UpdateFrequencyDaily,
+            "UPDATE_FREQUENCY_MONTHLY" => Self::UpdateFrequencyMonthly,
+            _ => Self::UnknownValue(data_profile_update_frequency::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DataProfileUpdateFrequency {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::UpdateFrequencyUnspecified => serializer.serialize_i32(0),
+            Self::UpdateFrequencyNever => serializer.serialize_i32(1),
+            Self::UpdateFrequencyDaily => serializer.serialize_i32(2),
+            Self::UpdateFrequencyMonthly => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DataProfileUpdateFrequency {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<DataProfileUpdateFrequency>::new(
+                ".google.privacy.dlp.v2.DataProfileUpdateFrequency",
+            ),
+        )
     }
 }
 
 /// Attributes evaluated to determine if a table has been modified. New values
 /// may be added at a later time.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQueryTableModification(i32);
-
-impl BigQueryTableModification {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BigQueryTableModification {
     /// Unused.
-    pub const TABLE_MODIFICATION_UNSPECIFIED: BigQueryTableModification =
-        BigQueryTableModification::new(0);
-
+    TableModificationUnspecified,
     /// A table will be considered modified when the last_modified_time from
     /// BigQuery has been updated.
-    pub const TABLE_MODIFIED_TIMESTAMP: BigQueryTableModification =
-        BigQueryTableModification::new(1);
+    TableModifiedTimestamp,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BigQueryTableModification::value] or
+    /// [BigQueryTableModification::name].
+    UnknownValue(big_query_table_modification::UnknownValue),
+}
 
-    /// Creates a new BigQueryTableModification instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod big_query_table_modification {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BigQueryTableModification {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::TableModificationUnspecified => std::option::Option::Some(0),
+            Self::TableModifiedTimestamp => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TABLE_MODIFICATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("TABLE_MODIFIED_TIMESTAMP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TABLE_MODIFICATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::TABLE_MODIFICATION_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::TableModificationUnspecified => {
+                std::option::Option::Some("TABLE_MODIFICATION_UNSPECIFIED")
             }
-            "TABLE_MODIFIED_TIMESTAMP" => std::option::Option::Some(Self::TABLE_MODIFIED_TIMESTAMP),
-            _ => std::option::Option::None,
+            Self::TableModifiedTimestamp => std::option::Option::Some("TABLE_MODIFIED_TIMESTAMP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for BigQueryTableModification {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQueryTableModification {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BigQueryTableModification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BigQueryTableModification {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::TableModificationUnspecified,
+            1 => Self::TableModifiedTimestamp,
+            _ => Self::UnknownValue(big_query_table_modification::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BigQueryTableModification {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TABLE_MODIFICATION_UNSPECIFIED" => Self::TableModificationUnspecified,
+            "TABLE_MODIFIED_TIMESTAMP" => Self::TableModifiedTimestamp,
+            _ => Self::UnknownValue(big_query_table_modification::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BigQueryTableModification {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::TableModificationUnspecified => serializer.serialize_i32(0),
+            Self::TableModifiedTimestamp => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BigQueryTableModification {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<BigQueryTableModification>::new(
+                ".google.privacy.dlp.v2.BigQueryTableModification",
+            ),
+        )
     }
 }
 
 /// Attributes evaluated to determine if a schema has been modified. New values
 /// may be added at a later time.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct BigQuerySchemaModification(i32);
-
-impl BigQuerySchemaModification {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum BigQuerySchemaModification {
     /// Unused
-    pub const SCHEMA_MODIFICATION_UNSPECIFIED: BigQuerySchemaModification =
-        BigQuerySchemaModification::new(0);
-
+    SchemaModificationUnspecified,
     /// Profiles should be regenerated when new columns are added to the table.
     /// Default.
-    pub const SCHEMA_NEW_COLUMNS: BigQuerySchemaModification = BigQuerySchemaModification::new(1);
-
+    SchemaNewColumns,
     /// Profiles should be regenerated when columns are removed from the table.
-    pub const SCHEMA_REMOVED_COLUMNS: BigQuerySchemaModification =
-        BigQuerySchemaModification::new(2);
+    SchemaRemovedColumns,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [BigQuerySchemaModification::value] or
+    /// [BigQuerySchemaModification::name].
+    UnknownValue(big_query_schema_modification::UnknownValue),
+}
 
-    /// Creates a new BigQuerySchemaModification instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod big_query_schema_modification {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl BigQuerySchemaModification {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::SchemaModificationUnspecified => std::option::Option::Some(0),
+            Self::SchemaNewColumns => std::option::Option::Some(1),
+            Self::SchemaRemovedColumns => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SCHEMA_MODIFICATION_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("SCHEMA_NEW_COLUMNS"),
-            2 => std::borrow::Cow::Borrowed("SCHEMA_REMOVED_COLUMNS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-        }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SCHEMA_MODIFICATION_UNSPECIFIED" => {
-                std::option::Option::Some(Self::SCHEMA_MODIFICATION_UNSPECIFIED)
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::SchemaModificationUnspecified => {
+                std::option::Option::Some("SCHEMA_MODIFICATION_UNSPECIFIED")
             }
-            "SCHEMA_NEW_COLUMNS" => std::option::Option::Some(Self::SCHEMA_NEW_COLUMNS),
-            "SCHEMA_REMOVED_COLUMNS" => std::option::Option::Some(Self::SCHEMA_REMOVED_COLUMNS),
-            _ => std::option::Option::None,
+            Self::SchemaNewColumns => std::option::Option::Some("SCHEMA_NEW_COLUMNS"),
+            Self::SchemaRemovedColumns => std::option::Option::Some("SCHEMA_REMOVED_COLUMNS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-}
-
-impl std::convert::From<i32> for BigQuerySchemaModification {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for BigQuerySchemaModification {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for BigQuerySchemaModification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for BigQuerySchemaModification {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::SchemaModificationUnspecified,
+            1 => Self::SchemaNewColumns,
+            2 => Self::SchemaRemovedColumns,
+            _ => Self::UnknownValue(big_query_schema_modification::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for BigQuerySchemaModification {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SCHEMA_MODIFICATION_UNSPECIFIED" => Self::SchemaModificationUnspecified,
+            "SCHEMA_NEW_COLUMNS" => Self::SchemaNewColumns,
+            "SCHEMA_REMOVED_COLUMNS" => Self::SchemaRemovedColumns,
+            _ => Self::UnknownValue(big_query_schema_modification::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for BigQuerySchemaModification {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::SchemaModificationUnspecified => serializer.serialize_i32(0),
+            Self::SchemaNewColumns => serializer.serialize_i32(1),
+            Self::SchemaRemovedColumns => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BigQuerySchemaModification {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(
+            wkt::internal::EnumVisitor::<BigQuerySchemaModification>::new(
+                ".google.privacy.dlp.v2.BigQuerySchemaModification",
+            ),
+        )
     }
 }
 
 /// Operators available for comparing the value of fields.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RelationalOperator(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RelationalOperator {
+    /// Unused
+    Unspecified,
+    /// Equal. Attempts to match even with incompatible types.
+    EqualTo,
+    /// Not equal to. Attempts to match even with incompatible types.
+    NotEqualTo,
+    /// Greater than.
+    GreaterThan,
+    /// Less than.
+    LessThan,
+    /// Greater than or equals.
+    GreaterThanOrEquals,
+    /// Less than or equals.
+    LessThanOrEquals,
+    /// Exists
+    Exists,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RelationalOperator::value] or
+    /// [RelationalOperator::name].
+    UnknownValue(relational_operator::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod relational_operator {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RelationalOperator {
-    /// Unused
-    pub const RELATIONAL_OPERATOR_UNSPECIFIED: RelationalOperator = RelationalOperator::new(0);
-
-    /// Equal. Attempts to match even with incompatible types.
-    pub const EQUAL_TO: RelationalOperator = RelationalOperator::new(1);
-
-    /// Not equal to. Attempts to match even with incompatible types.
-    pub const NOT_EQUAL_TO: RelationalOperator = RelationalOperator::new(2);
-
-    /// Greater than.
-    pub const GREATER_THAN: RelationalOperator = RelationalOperator::new(3);
-
-    /// Less than.
-    pub const LESS_THAN: RelationalOperator = RelationalOperator::new(4);
-
-    /// Greater than or equals.
-    pub const GREATER_THAN_OR_EQUALS: RelationalOperator = RelationalOperator::new(5);
-
-    /// Less than or equals.
-    pub const LESS_THAN_OR_EQUALS: RelationalOperator = RelationalOperator::new(6);
-
-    /// Exists
-    pub const EXISTS: RelationalOperator = RelationalOperator::new(7);
-
-    /// Creates a new RelationalOperator instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::EqualTo => std::option::Option::Some(1),
+            Self::NotEqualTo => std::option::Option::Some(2),
+            Self::GreaterThan => std::option::Option::Some(3),
+            Self::LessThan => std::option::Option::Some(4),
+            Self::GreaterThanOrEquals => std::option::Option::Some(5),
+            Self::LessThanOrEquals => std::option::Option::Some(6),
+            Self::Exists => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RELATIONAL_OPERATOR_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("EQUAL_TO"),
-            2 => std::borrow::Cow::Borrowed("NOT_EQUAL_TO"),
-            3 => std::borrow::Cow::Borrowed("GREATER_THAN"),
-            4 => std::borrow::Cow::Borrowed("LESS_THAN"),
-            5 => std::borrow::Cow::Borrowed("GREATER_THAN_OR_EQUALS"),
-            6 => std::borrow::Cow::Borrowed("LESS_THAN_OR_EQUALS"),
-            7 => std::borrow::Cow::Borrowed("EXISTS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RELATIONAL_OPERATOR_UNSPECIFIED"),
+            Self::EqualTo => std::option::Option::Some("EQUAL_TO"),
+            Self::NotEqualTo => std::option::Option::Some("NOT_EQUAL_TO"),
+            Self::GreaterThan => std::option::Option::Some("GREATER_THAN"),
+            Self::LessThan => std::option::Option::Some("LESS_THAN"),
+            Self::GreaterThanOrEquals => std::option::Option::Some("GREATER_THAN_OR_EQUALS"),
+            Self::LessThanOrEquals => std::option::Option::Some("LESS_THAN_OR_EQUALS"),
+            Self::Exists => std::option::Option::Some("EXISTS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RELATIONAL_OPERATOR_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RELATIONAL_OPERATOR_UNSPECIFIED)
-            }
-            "EQUAL_TO" => std::option::Option::Some(Self::EQUAL_TO),
-            "NOT_EQUAL_TO" => std::option::Option::Some(Self::NOT_EQUAL_TO),
-            "GREATER_THAN" => std::option::Option::Some(Self::GREATER_THAN),
-            "LESS_THAN" => std::option::Option::Some(Self::LESS_THAN),
-            "GREATER_THAN_OR_EQUALS" => std::option::Option::Some(Self::GREATER_THAN_OR_EQUALS),
-            "LESS_THAN_OR_EQUALS" => std::option::Option::Some(Self::LESS_THAN_OR_EQUALS),
-            "EXISTS" => std::option::Option::Some(Self::EXISTS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RelationalOperator {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RelationalOperator {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RelationalOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RelationalOperator {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::EqualTo,
+            2 => Self::NotEqualTo,
+            3 => Self::GreaterThan,
+            4 => Self::LessThan,
+            5 => Self::GreaterThanOrEquals,
+            6 => Self::LessThanOrEquals,
+            7 => Self::Exists,
+            _ => Self::UnknownValue(relational_operator::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RelationalOperator {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RELATIONAL_OPERATOR_UNSPECIFIED" => Self::Unspecified,
+            "EQUAL_TO" => Self::EqualTo,
+            "NOT_EQUAL_TO" => Self::NotEqualTo,
+            "GREATER_THAN" => Self::GreaterThan,
+            "LESS_THAN" => Self::LessThan,
+            "GREATER_THAN_OR_EQUALS" => Self::GreaterThanOrEquals,
+            "LESS_THAN_OR_EQUALS" => Self::LessThanOrEquals,
+            "EXISTS" => Self::Exists,
+            _ => Self::UnknownValue(relational_operator::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RelationalOperator {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::EqualTo => serializer.serialize_i32(1),
+            Self::NotEqualTo => serializer.serialize_i32(2),
+            Self::GreaterThan => serializer.serialize_i32(3),
+            Self::LessThan => serializer.serialize_i32(4),
+            Self::GreaterThanOrEquals => serializer.serialize_i32(5),
+            Self::LessThanOrEquals => serializer.serialize_i32(6),
+            Self::Exists => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RelationalOperator {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RelationalOperator>::new(
+            ".google.privacy.dlp.v2.RelationalOperator",
+        ))
     }
 }
 
 /// Type of the match which can be applied to different ways of matching, like
 /// Dictionary, regular expression and intersecting with findings of another
 /// info type.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MatchingType(i32);
-
-impl MatchingType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MatchingType {
     /// Invalid.
-    pub const MATCHING_TYPE_UNSPECIFIED: MatchingType = MatchingType::new(0);
-
+    Unspecified,
     /// Full match.
     ///
     /// - Dictionary: join of Dictionary results matched complete finding quote
     /// - Regex: all regex matches fill a finding quote start to end
     /// - Exclude info type: completely inside affecting info types findings
-    pub const MATCHING_TYPE_FULL_MATCH: MatchingType = MatchingType::new(1);
-
+    FullMatch,
     /// Partial match.
     ///
     /// - Dictionary: at least one of the tokens in the finding matches
     /// - Regex: substring of the finding matches
     /// - Exclude info type: intersects with affecting info types findings
-    pub const MATCHING_TYPE_PARTIAL_MATCH: MatchingType = MatchingType::new(2);
-
+    PartialMatch,
     /// Inverse match.
     ///
     /// - Dictionary: no tokens in the finding match the dictionary
     /// - Regex: finding doesn't match the regex
     /// - Exclude info type: no intersection with affecting info types findings
-    pub const MATCHING_TYPE_INVERSE_MATCH: MatchingType = MatchingType::new(3);
+    InverseMatch,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MatchingType::value] or
+    /// [MatchingType::name].
+    UnknownValue(matching_type::UnknownValue),
+}
 
-    /// Creates a new MatchingType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod matching_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl MatchingType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::FullMatch => std::option::Option::Some(1),
+            Self::PartialMatch => std::option::Option::Some(2),
+            Self::InverseMatch => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MATCHING_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MATCHING_TYPE_FULL_MATCH"),
-            2 => std::borrow::Cow::Borrowed("MATCHING_TYPE_PARTIAL_MATCH"),
-            3 => std::borrow::Cow::Borrowed("MATCHING_TYPE_INVERSE_MATCH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MATCHING_TYPE_UNSPECIFIED"),
+            Self::FullMatch => std::option::Option::Some("MATCHING_TYPE_FULL_MATCH"),
+            Self::PartialMatch => std::option::Option::Some("MATCHING_TYPE_PARTIAL_MATCH"),
+            Self::InverseMatch => std::option::Option::Some("MATCHING_TYPE_INVERSE_MATCH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MATCHING_TYPE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::MATCHING_TYPE_UNSPECIFIED)
-            }
-            "MATCHING_TYPE_FULL_MATCH" => std::option::Option::Some(Self::MATCHING_TYPE_FULL_MATCH),
-            "MATCHING_TYPE_PARTIAL_MATCH" => {
-                std::option::Option::Some(Self::MATCHING_TYPE_PARTIAL_MATCH)
-            }
-            "MATCHING_TYPE_INVERSE_MATCH" => {
-                std::option::Option::Some(Self::MATCHING_TYPE_INVERSE_MATCH)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MatchingType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MatchingType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MatchingType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MatchingType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::FullMatch,
+            2 => Self::PartialMatch,
+            3 => Self::InverseMatch,
+            _ => Self::UnknownValue(matching_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MatchingType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MATCHING_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "MATCHING_TYPE_FULL_MATCH" => Self::FullMatch,
+            "MATCHING_TYPE_PARTIAL_MATCH" => Self::PartialMatch,
+            "MATCHING_TYPE_INVERSE_MATCH" => Self::InverseMatch,
+            _ => Self::UnknownValue(matching_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MatchingType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::FullMatch => serializer.serialize_i32(1),
+            Self::PartialMatch => serializer.serialize_i32(2),
+            Self::InverseMatch => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MatchingType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MatchingType>::new(
+            ".google.privacy.dlp.v2.MatchingType",
+        ))
     }
 }
 
 /// Deprecated and unused.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ContentOption(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ContentOption {
+    /// Includes entire content of a file or a data stream.
+    ContentUnspecified,
+    /// Text content within the data, excluding any metadata.
+    ContentText,
+    /// Images found in the data.
+    ContentImage,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ContentOption::value] or
+    /// [ContentOption::name].
+    UnknownValue(content_option::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod content_option {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl ContentOption {
-    /// Includes entire content of a file or a data stream.
-    pub const CONTENT_UNSPECIFIED: ContentOption = ContentOption::new(0);
-
-    /// Text content within the data, excluding any metadata.
-    pub const CONTENT_TEXT: ContentOption = ContentOption::new(1);
-
-    /// Images found in the data.
-    pub const CONTENT_IMAGE: ContentOption = ContentOption::new(2);
-
-    /// Creates a new ContentOption instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::ContentUnspecified => std::option::Option::Some(0),
+            Self::ContentText => std::option::Option::Some(1),
+            Self::ContentImage => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONTENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("CONTENT_TEXT"),
-            2 => std::borrow::Cow::Borrowed("CONTENT_IMAGE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::ContentUnspecified => std::option::Option::Some("CONTENT_UNSPECIFIED"),
+            Self::ContentText => std::option::Option::Some("CONTENT_TEXT"),
+            Self::ContentImage => std::option::Option::Some("CONTENT_IMAGE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONTENT_UNSPECIFIED" => std::option::Option::Some(Self::CONTENT_UNSPECIFIED),
-            "CONTENT_TEXT" => std::option::Option::Some(Self::CONTENT_TEXT),
-            "CONTENT_IMAGE" => std::option::Option::Some(Self::CONTENT_IMAGE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ContentOption {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ContentOption {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ContentOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ContentOption {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::ContentUnspecified,
+            1 => Self::ContentText,
+            2 => Self::ContentImage,
+            _ => Self::UnknownValue(content_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ContentOption {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONTENT_UNSPECIFIED" => Self::ContentUnspecified,
+            "CONTENT_TEXT" => Self::ContentText,
+            "CONTENT_IMAGE" => Self::ContentImage,
+            _ => Self::UnknownValue(content_option::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ContentOption {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::ContentUnspecified => serializer.serialize_i32(0),
+            Self::ContentText => serializer.serialize_i32(1),
+            Self::ContentImage => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ContentOption {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ContentOption>::new(
+            ".google.privacy.dlp.v2.ContentOption",
+        ))
     }
 }
 
 /// Type of metadata containing the finding.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct MetadataType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum MetadataType {
+    /// Unused
+    MetadatatypeUnspecified,
+    /// General file metadata provided by Cloud Storage.
+    StorageMetadata,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [MetadataType::value] or
+    /// [MetadataType::name].
+    UnknownValue(metadata_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod metadata_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl MetadataType {
-    /// Unused
-    pub const METADATATYPE_UNSPECIFIED: MetadataType = MetadataType::new(0);
-
-    /// General file metadata provided by Cloud Storage.
-    pub const STORAGE_METADATA: MetadataType = MetadataType::new(2);
-
-    /// Creates a new MetadataType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::MetadatatypeUnspecified => std::option::Option::Some(0),
+            Self::StorageMetadata => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("METADATATYPE_UNSPECIFIED"),
-            2 => std::borrow::Cow::Borrowed("STORAGE_METADATA"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::MetadatatypeUnspecified => std::option::Option::Some("METADATATYPE_UNSPECIFIED"),
+            Self::StorageMetadata => std::option::Option::Some("STORAGE_METADATA"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "METADATATYPE_UNSPECIFIED" => std::option::Option::Some(Self::METADATATYPE_UNSPECIFIED),
-            "STORAGE_METADATA" => std::option::Option::Some(Self::STORAGE_METADATA),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for MetadataType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for MetadataType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for MetadataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for MetadataType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::MetadatatypeUnspecified,
+            2 => Self::StorageMetadata,
+            _ => Self::UnknownValue(metadata_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for MetadataType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "METADATATYPE_UNSPECIFIED" => Self::MetadatatypeUnspecified,
+            "STORAGE_METADATA" => Self::StorageMetadata,
+            _ => Self::UnknownValue(metadata_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for MetadataType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::MetadatatypeUnspecified => serializer.serialize_i32(0),
+            Self::StorageMetadata => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for MetadataType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<MetadataType>::new(
+            ".google.privacy.dlp.v2.MetadataType",
+        ))
     }
 }
 
 /// Parts of the APIs which use certain infoTypes.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct InfoTypeSupportedBy(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum InfoTypeSupportedBy {
+    /// Unused.
+    EnumTypeUnspecified,
+    /// Supported by the inspect operations.
+    Inspect,
+    /// Supported by the risk analysis operations.
+    RiskAnalysis,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [InfoTypeSupportedBy::value] or
+    /// [InfoTypeSupportedBy::name].
+    UnknownValue(info_type_supported_by::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod info_type_supported_by {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl InfoTypeSupportedBy {
-    /// Unused.
-    pub const ENUM_TYPE_UNSPECIFIED: InfoTypeSupportedBy = InfoTypeSupportedBy::new(0);
-
-    /// Supported by the inspect operations.
-    pub const INSPECT: InfoTypeSupportedBy = InfoTypeSupportedBy::new(1);
-
-    /// Supported by the risk analysis operations.
-    pub const RISK_ANALYSIS: InfoTypeSupportedBy = InfoTypeSupportedBy::new(2);
-
-    /// Creates a new InfoTypeSupportedBy instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::EnumTypeUnspecified => std::option::Option::Some(0),
+            Self::Inspect => std::option::Option::Some(1),
+            Self::RiskAnalysis => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENUM_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INSPECT"),
-            2 => std::borrow::Cow::Borrowed("RISK_ANALYSIS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::EnumTypeUnspecified => std::option::Option::Some("ENUM_TYPE_UNSPECIFIED"),
+            Self::Inspect => std::option::Option::Some("INSPECT"),
+            Self::RiskAnalysis => std::option::Option::Some("RISK_ANALYSIS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENUM_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::ENUM_TYPE_UNSPECIFIED),
-            "INSPECT" => std::option::Option::Some(Self::INSPECT),
-            "RISK_ANALYSIS" => std::option::Option::Some(Self::RISK_ANALYSIS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for InfoTypeSupportedBy {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for InfoTypeSupportedBy {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for InfoTypeSupportedBy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for InfoTypeSupportedBy {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::EnumTypeUnspecified,
+            1 => Self::Inspect,
+            2 => Self::RiskAnalysis,
+            _ => Self::UnknownValue(info_type_supported_by::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for InfoTypeSupportedBy {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENUM_TYPE_UNSPECIFIED" => Self::EnumTypeUnspecified,
+            "INSPECT" => Self::Inspect,
+            "RISK_ANALYSIS" => Self::RiskAnalysis,
+            _ => Self::UnknownValue(info_type_supported_by::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for InfoTypeSupportedBy {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::EnumTypeUnspecified => serializer.serialize_i32(0),
+            Self::Inspect => serializer.serialize_i32(1),
+            Self::RiskAnalysis => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for InfoTypeSupportedBy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<InfoTypeSupportedBy>::new(
+            ".google.privacy.dlp.v2.InfoTypeSupportedBy",
+        ))
     }
 }
 
 /// An enum to represent the various types of DLP jobs.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DlpJobType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DlpJobType {
+    /// Defaults to INSPECT_JOB.
+    Unspecified,
+    /// The job inspected Google Cloud for sensitive data.
+    InspectJob,
+    /// The job executed a Risk Analysis computation.
+    RiskAnalysisJob,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DlpJobType::value] or
+    /// [DlpJobType::name].
+    UnknownValue(dlp_job_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod dlp_job_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DlpJobType {
-    /// Defaults to INSPECT_JOB.
-    pub const DLP_JOB_TYPE_UNSPECIFIED: DlpJobType = DlpJobType::new(0);
-
-    /// The job inspected Google Cloud for sensitive data.
-    pub const INSPECT_JOB: DlpJobType = DlpJobType::new(1);
-
-    /// The job executed a Risk Analysis computation.
-    pub const RISK_ANALYSIS_JOB: DlpJobType = DlpJobType::new(2);
-
-    /// Creates a new DlpJobType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::InspectJob => std::option::Option::Some(1),
+            Self::RiskAnalysisJob => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DLP_JOB_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("INSPECT_JOB"),
-            2 => std::borrow::Cow::Borrowed("RISK_ANALYSIS_JOB"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DLP_JOB_TYPE_UNSPECIFIED"),
+            Self::InspectJob => std::option::Option::Some("INSPECT_JOB"),
+            Self::RiskAnalysisJob => std::option::Option::Some("RISK_ANALYSIS_JOB"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DLP_JOB_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::DLP_JOB_TYPE_UNSPECIFIED),
-            "INSPECT_JOB" => std::option::Option::Some(Self::INSPECT_JOB),
-            "RISK_ANALYSIS_JOB" => std::option::Option::Some(Self::RISK_ANALYSIS_JOB),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DlpJobType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DlpJobType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DlpJobType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DlpJobType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::InspectJob,
+            2 => Self::RiskAnalysisJob,
+            _ => Self::UnknownValue(dlp_job_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DlpJobType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DLP_JOB_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "INSPECT_JOB" => Self::InspectJob,
+            "RISK_ANALYSIS_JOB" => Self::RiskAnalysisJob,
+            _ => Self::UnknownValue(dlp_job_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DlpJobType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::InspectJob => serializer.serialize_i32(1),
+            Self::RiskAnalysisJob => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DlpJobType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DlpJobType>::new(
+            ".google.privacy.dlp.v2.DlpJobType",
+        ))
     }
 }
 
 /// State of a StoredInfoType version.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StoredInfoTypeState(i32);
-
-impl StoredInfoTypeState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum StoredInfoTypeState {
     /// Unused
-    pub const STORED_INFO_TYPE_STATE_UNSPECIFIED: StoredInfoTypeState = StoredInfoTypeState::new(0);
-
+    Unspecified,
     /// StoredInfoType version is being created.
-    pub const PENDING: StoredInfoTypeState = StoredInfoTypeState::new(1);
-
+    Pending,
     /// StoredInfoType version is ready for use.
-    pub const READY: StoredInfoTypeState = StoredInfoTypeState::new(2);
-
+    Ready,
     /// StoredInfoType creation failed. All relevant error messages are returned in
     /// the `StoredInfoTypeVersion` message.
-    pub const FAILED: StoredInfoTypeState = StoredInfoTypeState::new(3);
-
+    Failed,
     /// StoredInfoType is no longer valid because artifacts stored in
     /// user-controlled storage were modified. To fix an invalid StoredInfoType,
     /// use the `UpdateStoredInfoType` method to create a new version.
-    pub const INVALID: StoredInfoTypeState = StoredInfoTypeState::new(4);
+    Invalid,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [StoredInfoTypeState::value] or
+    /// [StoredInfoTypeState::name].
+    UnknownValue(stored_info_type_state::UnknownValue),
+}
 
-    /// Creates a new StoredInfoTypeState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod stored_info_type_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl StoredInfoTypeState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Pending => std::option::Option::Some(1),
+            Self::Ready => std::option::Option::Some(2),
+            Self::Failed => std::option::Option::Some(3),
+            Self::Invalid => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("STORED_INFO_TYPE_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("PENDING"),
-            2 => std::borrow::Cow::Borrowed("READY"),
-            3 => std::borrow::Cow::Borrowed("FAILED"),
-            4 => std::borrow::Cow::Borrowed("INVALID"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("STORED_INFO_TYPE_STATE_UNSPECIFIED"),
+            Self::Pending => std::option::Option::Some("PENDING"),
+            Self::Ready => std::option::Option::Some("READY"),
+            Self::Failed => std::option::Option::Some("FAILED"),
+            Self::Invalid => std::option::Option::Some("INVALID"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "STORED_INFO_TYPE_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::STORED_INFO_TYPE_STATE_UNSPECIFIED)
-            }
-            "PENDING" => std::option::Option::Some(Self::PENDING),
-            "READY" => std::option::Option::Some(Self::READY),
-            "FAILED" => std::option::Option::Some(Self::FAILED),
-            "INVALID" => std::option::Option::Some(Self::INVALID),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for StoredInfoTypeState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for StoredInfoTypeState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for StoredInfoTypeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for StoredInfoTypeState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Pending,
+            2 => Self::Ready,
+            3 => Self::Failed,
+            4 => Self::Invalid,
+            _ => Self::UnknownValue(stored_info_type_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for StoredInfoTypeState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "STORED_INFO_TYPE_STATE_UNSPECIFIED" => Self::Unspecified,
+            "PENDING" => Self::Pending,
+            "READY" => Self::Ready,
+            "FAILED" => Self::Failed,
+            "INVALID" => Self::Invalid,
+            _ => Self::UnknownValue(stored_info_type_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for StoredInfoTypeState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Pending => serializer.serialize_i32(1),
+            Self::Ready => serializer.serialize_i32(2),
+            Self::Failed => serializer.serialize_i32(3),
+            Self::Invalid => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for StoredInfoTypeState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<StoredInfoTypeState>::new(
+            ".google.privacy.dlp.v2.StoredInfoTypeState",
+        ))
     }
 }
 
 /// How broadly the data in the resource has been shared. New items may be added
 /// over time. A higher number means more restricted.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ResourceVisibility(i32);
-
-impl ResourceVisibility {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ResourceVisibility {
     /// Unused.
-    pub const RESOURCE_VISIBILITY_UNSPECIFIED: ResourceVisibility = ResourceVisibility::new(0);
-
+    Unspecified,
     /// Visible to any user.
-    pub const RESOURCE_VISIBILITY_PUBLIC: ResourceVisibility = ResourceVisibility::new(10);
-
+    Public,
     /// May contain public items.
     /// For example, if a Cloud Storage bucket has uniform bucket level access
     /// disabled, some objects inside it may be public, but none are known yet.
-    pub const RESOURCE_VISIBILITY_INCONCLUSIVE: ResourceVisibility = ResourceVisibility::new(15);
-
+    Inconclusive,
     /// Visible only to specific users.
-    pub const RESOURCE_VISIBILITY_RESTRICTED: ResourceVisibility = ResourceVisibility::new(20);
+    Restricted,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ResourceVisibility::value] or
+    /// [ResourceVisibility::name].
+    UnknownValue(resource_visibility::UnknownValue),
+}
 
-    /// Creates a new ResourceVisibility instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod resource_visibility {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ResourceVisibility {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Public => std::option::Option::Some(10),
+            Self::Inconclusive => std::option::Option::Some(15),
+            Self::Restricted => std::option::Option::Some(20),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_UNSPECIFIED"),
-            10 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_PUBLIC"),
-            15 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_INCONCLUSIVE"),
-            20 => std::borrow::Cow::Borrowed("RESOURCE_VISIBILITY_RESTRICTED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("RESOURCE_VISIBILITY_UNSPECIFIED"),
+            Self::Public => std::option::Option::Some("RESOURCE_VISIBILITY_PUBLIC"),
+            Self::Inconclusive => std::option::Option::Some("RESOURCE_VISIBILITY_INCONCLUSIVE"),
+            Self::Restricted => std::option::Option::Some("RESOURCE_VISIBILITY_RESTRICTED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "RESOURCE_VISIBILITY_UNSPECIFIED" => {
-                std::option::Option::Some(Self::RESOURCE_VISIBILITY_UNSPECIFIED)
-            }
-            "RESOURCE_VISIBILITY_PUBLIC" => {
-                std::option::Option::Some(Self::RESOURCE_VISIBILITY_PUBLIC)
-            }
-            "RESOURCE_VISIBILITY_INCONCLUSIVE" => {
-                std::option::Option::Some(Self::RESOURCE_VISIBILITY_INCONCLUSIVE)
-            }
-            "RESOURCE_VISIBILITY_RESTRICTED" => {
-                std::option::Option::Some(Self::RESOURCE_VISIBILITY_RESTRICTED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ResourceVisibility {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ResourceVisibility {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ResourceVisibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ResourceVisibility {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            10 => Self::Public,
+            15 => Self::Inconclusive,
+            20 => Self::Restricted,
+            _ => Self::UnknownValue(resource_visibility::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ResourceVisibility {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "RESOURCE_VISIBILITY_UNSPECIFIED" => Self::Unspecified,
+            "RESOURCE_VISIBILITY_PUBLIC" => Self::Public,
+            "RESOURCE_VISIBILITY_INCONCLUSIVE" => Self::Inconclusive,
+            "RESOURCE_VISIBILITY_RESTRICTED" => Self::Restricted,
+            _ => Self::UnknownValue(resource_visibility::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ResourceVisibility {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Public => serializer.serialize_i32(10),
+            Self::Inconclusive => serializer.serialize_i32(15),
+            Self::Restricted => serializer.serialize_i32(20),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ResourceVisibility {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ResourceVisibility>::new(
+            ".google.privacy.dlp.v2.ResourceVisibility",
+        ))
     }
 }
 
 /// How a resource is encrypted.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EncryptionStatus(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum EncryptionStatus {
+    /// Unused.
+    Unspecified,
+    /// Google manages server-side encryption keys on your behalf.
+    EncryptionGoogleManaged,
+    /// Customer provides the key.
+    EncryptionCustomerManaged,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [EncryptionStatus::value] or
+    /// [EncryptionStatus::name].
+    UnknownValue(encryption_status::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod encryption_status {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl EncryptionStatus {
-    /// Unused.
-    pub const ENCRYPTION_STATUS_UNSPECIFIED: EncryptionStatus = EncryptionStatus::new(0);
-
-    /// Google manages server-side encryption keys on your behalf.
-    pub const ENCRYPTION_GOOGLE_MANAGED: EncryptionStatus = EncryptionStatus::new(1);
-
-    /// Customer provides the key.
-    pub const ENCRYPTION_CUSTOMER_MANAGED: EncryptionStatus = EncryptionStatus::new(2);
-
-    /// Creates a new EncryptionStatus instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::EncryptionGoogleManaged => std::option::Option::Some(1),
+            Self::EncryptionCustomerManaged => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("ENCRYPTION_STATUS_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("ENCRYPTION_GOOGLE_MANAGED"),
-            2 => std::borrow::Cow::Borrowed("ENCRYPTION_CUSTOMER_MANAGED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("ENCRYPTION_STATUS_UNSPECIFIED"),
+            Self::EncryptionGoogleManaged => std::option::Option::Some("ENCRYPTION_GOOGLE_MANAGED"),
+            Self::EncryptionCustomerManaged => {
+                std::option::Option::Some("ENCRYPTION_CUSTOMER_MANAGED")
+            }
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "ENCRYPTION_STATUS_UNSPECIFIED" => {
-                std::option::Option::Some(Self::ENCRYPTION_STATUS_UNSPECIFIED)
-            }
-            "ENCRYPTION_GOOGLE_MANAGED" => {
-                std::option::Option::Some(Self::ENCRYPTION_GOOGLE_MANAGED)
-            }
-            "ENCRYPTION_CUSTOMER_MANAGED" => {
-                std::option::Option::Some(Self::ENCRYPTION_CUSTOMER_MANAGED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for EncryptionStatus {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for EncryptionStatus {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for EncryptionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for EncryptionStatus {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::EncryptionGoogleManaged,
+            2 => Self::EncryptionCustomerManaged,
+            _ => Self::UnknownValue(encryption_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for EncryptionStatus {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "ENCRYPTION_STATUS_UNSPECIFIED" => Self::Unspecified,
+            "ENCRYPTION_GOOGLE_MANAGED" => Self::EncryptionGoogleManaged,
+            "ENCRYPTION_CUSTOMER_MANAGED" => Self::EncryptionCustomerManaged,
+            _ => Self::UnknownValue(encryption_status::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for EncryptionStatus {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::EncryptionGoogleManaged => serializer.serialize_i32(1),
+            Self::EncryptionCustomerManaged => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for EncryptionStatus {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionStatus>::new(
+            ".google.privacy.dlp.v2.EncryptionStatus",
+        ))
     }
 }
 
 /// Bucketized nullness percentage levels. A higher level means a higher
 /// percentage of the column is null.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct NullPercentageLevel(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum NullPercentageLevel {
+    /// Unused.
+    Unspecified,
+    /// Very few null entries.
+    NullPercentageVeryLow,
+    /// Some null entries.
+    NullPercentageLow,
+    /// A few null entries.
+    NullPercentageMedium,
+    /// A lot of null entries.
+    NullPercentageHigh,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [NullPercentageLevel::value] or
+    /// [NullPercentageLevel::name].
+    UnknownValue(null_percentage_level::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod null_percentage_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl NullPercentageLevel {
-    /// Unused.
-    pub const NULL_PERCENTAGE_LEVEL_UNSPECIFIED: NullPercentageLevel = NullPercentageLevel::new(0);
-
-    /// Very few null entries.
-    pub const NULL_PERCENTAGE_VERY_LOW: NullPercentageLevel = NullPercentageLevel::new(1);
-
-    /// Some null entries.
-    pub const NULL_PERCENTAGE_LOW: NullPercentageLevel = NullPercentageLevel::new(2);
-
-    /// A few null entries.
-    pub const NULL_PERCENTAGE_MEDIUM: NullPercentageLevel = NullPercentageLevel::new(3);
-
-    /// A lot of null entries.
-    pub const NULL_PERCENTAGE_HIGH: NullPercentageLevel = NullPercentageLevel::new(4);
-
-    /// Creates a new NullPercentageLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::NullPercentageVeryLow => std::option::Option::Some(1),
+            Self::NullPercentageLow => std::option::Option::Some(2),
+            Self::NullPercentageMedium => std::option::Option::Some(3),
+            Self::NullPercentageHigh => std::option::Option::Some(4),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_VERY_LOW"),
-            2 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_LOW"),
-            3 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_MEDIUM"),
-            4 => std::borrow::Cow::Borrowed("NULL_PERCENTAGE_HIGH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("NULL_PERCENTAGE_LEVEL_UNSPECIFIED"),
+            Self::NullPercentageVeryLow => std::option::Option::Some("NULL_PERCENTAGE_VERY_LOW"),
+            Self::NullPercentageLow => std::option::Option::Some("NULL_PERCENTAGE_LOW"),
+            Self::NullPercentageMedium => std::option::Option::Some("NULL_PERCENTAGE_MEDIUM"),
+            Self::NullPercentageHigh => std::option::Option::Some("NULL_PERCENTAGE_HIGH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "NULL_PERCENTAGE_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::NULL_PERCENTAGE_LEVEL_UNSPECIFIED)
-            }
-            "NULL_PERCENTAGE_VERY_LOW" => std::option::Option::Some(Self::NULL_PERCENTAGE_VERY_LOW),
-            "NULL_PERCENTAGE_LOW" => std::option::Option::Some(Self::NULL_PERCENTAGE_LOW),
-            "NULL_PERCENTAGE_MEDIUM" => std::option::Option::Some(Self::NULL_PERCENTAGE_MEDIUM),
-            "NULL_PERCENTAGE_HIGH" => std::option::Option::Some(Self::NULL_PERCENTAGE_HIGH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for NullPercentageLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for NullPercentageLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for NullPercentageLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for NullPercentageLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::NullPercentageVeryLow,
+            2 => Self::NullPercentageLow,
+            3 => Self::NullPercentageMedium,
+            4 => Self::NullPercentageHigh,
+            _ => Self::UnknownValue(null_percentage_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for NullPercentageLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "NULL_PERCENTAGE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "NULL_PERCENTAGE_VERY_LOW" => Self::NullPercentageVeryLow,
+            "NULL_PERCENTAGE_LOW" => Self::NullPercentageLow,
+            "NULL_PERCENTAGE_MEDIUM" => Self::NullPercentageMedium,
+            "NULL_PERCENTAGE_HIGH" => Self::NullPercentageHigh,
+            _ => Self::UnknownValue(null_percentage_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for NullPercentageLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::NullPercentageVeryLow => serializer.serialize_i32(1),
+            Self::NullPercentageLow => serializer.serialize_i32(2),
+            Self::NullPercentageMedium => serializer.serialize_i32(3),
+            Self::NullPercentageHigh => serializer.serialize_i32(4),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for NullPercentageLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<NullPercentageLevel>::new(
+            ".google.privacy.dlp.v2.NullPercentageLevel",
+        ))
     }
 }
 
@@ -34462,87 +38113,143 @@ impl std::default::Default for NullPercentageLevel {
 /// signal that the column may contain a unique identifier like user id. A low
 /// value indicates that the column contains few unique values like booleans or
 /// other classifiers.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct UniquenessScoreLevel(i32);
-
-impl UniquenessScoreLevel {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum UniquenessScoreLevel {
     /// Some columns do not have estimated uniqueness. Possible reasons include
     /// having too few values.
-    pub const UNIQUENESS_SCORE_LEVEL_UNSPECIFIED: UniquenessScoreLevel =
-        UniquenessScoreLevel::new(0);
-
+    Unspecified,
     /// Low uniqueness, possibly a boolean, enum or similiarly typed column.
-    pub const UNIQUENESS_SCORE_LOW: UniquenessScoreLevel = UniquenessScoreLevel::new(1);
-
+    UniquenessScoreLow,
     /// Medium uniqueness.
-    pub const UNIQUENESS_SCORE_MEDIUM: UniquenessScoreLevel = UniquenessScoreLevel::new(2);
-
+    UniquenessScoreMedium,
     /// High uniqueness, possibly a column of free text or unique identifiers.
-    pub const UNIQUENESS_SCORE_HIGH: UniquenessScoreLevel = UniquenessScoreLevel::new(3);
+    UniquenessScoreHigh,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [UniquenessScoreLevel::value] or
+    /// [UniquenessScoreLevel::name].
+    UnknownValue(uniqueness_score_level::UnknownValue),
+}
 
-    /// Creates a new UniquenessScoreLevel instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod uniqueness_score_level {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl UniquenessScoreLevel {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::UniquenessScoreLow => std::option::Option::Some(1),
+            Self::UniquenessScoreMedium => std::option::Option::Some(2),
+            Self::UniquenessScoreHigh => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_LEVEL_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_LOW"),
-            2 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_MEDIUM"),
-            3 => std::borrow::Cow::Borrowed("UNIQUENESS_SCORE_HIGH"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("UNIQUENESS_SCORE_LEVEL_UNSPECIFIED"),
+            Self::UniquenessScoreLow => std::option::Option::Some("UNIQUENESS_SCORE_LOW"),
+            Self::UniquenessScoreMedium => std::option::Option::Some("UNIQUENESS_SCORE_MEDIUM"),
+            Self::UniquenessScoreHigh => std::option::Option::Some("UNIQUENESS_SCORE_HIGH"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UNIQUENESS_SCORE_LEVEL_UNSPECIFIED" => {
-                std::option::Option::Some(Self::UNIQUENESS_SCORE_LEVEL_UNSPECIFIED)
-            }
-            "UNIQUENESS_SCORE_LOW" => std::option::Option::Some(Self::UNIQUENESS_SCORE_LOW),
-            "UNIQUENESS_SCORE_MEDIUM" => std::option::Option::Some(Self::UNIQUENESS_SCORE_MEDIUM),
-            "UNIQUENESS_SCORE_HIGH" => std::option::Option::Some(Self::UNIQUENESS_SCORE_HIGH),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for UniquenessScoreLevel {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for UniquenessScoreLevel {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for UniquenessScoreLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for UniquenessScoreLevel {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::UniquenessScoreLow,
+            2 => Self::UniquenessScoreMedium,
+            3 => Self::UniquenessScoreHigh,
+            _ => Self::UnknownValue(uniqueness_score_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for UniquenessScoreLevel {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UNIQUENESS_SCORE_LEVEL_UNSPECIFIED" => Self::Unspecified,
+            "UNIQUENESS_SCORE_LOW" => Self::UniquenessScoreLow,
+            "UNIQUENESS_SCORE_MEDIUM" => Self::UniquenessScoreMedium,
+            "UNIQUENESS_SCORE_HIGH" => Self::UniquenessScoreHigh,
+            _ => Self::UnknownValue(uniqueness_score_level::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for UniquenessScoreLevel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::UniquenessScoreLow => serializer.serialize_i32(1),
+            Self::UniquenessScoreMedium => serializer.serialize_i32(2),
+            Self::UniquenessScoreHigh => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for UniquenessScoreLevel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<UniquenessScoreLevel>::new(
+            ".google.privacy.dlp.v2.UniquenessScoreLevel",
+        ))
     }
 }
 
 /// State of the connection.
 /// New values may be added over time.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ConnectionState(i32);
-
-impl ConnectionState {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum ConnectionState {
     /// Unused
-    pub const CONNECTION_STATE_UNSPECIFIED: ConnectionState = ConnectionState::new(0);
-
+    Unspecified,
     /// The DLP API automatically created this connection during an initial scan,
     /// and it is awaiting full configuration by a user.
-    pub const MISSING_CREDENTIALS: ConnectionState = ConnectionState::new(1);
-
+    MissingCredentials,
     /// A configured connection that has not encountered any errors.
-    pub const AVAILABLE: ConnectionState = ConnectionState::new(2);
-
+    Available,
     /// A configured connection that encountered errors during its last use. It
     /// will not be used again until it is set to AVAILABLE.
     ///
@@ -34550,52 +38257,117 @@ impl ConnectionState {
     /// request to set the status to AVAILABLE when the connection is ready for
     /// use. If the resolution doesn't require external action, then any changes to
     /// the connection properties will automatically mark it as AVAILABLE.
-    pub const ERROR: ConnectionState = ConnectionState::new(3);
+    Error,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [ConnectionState::value] or
+    /// [ConnectionState::name].
+    UnknownValue(connection_state::UnknownValue),
+}
 
-    /// Creates a new ConnectionState instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod connection_state {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl ConnectionState {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::MissingCredentials => std::option::Option::Some(1),
+            Self::Available => std::option::Option::Some(2),
+            Self::Error => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONNECTION_STATE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MISSING_CREDENTIALS"),
-            2 => std::borrow::Cow::Borrowed("AVAILABLE"),
-            3 => std::borrow::Cow::Borrowed("ERROR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONNECTION_STATE_UNSPECIFIED"),
+            Self::MissingCredentials => std::option::Option::Some("MISSING_CREDENTIALS"),
+            Self::Available => std::option::Option::Some("AVAILABLE"),
+            Self::Error => std::option::Option::Some("ERROR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONNECTION_STATE_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CONNECTION_STATE_UNSPECIFIED)
-            }
-            "MISSING_CREDENTIALS" => std::option::Option::Some(Self::MISSING_CREDENTIALS),
-            "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-            "ERROR" => std::option::Option::Some(Self::ERROR),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for ConnectionState {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for ConnectionState {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for ConnectionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for ConnectionState {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::MissingCredentials,
+            2 => Self::Available,
+            3 => Self::Error,
+            _ => Self::UnknownValue(connection_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for ConnectionState {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONNECTION_STATE_UNSPECIFIED" => Self::Unspecified,
+            "MISSING_CREDENTIALS" => Self::MissingCredentials,
+            "AVAILABLE" => Self::Available,
+            "ERROR" => Self::Error,
+            _ => Self::UnknownValue(connection_state::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for ConnectionState {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::MissingCredentials => serializer.serialize_i32(1),
+            Self::Available => serializer.serialize_i32(2),
+            Self::Error => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ConnectionState {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<ConnectionState>::new(
+            ".google.privacy.dlp.v2.ConnectionState",
+        ))
     }
 }
 
@@ -34614,93 +38386,157 @@ impl std::default::Default for ConnectionState {
 /// For more information about each likelihood level
 /// and how likelihood works, see [Match
 /// likelihood](https://cloud.google.com/sensitive-data-protection/docs/likelihood).
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Likelihood(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Likelihood {
+    /// Default value; same as POSSIBLE.
+    Unspecified,
+    /// Highest chance of a false positive.
+    VeryUnlikely,
+    /// High chance of a false positive.
+    Unlikely,
+    /// Some matching signals. The default value.
+    Possible,
+    /// Low chance of a false positive.
+    Likely,
+    /// Confidence level is high. Lowest chance of a false positive.
+    VeryLikely,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Likelihood::value] or
+    /// [Likelihood::name].
+    UnknownValue(likelihood::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod likelihood {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Likelihood {
-    /// Default value; same as POSSIBLE.
-    pub const LIKELIHOOD_UNSPECIFIED: Likelihood = Likelihood::new(0);
-
-    /// Highest chance of a false positive.
-    pub const VERY_UNLIKELY: Likelihood = Likelihood::new(1);
-
-    /// High chance of a false positive.
-    pub const UNLIKELY: Likelihood = Likelihood::new(2);
-
-    /// Some matching signals. The default value.
-    pub const POSSIBLE: Likelihood = Likelihood::new(3);
-
-    /// Low chance of a false positive.
-    pub const LIKELY: Likelihood = Likelihood::new(4);
-
-    /// Confidence level is high. Lowest chance of a false positive.
-    pub const VERY_LIKELY: Likelihood = Likelihood::new(5);
-
-    /// Creates a new Likelihood instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::VeryUnlikely => std::option::Option::Some(1),
+            Self::Unlikely => std::option::Option::Some(2),
+            Self::Possible => std::option::Option::Some(3),
+            Self::Likely => std::option::Option::Some(4),
+            Self::VeryLikely => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("LIKELIHOOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("VERY_UNLIKELY"),
-            2 => std::borrow::Cow::Borrowed("UNLIKELY"),
-            3 => std::borrow::Cow::Borrowed("POSSIBLE"),
-            4 => std::borrow::Cow::Borrowed("LIKELY"),
-            5 => std::borrow::Cow::Borrowed("VERY_LIKELY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("LIKELIHOOD_UNSPECIFIED"),
+            Self::VeryUnlikely => std::option::Option::Some("VERY_UNLIKELY"),
+            Self::Unlikely => std::option::Option::Some("UNLIKELY"),
+            Self::Possible => std::option::Option::Some("POSSIBLE"),
+            Self::Likely => std::option::Option::Some("LIKELY"),
+            Self::VeryLikely => std::option::Option::Some("VERY_LIKELY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "LIKELIHOOD_UNSPECIFIED" => std::option::Option::Some(Self::LIKELIHOOD_UNSPECIFIED),
-            "VERY_UNLIKELY" => std::option::Option::Some(Self::VERY_UNLIKELY),
-            "UNLIKELY" => std::option::Option::Some(Self::UNLIKELY),
-            "POSSIBLE" => std::option::Option::Some(Self::POSSIBLE),
-            "LIKELY" => std::option::Option::Some(Self::LIKELY),
-            "VERY_LIKELY" => std::option::Option::Some(Self::VERY_LIKELY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Likelihood {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Likelihood {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Likelihood {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Likelihood {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::VeryUnlikely,
+            2 => Self::Unlikely,
+            3 => Self::Possible,
+            4 => Self::Likely,
+            5 => Self::VeryLikely,
+            _ => Self::UnknownValue(likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Likelihood {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "LIKELIHOOD_UNSPECIFIED" => Self::Unspecified,
+            "VERY_UNLIKELY" => Self::VeryUnlikely,
+            "UNLIKELY" => Self::Unlikely,
+            "POSSIBLE" => Self::Possible,
+            "LIKELY" => Self::Likely,
+            "VERY_LIKELY" => Self::VeryLikely,
+            _ => Self::UnknownValue(likelihood::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Likelihood {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::VeryUnlikely => serializer.serialize_i32(1),
+            Self::Unlikely => serializer.serialize_i32(2),
+            Self::Possible => serializer.serialize_i32(3),
+            Self::Likely => serializer.serialize_i32(4),
+            Self::VeryLikely => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Likelihood {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Likelihood>::new(
+            ".google.privacy.dlp.v2.Likelihood",
+        ))
     }
 }
 
 /// Definitions of file type groups to scan. New types will be added to this
 /// list.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FileType(i32);
-
-impl FileType {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FileType {
     /// Includes all files.
-    pub const FILE_TYPE_UNSPECIFIED: FileType = FileType::new(0);
-
+    Unspecified,
     /// Includes all file extensions not covered by another entry. Binary
     /// scanning attempts to convert the content of the file to utf_8 to scan
     /// the file.
     /// If you wish to avoid this fall back, specify one or more of the other
     /// file types in your storage scan.
-    pub const BINARY_FILE: FileType = FileType::new(1);
-
+    BinaryFile,
     /// Included file extensions:
     /// asc,asp, aspx, brf, c, cc,cfm, cgi, cpp, csv, cxx, c++, cs, css, dart,
     /// dat, dot, eml,, epbub, ged, go, h, hh, hpp, hxx, h++, hs, html, htm,
@@ -34709,8 +38545,7 @@ impl FileType {
     /// shtml, shtm, xhtml, lhs, ics, ini, java, js, json, jsonl, kix, kml,
     /// ocaml, md, txt, text, tsv, vb, vcard, vcs, wml, xcodeproj, xml, xsl, xsd,
     /// yml, yaml.
-    pub const TEXT_FILE: FileType = FileType::new(2);
-
+    TextFile,
     /// Included file extensions:
     /// bmp, gif, jpg, jpeg, jpe, png. Setting
     /// [bytes_limit_per_file][google.privacy.dlp.v2.CloudStorageOptions.bytes_limit_per_file]
@@ -34720,99 +38555,180 @@ impl FileType {
     /// `global`, `us`, `asia`, and `europe` regions.
     ///
     /// [google.privacy.dlp.v2.CloudStorageOptions.bytes_limit_per_file]: crate::model::CloudStorageOptions::bytes_limit_per_file
-    pub const IMAGE: FileType = FileType::new(3);
-
+    Image,
     /// Microsoft Word files larger than 30 MB will be scanned as binary files.
     /// Included file extensions:
     /// docx, dotx, docm, dotm. Setting `bytes_limit_per_file` or
     /// `bytes_limit_per_file_percent` has no effect on Word files.
-    pub const WORD: FileType = FileType::new(5);
-
+    Word,
     /// PDF files larger than 30 MB will be scanned as binary files.
     /// Included file extensions:
     /// pdf. Setting `bytes_limit_per_file` or `bytes_limit_per_file_percent`
     /// has no effect on PDF files.
-    pub const PDF: FileType = FileType::new(6);
-
+    Pdf,
     /// Included file extensions:
     /// avro
-    pub const AVRO: FileType = FileType::new(7);
-
+    Avro,
     /// Included file extensions:
     /// csv
-    pub const CSV: FileType = FileType::new(8);
-
+    Csv,
     /// Included file extensions:
     /// tsv
-    pub const TSV: FileType = FileType::new(9);
-
+    Tsv,
     /// Microsoft PowerPoint files larger than 30 MB will be scanned as binary
     /// files. Included file extensions:
     /// pptx, pptm, potx, potm, pot. Setting `bytes_limit_per_file` or
     /// `bytes_limit_per_file_percent` has no effect on PowerPoint files.
-    pub const POWERPOINT: FileType = FileType::new(11);
-
+    Powerpoint,
     /// Microsoft Excel files larger than 30 MB will be scanned as binary files.
     /// Included file extensions:
     /// xlsx, xlsm, xltx, xltm. Setting `bytes_limit_per_file` or
     /// `bytes_limit_per_file_percent` has no effect on Excel files.
-    pub const EXCEL: FileType = FileType::new(12);
+    Excel,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FileType::value] or
+    /// [FileType::name].
+    UnknownValue(file_type::UnknownValue),
+}
 
-    /// Creates a new FileType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod file_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl FileType {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::BinaryFile => std::option::Option::Some(1),
+            Self::TextFile => std::option::Option::Some(2),
+            Self::Image => std::option::Option::Some(3),
+            Self::Word => std::option::Option::Some(5),
+            Self::Pdf => std::option::Option::Some(6),
+            Self::Avro => std::option::Option::Some(7),
+            Self::Csv => std::option::Option::Some(8),
+            Self::Tsv => std::option::Option::Some(9),
+            Self::Powerpoint => std::option::Option::Some(11),
+            Self::Excel => std::option::Option::Some(12),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FILE_TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BINARY_FILE"),
-            2 => std::borrow::Cow::Borrowed("TEXT_FILE"),
-            3 => std::borrow::Cow::Borrowed("IMAGE"),
-            5 => std::borrow::Cow::Borrowed("WORD"),
-            6 => std::borrow::Cow::Borrowed("PDF"),
-            7 => std::borrow::Cow::Borrowed("AVRO"),
-            8 => std::borrow::Cow::Borrowed("CSV"),
-            9 => std::borrow::Cow::Borrowed("TSV"),
-            11 => std::borrow::Cow::Borrowed("POWERPOINT"),
-            12 => std::borrow::Cow::Borrowed("EXCEL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FILE_TYPE_UNSPECIFIED"),
+            Self::BinaryFile => std::option::Option::Some("BINARY_FILE"),
+            Self::TextFile => std::option::Option::Some("TEXT_FILE"),
+            Self::Image => std::option::Option::Some("IMAGE"),
+            Self::Word => std::option::Option::Some("WORD"),
+            Self::Pdf => std::option::Option::Some("PDF"),
+            Self::Avro => std::option::Option::Some("AVRO"),
+            Self::Csv => std::option::Option::Some("CSV"),
+            Self::Tsv => std::option::Option::Some("TSV"),
+            Self::Powerpoint => std::option::Option::Some("POWERPOINT"),
+            Self::Excel => std::option::Option::Some("EXCEL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FILE_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::FILE_TYPE_UNSPECIFIED),
-            "BINARY_FILE" => std::option::Option::Some(Self::BINARY_FILE),
-            "TEXT_FILE" => std::option::Option::Some(Self::TEXT_FILE),
-            "IMAGE" => std::option::Option::Some(Self::IMAGE),
-            "WORD" => std::option::Option::Some(Self::WORD),
-            "PDF" => std::option::Option::Some(Self::PDF),
-            "AVRO" => std::option::Option::Some(Self::AVRO),
-            "CSV" => std::option::Option::Some(Self::CSV),
-            "TSV" => std::option::Option::Some(Self::TSV),
-            "POWERPOINT" => std::option::Option::Some(Self::POWERPOINT),
-            "EXCEL" => std::option::Option::Some(Self::EXCEL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FileType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FileType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FileType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::BinaryFile,
+            2 => Self::TextFile,
+            3 => Self::Image,
+            5 => Self::Word,
+            6 => Self::Pdf,
+            7 => Self::Avro,
+            8 => Self::Csv,
+            9 => Self::Tsv,
+            11 => Self::Powerpoint,
+            12 => Self::Excel,
+            _ => Self::UnknownValue(file_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FileType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FILE_TYPE_UNSPECIFIED" => Self::Unspecified,
+            "BINARY_FILE" => Self::BinaryFile,
+            "TEXT_FILE" => Self::TextFile,
+            "IMAGE" => Self::Image,
+            "WORD" => Self::Word,
+            "PDF" => Self::Pdf,
+            "AVRO" => Self::Avro,
+            "CSV" => Self::Csv,
+            "TSV" => Self::Tsv,
+            "POWERPOINT" => Self::Powerpoint,
+            "EXCEL" => Self::Excel,
+            _ => Self::UnknownValue(file_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FileType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::BinaryFile => serializer.serialize_i32(1),
+            Self::TextFile => serializer.serialize_i32(2),
+            Self::Image => serializer.serialize_i32(3),
+            Self::Word => serializer.serialize_i32(5),
+            Self::Pdf => serializer.serialize_i32(6),
+            Self::Avro => serializer.serialize_i32(7),
+            Self::Csv => serializer.serialize_i32(8),
+            Self::Tsv => serializer.serialize_i32(9),
+            Self::Powerpoint => serializer.serialize_i32(11),
+            Self::Excel => serializer.serialize_i32(12),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FileType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FileType>::new(
+            ".google.privacy.dlp.v2.FileType",
+        ))
     }
 }

--- a/src/generated/privacy/dlp/v2/src/transport.rs
+++ b/src/generated/privacy/dlp/v2/src/transport.rs
@@ -450,7 +450,7 @@ impl super::stub::DlpService for DlpService {
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         let builder = builder.query(&[("filter", &req.filter)]);
-        let builder = builder.query(&[("type", &req.r#type.value())]);
+        let builder = builder.query(&[("type", &req.r#type)]);
         let builder = builder.query(&[("locationId", &req.location_id)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
@@ -635,7 +635,7 @@ impl super::stub::DlpService for DlpService {
         let builder = builder.query(&[("filter", &req.filter)]);
         let builder = builder.query(&[("pageSize", &req.page_size)]);
         let builder = builder.query(&[("pageToken", &req.page_token)]);
-        let builder = builder.query(&[("type", &req.r#type.value())]);
+        let builder = builder.query(&[("type", &req.r#type)]);
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         let builder = builder.query(&[("locationId", &req.location_id)]);
         self.inner

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -769,7 +769,7 @@ pub struct ResourceInfo {
     /// error is
     /// [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
     ///
-    /// [google.rpc.Code.PERMISSION_DENIED]: crate::model::code::PERMISSION_DENIED
+    /// [google.rpc.Code.PERMISSION_DENIED]: crate::model::Code::PermissionDenied
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub resource_name: std::string::String,
 
@@ -1217,20 +1217,17 @@ impl wkt::message::Message for Status {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Code(i32);
-
-impl Code {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Code {
     /// Not an error; returned on success.
     ///
     /// HTTP Mapping: 200 OK
-    pub const OK: Code = Code::new(0);
-
+    Ok,
     /// The operation was cancelled, typically by the caller.
     ///
     /// HTTP Mapping: 499 Client Closed Request
-    pub const CANCELLED: Code = Code::new(1);
-
+    Cancelled,
     /// Unknown error.  For example, this error may be returned when
     /// a `Status` value received from another address space belongs to
     /// an error space that is not known in this address space.  Also
@@ -1238,16 +1235,14 @@ impl Code {
     /// may be converted to this error.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const UNKNOWN: Code = Code::new(2);
-
+    Unknown,
     /// The client specified an invalid argument.  Note that this differs
     /// from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
     /// that are problematic regardless of the state of the system
     /// (e.g., a malformed file name).
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const INVALID_ARGUMENT: Code = Code::new(3);
-
+    InvalidArgument,
     /// The deadline expired before the operation could complete. For operations
     /// that change the state of the system, this error may be returned
     /// even if the operation has completed successfully.  For example, a
@@ -1255,8 +1250,7 @@ impl Code {
     /// enough for the deadline to expire.
     ///
     /// HTTP Mapping: 504 Gateway Timeout
-    pub const DEADLINE_EXCEEDED: Code = Code::new(4);
-
+    DeadlineExceeded,
     /// Some requested entity (e.g., file or directory) was not found.
     ///
     /// Note to server developers: if a request is denied for an entire class
@@ -1266,14 +1260,12 @@ impl Code {
     /// must be used.
     ///
     /// HTTP Mapping: 404 Not Found
-    pub const NOT_FOUND: Code = Code::new(5);
-
+    NotFound,
     /// The entity that a client attempted to create (e.g., file or directory)
     /// already exists.
     ///
     /// HTTP Mapping: 409 Conflict
-    pub const ALREADY_EXISTS: Code = Code::new(6);
-
+    AlreadyExists,
     /// The caller does not have permission to execute the specified
     /// operation. `PERMISSION_DENIED` must not be used for rejections
     /// caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
@@ -1284,20 +1276,17 @@ impl Code {
     /// other pre-conditions.
     ///
     /// HTTP Mapping: 403 Forbidden
-    pub const PERMISSION_DENIED: Code = Code::new(7);
-
+    PermissionDenied,
     /// The request does not have valid authentication credentials for the
     /// operation.
     ///
     /// HTTP Mapping: 401 Unauthorized
-    pub const UNAUTHENTICATED: Code = Code::new(16);
-
+    Unauthenticated,
     /// Some resource has been exhausted, perhaps a per-user quota, or
     /// perhaps the entire file system is out of space.
     ///
     /// HTTP Mapping: 429 Too Many Requests
-    pub const RESOURCE_EXHAUSTED: Code = Code::new(8);
-
+    ResourceExhausted,
     /// The operation was rejected because the system is not in a state
     /// required for the operation's execution.  For example, the directory
     /// to be deleted is non-empty, an rmdir operation is applied to
@@ -1316,8 +1305,7 @@ impl Code {
     /// the files are deleted from the directory.
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const FAILED_PRECONDITION: Code = Code::new(9);
-
+    FailedPrecondition,
     /// The operation was aborted, typically due to a concurrency issue such as
     /// a sequencer check failure or transaction abort.
     ///
@@ -1325,8 +1313,7 @@ impl Code {
     /// `ABORTED`, and `UNAVAILABLE`.
     ///
     /// HTTP Mapping: 409 Conflict
-    pub const ABORTED: Code = Code::new(10);
-
+    Aborted,
     /// The operation was attempted past the valid range.  E.g., seeking or
     /// reading past end-of-file.
     ///
@@ -1344,21 +1331,18 @@ impl Code {
     /// they are done.
     ///
     /// HTTP Mapping: 400 Bad Request
-    pub const OUT_OF_RANGE: Code = Code::new(11);
-
+    OutOfRange,
     /// The operation is not implemented or is not supported/enabled in this
     /// service.
     ///
     /// HTTP Mapping: 501 Not Implemented
-    pub const UNIMPLEMENTED: Code = Code::new(12);
-
+    Unimplemented,
     /// Internal errors.  This means that some invariants expected by the
     /// underlying system have been broken.  This error code is reserved
     /// for serious errors.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const INTERNAL: Code = Code::new(13);
-
+    Internal,
     /// The service is currently unavailable.  This is most likely a
     /// transient condition, which can be corrected by retrying with
     /// a backoff. Note that it is not always safe to retry
@@ -1368,80 +1352,183 @@ impl Code {
     /// `ABORTED`, and `UNAVAILABLE`.
     ///
     /// HTTP Mapping: 503 Service Unavailable
-    pub const UNAVAILABLE: Code = Code::new(14);
-
+    Unavailable,
     /// Unrecoverable data loss or corruption.
     ///
     /// HTTP Mapping: 500 Internal Server Error
-    pub const DATA_LOSS: Code = Code::new(15);
+    DataLoss,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Code::value] or
+    /// [Code::name].
+    UnknownValue(code::UnknownValue),
+}
 
-    /// Creates a new Code instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod code {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl Code {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Ok => std::option::Option::Some(0),
+            Self::Cancelled => std::option::Option::Some(1),
+            Self::Unknown => std::option::Option::Some(2),
+            Self::InvalidArgument => std::option::Option::Some(3),
+            Self::DeadlineExceeded => std::option::Option::Some(4),
+            Self::NotFound => std::option::Option::Some(5),
+            Self::AlreadyExists => std::option::Option::Some(6),
+            Self::PermissionDenied => std::option::Option::Some(7),
+            Self::Unauthenticated => std::option::Option::Some(16),
+            Self::ResourceExhausted => std::option::Option::Some(8),
+            Self::FailedPrecondition => std::option::Option::Some(9),
+            Self::Aborted => std::option::Option::Some(10),
+            Self::OutOfRange => std::option::Option::Some(11),
+            Self::Unimplemented => std::option::Option::Some(12),
+            Self::Internal => std::option::Option::Some(13),
+            Self::Unavailable => std::option::Option::Some(14),
+            Self::DataLoss => std::option::Option::Some(15),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("OK"),
-            1 => std::borrow::Cow::Borrowed("CANCELLED"),
-            2 => std::borrow::Cow::Borrowed("UNKNOWN"),
-            3 => std::borrow::Cow::Borrowed("INVALID_ARGUMENT"),
-            4 => std::borrow::Cow::Borrowed("DEADLINE_EXCEEDED"),
-            5 => std::borrow::Cow::Borrowed("NOT_FOUND"),
-            6 => std::borrow::Cow::Borrowed("ALREADY_EXISTS"),
-            7 => std::borrow::Cow::Borrowed("PERMISSION_DENIED"),
-            8 => std::borrow::Cow::Borrowed("RESOURCE_EXHAUSTED"),
-            9 => std::borrow::Cow::Borrowed("FAILED_PRECONDITION"),
-            10 => std::borrow::Cow::Borrowed("ABORTED"),
-            11 => std::borrow::Cow::Borrowed("OUT_OF_RANGE"),
-            12 => std::borrow::Cow::Borrowed("UNIMPLEMENTED"),
-            13 => std::borrow::Cow::Borrowed("INTERNAL"),
-            14 => std::borrow::Cow::Borrowed("UNAVAILABLE"),
-            15 => std::borrow::Cow::Borrowed("DATA_LOSS"),
-            16 => std::borrow::Cow::Borrowed("UNAUTHENTICATED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Ok => std::option::Option::Some("OK"),
+            Self::Cancelled => std::option::Option::Some("CANCELLED"),
+            Self::Unknown => std::option::Option::Some("UNKNOWN"),
+            Self::InvalidArgument => std::option::Option::Some("INVALID_ARGUMENT"),
+            Self::DeadlineExceeded => std::option::Option::Some("DEADLINE_EXCEEDED"),
+            Self::NotFound => std::option::Option::Some("NOT_FOUND"),
+            Self::AlreadyExists => std::option::Option::Some("ALREADY_EXISTS"),
+            Self::PermissionDenied => std::option::Option::Some("PERMISSION_DENIED"),
+            Self::Unauthenticated => std::option::Option::Some("UNAUTHENTICATED"),
+            Self::ResourceExhausted => std::option::Option::Some("RESOURCE_EXHAUSTED"),
+            Self::FailedPrecondition => std::option::Option::Some("FAILED_PRECONDITION"),
+            Self::Aborted => std::option::Option::Some("ABORTED"),
+            Self::OutOfRange => std::option::Option::Some("OUT_OF_RANGE"),
+            Self::Unimplemented => std::option::Option::Some("UNIMPLEMENTED"),
+            Self::Internal => std::option::Option::Some("INTERNAL"),
+            Self::Unavailable => std::option::Option::Some("UNAVAILABLE"),
+            Self::DataLoss => std::option::Option::Some("DATA_LOSS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "OK" => std::option::Option::Some(Self::OK),
-            "CANCELLED" => std::option::Option::Some(Self::CANCELLED),
-            "UNKNOWN" => std::option::Option::Some(Self::UNKNOWN),
-            "INVALID_ARGUMENT" => std::option::Option::Some(Self::INVALID_ARGUMENT),
-            "DEADLINE_EXCEEDED" => std::option::Option::Some(Self::DEADLINE_EXCEEDED),
-            "NOT_FOUND" => std::option::Option::Some(Self::NOT_FOUND),
-            "ALREADY_EXISTS" => std::option::Option::Some(Self::ALREADY_EXISTS),
-            "PERMISSION_DENIED" => std::option::Option::Some(Self::PERMISSION_DENIED),
-            "UNAUTHENTICATED" => std::option::Option::Some(Self::UNAUTHENTICATED),
-            "RESOURCE_EXHAUSTED" => std::option::Option::Some(Self::RESOURCE_EXHAUSTED),
-            "FAILED_PRECONDITION" => std::option::Option::Some(Self::FAILED_PRECONDITION),
-            "ABORTED" => std::option::Option::Some(Self::ABORTED),
-            "OUT_OF_RANGE" => std::option::Option::Some(Self::OUT_OF_RANGE),
-            "UNIMPLEMENTED" => std::option::Option::Some(Self::UNIMPLEMENTED),
-            "INTERNAL" => std::option::Option::Some(Self::INTERNAL),
-            "UNAVAILABLE" => std::option::Option::Some(Self::UNAVAILABLE),
-            "DATA_LOSS" => std::option::Option::Some(Self::DATA_LOSS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Code {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Code {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Code {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Code {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Ok,
+            1 => Self::Cancelled,
+            2 => Self::Unknown,
+            3 => Self::InvalidArgument,
+            4 => Self::DeadlineExceeded,
+            5 => Self::NotFound,
+            6 => Self::AlreadyExists,
+            7 => Self::PermissionDenied,
+            8 => Self::ResourceExhausted,
+            9 => Self::FailedPrecondition,
+            10 => Self::Aborted,
+            11 => Self::OutOfRange,
+            12 => Self::Unimplemented,
+            13 => Self::Internal,
+            14 => Self::Unavailable,
+            15 => Self::DataLoss,
+            16 => Self::Unauthenticated,
+            _ => Self::UnknownValue(code::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Code {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "OK" => Self::Ok,
+            "CANCELLED" => Self::Cancelled,
+            "UNKNOWN" => Self::Unknown,
+            "INVALID_ARGUMENT" => Self::InvalidArgument,
+            "DEADLINE_EXCEEDED" => Self::DeadlineExceeded,
+            "NOT_FOUND" => Self::NotFound,
+            "ALREADY_EXISTS" => Self::AlreadyExists,
+            "PERMISSION_DENIED" => Self::PermissionDenied,
+            "UNAUTHENTICATED" => Self::Unauthenticated,
+            "RESOURCE_EXHAUSTED" => Self::ResourceExhausted,
+            "FAILED_PRECONDITION" => Self::FailedPrecondition,
+            "ABORTED" => Self::Aborted,
+            "OUT_OF_RANGE" => Self::OutOfRange,
+            "UNIMPLEMENTED" => Self::Unimplemented,
+            "INTERNAL" => Self::Internal,
+            "UNAVAILABLE" => Self::Unavailable,
+            "DATA_LOSS" => Self::DataLoss,
+            _ => Self::UnknownValue(code::UnknownValue(wkt::internal::UnknownEnumValue::String(
+                value.to_string(),
+            ))),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Code {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Ok => serializer.serialize_i32(0),
+            Self::Cancelled => serializer.serialize_i32(1),
+            Self::Unknown => serializer.serialize_i32(2),
+            Self::InvalidArgument => serializer.serialize_i32(3),
+            Self::DeadlineExceeded => serializer.serialize_i32(4),
+            Self::NotFound => serializer.serialize_i32(5),
+            Self::AlreadyExists => serializer.serialize_i32(6),
+            Self::PermissionDenied => serializer.serialize_i32(7),
+            Self::Unauthenticated => serializer.serialize_i32(16),
+            Self::ResourceExhausted => serializer.serialize_i32(8),
+            Self::FailedPrecondition => serializer.serialize_i32(9),
+            Self::Aborted => serializer.serialize_i32(10),
+            Self::OutOfRange => serializer.serialize_i32(11),
+            Self::Unimplemented => serializer.serialize_i32(12),
+            Self::Internal => serializer.serialize_i32(13),
+            Self::Unavailable => serializer.serialize_i32(14),
+            Self::DataLoss => serializer.serialize_i32(15),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Code {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Code>::new(".google.rpc.Code"))
     }
 }

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -564,74 +564,141 @@ pub mod compliance_data {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LifeKingdom(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LifeKingdom {
+        Unspecified,
+        Archaebacteria,
+        Eubacteria,
+        Protista,
+        Fungi,
+        Plantae,
+        Animalia,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LifeKingdom::value] or
+        /// [LifeKingdom::name].
+        UnknownValue(life_kingdom::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod life_kingdom {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LifeKingdom {
-        pub const LIFE_KINGDOM_UNSPECIFIED: LifeKingdom = LifeKingdom::new(0);
-
-        pub const ARCHAEBACTERIA: LifeKingdom = LifeKingdom::new(1);
-
-        pub const EUBACTERIA: LifeKingdom = LifeKingdom::new(2);
-
-        pub const PROTISTA: LifeKingdom = LifeKingdom::new(3);
-
-        pub const FUNGI: LifeKingdom = LifeKingdom::new(4);
-
-        pub const PLANTAE: LifeKingdom = LifeKingdom::new(5);
-
-        pub const ANIMALIA: LifeKingdom = LifeKingdom::new(6);
-
-        /// Creates a new LifeKingdom instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Archaebacteria => std::option::Option::Some(1),
+                Self::Eubacteria => std::option::Option::Some(2),
+                Self::Protista => std::option::Option::Some(3),
+                Self::Fungi => std::option::Option::Some(4),
+                Self::Plantae => std::option::Option::Some(5),
+                Self::Animalia => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LIFE_KINGDOM_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ARCHAEBACTERIA"),
-                2 => std::borrow::Cow::Borrowed("EUBACTERIA"),
-                3 => std::borrow::Cow::Borrowed("PROTISTA"),
-                4 => std::borrow::Cow::Borrowed("FUNGI"),
-                5 => std::borrow::Cow::Borrowed("PLANTAE"),
-                6 => std::borrow::Cow::Borrowed("ANIMALIA"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LIFE_KINGDOM_UNSPECIFIED"),
+                Self::Archaebacteria => std::option::Option::Some("ARCHAEBACTERIA"),
+                Self::Eubacteria => std::option::Option::Some("EUBACTERIA"),
+                Self::Protista => std::option::Option::Some("PROTISTA"),
+                Self::Fungi => std::option::Option::Some("FUNGI"),
+                Self::Plantae => std::option::Option::Some("PLANTAE"),
+                Self::Animalia => std::option::Option::Some("ANIMALIA"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LIFE_KINGDOM_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LIFE_KINGDOM_UNSPECIFIED)
-                }
-                "ARCHAEBACTERIA" => std::option::Option::Some(Self::ARCHAEBACTERIA),
-                "EUBACTERIA" => std::option::Option::Some(Self::EUBACTERIA),
-                "PROTISTA" => std::option::Option::Some(Self::PROTISTA),
-                "FUNGI" => std::option::Option::Some(Self::FUNGI),
-                "PLANTAE" => std::option::Option::Some(Self::PLANTAE),
-                "ANIMALIA" => std::option::Option::Some(Self::ANIMALIA),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LifeKingdom {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LifeKingdom {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LifeKingdom {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LifeKingdom {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Archaebacteria,
+                2 => Self::Eubacteria,
+                3 => Self::Protista,
+                4 => Self::Fungi,
+                5 => Self::Plantae,
+                6 => Self::Animalia,
+                _ => Self::UnknownValue(life_kingdom::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LifeKingdom {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LIFE_KINGDOM_UNSPECIFIED" => Self::Unspecified,
+                "ARCHAEBACTERIA" => Self::Archaebacteria,
+                "EUBACTERIA" => Self::Eubacteria,
+                "PROTISTA" => Self::Protista,
+                "FUNGI" => Self::Fungi,
+                "PLANTAE" => Self::Plantae,
+                "ANIMALIA" => Self::Animalia,
+                _ => Self::UnknownValue(life_kingdom::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LifeKingdom {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Archaebacteria => serializer.serialize_i32(1),
+                Self::Eubacteria => serializer.serialize_i32(2),
+                Self::Protista => serializer.serialize_i32(3),
+                Self::Fungi => serializer.serialize_i32(4),
+                Self::Plantae => serializer.serialize_i32(5),
+                Self::Animalia => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LifeKingdom {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LifeKingdom>::new(
+                ".google.showcase.v1beta1.ComplianceData.LifeKingdom",
+            ))
         }
     }
 }
@@ -3669,63 +3736,126 @@ pub mod stream_blurbs_response {
     use super::*;
 
     /// The action that triggered the blurb to be returned.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Action(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Action {
+        Unspecified,
+        /// Specifies that the blurb was created.
+        Create,
+        /// Specifies that the blurb was updated.
+        Update,
+        /// Specifies that the blurb was deleted.
+        Delete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Action::value] or
+        /// [Action::name].
+        UnknownValue(action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Action {
-        pub const ACTION_UNSPECIFIED: Action = Action::new(0);
-
-        /// Specifies that the blurb was created.
-        pub const CREATE: Action = Action::new(1);
-
-        /// Specifies that the blurb was updated.
-        pub const UPDATE: Action = Action::new(2);
-
-        /// Specifies that the blurb was deleted.
-        pub const DELETE: Action = Action::new(3);
-
-        /// Creates a new Action instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Create => std::option::Option::Some(1),
+                Self::Update => std::option::Option::Some(2),
+                Self::Delete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATE"),
-                2 => std::borrow::Cow::Borrowed("UPDATE"),
-                3 => std::borrow::Cow::Borrowed("DELETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACTION_UNSPECIFIED"),
+                Self::Create => std::option::Option::Some("CREATE"),
+                Self::Update => std::option::Option::Some("UPDATE"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACTION_UNSPECIFIED" => std::option::Option::Some(Self::ACTION_UNSPECIFIED),
-                "CREATE" => std::option::Option::Some(Self::CREATE),
-                "UPDATE" => std::option::Option::Some(Self::UPDATE),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Action {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Action {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Action {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Create,
+                2 => Self::Update,
+                3 => Self::Delete,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Action {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACTION_UNSPECIFIED" => Self::Unspecified,
+                "CREATE" => Self::Create,
+                "UPDATE" => Self::Update,
+                "DELETE" => Self::Delete,
+                _ => Self::UnknownValue(action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Action {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Create => serializer.serialize_i32(1),
+                Self::Update => serializer.serialize_i32(2),
+                Self::Delete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Action {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Action>::new(
+                ".google.showcase.v1beta1.StreamBlurbsResponse.Action",
+            ))
         }
     }
 }
@@ -4799,60 +4929,121 @@ pub mod session {
     use super::*;
 
     /// The specification versions understood by Showcase.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Version(i32);
-
-    impl Version {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Version {
         /// Unspecified version. If passed on creation, the session will default
         /// to using the latest stable release.
-        pub const VERSION_UNSPECIFIED: Version = Version::new(0);
-
+        Unspecified,
         /// The latest v1. Currently, this is v1.0.
-        pub const V1_LATEST: Version = Version::new(1);
-
+        V1Latest,
         /// v1.0. (Until the spec is "GA", this will be a moving target.)
-        pub const V1_0: Version = Version::new(2);
+        V10,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Version::value] or
+        /// [Version::name].
+        UnknownValue(version::UnknownValue),
+    }
 
-        /// Creates a new Version instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod version {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Version {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::V1Latest => std::option::Option::Some(1),
+                Self::V10 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VERSION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("V1_LATEST"),
-                2 => std::borrow::Cow::Borrowed("V1_0"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VERSION_UNSPECIFIED"),
+                Self::V1Latest => std::option::Option::Some("V1_LATEST"),
+                Self::V10 => std::option::Option::Some("V1_0"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VERSION_UNSPECIFIED" => std::option::Option::Some(Self::VERSION_UNSPECIFIED),
-                "V1_LATEST" => std::option::Option::Some(Self::V1_LATEST),
-                "V1_0" => std::option::Option::Some(Self::V1_0),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Version {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Version {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Version {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Version {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::V1Latest,
+                2 => Self::V10,
+                _ => Self::UnknownValue(version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Version {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VERSION_UNSPECIFIED" => Self::Unspecified,
+                "V1_LATEST" => Self::V1Latest,
+                "V1_0" => Self::V10,
+                _ => Self::UnknownValue(version::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Version {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::V1Latest => serializer.serialize_i32(1),
+                Self::V10 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Version {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Version>::new(
+                ".google.showcase.v1beta1.Session.Version",
+            ))
         }
     }
 }
@@ -5149,63 +5340,126 @@ pub mod report_session_response {
     use super::*;
 
     /// The topline state of the report.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Result(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Result {
+        Unspecified,
+        /// The session is complete, and everything passed.
+        Passed,
+        /// The session had an explicit failure.
+        Failed,
+        /// The session is incomplete. This is a failure response.
+        Incomplete,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Result::value] or
+        /// [Result::name].
+        UnknownValue(result::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod result {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Result {
-        pub const RESULT_UNSPECIFIED: Result = Result::new(0);
-
-        /// The session is complete, and everything passed.
-        pub const PASSED: Result = Result::new(1);
-
-        /// The session had an explicit failure.
-        pub const FAILED: Result = Result::new(2);
-
-        /// The session is incomplete. This is a failure response.
-        pub const INCOMPLETE: Result = Result::new(3);
-
-        /// Creates a new Result instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Passed => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::Incomplete => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RESULT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PASSED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                3 => std::borrow::Cow::Borrowed("INCOMPLETE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("RESULT_UNSPECIFIED"),
+                Self::Passed => std::option::Option::Some("PASSED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Incomplete => std::option::Option::Some("INCOMPLETE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RESULT_UNSPECIFIED" => std::option::Option::Some(Self::RESULT_UNSPECIFIED),
-                "PASSED" => std::option::Option::Some(Self::PASSED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "INCOMPLETE" => std::option::Option::Some(Self::INCOMPLETE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Result {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Result {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Result {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Passed,
+                2 => Self::Failed,
+                3 => Self::Incomplete,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Result {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RESULT_UNSPECIFIED" => Self::Unspecified,
+                "PASSED" => Self::Passed,
+                "FAILED" => Self::Failed,
+                "INCOMPLETE" => Self::Incomplete,
+                _ => Self::UnknownValue(result::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Result {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Passed => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::Incomplete => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Result {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Result>::new(
+                ".google.showcase.v1beta1.ReportSessionResponse.Result",
+            ))
         }
     }
 }
@@ -5416,15 +5670,12 @@ pub mod test {
     }
 
     /// Whether or not a test is required, recommended, or optional.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExpectationLevel(i32);
-
-    impl ExpectationLevel {
-        pub const EXPECTATION_LEVEL_UNSPECIFIED: ExpectationLevel = ExpectationLevel::new(0);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExpectationLevel {
+        Unspecified,
         /// This test is strictly required.
-        pub const REQUIRED: ExpectationLevel = ExpectationLevel::new(1);
-
+        Required,
         /// This test is recommended.
         ///
         /// If a generator explicitly ignores a recommended test (see `DeleteTest`),
@@ -5432,8 +5683,7 @@ pub mod test {
         ///
         /// If a generator skips a recommended test and does not explicitly
         /// express that intention, the report will fail.
-        pub const RECOMMENDED: ExpectationLevel = ExpectationLevel::new(2);
-
+        Recommended,
         /// This test is optional.
         ///
         /// If a generator explicitly ignores an optional test (see `DeleteTest`),
@@ -5442,52 +5692,117 @@ pub mod test {
         /// If a generator skips an optional test and does not explicitly
         /// express that intention, the report may still pass, but with a
         /// warning.
-        pub const OPTIONAL: ExpectationLevel = ExpectationLevel::new(3);
+        Optional,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExpectationLevel::value] or
+        /// [ExpectationLevel::name].
+        UnknownValue(expectation_level::UnknownValue),
+    }
 
-        /// Creates a new ExpectationLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod expectation_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExpectationLevel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Required => std::option::Option::Some(1),
+                Self::Recommended => std::option::Option::Some(2),
+                Self::Optional => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXPECTATION_LEVEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REQUIRED"),
-                2 => std::borrow::Cow::Borrowed("RECOMMENDED"),
-                3 => std::borrow::Cow::Borrowed("OPTIONAL"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXPECTATION_LEVEL_UNSPECIFIED"),
+                Self::Required => std::option::Option::Some("REQUIRED"),
+                Self::Recommended => std::option::Option::Some("RECOMMENDED"),
+                Self::Optional => std::option::Option::Some("OPTIONAL"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXPECTATION_LEVEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXPECTATION_LEVEL_UNSPECIFIED)
-                }
-                "REQUIRED" => std::option::Option::Some(Self::REQUIRED),
-                "RECOMMENDED" => std::option::Option::Some(Self::RECOMMENDED),
-                "OPTIONAL" => std::option::Option::Some(Self::OPTIONAL),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ExpectationLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExpectationLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExpectationLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExpectationLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Required,
+                2 => Self::Recommended,
+                3 => Self::Optional,
+                _ => Self::UnknownValue(expectation_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExpectationLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXPECTATION_LEVEL_UNSPECIFIED" => Self::Unspecified,
+                "REQUIRED" => Self::Required,
+                "RECOMMENDED" => Self::Recommended,
+                "OPTIONAL" => Self::Optional,
+                _ => Self::UnknownValue(expectation_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExpectationLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Required => serializer.serialize_i32(1),
+                Self::Recommended => serializer.serialize_i32(2),
+                Self::Optional => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExpectationLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExpectationLevel>::new(
+                ".google.showcase.v1beta1.Test.ExpectationLevel",
+            ))
         }
     }
 }
@@ -5552,120 +5867,244 @@ pub mod issue {
     use super::*;
 
     /// The different potential types of issues.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        Unspecified,
         /// The test was never instrumented.
-        pub const SKIPPED: Type = Type::new(1);
-
+        Skipped,
         /// The test was started but never confirmed.
-        pub const PENDING: Type = Type::new(2);
-
+        Pending,
         /// The test was instrumented, but Showcase got an unexpected
         /// value when the generator tried to confirm success.
-        pub const INCORRECT_CONFIRMATION: Type = Type::new(3);
+        IncorrectConfirmation,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skipped => std::option::Option::Some(1),
+                Self::Pending => std::option::Option::Some(2),
+                Self::IncorrectConfirmation => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SKIPPED"),
-                2 => std::borrow::Cow::Borrowed("PENDING"),
-                3 => std::borrow::Cow::Borrowed("INCORRECT_CONFIRMATION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::Skipped => std::option::Option::Some("SKIPPED"),
+                Self::Pending => std::option::Option::Some("PENDING"),
+                Self::IncorrectConfirmation => std::option::Option::Some("INCORRECT_CONFIRMATION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "SKIPPED" => std::option::Option::Some(Self::SKIPPED),
-                "PENDING" => std::option::Option::Some(Self::PENDING),
-                "INCORRECT_CONFIRMATION" => std::option::Option::Some(Self::INCORRECT_CONFIRMATION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skipped,
+                2 => Self::Pending,
+                3 => Self::IncorrectConfirmation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "SKIPPED" => Self::Skipped,
+                "PENDING" => Self::Pending,
+                "INCORRECT_CONFIRMATION" => Self::IncorrectConfirmation,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skipped => serializer.serialize_i32(1),
+                Self::Pending => serializer.serialize_i32(2),
+                Self::IncorrectConfirmation => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.showcase.v1beta1.Issue.Type",
+            ))
         }
     }
 
     /// Severity levels.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Severity(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Severity {
+        Unspecified,
+        /// Errors.
+        Error,
+        /// Warnings.
+        Warning,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Severity::value] or
+        /// [Severity::name].
+        UnknownValue(severity::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod severity {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Severity {
-        pub const SEVERITY_UNSPECIFIED: Severity = Severity::new(0);
-
-        /// Errors.
-        pub const ERROR: Severity = Severity::new(1);
-
-        /// Warnings.
-        pub const WARNING: Severity = Severity::new(2);
-
-        /// Creates a new Severity instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Error => std::option::Option::Some(1),
+                Self::Warning => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SEVERITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ERROR"),
-                2 => std::borrow::Cow::Borrowed("WARNING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SEVERITY_UNSPECIFIED"),
+                Self::Error => std::option::Option::Some("ERROR"),
+                Self::Warning => std::option::Option::Some("WARNING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SEVERITY_UNSPECIFIED" => std::option::Option::Some(Self::SEVERITY_UNSPECIFIED),
-                "ERROR" => std::option::Option::Some(Self::ERROR),
-                "WARNING" => std::option::Option::Some(Self::WARNING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Severity {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Severity {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Severity {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Error,
+                2 => Self::Warning,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Severity {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SEVERITY_UNSPECIFIED" => Self::Unspecified,
+                "ERROR" => Self::Error,
+                "WARNING" => Self::Warning,
+                _ => Self::UnknownValue(severity::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Severity {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Error => serializer.serialize_i32(1),
+                Self::Warning => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Severity {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+                ".google.showcase.v1beta1.Issue.Severity",
+            ))
         }
     }
 }
@@ -5955,125 +6394,255 @@ impl wkt::message::Message for VerifyTestResponse {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Continent(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Continent {
+    Unspecified,
+    Africa,
+    America,
+    Antartica,
+    Australia,
+    Europe,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Continent::value] or
+    /// [Continent::name].
+    UnknownValue(continent::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod continent {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Continent {
-    pub const CONTINENT_UNSPECIFIED: Continent = Continent::new(0);
-
-    pub const AFRICA: Continent = Continent::new(1);
-
-    pub const AMERICA: Continent = Continent::new(2);
-
-    pub const ANTARTICA: Continent = Continent::new(3);
-
-    pub const AUSTRALIA: Continent = Continent::new(4);
-
-    pub const EUROPE: Continent = Continent::new(5);
-
-    /// Creates a new Continent instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Africa => std::option::Option::Some(1),
+            Self::America => std::option::Option::Some(2),
+            Self::Antartica => std::option::Option::Some(3),
+            Self::Australia => std::option::Option::Some(4),
+            Self::Europe => std::option::Option::Some(5),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CONTINENT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("AFRICA"),
-            2 => std::borrow::Cow::Borrowed("AMERICA"),
-            3 => std::borrow::Cow::Borrowed("ANTARTICA"),
-            4 => std::borrow::Cow::Borrowed("AUSTRALIA"),
-            5 => std::borrow::Cow::Borrowed("EUROPE"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CONTINENT_UNSPECIFIED"),
+            Self::Africa => std::option::Option::Some("AFRICA"),
+            Self::America => std::option::Option::Some("AMERICA"),
+            Self::Antartica => std::option::Option::Some("ANTARTICA"),
+            Self::Australia => std::option::Option::Some("AUSTRALIA"),
+            Self::Europe => std::option::Option::Some("EUROPE"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CONTINENT_UNSPECIFIED" => std::option::Option::Some(Self::CONTINENT_UNSPECIFIED),
-            "AFRICA" => std::option::Option::Some(Self::AFRICA),
-            "AMERICA" => std::option::Option::Some(Self::AMERICA),
-            "ANTARTICA" => std::option::Option::Some(Self::ANTARTICA),
-            "AUSTRALIA" => std::option::Option::Some(Self::AUSTRALIA),
-            "EUROPE" => std::option::Option::Some(Self::EUROPE),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Continent {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Continent {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Continent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Continent {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Africa,
+            2 => Self::America,
+            3 => Self::Antartica,
+            4 => Self::Australia,
+            5 => Self::Europe,
+            _ => Self::UnknownValue(continent::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Continent {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CONTINENT_UNSPECIFIED" => Self::Unspecified,
+            "AFRICA" => Self::Africa,
+            "AMERICA" => Self::America,
+            "ANTARTICA" => Self::Antartica,
+            "AUSTRALIA" => Self::Australia,
+            "EUROPE" => Self::Europe,
+            _ => Self::UnknownValue(continent::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Continent {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Africa => serializer.serialize_i32(1),
+            Self::America => serializer.serialize_i32(2),
+            Self::Antartica => serializer.serialize_i32(3),
+            Self::Australia => serializer.serialize_i32(4),
+            Self::Europe => serializer.serialize_i32(5),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Continent {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Continent>::new(
+            ".google.showcase.v1beta1.Continent",
+        ))
     }
 }
 
 /// A severity enum used to test enum capabilities in GAPIC surfaces.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Severity(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Severity {
+    Unnecessary,
+    Necessary,
+    Urgent,
+    Critical,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Severity::value] or
+    /// [Severity::name].
+    UnknownValue(severity::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod severity {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Severity {
-    pub const UNNECESSARY: Severity = Severity::new(0);
-
-    pub const NECESSARY: Severity = Severity::new(1);
-
-    pub const URGENT: Severity = Severity::new(2);
-
-    pub const CRITICAL: Severity = Severity::new(3);
-
-    /// Creates a new Severity instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unnecessary => std::option::Option::Some(0),
+            Self::Necessary => std::option::Option::Some(1),
+            Self::Urgent => std::option::Option::Some(2),
+            Self::Critical => std::option::Option::Some(3),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("UNNECESSARY"),
-            1 => std::borrow::Cow::Borrowed("NECESSARY"),
-            2 => std::borrow::Cow::Borrowed("URGENT"),
-            3 => std::borrow::Cow::Borrowed("CRITICAL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unnecessary => std::option::Option::Some("UNNECESSARY"),
+            Self::Necessary => std::option::Option::Some("NECESSARY"),
+            Self::Urgent => std::option::Option::Some("URGENT"),
+            Self::Critical => std::option::Option::Some("CRITICAL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "UNNECESSARY" => std::option::Option::Some(Self::UNNECESSARY),
-            "NECESSARY" => std::option::Option::Some(Self::NECESSARY),
-            "URGENT" => std::option::Option::Some(Self::URGENT),
-            "CRITICAL" => std::option::Option::Some(Self::CRITICAL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Severity {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Severity {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Severity {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unnecessary,
+            1 => Self::Necessary,
+            2 => Self::Urgent,
+            3 => Self::Critical,
+            _ => Self::UnknownValue(severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Severity {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "UNNECESSARY" => Self::Unnecessary,
+            "NECESSARY" => Self::Necessary,
+            "URGENT" => Self::Urgent,
+            "CRITICAL" => Self::Critical,
+            _ => Self::UnknownValue(severity::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Severity {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unnecessary => serializer.serialize_i32(0),
+            Self::Necessary => serializer.serialize_i32(1),
+            Self::Urgent => serializer.serialize_i32(2),
+            Self::Critical => serializer.serialize_i32(3),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Severity {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Severity>::new(
+            ".google.showcase.v1beta1.Severity",
+        ))
     }
 }

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -178,7 +178,6 @@ impl super::stub::Compliance for Compliance {
                         .as_ref()
                         .ok_or_else(|| gaxi::path_parameter::missing("info"))?
                         .f_kingdom
-                        .value()
                 ),
             )
             .query(&[("$alt", "json;enum-encoding=int")])
@@ -439,7 +438,7 @@ impl super::stub::Compliance for Compliance {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "request")
             });
-        let builder = builder.query(&[("continent", &req.continent.value())]);
+        let builder = builder.query(&[("continent", &req.continent)]);
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -397,60 +397,121 @@ pub mod backup {
     use super::*;
 
     /// Indicates the current state of the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The pending backup is still being created. Operations on the
         /// backup may fail with `FAILED_PRECONDITION` in this state.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The backup is complete and ready for use.
-        pub const READY: State = State::new(2);
+        Ready,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.spanner.admin.database.v1.Backup.State",
+            ))
         }
     }
 }
@@ -1537,13 +1598,11 @@ pub mod create_backup_encryption_config {
     use super::*;
 
     /// Encryption types for the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(i32);
-
-    impl EncryptionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EncryptionType {
         /// Unspecified. Do not use.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
-
+        Unspecified,
         /// Use the same encryption configuration as the database. This is the
         /// default option when
         /// [encryption_config][google.spanner.admin.database.v1.CreateBackupEncryptionConfig]
@@ -1552,65 +1611,126 @@ pub mod create_backup_encryption_config {
         /// KMS key as the database.
         ///
         /// [google.spanner.admin.database.v1.CreateBackupEncryptionConfig]: crate::model::CreateBackupEncryptionConfig
-        pub const USE_DATABASE_ENCRYPTION: EncryptionType = EncryptionType::new(1);
-
+        UseDatabaseEncryption,
         /// Use Google default encryption.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(2);
-
+        GoogleDefaultEncryption,
         /// Use customer managed encryption. If specified, `kms_key_name`
         /// must contain a valid Cloud KMS key.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(3);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EncryptionType::value] or
+        /// [EncryptionType::name].
+        UnknownValue(encryption_type::UnknownValue),
+    }
 
-        /// Creates a new EncryptionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod encryption_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EncryptionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UseDatabaseEncryption => std::option::Option::Some(1),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(2),
+                Self::CustomerManagedEncryption => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USE_DATABASE_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                3 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENCRYPTION_TYPE_UNSPECIFIED"),
+                Self::UseDatabaseEncryption => std::option::Option::Some("USE_DATABASE_ENCRYPTION"),
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
+                }
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENCRYPTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
-                }
-                "USE_DATABASE_ENCRYPTION" => {
-                    std::option::Option::Some(Self::USE_DATABASE_ENCRYPTION)
-                }
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
-                }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EncryptionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EncryptionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UseDatabaseEncryption,
+                2 => Self::GoogleDefaultEncryption,
+                3 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EncryptionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "USE_DATABASE_ENCRYPTION" => Self::UseDatabaseEncryption,
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EncryptionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UseDatabaseEncryption => serializer.serialize_i32(1),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(2),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EncryptionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionType>::new(
+                ".google.spanner.admin.database.v1.CreateBackupEncryptionConfig.EncryptionType",
+            ))
         }
     }
 }
@@ -1704,13 +1824,11 @@ pub mod copy_backup_encryption_config {
     use super::*;
 
     /// Encryption types for the backup.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(i32);
-
-    impl EncryptionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EncryptionType {
         /// Unspecified. Do not use.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
-
+        Unspecified,
         /// This is the default option for
         /// [CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]
         /// when
@@ -1721,65 +1839,130 @@ pub mod copy_backup_encryption_config {
         ///
         /// [google.spanner.admin.database.v1.CopyBackupEncryptionConfig]: crate::model::CopyBackupEncryptionConfig
         /// [google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup]: crate::client::DatabaseAdmin::copy_backup
-        pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: EncryptionType = EncryptionType::new(1);
-
+        UseConfigDefaultOrBackupEncryption,
         /// Use Google default encryption.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(2);
-
+        GoogleDefaultEncryption,
         /// Use customer managed encryption. If specified, either `kms_key_name` or
         /// `kms_key_names` must contain valid Cloud KMS key(s).
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(3);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EncryptionType::value] or
+        /// [EncryptionType::name].
+        UnknownValue(encryption_type::UnknownValue),
+    }
 
-        /// Creates a new EncryptionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod encryption_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EncryptionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UseConfigDefaultOrBackupEncryption => std::option::Option::Some(1),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(2),
+                Self::CustomerManagedEncryption => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                3 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENCRYPTION_TYPE_UNSPECIFIED"),
+                Self::UseConfigDefaultOrBackupEncryption => {
+                    std::option::Option::Some("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION")
+                }
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
+                }
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENCRYPTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
-                }
-                "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION" => {
-                    std::option::Option::Some(Self::USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION)
-                }
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
-                }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EncryptionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EncryptionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UseConfigDefaultOrBackupEncryption,
+                2 => Self::GoogleDefaultEncryption,
+                3 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EncryptionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION" => {
+                    Self::UseConfigDefaultOrBackupEncryption
+                }
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EncryptionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UseConfigDefaultOrBackupEncryption => serializer.serialize_i32(1),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(2),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EncryptionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionType>::new(
+                ".google.spanner.admin.database.v1.CopyBackupEncryptionConfig.EncryptionType",
+            ))
         }
     }
 }
@@ -2759,67 +2942,128 @@ pub mod encryption_info {
     use super::*;
 
     /// Possible encryption types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// Encryption type was not specified, though data at rest remains encrypted.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
+        Unspecified,
         /// The data is encrypted at rest with a key that is
         /// fully managed by Google. No key version or status will be populated.
         /// This is the default state.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: Type = Type::new(1);
-
+        GoogleDefaultEncryption,
         /// The data is encrypted at rest with a key that is
         /// managed by the customer. The active version of the key. `kms_key_version`
         /// will be populated, and `encryption_status` may be populated.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: Type = Type::new(2);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(1),
+                Self::CustomerManagedEncryption => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
                 }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
                 }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleDefaultEncryption,
+                2 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(1),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.spanner.admin.database.v1.EncryptionInfo.Type",
+            ))
         }
     }
 }
@@ -3126,20 +3370,16 @@ pub mod database {
     use super::*;
 
     /// Indicates the current state of the database.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The database is still being created. Operations on the database may fail
         /// with `FAILED_PRECONDITION` in this state.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The database is fully created and ready for use.
-        pub const READY: State = State::new(2);
-
+        Ready,
         /// The database is fully created and ready for use, but is still
         /// being optimized for performance and cannot handle full load.
         ///
@@ -3148,50 +3388,117 @@ pub mod database {
         /// from being deleted. When optimizations are complete, the full performance
         /// of the database will be restored, and the database will transition to
         /// `READY` state.
-        pub const READY_OPTIMIZING: State = State::new(3);
+        ReadyOptimizing,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::ReadyOptimizing => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                3 => std::borrow::Cow::Borrowed("READY_OPTIMIZING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::ReadyOptimizing => std::option::Option::Some("READY_OPTIMIZING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                "READY_OPTIMIZING" => std::option::Option::Some(Self::READY_OPTIMIZING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                3 => Self::ReadyOptimizing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                "READY_OPTIMIZING" => Self::ReadyOptimizing,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::ReadyOptimizing => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.spanner.admin.database.v1.Database.State",
+            ))
         }
     }
 }
@@ -4514,77 +4821,140 @@ pub mod restore_database_encryption_config {
     use super::*;
 
     /// Encryption types for the database to be restored.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EncryptionType(i32);
-
-    impl EncryptionType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EncryptionType {
         /// Unspecified. Do not use.
-        pub const ENCRYPTION_TYPE_UNSPECIFIED: EncryptionType = EncryptionType::new(0);
-
+        Unspecified,
         /// This is the default option when
         /// [encryption_config][google.spanner.admin.database.v1.RestoreDatabaseEncryptionConfig]
         /// is not specified.
         ///
         /// [google.spanner.admin.database.v1.RestoreDatabaseEncryptionConfig]: crate::model::RestoreDatabaseEncryptionConfig
-        pub const USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION: EncryptionType = EncryptionType::new(1);
-
+        UseConfigDefaultOrBackupEncryption,
         /// Use Google default encryption.
-        pub const GOOGLE_DEFAULT_ENCRYPTION: EncryptionType = EncryptionType::new(2);
-
+        GoogleDefaultEncryption,
         /// Use customer managed encryption. If specified, `kms_key_name` must
         /// must contain a valid Cloud KMS key.
-        pub const CUSTOMER_MANAGED_ENCRYPTION: EncryptionType = EncryptionType::new(3);
+        CustomerManagedEncryption,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EncryptionType::value] or
+        /// [EncryptionType::name].
+        UnknownValue(encryption_type::UnknownValue),
+    }
 
-        /// Creates a new EncryptionType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod encryption_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EncryptionType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::UseConfigDefaultOrBackupEncryption => std::option::Option::Some(1),
+                Self::GoogleDefaultEncryption => std::option::Option::Some(2),
+                Self::CustomerManagedEncryption => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENCRYPTION_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"),
-                2 => std::borrow::Cow::Borrowed("GOOGLE_DEFAULT_ENCRYPTION"),
-                3 => std::borrow::Cow::Borrowed("CUSTOMER_MANAGED_ENCRYPTION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ENCRYPTION_TYPE_UNSPECIFIED"),
+                Self::UseConfigDefaultOrBackupEncryption => {
+                    std::option::Option::Some("USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION")
+                }
+                Self::GoogleDefaultEncryption => {
+                    std::option::Option::Some("GOOGLE_DEFAULT_ENCRYPTION")
+                }
+                Self::CustomerManagedEncryption => {
+                    std::option::Option::Some("CUSTOMER_MANAGED_ENCRYPTION")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENCRYPTION_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::ENCRYPTION_TYPE_UNSPECIFIED)
-                }
-                "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION" => {
-                    std::option::Option::Some(Self::USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION)
-                }
-                "GOOGLE_DEFAULT_ENCRYPTION" => {
-                    std::option::Option::Some(Self::GOOGLE_DEFAULT_ENCRYPTION)
-                }
-                "CUSTOMER_MANAGED_ENCRYPTION" => {
-                    std::option::Option::Some(Self::CUSTOMER_MANAGED_ENCRYPTION)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EncryptionType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EncryptionType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EncryptionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EncryptionType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::UseConfigDefaultOrBackupEncryption,
+                2 => Self::GoogleDefaultEncryption,
+                3 => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EncryptionType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENCRYPTION_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION" => {
+                    Self::UseConfigDefaultOrBackupEncryption
+                }
+                "GOOGLE_DEFAULT_ENCRYPTION" => Self::GoogleDefaultEncryption,
+                "CUSTOMER_MANAGED_ENCRYPTION" => Self::CustomerManagedEncryption,
+                _ => Self::UnknownValue(encryption_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EncryptionType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::UseConfigDefaultOrBackupEncryption => serializer.serialize_i32(1),
+                Self::GoogleDefaultEncryption => serializer.serialize_i32(2),
+                Self::CustomerManagedEncryption => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EncryptionType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EncryptionType>::new(
+                ".google.spanner.admin.database.v1.RestoreDatabaseEncryptionConfig.EncryptionType",
+            ))
         }
     }
 }
@@ -5201,113 +5571,231 @@ pub mod split_points {
 }
 
 /// Indicates the dialect type of a database.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DatabaseDialect(i32);
-
-impl DatabaseDialect {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DatabaseDialect {
     /// Default value. This value will create a database with the
     /// GOOGLE_STANDARD_SQL dialect.
-    pub const DATABASE_DIALECT_UNSPECIFIED: DatabaseDialect = DatabaseDialect::new(0);
-
+    Unspecified,
     /// GoogleSQL supported SQL.
-    pub const GOOGLE_STANDARD_SQL: DatabaseDialect = DatabaseDialect::new(1);
-
+    GoogleStandardSql,
     /// PostgreSQL supported SQL.
-    pub const POSTGRESQL: DatabaseDialect = DatabaseDialect::new(2);
+    Postgresql,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DatabaseDialect::value] or
+    /// [DatabaseDialect::name].
+    UnknownValue(database_dialect::UnknownValue),
+}
 
-    /// Creates a new DatabaseDialect instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod database_dialect {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl DatabaseDialect {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::GoogleStandardSql => std::option::Option::Some(1),
+            Self::Postgresql => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DATABASE_DIALECT_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("GOOGLE_STANDARD_SQL"),
-            2 => std::borrow::Cow::Borrowed("POSTGRESQL"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DATABASE_DIALECT_UNSPECIFIED"),
+            Self::GoogleStandardSql => std::option::Option::Some("GOOGLE_STANDARD_SQL"),
+            Self::Postgresql => std::option::Option::Some("POSTGRESQL"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DATABASE_DIALECT_UNSPECIFIED" => {
-                std::option::Option::Some(Self::DATABASE_DIALECT_UNSPECIFIED)
-            }
-            "GOOGLE_STANDARD_SQL" => std::option::Option::Some(Self::GOOGLE_STANDARD_SQL),
-            "POSTGRESQL" => std::option::Option::Some(Self::POSTGRESQL),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DatabaseDialect {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DatabaseDialect {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DatabaseDialect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DatabaseDialect {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::GoogleStandardSql,
+            2 => Self::Postgresql,
+            _ => Self::UnknownValue(database_dialect::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DatabaseDialect {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DATABASE_DIALECT_UNSPECIFIED" => Self::Unspecified,
+            "GOOGLE_STANDARD_SQL" => Self::GoogleStandardSql,
+            "POSTGRESQL" => Self::Postgresql,
+            _ => Self::UnknownValue(database_dialect::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DatabaseDialect {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::GoogleStandardSql => serializer.serialize_i32(1),
+            Self::Postgresql => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DatabaseDialect {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DatabaseDialect>::new(
+            ".google.spanner.admin.database.v1.DatabaseDialect",
+        ))
     }
 }
 
 /// Indicates the type of the restore source.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RestoreSourceType(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum RestoreSourceType {
+    /// No restore associated.
+    TypeUnspecified,
+    /// A backup was used as the source of the restore.
+    Backup,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [RestoreSourceType::value] or
+    /// [RestoreSourceType::name].
+    UnknownValue(restore_source_type::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod restore_source_type {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl RestoreSourceType {
-    /// No restore associated.
-    pub const TYPE_UNSPECIFIED: RestoreSourceType = RestoreSourceType::new(0);
-
-    /// A backup was used as the source of the restore.
-    pub const BACKUP: RestoreSourceType = RestoreSourceType::new(1);
-
-    /// Creates a new RestoreSourceType instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::TypeUnspecified => std::option::Option::Some(0),
+            Self::Backup => std::option::Option::Some(1),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("BACKUP"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::TypeUnspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+            Self::Backup => std::option::Option::Some("BACKUP"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-            "BACKUP" => std::option::Option::Some(Self::BACKUP),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for RestoreSourceType {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for RestoreSourceType {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for RestoreSourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for RestoreSourceType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::TypeUnspecified,
+            1 => Self::Backup,
+            _ => Self::UnknownValue(restore_source_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for RestoreSourceType {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "TYPE_UNSPECIFIED" => Self::TypeUnspecified,
+            "BACKUP" => Self::Backup,
+            _ => Self::UnknownValue(restore_source_type::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for RestoreSourceType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::TypeUnspecified => serializer.serialize_i32(0),
+            Self::Backup => serializer.serialize_i32(1),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for RestoreSourceType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<RestoreSourceType>::new(
+            ".google.spanner.admin.database.v1.RestoreSourceType",
+        ))
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -191,13 +191,11 @@ pub mod replica_info {
     /// Indicates the type of replica.  See the [replica types
     /// documentation](https://cloud.google.com/spanner/docs/replication#replica_types)
     /// for more details.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ReplicaType(i32);
-
-    impl ReplicaType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ReplicaType {
         /// Not specified.
-        pub const TYPE_UNSPECIFIED: ReplicaType = ReplicaType::new(0);
-
+        TypeUnspecified,
         /// Read-write replicas support both reads and writes. These replicas:
         ///
         /// * Maintain a full copy of your data.
@@ -205,16 +203,14 @@ pub mod replica_info {
         /// * Can vote whether to commit a write.
         /// * Participate in leadership election.
         /// * Are eligible to become a leader.
-        pub const READ_WRITE: ReplicaType = ReplicaType::new(1);
-
+        ReadWrite,
         /// Read-only replicas only support reads (not writes). Read-only replicas:
         ///
         /// * Maintain a full copy of your data.
         /// * Serve reads.
         /// * Do not participate in voting to commit writes.
         /// * Are not eligible to become a leader.
-        pub const READ_ONLY: ReplicaType = ReplicaType::new(2);
-
+        ReadOnly,
         /// Witness replicas don't support reads but do participate in voting to
         /// commit writes. Witness replicas:
         ///
@@ -222,50 +218,117 @@ pub mod replica_info {
         /// * Do not serve reads.
         /// * Vote whether to commit writes.
         /// * Participate in leader election but are not eligible to become leader.
-        pub const WITNESS: ReplicaType = ReplicaType::new(3);
+        Witness,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ReplicaType::value] or
+        /// [ReplicaType::name].
+        UnknownValue(replica_type::UnknownValue),
+    }
 
-        /// Creates a new ReplicaType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod replica_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ReplicaType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::TypeUnspecified => std::option::Option::Some(0),
+                Self::ReadWrite => std::option::Option::Some(1),
+                Self::ReadOnly => std::option::Option::Some(2),
+                Self::Witness => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("READ_WRITE"),
-                2 => std::borrow::Cow::Borrowed("READ_ONLY"),
-                3 => std::borrow::Cow::Borrowed("WITNESS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::TypeUnspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::ReadWrite => std::option::Option::Some("READ_WRITE"),
+                Self::ReadOnly => std::option::Option::Some("READ_ONLY"),
+                Self::Witness => std::option::Option::Some("WITNESS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "READ_WRITE" => std::option::Option::Some(Self::READ_WRITE),
-                "READ_ONLY" => std::option::Option::Some(Self::READ_ONLY),
-                "WITNESS" => std::option::Option::Some(Self::WITNESS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ReplicaType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ReplicaType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ReplicaType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ReplicaType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::TypeUnspecified,
+                1 => Self::ReadWrite,
+                2 => Self::ReadOnly,
+                3 => Self::Witness,
+                _ => Self::UnknownValue(replica_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ReplicaType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::TypeUnspecified,
+                "READ_WRITE" => Self::ReadWrite,
+                "READ_ONLY" => Self::ReadOnly,
+                "WITNESS" => Self::Witness,
+                _ => Self::UnknownValue(replica_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ReplicaType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::TypeUnspecified => serializer.serialize_i32(0),
+                Self::ReadWrite => serializer.serialize_i32(1),
+                Self::ReadOnly => serializer.serialize_i32(2),
+                Self::Witness => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ReplicaType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ReplicaType>::new(
+                ".google.spanner.admin.instance.v1.ReplicaInfo.ReplicaType",
+            ))
         }
     }
 }
@@ -524,265 +587,514 @@ pub mod instance_config {
     use super::*;
 
     /// The type of this configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
+        /// Unspecified.
+        Unspecified,
+        /// Google-managed configuration.
+        GoogleManaged,
+        /// User-managed configuration.
+        UserManaged,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Type {
-        /// Unspecified.
-        pub const TYPE_UNSPECIFIED: Type = Type::new(0);
-
-        /// Google-managed configuration.
-        pub const GOOGLE_MANAGED: Type = Type::new(1);
-
-        /// User-managed configuration.
-        pub const USER_MANAGED: Type = Type::new(2);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::GoogleManaged => std::option::Option::Some(1),
+                Self::UserManaged => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GOOGLE_MANAGED"),
-                2 => std::borrow::Cow::Borrowed("USER_MANAGED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TYPE_UNSPECIFIED"),
+                Self::GoogleManaged => std::option::Option::Some("GOOGLE_MANAGED"),
+                Self::UserManaged => std::option::Option::Some("USER_MANAGED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNSPECIFIED" => std::option::Option::Some(Self::TYPE_UNSPECIFIED),
-                "GOOGLE_MANAGED" => std::option::Option::Some(Self::GOOGLE_MANAGED),
-                "USER_MANAGED" => std::option::Option::Some(Self::USER_MANAGED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::GoogleManaged,
+                2 => Self::UserManaged,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNSPECIFIED" => Self::Unspecified,
+                "GOOGLE_MANAGED" => Self::GoogleManaged,
+                "USER_MANAGED" => Self::UserManaged,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::GoogleManaged => serializer.serialize_i32(1),
+                Self::UserManaged => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.spanner.admin.instance.v1.InstanceConfig.Type",
+            ))
         }
     }
 
     /// Indicates the current state of the instance configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The instance configuration is still being created.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The instance configuration is fully created and ready to be used to
         /// create instances.
-        pub const READY: State = State::new(2);
+        Ready,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.spanner.admin.instance.v1.InstanceConfig.State",
+            ))
         }
     }
 
     /// Describes the availability for free instances to be created in an instance
     /// configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FreeInstanceAvailability(i32);
-
-    impl FreeInstanceAvailability {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FreeInstanceAvailability {
         /// Not specified.
-        pub const FREE_INSTANCE_AVAILABILITY_UNSPECIFIED: FreeInstanceAvailability =
-            FreeInstanceAvailability::new(0);
-
+        Unspecified,
         /// Indicates that free instances are available to be created in this
         /// instance configuration.
-        pub const AVAILABLE: FreeInstanceAvailability = FreeInstanceAvailability::new(1);
-
+        Available,
         /// Indicates that free instances are not supported in this instance
         /// configuration.
-        pub const UNSUPPORTED: FreeInstanceAvailability = FreeInstanceAvailability::new(2);
-
+        Unsupported,
         /// Indicates that free instances are currently not available to be created
         /// in this instance configuration.
-        pub const DISABLED: FreeInstanceAvailability = FreeInstanceAvailability::new(3);
-
+        Disabled,
         /// Indicates that additional free instances cannot be created in this
         /// instance configuration because the project has reached its limit of free
         /// instances.
-        pub const QUOTA_EXCEEDED: FreeInstanceAvailability = FreeInstanceAvailability::new(4);
+        QuotaExceeded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FreeInstanceAvailability::value] or
+        /// [FreeInstanceAvailability::name].
+        UnknownValue(free_instance_availability::UnknownValue),
+    }
 
-        /// Creates a new FreeInstanceAvailability instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod free_instance_availability {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl FreeInstanceAvailability {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Available => std::option::Option::Some(1),
+                Self::Unsupported => std::option::Option::Some(2),
+                Self::Disabled => std::option::Option::Some(3),
+                Self::QuotaExceeded => std::option::Option::Some(4),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FREE_INSTANCE_AVAILABILITY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AVAILABLE"),
-                2 => std::borrow::Cow::Borrowed("UNSUPPORTED"),
-                3 => std::borrow::Cow::Borrowed("DISABLED"),
-                4 => std::borrow::Cow::Borrowed("QUOTA_EXCEEDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FREE_INSTANCE_AVAILABILITY_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::FREE_INSTANCE_AVAILABILITY_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("FREE_INSTANCE_AVAILABILITY_UNSPECIFIED")
                 }
-                "AVAILABLE" => std::option::Option::Some(Self::AVAILABLE),
-                "UNSUPPORTED" => std::option::Option::Some(Self::UNSUPPORTED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "QUOTA_EXCEEDED" => std::option::Option::Some(Self::QUOTA_EXCEEDED),
-                _ => std::option::Option::None,
+                Self::Available => std::option::Option::Some("AVAILABLE"),
+                Self::Unsupported => std::option::Option::Some("UNSUPPORTED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::QuotaExceeded => std::option::Option::Some("QUOTA_EXCEEDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for FreeInstanceAvailability {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FreeInstanceAvailability {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for FreeInstanceAvailability {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FreeInstanceAvailability {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Available,
+                2 => Self::Unsupported,
+                3 => Self::Disabled,
+                4 => Self::QuotaExceeded,
+                _ => Self::UnknownValue(free_instance_availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FreeInstanceAvailability {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FREE_INSTANCE_AVAILABILITY_UNSPECIFIED" => Self::Unspecified,
+                "AVAILABLE" => Self::Available,
+                "UNSUPPORTED" => Self::Unsupported,
+                "DISABLED" => Self::Disabled,
+                "QUOTA_EXCEEDED" => Self::QuotaExceeded,
+                _ => Self::UnknownValue(free_instance_availability::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FreeInstanceAvailability {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Available => serializer.serialize_i32(1),
+                Self::Unsupported => serializer.serialize_i32(2),
+                Self::Disabled => serializer.serialize_i32(3),
+                Self::QuotaExceeded => serializer.serialize_i32(4),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FreeInstanceAvailability {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<FreeInstanceAvailability>::new(
+                    ".google.spanner.admin.instance.v1.InstanceConfig.FreeInstanceAvailability",
+                ),
+            )
         }
     }
 
     /// Indicates the quorum type of this instance configuration.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct QuorumType(i32);
-
-    impl QuorumType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum QuorumType {
         /// Quorum type not specified.
-        pub const QUORUM_TYPE_UNSPECIFIED: QuorumType = QuorumType::new(0);
-
+        Unspecified,
         /// An instance configuration tagged with `REGION` quorum type forms a write
         /// quorum in a single region.
-        pub const REGION: QuorumType = QuorumType::new(1);
-
+        Region,
         /// An instance configuration tagged with the `DUAL_REGION` quorum type forms
         /// a write quorum with exactly two read-write regions in a multi-region
         /// configuration.
         ///
         /// This instance configuration requires failover in the event of
         /// regional failures.
-        pub const DUAL_REGION: QuorumType = QuorumType::new(2);
-
+        DualRegion,
         /// An instance configuration tagged with the `MULTI_REGION` quorum type
         /// forms a write quorum from replicas that are spread across more than one
         /// region in a multi-region configuration.
-        pub const MULTI_REGION: QuorumType = QuorumType::new(3);
+        MultiRegion,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [QuorumType::value] or
+        /// [QuorumType::name].
+        UnknownValue(quorum_type::UnknownValue),
+    }
 
-        /// Creates a new QuorumType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod quorum_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl QuorumType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Region => std::option::Option::Some(1),
+                Self::DualRegion => std::option::Option::Some(2),
+                Self::MultiRegion => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("QUORUM_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REGION"),
-                2 => std::borrow::Cow::Borrowed("DUAL_REGION"),
-                3 => std::borrow::Cow::Borrowed("MULTI_REGION"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("QUORUM_TYPE_UNSPECIFIED"),
+                Self::Region => std::option::Option::Some("REGION"),
+                Self::DualRegion => std::option::Option::Some("DUAL_REGION"),
+                Self::MultiRegion => std::option::Option::Some("MULTI_REGION"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "QUORUM_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::QUORUM_TYPE_UNSPECIFIED)
-                }
-                "REGION" => std::option::Option::Some(Self::REGION),
-                "DUAL_REGION" => std::option::Option::Some(Self::DUAL_REGION),
-                "MULTI_REGION" => std::option::Option::Some(Self::MULTI_REGION),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for QuorumType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for QuorumType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for QuorumType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for QuorumType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Region,
+                2 => Self::DualRegion,
+                3 => Self::MultiRegion,
+                _ => Self::UnknownValue(quorum_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for QuorumType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "QUORUM_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "REGION" => Self::Region,
+                "DUAL_REGION" => Self::DualRegion,
+                "MULTI_REGION" => Self::MultiRegion,
+                _ => Self::UnknownValue(quorum_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for QuorumType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Region => serializer.serialize_i32(1),
+                Self::DualRegion => serializer.serialize_i32(2),
+                Self::MultiRegion => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for QuorumType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<QuorumType>::new(
+                ".google.spanner.admin.instance.v1.InstanceConfig.QuorumType",
+            ))
         }
     }
 }
@@ -1701,62 +2013,123 @@ pub mod instance {
     use super::*;
 
     /// Indicates the current state of the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The instance is still being created. Resources may not be
         /// available yet, and operations such as database creation may not
         /// work.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The instance is fully created and ready to do work such as
         /// creating databases.
-        pub const READY: State = State::new(2);
+        Ready,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.spanner.admin.instance.v1.Instance.State",
+            ))
         }
     }
 
@@ -1764,127 +2137,249 @@ pub mod instance {
     /// variants, that can affect aspects like: usage restrictions, quotas and
     /// billing. Currently this is used to distinguish FREE_INSTANCE vs PROVISIONED
     /// instances.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct InstanceType(i32);
-
-    impl InstanceType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum InstanceType {
         /// Not specified.
-        pub const INSTANCE_TYPE_UNSPECIFIED: InstanceType = InstanceType::new(0);
-
+        Unspecified,
         /// Provisioned instances have dedicated resources, standard usage limits and
         /// support.
-        pub const PROVISIONED: InstanceType = InstanceType::new(1);
-
+        Provisioned,
         /// Free instances provide no guarantee for dedicated resources,
         /// [node_count, processing_units] should be 0. They come
         /// with stricter usage limits and limited support.
-        pub const FREE_INSTANCE: InstanceType = InstanceType::new(2);
+        FreeInstance,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [InstanceType::value] or
+        /// [InstanceType::name].
+        UnknownValue(instance_type::UnknownValue),
+    }
 
-        /// Creates a new InstanceType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod instance_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl InstanceType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Provisioned => std::option::Option::Some(1),
+                Self::FreeInstance => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("INSTANCE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("PROVISIONED"),
-                2 => std::borrow::Cow::Borrowed("FREE_INSTANCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("INSTANCE_TYPE_UNSPECIFIED"),
+                Self::Provisioned => std::option::Option::Some("PROVISIONED"),
+                Self::FreeInstance => std::option::Option::Some("FREE_INSTANCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "INSTANCE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::INSTANCE_TYPE_UNSPECIFIED)
-                }
-                "PROVISIONED" => std::option::Option::Some(Self::PROVISIONED),
-                "FREE_INSTANCE" => std::option::Option::Some(Self::FREE_INSTANCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for InstanceType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for InstanceType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for InstanceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for InstanceType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Provisioned,
+                2 => Self::FreeInstance,
+                _ => Self::UnknownValue(instance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for InstanceType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "INSTANCE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "PROVISIONED" => Self::Provisioned,
+                "FREE_INSTANCE" => Self::FreeInstance,
+                _ => Self::UnknownValue(instance_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for InstanceType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Provisioned => serializer.serialize_i32(1),
+                Self::FreeInstance => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for InstanceType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<InstanceType>::new(
+                ".google.spanner.admin.instance.v1.Instance.InstanceType",
+            ))
         }
     }
 
     /// The edition selected for this instance. Different editions provide
     /// different capabilities at different price points.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Edition(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Edition {
+        /// Edition not specified.
+        Unspecified,
+        /// Standard edition.
+        Standard,
+        /// Enterprise edition.
+        Enterprise,
+        /// Enterprise Plus edition.
+        EnterprisePlus,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Edition::value] or
+        /// [Edition::name].
+        UnknownValue(edition::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod edition {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Edition {
-        /// Edition not specified.
-        pub const EDITION_UNSPECIFIED: Edition = Edition::new(0);
-
-        /// Standard edition.
-        pub const STANDARD: Edition = Edition::new(1);
-
-        /// Enterprise edition.
-        pub const ENTERPRISE: Edition = Edition::new(2);
-
-        /// Enterprise Plus edition.
-        pub const ENTERPRISE_PLUS: Edition = Edition::new(3);
-
-        /// Creates a new Edition instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Standard => std::option::Option::Some(1),
+                Self::Enterprise => std::option::Option::Some(2),
+                Self::EnterprisePlus => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EDITION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STANDARD"),
-                2 => std::borrow::Cow::Borrowed("ENTERPRISE"),
-                3 => std::borrow::Cow::Borrowed("ENTERPRISE_PLUS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EDITION_UNSPECIFIED"),
+                Self::Standard => std::option::Option::Some("STANDARD"),
+                Self::Enterprise => std::option::Option::Some("ENTERPRISE"),
+                Self::EnterprisePlus => std::option::Option::Some("ENTERPRISE_PLUS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EDITION_UNSPECIFIED" => std::option::Option::Some(Self::EDITION_UNSPECIFIED),
-                "STANDARD" => std::option::Option::Some(Self::STANDARD),
-                "ENTERPRISE" => std::option::Option::Some(Self::ENTERPRISE),
-                "ENTERPRISE_PLUS" => std::option::Option::Some(Self::ENTERPRISE_PLUS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Edition {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Edition {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Edition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Edition {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Standard,
+                2 => Self::Enterprise,
+                3 => Self::EnterprisePlus,
+                _ => Self::UnknownValue(edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Edition {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EDITION_UNSPECIFIED" => Self::Unspecified,
+                "STANDARD" => Self::Standard,
+                "ENTERPRISE" => Self::Enterprise,
+                "ENTERPRISE_PLUS" => Self::EnterprisePlus,
+                _ => Self::UnknownValue(edition::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Edition {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Standard => serializer.serialize_i32(1),
+                Self::Enterprise => serializer.serialize_i32(2),
+                Self::EnterprisePlus => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Edition {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Edition>::new(
+                ".google.spanner.admin.instance.v1.Instance.Edition",
+            ))
         }
     }
 
@@ -1892,66 +2387,128 @@ pub mod instance {
     /// [default backup
     /// schedule](https://cloud.google.com/spanner/docs/backup#default-backup-schedules)
     /// behavior for new databases within the instance.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct DefaultBackupScheduleType(i32);
-
-    impl DefaultBackupScheduleType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum DefaultBackupScheduleType {
         /// Not specified.
-        pub const DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED: DefaultBackupScheduleType =
-            DefaultBackupScheduleType::new(0);
-
+        Unspecified,
         /// A default backup schedule isn't created automatically when a new database
         /// is created in the instance.
-        pub const NONE: DefaultBackupScheduleType = DefaultBackupScheduleType::new(1);
-
+        None,
         /// A default backup schedule is created automatically when a new database
         /// is created in the instance. The default backup schedule creates a full
         /// backup every 24 hours. These full backups are retained for 7 days.
         /// You can edit or delete the default backup schedule once it's created.
-        pub const AUTOMATIC: DefaultBackupScheduleType = DefaultBackupScheduleType::new(2);
+        Automatic,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [DefaultBackupScheduleType::value] or
+        /// [DefaultBackupScheduleType::name].
+        UnknownValue(default_backup_schedule_type::UnknownValue),
+    }
 
-        /// Creates a new DefaultBackupScheduleType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod default_backup_schedule_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl DefaultBackupScheduleType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Automatic => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("AUTOMATIC"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => {
+                    std::option::Option::Some("DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED")
                 }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "AUTOMATIC" => std::option::Option::Some(Self::AUTOMATIC),
-                _ => std::option::Option::None,
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Automatic => std::option::Option::Some("AUTOMATIC"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for DefaultBackupScheduleType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for DefaultBackupScheduleType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for DefaultBackupScheduleType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for DefaultBackupScheduleType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Automatic,
+                _ => Self::UnknownValue(default_backup_schedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for DefaultBackupScheduleType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DEFAULT_BACKUP_SCHEDULE_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "AUTOMATIC" => Self::Automatic,
+                _ => Self::UnknownValue(default_backup_schedule_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for DefaultBackupScheduleType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Automatic => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for DefaultBackupScheduleType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(
+                wkt::internal::EnumVisitor::<DefaultBackupScheduleType>::new(
+                    ".google.spanner.admin.instance.v1.Instance.DefaultBackupScheduleType",
+                ),
+            )
         }
     }
 }
@@ -3222,65 +3779,124 @@ pub mod free_instance_metadata {
     use super::*;
 
     /// Allows users to change behavior when a free instance expires.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ExpireBehavior(i32);
-
-    impl ExpireBehavior {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ExpireBehavior {
         /// Not specified.
-        pub const EXPIRE_BEHAVIOR_UNSPECIFIED: ExpireBehavior = ExpireBehavior::new(0);
-
+        Unspecified,
         /// When the free instance expires, upgrade the instance to a provisioned
         /// instance.
-        pub const FREE_TO_PROVISIONED: ExpireBehavior = ExpireBehavior::new(1);
-
+        FreeToProvisioned,
         /// When the free instance expires, disable the instance, and delete it
         /// after the grace period passes if it has not been upgraded.
-        pub const REMOVE_AFTER_GRACE_PERIOD: ExpireBehavior = ExpireBehavior::new(2);
+        RemoveAfterGracePeriod,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ExpireBehavior::value] or
+        /// [ExpireBehavior::name].
+        UnknownValue(expire_behavior::UnknownValue),
+    }
 
-        /// Creates a new ExpireBehavior instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod expire_behavior {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl ExpireBehavior {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::FreeToProvisioned => std::option::Option::Some(1),
+                Self::RemoveAfterGracePeriod => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EXPIRE_BEHAVIOR_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FREE_TO_PROVISIONED"),
-                2 => std::borrow::Cow::Borrowed("REMOVE_AFTER_GRACE_PERIOD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EXPIRE_BEHAVIOR_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::EXPIRE_BEHAVIOR_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EXPIRE_BEHAVIOR_UNSPECIFIED"),
+                Self::FreeToProvisioned => std::option::Option::Some("FREE_TO_PROVISIONED"),
+                Self::RemoveAfterGracePeriod => {
+                    std::option::Option::Some("REMOVE_AFTER_GRACE_PERIOD")
                 }
-                "FREE_TO_PROVISIONED" => std::option::Option::Some(Self::FREE_TO_PROVISIONED),
-                "REMOVE_AFTER_GRACE_PERIOD" => {
-                    std::option::Option::Some(Self::REMOVE_AFTER_GRACE_PERIOD)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for ExpireBehavior {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ExpireBehavior {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ExpireBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ExpireBehavior {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::FreeToProvisioned,
+                2 => Self::RemoveAfterGracePeriod,
+                _ => Self::UnknownValue(expire_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ExpireBehavior {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EXPIRE_BEHAVIOR_UNSPECIFIED" => Self::Unspecified,
+                "FREE_TO_PROVISIONED" => Self::FreeToProvisioned,
+                "REMOVE_AFTER_GRACE_PERIOD" => Self::RemoveAfterGracePeriod,
+                _ => Self::UnknownValue(expire_behavior::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ExpireBehavior {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::FreeToProvisioned => serializer.serialize_i32(1),
+                Self::RemoveAfterGracePeriod => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ExpireBehavior {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ExpireBehavior>::new(
+                ".google.spanner.admin.instance.v1.FreeInstanceMetadata.ExpireBehavior",
+            ))
         }
     }
 }
@@ -3668,62 +4284,123 @@ pub mod instance_partition {
     use super::*;
 
     /// Indicates the current state of the instance partition.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Not specified.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// The instance partition is still being created. Resources may not be
         /// available yet, and operations such as creating placements using this
         /// instance partition may not work.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// The instance partition is fully created and ready to do work such as
         /// creating placements and using in databases.
-        pub const READY: State = State::new(2);
+        Ready,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Ready => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("READY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Ready => std::option::Option::Some("READY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "READY" => std::option::Option::Some(Self::READY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "READY" => Self::Ready,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Ready => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.spanner.admin.instance.v1.InstancePartition.State",
+            ))
         }
     }
 
@@ -4699,66 +5376,121 @@ impl wkt::message::Message for MoveInstanceMetadata {
 }
 
 /// Indicates the expected fulfillment period of an operation.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct FulfillmentPeriod(i32);
-
-impl FulfillmentPeriod {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum FulfillmentPeriod {
     /// Not specified.
-    pub const FULFILLMENT_PERIOD_UNSPECIFIED: FulfillmentPeriod = FulfillmentPeriod::new(0);
-
+    Unspecified,
     /// Normal fulfillment period. The operation is expected to complete within
     /// minutes.
-    pub const FULFILLMENT_PERIOD_NORMAL: FulfillmentPeriod = FulfillmentPeriod::new(1);
-
+    Normal,
     /// Extended fulfillment period. It can take up to an hour for the operation
     /// to complete.
-    pub const FULFILLMENT_PERIOD_EXTENDED: FulfillmentPeriod = FulfillmentPeriod::new(2);
+    Extended,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [FulfillmentPeriod::value] or
+    /// [FulfillmentPeriod::name].
+    UnknownValue(fulfillment_period::UnknownValue),
+}
 
-    /// Creates a new FulfillmentPeriod instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod fulfillment_period {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl FulfillmentPeriod {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Normal => std::option::Option::Some(1),
+            Self::Extended => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("FULFILLMENT_PERIOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("FULFILLMENT_PERIOD_NORMAL"),
-            2 => std::borrow::Cow::Borrowed("FULFILLMENT_PERIOD_EXTENDED"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("FULFILLMENT_PERIOD_UNSPECIFIED"),
+            Self::Normal => std::option::Option::Some("FULFILLMENT_PERIOD_NORMAL"),
+            Self::Extended => std::option::Option::Some("FULFILLMENT_PERIOD_EXTENDED"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "FULFILLMENT_PERIOD_UNSPECIFIED" => {
-                std::option::Option::Some(Self::FULFILLMENT_PERIOD_UNSPECIFIED)
-            }
-            "FULFILLMENT_PERIOD_NORMAL" => {
-                std::option::Option::Some(Self::FULFILLMENT_PERIOD_NORMAL)
-            }
-            "FULFILLMENT_PERIOD_EXTENDED" => {
-                std::option::Option::Some(Self::FULFILLMENT_PERIOD_EXTENDED)
-            }
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for FulfillmentPeriod {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for FulfillmentPeriod {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for FulfillmentPeriod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for FulfillmentPeriod {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Normal,
+            2 => Self::Extended,
+            _ => Self::UnknownValue(fulfillment_period::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for FulfillmentPeriod {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "FULFILLMENT_PERIOD_UNSPECIFIED" => Self::Unspecified,
+            "FULFILLMENT_PERIOD_NORMAL" => Self::Normal,
+            "FULFILLMENT_PERIOD_EXTENDED" => Self::Extended,
+            _ => Self::UnknownValue(fulfillment_period::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for FulfillmentPeriod {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Normal => serializer.serialize_i32(1),
+            Self::Extended => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for FulfillmentPeriod {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<FulfillmentPeriod>::new(
+            ".google.spanner.admin.instance.v1.FulfillmentPeriod",
+        ))
     }
 }

--- a/src/generated/storagetransfer/v1/src/client.rs
+++ b/src/generated/storagetransfer/v1/src/client.rs
@@ -155,9 +155,9 @@ impl StorageTransferService {
     /// [DISABLED][google.storagetransfer.v1.TransferJob.Status.DISABLED], or
     /// [ENABLED][google.storagetransfer.v1.TransferJob.Status.ENABLED]).
     ///
-    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::status::DELETED
-    /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::status::DISABLED
-    /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::status::ENABLED
+    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::Status::Deleted
+    /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::Status::Disabled
+    /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::Status::Enabled
     /// [google.storagetransfer.v1.TransferJob.status]: crate::model::TransferJob::status
     pub fn update_transfer_job(
         &self,
@@ -224,7 +224,7 @@ impl StorageTransferService {
     /// Deletes a transfer job. Deleting a transfer job sets its status to
     /// [DELETED][google.storagetransfer.v1.TransferJob.Status.DELETED].
     ///
-    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::status::DELETED
+    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::Status::Deleted
     pub fn delete_transfer_job(
         &self,
         job_name: impl Into<std::string::String>,

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -132,8 +132,8 @@ pub struct UpdateTransferJobRequest {
     /// [DELETED][google.storagetransfer.v1.TransferJob.Status.DELETED] requires
     /// `storagetransfer.jobs.delete` permission.
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
-    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::status::DELETED
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
+    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::Status::Deleted
     /// [google.storagetransfer.v1.TransferJob.description]: crate::model::TransferJob::description
     /// [google.storagetransfer.v1.TransferJob.logging_config]: crate::model::TransferJob::logging_config
     /// [google.storagetransfer.v1.TransferJob.notification_config]: crate::model::TransferJob::notification_config
@@ -154,7 +154,7 @@ pub struct UpdateTransferJobRequest {
     /// rejected with the error
     /// [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     /// [google.storagetransfer.v1.TransferJob.description]: crate::model::TransferJob::description
     /// [google.storagetransfer.v1.TransferJob.logging_config]: crate::model::TransferJob::logging_config
     /// [google.storagetransfer.v1.TransferJob.notification_config]: crate::model::TransferJob::notification_config
@@ -334,9 +334,9 @@ pub struct ListTransferJobsRequest {
     /// * Limit the results to jobs from a particular bucket with `sourceBucket`
     ///   and/or to a particular bucket with `sinkBucket`.
     ///
-    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::status::DELETED
-    /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::status::DISABLED
-    /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::status::ENABLED
+    /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::Status::Deleted
+    /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::Status::Disabled
+    /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::Status::Enabled
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub filter: std::string::String,
 
@@ -636,7 +636,7 @@ pub struct UpdateAgentPoolRequest {
     ///   with the error [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
     ///
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     /// [google.storagetransfer.v1.AgentPool.bandwidth_limit]: crate::model::AgentPool::bandwidth_limit
     /// [google.storagetransfer.v1.AgentPool.display_name]: crate::model::AgentPool::display_name
     /// [google.storagetransfer.v1.AgentPool.name]: crate::model::AgentPool::name
@@ -2008,248 +2008,480 @@ pub mod s_3_compatible_metadata {
     use super::*;
 
     /// The authentication and authorization method used by the storage service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct AuthMethod(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum AuthMethod {
+        /// AuthMethod is not specified.
+        Unspecified,
+        /// Auth requests with AWS SigV4.
+        AwsSignatureV4,
+        /// Auth requests with AWS SigV2.
+        AwsSignatureV2,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [AuthMethod::value] or
+        /// [AuthMethod::name].
+        UnknownValue(auth_method::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod auth_method {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl AuthMethod {
-        /// AuthMethod is not specified.
-        pub const AUTH_METHOD_UNSPECIFIED: AuthMethod = AuthMethod::new(0);
-
-        /// Auth requests with AWS SigV4.
-        pub const AUTH_METHOD_AWS_SIGNATURE_V4: AuthMethod = AuthMethod::new(1);
-
-        /// Auth requests with AWS SigV2.
-        pub const AUTH_METHOD_AWS_SIGNATURE_V2: AuthMethod = AuthMethod::new(2);
-
-        /// Creates a new AuthMethod instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::AwsSignatureV4 => std::option::Option::Some(1),
+                Self::AwsSignatureV2 => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("AUTH_METHOD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("AUTH_METHOD_AWS_SIGNATURE_V4"),
-                2 => std::borrow::Cow::Borrowed("AUTH_METHOD_AWS_SIGNATURE_V2"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("AUTH_METHOD_UNSPECIFIED"),
+                Self::AwsSignatureV4 => std::option::Option::Some("AUTH_METHOD_AWS_SIGNATURE_V4"),
+                Self::AwsSignatureV2 => std::option::Option::Some("AUTH_METHOD_AWS_SIGNATURE_V2"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "AUTH_METHOD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::AUTH_METHOD_UNSPECIFIED)
-                }
-                "AUTH_METHOD_AWS_SIGNATURE_V4" => {
-                    std::option::Option::Some(Self::AUTH_METHOD_AWS_SIGNATURE_V4)
-                }
-                "AUTH_METHOD_AWS_SIGNATURE_V2" => {
-                    std::option::Option::Some(Self::AUTH_METHOD_AWS_SIGNATURE_V2)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for AuthMethod {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for AuthMethod {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for AuthMethod {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for AuthMethod {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::AwsSignatureV4,
+                2 => Self::AwsSignatureV2,
+                _ => Self::UnknownValue(auth_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for AuthMethod {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "AUTH_METHOD_UNSPECIFIED" => Self::Unspecified,
+                "AUTH_METHOD_AWS_SIGNATURE_V4" => Self::AwsSignatureV4,
+                "AUTH_METHOD_AWS_SIGNATURE_V2" => Self::AwsSignatureV2,
+                _ => Self::UnknownValue(auth_method::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for AuthMethod {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::AwsSignatureV4 => serializer.serialize_i32(1),
+                Self::AwsSignatureV2 => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for AuthMethod {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<AuthMethod>::new(
+                ".google.storagetransfer.v1.S3CompatibleMetadata.AuthMethod",
+            ))
         }
     }
 
     /// The request model of the API.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RequestModel(i32);
-
-    impl RequestModel {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RequestModel {
         /// RequestModel is not specified.
-        pub const REQUEST_MODEL_UNSPECIFIED: RequestModel = RequestModel::new(0);
-
+        Unspecified,
         /// Perform requests using Virtual Hosted Style.
         /// Example: <https://bucket-name.s3.region.amazonaws.com/key-name>
-        pub const REQUEST_MODEL_VIRTUAL_HOSTED_STYLE: RequestModel = RequestModel::new(1);
-
+        VirtualHostedStyle,
         /// Perform requests using Path Style.
         /// Example: <https://s3.region.amazonaws.com/bucket-name/key-name>
-        pub const REQUEST_MODEL_PATH_STYLE: RequestModel = RequestModel::new(2);
+        PathStyle,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RequestModel::value] or
+        /// [RequestModel::name].
+        UnknownValue(request_model::UnknownValue),
+    }
 
-        /// Creates a new RequestModel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod request_model {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl RequestModel {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::VirtualHostedStyle => std::option::Option::Some(1),
+                Self::PathStyle => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REQUEST_MODEL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("REQUEST_MODEL_VIRTUAL_HOSTED_STYLE"),
-                2 => std::borrow::Cow::Borrowed("REQUEST_MODEL_PATH_STYLE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("REQUEST_MODEL_UNSPECIFIED"),
+                Self::VirtualHostedStyle => {
+                    std::option::Option::Some("REQUEST_MODEL_VIRTUAL_HOSTED_STYLE")
+                }
+                Self::PathStyle => std::option::Option::Some("REQUEST_MODEL_PATH_STYLE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REQUEST_MODEL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::REQUEST_MODEL_UNSPECIFIED)
-                }
-                "REQUEST_MODEL_VIRTUAL_HOSTED_STYLE" => {
-                    std::option::Option::Some(Self::REQUEST_MODEL_VIRTUAL_HOSTED_STYLE)
-                }
-                "REQUEST_MODEL_PATH_STYLE" => {
-                    std::option::Option::Some(Self::REQUEST_MODEL_PATH_STYLE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RequestModel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RequestModel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for RequestModel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RequestModel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::VirtualHostedStyle,
+                2 => Self::PathStyle,
+                _ => Self::UnknownValue(request_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RequestModel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REQUEST_MODEL_UNSPECIFIED" => Self::Unspecified,
+                "REQUEST_MODEL_VIRTUAL_HOSTED_STYLE" => Self::VirtualHostedStyle,
+                "REQUEST_MODEL_PATH_STYLE" => Self::PathStyle,
+                _ => Self::UnknownValue(request_model::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RequestModel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::VirtualHostedStyle => serializer.serialize_i32(1),
+                Self::PathStyle => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RequestModel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RequestModel>::new(
+                ".google.storagetransfer.v1.S3CompatibleMetadata.RequestModel",
+            ))
         }
     }
 
     /// The agent network protocol to access the storage service.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct NetworkProtocol(i32);
-
-    impl NetworkProtocol {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum NetworkProtocol {
         /// NetworkProtocol is not specified.
-        pub const NETWORK_PROTOCOL_UNSPECIFIED: NetworkProtocol = NetworkProtocol::new(0);
-
+        Unspecified,
         /// Perform requests using HTTPS.
-        pub const NETWORK_PROTOCOL_HTTPS: NetworkProtocol = NetworkProtocol::new(1);
-
+        Https,
         /// Not recommended: This sends data in clear-text. This is only
         /// appropriate within a closed network or for publicly available data.
         /// Perform requests using HTTP.
-        pub const NETWORK_PROTOCOL_HTTP: NetworkProtocol = NetworkProtocol::new(2);
+        Http,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [NetworkProtocol::value] or
+        /// [NetworkProtocol::name].
+        UnknownValue(network_protocol::UnknownValue),
+    }
 
-        /// Creates a new NetworkProtocol instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod network_protocol {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl NetworkProtocol {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Https => std::option::Option::Some(1),
+                Self::Http => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("NETWORK_PROTOCOL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NETWORK_PROTOCOL_HTTPS"),
-                2 => std::borrow::Cow::Borrowed("NETWORK_PROTOCOL_HTTP"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("NETWORK_PROTOCOL_UNSPECIFIED"),
+                Self::Https => std::option::Option::Some("NETWORK_PROTOCOL_HTTPS"),
+                Self::Http => std::option::Option::Some("NETWORK_PROTOCOL_HTTP"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "NETWORK_PROTOCOL_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::NETWORK_PROTOCOL_UNSPECIFIED)
-                }
-                "NETWORK_PROTOCOL_HTTPS" => std::option::Option::Some(Self::NETWORK_PROTOCOL_HTTPS),
-                "NETWORK_PROTOCOL_HTTP" => std::option::Option::Some(Self::NETWORK_PROTOCOL_HTTP),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for NetworkProtocol {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for NetworkProtocol {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for NetworkProtocol {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for NetworkProtocol {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Https,
+                2 => Self::Http,
+                _ => Self::UnknownValue(network_protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for NetworkProtocol {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "NETWORK_PROTOCOL_UNSPECIFIED" => Self::Unspecified,
+                "NETWORK_PROTOCOL_HTTPS" => Self::Https,
+                "NETWORK_PROTOCOL_HTTP" => Self::Http,
+                _ => Self::UnknownValue(network_protocol::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for NetworkProtocol {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Https => serializer.serialize_i32(1),
+                Self::Http => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for NetworkProtocol {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<NetworkProtocol>::new(
+                ".google.storagetransfer.v1.S3CompatibleMetadata.NetworkProtocol",
+            ))
         }
     }
 
     /// The Listing API to use for discovering objects.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct ListApi(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum ListApi {
+        /// ListApi is not specified.
+        Unspecified,
+        /// Perform listing using ListObjectsV2 API.
+        ListObjectsV2,
+        /// Legacy ListObjects API.
+        ListObjects,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [ListApi::value] or
+        /// [ListApi::name].
+        UnknownValue(list_api::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod list_api {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl ListApi {
-        /// ListApi is not specified.
-        pub const LIST_API_UNSPECIFIED: ListApi = ListApi::new(0);
-
-        /// Perform listing using ListObjectsV2 API.
-        pub const LIST_OBJECTS_V2: ListApi = ListApi::new(1);
-
-        /// Legacy ListObjects API.
-        pub const LIST_OBJECTS: ListApi = ListApi::new(2);
-
-        /// Creates a new ListApi instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::ListObjectsV2 => std::option::Option::Some(1),
+                Self::ListObjects => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LIST_API_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("LIST_OBJECTS_V2"),
-                2 => std::borrow::Cow::Borrowed("LIST_OBJECTS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LIST_API_UNSPECIFIED"),
+                Self::ListObjectsV2 => std::option::Option::Some("LIST_OBJECTS_V2"),
+                Self::ListObjects => std::option::Option::Some("LIST_OBJECTS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LIST_API_UNSPECIFIED" => std::option::Option::Some(Self::LIST_API_UNSPECIFIED),
-                "LIST_OBJECTS_V2" => std::option::Option::Some(Self::LIST_OBJECTS_V2),
-                "LIST_OBJECTS" => std::option::Option::Some(Self::LIST_OBJECTS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for ListApi {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for ListApi {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for ListApi {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for ListApi {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::ListObjectsV2,
+                2 => Self::ListObjects,
+                _ => Self::UnknownValue(list_api::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for ListApi {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LIST_API_UNSPECIFIED" => Self::Unspecified,
+                "LIST_OBJECTS_V2" => Self::ListObjectsV2,
+                "LIST_OBJECTS" => Self::ListObjects,
+                _ => Self::UnknownValue(list_api::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for ListApi {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::ListObjectsV2 => serializer.serialize_i32(1),
+                Self::ListObjects => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for ListApi {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<ListApi>::new(
+                ".google.storagetransfer.v1.S3CompatibleMetadata.ListApi",
+            ))
         }
     }
 }
@@ -2366,67 +2598,130 @@ pub mod agent_pool {
     }
 
     /// The state of an AgentPool.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct State(i32);
-
-    impl State {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum State {
         /// Default value. This value is unused.
-        pub const STATE_UNSPECIFIED: State = State::new(0);
-
+        Unspecified,
         /// This is an initialization state. During this stage, resources are
         /// allocated for the AgentPool.
-        pub const CREATING: State = State::new(1);
-
+        Creating,
         /// Determines that the AgentPool is created for use. At this state, Agents
         /// can join the AgentPool and participate in the transfer jobs in that pool.
-        pub const CREATED: State = State::new(2);
-
+        Created,
         /// Determines that the AgentPool deletion has been initiated, and all the
         /// resources are scheduled to be cleaned up and freed.
-        pub const DELETING: State = State::new(3);
+        Deleting,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [State::value] or
+        /// [State::name].
+        UnknownValue(state::UnknownValue),
+    }
 
-        /// Creates a new State instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl State {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Creating => std::option::Option::Some(1),
+                Self::Created => std::option::Option::Some(2),
+                Self::Deleting => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("CREATING"),
-                2 => std::borrow::Cow::Borrowed("CREATED"),
-                3 => std::borrow::Cow::Borrowed("DELETING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATE_UNSPECIFIED"),
+                Self::Creating => std::option::Option::Some("CREATING"),
+                Self::Created => std::option::Option::Some("CREATED"),
+                Self::Deleting => std::option::Option::Some("DELETING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATE_UNSPECIFIED" => std::option::Option::Some(Self::STATE_UNSPECIFIED),
-                "CREATING" => std::option::Option::Some(Self::CREATING),
-                "CREATED" => std::option::Option::Some(Self::CREATED),
-                "DELETING" => std::option::Option::Some(Self::DELETING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for State {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for State {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for State {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Creating,
+                2 => Self::Created,
+                3 => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for State {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATE_UNSPECIFIED" => Self::Unspecified,
+                "CREATING" => Self::Creating,
+                "CREATED" => Self::Created,
+                "DELETING" => Self::Deleting,
+                _ => Self::UnknownValue(state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for State {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Creating => serializer.serialize_i32(1),
+                Self::Created => serializer.serialize_i32(2),
+                Self::Deleting => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for State {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<State>::new(
+                ".google.storagetransfer.v1.AgentPool.State",
+            ))
         }
     }
 }
@@ -2545,69 +2840,130 @@ pub mod transfer_options {
 
     /// Specifies when to overwrite an object in the sink when an object with
     /// matching name is found in the source.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OverwriteWhen(i32);
-
-    impl OverwriteWhen {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OverwriteWhen {
         /// Overwrite behavior is unspecified.
-        pub const OVERWRITE_WHEN_UNSPECIFIED: OverwriteWhen = OverwriteWhen::new(0);
-
+        Unspecified,
         /// Overwrites destination objects with the source objects, only if the
         /// objects have the same name but different HTTP ETags or checksum values.
-        pub const DIFFERENT: OverwriteWhen = OverwriteWhen::new(1);
-
+        Different,
         /// Never overwrites a destination object if a source object has the
         /// same name. In this case, the source object is not transferred.
-        pub const NEVER: OverwriteWhen = OverwriteWhen::new(2);
-
+        Never,
         /// Always overwrite the destination object with the source object, even if
         /// the HTTP Etags or checksum values are the same.
-        pub const ALWAYS: OverwriteWhen = OverwriteWhen::new(3);
+        Always,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OverwriteWhen::value] or
+        /// [OverwriteWhen::name].
+        UnknownValue(overwrite_when::UnknownValue),
+    }
 
-        /// Creates a new OverwriteWhen instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod overwrite_when {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl OverwriteWhen {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Different => std::option::Option::Some(1),
+                Self::Never => std::option::Option::Some(2),
+                Self::Always => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("OVERWRITE_WHEN_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("DIFFERENT"),
-                2 => std::borrow::Cow::Borrowed("NEVER"),
-                3 => std::borrow::Cow::Borrowed("ALWAYS"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("OVERWRITE_WHEN_UNSPECIFIED"),
+                Self::Different => std::option::Option::Some("DIFFERENT"),
+                Self::Never => std::option::Option::Some("NEVER"),
+                Self::Always => std::option::Option::Some("ALWAYS"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "OVERWRITE_WHEN_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::OVERWRITE_WHEN_UNSPECIFIED)
-                }
-                "DIFFERENT" => std::option::Option::Some(Self::DIFFERENT),
-                "NEVER" => std::option::Option::Some(Self::NEVER),
-                "ALWAYS" => std::option::Option::Some(Self::ALWAYS),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OverwriteWhen {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OverwriteWhen {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OverwriteWhen {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OverwriteWhen {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Different,
+                2 => Self::Never,
+                3 => Self::Always,
+                _ => Self::UnknownValue(overwrite_when::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OverwriteWhen {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "OVERWRITE_WHEN_UNSPECIFIED" => Self::Unspecified,
+                "DIFFERENT" => Self::Different,
+                "NEVER" => Self::Never,
+                "ALWAYS" => Self::Always,
+                _ => Self::UnknownValue(overwrite_when::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OverwriteWhen {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Different => serializer.serialize_i32(1),
+                Self::Never => serializer.serialize_i32(2),
+                Self::Always => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OverwriteWhen {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OverwriteWhen>::new(
+                ".google.storagetransfer.v1.TransferOptions.OverwriteWhen",
+            ))
         }
     }
 }
@@ -2630,7 +2986,7 @@ pub struct TransferSpec {
     /// are specified, the request fails with an
     /// [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] error.
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     /// [google.storagetransfer.v1.TransferOptions.delete_objects_unique_in_sink]: crate::model::TransferOptions::delete_objects_unique_in_sink
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub transfer_options: std::option::Option<crate::model::TransferOptions>,
@@ -3148,7 +3504,7 @@ pub struct ReplicationSpec {
     /// request fails with an [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT]
     /// error.
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     pub transfer_options: std::option::Option<crate::model::TransferOptions>,
 
@@ -3341,7 +3697,7 @@ pub struct MetadataOptions {
     /// Cloud Storage buckets.  If unspecified, the default behavior is the same as
     /// [STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT][google.storagetransfer.v1.MetadataOptions.StorageClass.STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT].
     ///
-    /// [google.storagetransfer.v1.MetadataOptions.StorageClass.STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT]: crate::model::metadata_options::storage_class::STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT
+    /// [google.storagetransfer.v1.MetadataOptions.StorageClass.STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT]: crate::model::metadata_options::StorageClass::DestinationBucketDefault
     pub storage_class: crate::model::metadata_options::StorageClass,
 
     /// Specifies how each object's temporary hold status should be preserved for
@@ -3349,7 +3705,7 @@ pub struct MetadataOptions {
     /// default behavior is the same as
     /// [TEMPORARY_HOLD_PRESERVE][google.storagetransfer.v1.MetadataOptions.TemporaryHold.TEMPORARY_HOLD_PRESERVE].
     ///
-    /// [google.storagetransfer.v1.MetadataOptions.TemporaryHold.TEMPORARY_HOLD_PRESERVE]: crate::model::metadata_options::temporary_hold::TEMPORARY_HOLD_PRESERVE
+    /// [google.storagetransfer.v1.MetadataOptions.TemporaryHold.TEMPORARY_HOLD_PRESERVE]: crate::model::metadata_options::TemporaryHold::Preserve
     pub temporary_hold: crate::model::metadata_options::TemporaryHold,
 
     /// Specifies how each object's Cloud KMS customer-managed encryption key
@@ -3357,7 +3713,7 @@ pub struct MetadataOptions {
     /// unspecified, the default behavior is the same as
     /// [KMS_KEY_DESTINATION_BUCKET_DEFAULT][google.storagetransfer.v1.MetadataOptions.KmsKey.KMS_KEY_DESTINATION_BUCKET_DEFAULT].
     ///
-    /// [google.storagetransfer.v1.MetadataOptions.KmsKey.KMS_KEY_DESTINATION_BUCKET_DEFAULT]: crate::model::metadata_options::kms_key::KMS_KEY_DESTINATION_BUCKET_DEFAULT
+    /// [google.storagetransfer.v1.MetadataOptions.KmsKey.KMS_KEY_DESTINATION_BUCKET_DEFAULT]: crate::model::metadata_options::KmsKey::DestinationBucketDefault
     pub kms_key: crate::model::metadata_options::KmsKey,
 
     /// Specifies how each object's `timeCreated` metadata is preserved for
@@ -3366,7 +3722,7 @@ pub struct MetadataOptions {
     /// This behavior is supported for transfers to Cloud Storage buckets from
     /// Cloud Storage, Amazon S3, S3-compatible storage, and Azure sources.
     ///
-    /// [google.storagetransfer.v1.MetadataOptions.TimeCreated.TIME_CREATED_SKIP]: crate::model::metadata_options::time_created::TIME_CREATED_SKIP
+    /// [google.storagetransfer.v1.MetadataOptions.TimeCreated.TIME_CREATED_SKIP]: crate::model::metadata_options::TimeCreated::Skip
     pub time_created: crate::model::metadata_options::TimeCreated,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3476,564 +3832,1113 @@ pub mod metadata_options {
     use super::*;
 
     /// Whether symlinks should be skipped or preserved during a transfer job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Symlink(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Symlink {
+        /// Symlink behavior is unspecified.
+        Unspecified,
+        /// Do not preserve symlinks during a transfer job.
+        Skip,
+        /// Preserve symlinks during a transfer job.
+        Preserve,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Symlink::value] or
+        /// [Symlink::name].
+        UnknownValue(symlink::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod symlink {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Symlink {
-        /// Symlink behavior is unspecified.
-        pub const SYMLINK_UNSPECIFIED: Symlink = Symlink::new(0);
-
-        /// Do not preserve symlinks during a transfer job.
-        pub const SYMLINK_SKIP: Symlink = Symlink::new(1);
-
-        /// Preserve symlinks during a transfer job.
-        pub const SYMLINK_PRESERVE: Symlink = Symlink::new(2);
-
-        /// Creates a new Symlink instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::Preserve => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("SYMLINK_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SYMLINK_SKIP"),
-                2 => std::borrow::Cow::Borrowed("SYMLINK_PRESERVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("SYMLINK_UNSPECIFIED"),
+                Self::Skip => std::option::Option::Some("SYMLINK_SKIP"),
+                Self::Preserve => std::option::Option::Some("SYMLINK_PRESERVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SYMLINK_UNSPECIFIED" => std::option::Option::Some(Self::SYMLINK_UNSPECIFIED),
-                "SYMLINK_SKIP" => std::option::Option::Some(Self::SYMLINK_SKIP),
-                "SYMLINK_PRESERVE" => std::option::Option::Some(Self::SYMLINK_PRESERVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Symlink {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Symlink {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Symlink {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Symlink {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::Preserve,
+                _ => Self::UnknownValue(symlink::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Symlink {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SYMLINK_UNSPECIFIED" => Self::Unspecified,
+                "SYMLINK_SKIP" => Self::Skip,
+                "SYMLINK_PRESERVE" => Self::Preserve,
+                _ => Self::UnknownValue(symlink::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Symlink {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::Preserve => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Symlink {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Symlink>::new(
+                ".google.storagetransfer.v1.MetadataOptions.Symlink",
+            ))
         }
     }
 
     /// Options for handling file mode attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Mode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Mode {
+        /// Mode behavior is unspecified.
+        Unspecified,
+        /// Do not preserve mode during a transfer job.
+        Skip,
+        /// Preserve mode during a transfer job.
+        Preserve,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Mode::value] or
+        /// [Mode::name].
+        UnknownValue(mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Mode {
-        /// Mode behavior is unspecified.
-        pub const MODE_UNSPECIFIED: Mode = Mode::new(0);
-
-        /// Do not preserve mode during a transfer job.
-        pub const MODE_SKIP: Mode = Mode::new(1);
-
-        /// Preserve mode during a transfer job.
-        pub const MODE_PRESERVE: Mode = Mode::new(2);
-
-        /// Creates a new Mode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::Preserve => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MODE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("MODE_SKIP"),
-                2 => std::borrow::Cow::Borrowed("MODE_PRESERVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("MODE_UNSPECIFIED"),
+                Self::Skip => std::option::Option::Some("MODE_SKIP"),
+                Self::Preserve => std::option::Option::Some("MODE_PRESERVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MODE_UNSPECIFIED" => std::option::Option::Some(Self::MODE_UNSPECIFIED),
-                "MODE_SKIP" => std::option::Option::Some(Self::MODE_SKIP),
-                "MODE_PRESERVE" => std::option::Option::Some(Self::MODE_PRESERVE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Mode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Mode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Mode {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::Preserve,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Mode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MODE_UNSPECIFIED" => Self::Unspecified,
+                "MODE_SKIP" => Self::Skip,
+                "MODE_PRESERVE" => Self::Preserve,
+                _ => Self::UnknownValue(mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Mode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::Preserve => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Mode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Mode>::new(
+                ".google.storagetransfer.v1.MetadataOptions.Mode",
+            ))
         }
     }
 
     /// Options for handling file GID attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Gid(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Gid {
+        /// GID behavior is unspecified.
+        Unspecified,
+        /// Do not preserve GID during a transfer job.
+        Skip,
+        /// Preserve GID during a transfer job.
+        Number,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Gid::value] or
+        /// [Gid::name].
+        UnknownValue(gid::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod gid {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Gid {
-        /// GID behavior is unspecified.
-        pub const GID_UNSPECIFIED: Gid = Gid::new(0);
-
-        /// Do not preserve GID during a transfer job.
-        pub const GID_SKIP: Gid = Gid::new(1);
-
-        /// Preserve GID during a transfer job.
-        pub const GID_NUMBER: Gid = Gid::new(2);
-
-        /// Creates a new Gid instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::Number => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("GID_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("GID_SKIP"),
-                2 => std::borrow::Cow::Borrowed("GID_NUMBER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("GID_UNSPECIFIED"),
+                Self::Skip => std::option::Option::Some("GID_SKIP"),
+                Self::Number => std::option::Option::Some("GID_NUMBER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "GID_UNSPECIFIED" => std::option::Option::Some(Self::GID_UNSPECIFIED),
-                "GID_SKIP" => std::option::Option::Some(Self::GID_SKIP),
-                "GID_NUMBER" => std::option::Option::Some(Self::GID_NUMBER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Gid {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Gid {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Gid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Gid {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::Number,
+                _ => Self::UnknownValue(gid::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Gid {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "GID_UNSPECIFIED" => Self::Unspecified,
+                "GID_SKIP" => Self::Skip,
+                "GID_NUMBER" => Self::Number,
+                _ => Self::UnknownValue(gid::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Gid {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::Number => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Gid {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Gid>::new(
+                ".google.storagetransfer.v1.MetadataOptions.GID",
+            ))
         }
     }
 
     /// Options for handling file UID attribute.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Uid(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Uid {
+        /// UID behavior is unspecified.
+        Unspecified,
+        /// Do not preserve UID during a transfer job.
+        Skip,
+        /// Preserve UID during a transfer job.
+        Number,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Uid::value] or
+        /// [Uid::name].
+        UnknownValue(uid::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod uid {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Uid {
-        /// UID behavior is unspecified.
-        pub const UID_UNSPECIFIED: Uid = Uid::new(0);
-
-        /// Do not preserve UID during a transfer job.
-        pub const UID_SKIP: Uid = Uid::new(1);
-
-        /// Preserve UID during a transfer job.
-        pub const UID_NUMBER: Uid = Uid::new(2);
-
-        /// Creates a new Uid instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::Number => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UID_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("UID_SKIP"),
-                2 => std::borrow::Cow::Borrowed("UID_NUMBER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("UID_UNSPECIFIED"),
+                Self::Skip => std::option::Option::Some("UID_SKIP"),
+                Self::Number => std::option::Option::Some("UID_NUMBER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UID_UNSPECIFIED" => std::option::Option::Some(Self::UID_UNSPECIFIED),
-                "UID_SKIP" => std::option::Option::Some(Self::UID_SKIP),
-                "UID_NUMBER" => std::option::Option::Some(Self::UID_NUMBER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Uid {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Uid {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Uid {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Uid {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::Number,
+                _ => Self::UnknownValue(uid::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Uid {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UID_UNSPECIFIED" => Self::Unspecified,
+                "UID_SKIP" => Self::Skip,
+                "UID_NUMBER" => Self::Number,
+                _ => Self::UnknownValue(uid::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Uid {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::Number => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Uid {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Uid>::new(
+                ".google.storagetransfer.v1.MetadataOptions.UID",
+            ))
         }
     }
 
     /// Options for handling Cloud Storage object ACLs.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Acl(i32);
-
-    impl Acl {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Acl {
         /// ACL behavior is unspecified.
-        pub const ACL_UNSPECIFIED: Acl = Acl::new(0);
-
+        Unspecified,
         /// Use the destination bucket's default object ACLS, if applicable.
-        pub const ACL_DESTINATION_BUCKET_DEFAULT: Acl = Acl::new(1);
-
+        DestinationBucketDefault,
         /// Preserve the object's original ACLs. This requires the service account
         /// to have `storage.objects.getIamPolicy` permission for the source object.
         /// [Uniform bucket-level
         /// access](https://cloud.google.com/storage/docs/uniform-bucket-level-access)
         /// must not be enabled on either the source or destination buckets.
-        pub const ACL_PRESERVE: Acl = Acl::new(2);
+        Preserve,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Acl::value] or
+        /// [Acl::name].
+        UnknownValue(acl::UnknownValue),
+    }
 
-        /// Creates a new Acl instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod acl {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Acl {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DestinationBucketDefault => std::option::Option::Some(1),
+                Self::Preserve => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ACL_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ACL_DESTINATION_BUCKET_DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("ACL_PRESERVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ACL_UNSPECIFIED" => std::option::Option::Some(Self::ACL_UNSPECIFIED),
-                "ACL_DESTINATION_BUCKET_DEFAULT" => {
-                    std::option::Option::Some(Self::ACL_DESTINATION_BUCKET_DEFAULT)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("ACL_UNSPECIFIED"),
+                Self::DestinationBucketDefault => {
+                    std::option::Option::Some("ACL_DESTINATION_BUCKET_DEFAULT")
                 }
-                "ACL_PRESERVE" => std::option::Option::Some(Self::ACL_PRESERVE),
-                _ => std::option::Option::None,
+                Self::Preserve => std::option::Option::Some("ACL_PRESERVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for Acl {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Acl {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Acl {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Acl {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DestinationBucketDefault,
+                2 => Self::Preserve,
+                _ => Self::UnknownValue(acl::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Acl {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ACL_UNSPECIFIED" => Self::Unspecified,
+                "ACL_DESTINATION_BUCKET_DEFAULT" => Self::DestinationBucketDefault,
+                "ACL_PRESERVE" => Self::Preserve,
+                _ => Self::UnknownValue(acl::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Acl {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DestinationBucketDefault => serializer.serialize_i32(1),
+                Self::Preserve => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Acl {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Acl>::new(
+                ".google.storagetransfer.v1.MetadataOptions.Acl",
+            ))
         }
     }
 
     /// Options for handling Google Cloud Storage object storage class.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct StorageClass(i32);
-
-    impl StorageClass {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum StorageClass {
         /// Storage class behavior is unspecified.
-        pub const STORAGE_CLASS_UNSPECIFIED: StorageClass = StorageClass::new(0);
-
+        Unspecified,
         /// Use the destination bucket's default storage class.
-        pub const STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT: StorageClass = StorageClass::new(1);
-
+        DestinationBucketDefault,
         /// Preserve the object's original storage class. This is only supported for
         /// transfers from Google Cloud Storage buckets. REGIONAL and MULTI_REGIONAL
         /// storage classes will be mapped to STANDARD to ensure they can be written
         /// to the destination bucket.
-        pub const STORAGE_CLASS_PRESERVE: StorageClass = StorageClass::new(2);
-
+        Preserve,
         /// Set the storage class to STANDARD.
-        pub const STORAGE_CLASS_STANDARD: StorageClass = StorageClass::new(3);
-
+        Standard,
         /// Set the storage class to NEARLINE.
-        pub const STORAGE_CLASS_NEARLINE: StorageClass = StorageClass::new(4);
-
+        Nearline,
         /// Set the storage class to COLDLINE.
-        pub const STORAGE_CLASS_COLDLINE: StorageClass = StorageClass::new(5);
-
+        Coldline,
         /// Set the storage class to ARCHIVE.
-        pub const STORAGE_CLASS_ARCHIVE: StorageClass = StorageClass::new(6);
+        Archive,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [StorageClass::value] or
+        /// [StorageClass::name].
+        UnknownValue(storage_class::UnknownValue),
+    }
 
-        /// Creates a new StorageClass instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod storage_class {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl StorageClass {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DestinationBucketDefault => std::option::Option::Some(1),
+                Self::Preserve => std::option::Option::Some(2),
+                Self::Standard => std::option::Option::Some(3),
+                Self::Nearline => std::option::Option::Some(4),
+                Self::Coldline => std::option::Option::Some(5),
+                Self::Archive => std::option::Option::Some(6),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STORAGE_CLASS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("STORAGE_CLASS_PRESERVE"),
-                3 => std::borrow::Cow::Borrowed("STORAGE_CLASS_STANDARD"),
-                4 => std::borrow::Cow::Borrowed("STORAGE_CLASS_NEARLINE"),
-                5 => std::borrow::Cow::Borrowed("STORAGE_CLASS_COLDLINE"),
-                6 => std::borrow::Cow::Borrowed("STORAGE_CLASS_ARCHIVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STORAGE_CLASS_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::STORAGE_CLASS_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STORAGE_CLASS_UNSPECIFIED"),
+                Self::DestinationBucketDefault => {
+                    std::option::Option::Some("STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT")
                 }
-                "STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT" => {
-                    std::option::Option::Some(Self::STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT)
-                }
-                "STORAGE_CLASS_PRESERVE" => std::option::Option::Some(Self::STORAGE_CLASS_PRESERVE),
-                "STORAGE_CLASS_STANDARD" => std::option::Option::Some(Self::STORAGE_CLASS_STANDARD),
-                "STORAGE_CLASS_NEARLINE" => std::option::Option::Some(Self::STORAGE_CLASS_NEARLINE),
-                "STORAGE_CLASS_COLDLINE" => std::option::Option::Some(Self::STORAGE_CLASS_COLDLINE),
-                "STORAGE_CLASS_ARCHIVE" => std::option::Option::Some(Self::STORAGE_CLASS_ARCHIVE),
-                _ => std::option::Option::None,
+                Self::Preserve => std::option::Option::Some("STORAGE_CLASS_PRESERVE"),
+                Self::Standard => std::option::Option::Some("STORAGE_CLASS_STANDARD"),
+                Self::Nearline => std::option::Option::Some("STORAGE_CLASS_NEARLINE"),
+                Self::Coldline => std::option::Option::Some("STORAGE_CLASS_COLDLINE"),
+                Self::Archive => std::option::Option::Some("STORAGE_CLASS_ARCHIVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for StorageClass {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for StorageClass {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for StorageClass {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for StorageClass {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DestinationBucketDefault,
+                2 => Self::Preserve,
+                3 => Self::Standard,
+                4 => Self::Nearline,
+                5 => Self::Coldline,
+                6 => Self::Archive,
+                _ => Self::UnknownValue(storage_class::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for StorageClass {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STORAGE_CLASS_UNSPECIFIED" => Self::Unspecified,
+                "STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT" => Self::DestinationBucketDefault,
+                "STORAGE_CLASS_PRESERVE" => Self::Preserve,
+                "STORAGE_CLASS_STANDARD" => Self::Standard,
+                "STORAGE_CLASS_NEARLINE" => Self::Nearline,
+                "STORAGE_CLASS_COLDLINE" => Self::Coldline,
+                "STORAGE_CLASS_ARCHIVE" => Self::Archive,
+                _ => Self::UnknownValue(storage_class::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for StorageClass {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DestinationBucketDefault => serializer.serialize_i32(1),
+                Self::Preserve => serializer.serialize_i32(2),
+                Self::Standard => serializer.serialize_i32(3),
+                Self::Nearline => serializer.serialize_i32(4),
+                Self::Coldline => serializer.serialize_i32(5),
+                Self::Archive => serializer.serialize_i32(6),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for StorageClass {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<StorageClass>::new(
+                ".google.storagetransfer.v1.MetadataOptions.StorageClass",
+            ))
         }
     }
 
     /// Options for handling temporary holds for Google Cloud Storage objects.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TemporaryHold(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TemporaryHold {
+        /// Temporary hold behavior is unspecified.
+        Unspecified,
+        /// Do not set a temporary hold on the destination object.
+        Skip,
+        /// Preserve the object's original temporary hold status.
+        Preserve,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TemporaryHold::value] or
+        /// [TemporaryHold::name].
+        UnknownValue(temporary_hold::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod temporary_hold {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl TemporaryHold {
-        /// Temporary hold behavior is unspecified.
-        pub const TEMPORARY_HOLD_UNSPECIFIED: TemporaryHold = TemporaryHold::new(0);
-
-        /// Do not set a temporary hold on the destination object.
-        pub const TEMPORARY_HOLD_SKIP: TemporaryHold = TemporaryHold::new(1);
-
-        /// Preserve the object's original temporary hold status.
-        pub const TEMPORARY_HOLD_PRESERVE: TemporaryHold = TemporaryHold::new(2);
-
-        /// Creates a new TemporaryHold instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::Preserve => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TEMPORARY_HOLD_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TEMPORARY_HOLD_SKIP"),
-                2 => std::borrow::Cow::Borrowed("TEMPORARY_HOLD_PRESERVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TEMPORARY_HOLD_UNSPECIFIED"),
+                Self::Skip => std::option::Option::Some("TEMPORARY_HOLD_SKIP"),
+                Self::Preserve => std::option::Option::Some("TEMPORARY_HOLD_PRESERVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TEMPORARY_HOLD_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TEMPORARY_HOLD_UNSPECIFIED)
-                }
-                "TEMPORARY_HOLD_SKIP" => std::option::Option::Some(Self::TEMPORARY_HOLD_SKIP),
-                "TEMPORARY_HOLD_PRESERVE" => {
-                    std::option::Option::Some(Self::TEMPORARY_HOLD_PRESERVE)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for TemporaryHold {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TemporaryHold {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TemporaryHold {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TemporaryHold {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::Preserve,
+                _ => Self::UnknownValue(temporary_hold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TemporaryHold {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TEMPORARY_HOLD_UNSPECIFIED" => Self::Unspecified,
+                "TEMPORARY_HOLD_SKIP" => Self::Skip,
+                "TEMPORARY_HOLD_PRESERVE" => Self::Preserve,
+                _ => Self::UnknownValue(temporary_hold::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TemporaryHold {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::Preserve => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TemporaryHold {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TemporaryHold>::new(
+                ".google.storagetransfer.v1.MetadataOptions.TemporaryHold",
+            ))
         }
     }
 
     /// Options for handling the KmsKey setting for Google Cloud Storage objects.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct KmsKey(i32);
-
-    impl KmsKey {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum KmsKey {
         /// KmsKey behavior is unspecified.
-        pub const KMS_KEY_UNSPECIFIED: KmsKey = KmsKey::new(0);
-
+        Unspecified,
         /// Use the destination bucket's default encryption settings.
-        pub const KMS_KEY_DESTINATION_BUCKET_DEFAULT: KmsKey = KmsKey::new(1);
-
+        DestinationBucketDefault,
         /// Preserve the object's original Cloud KMS customer-managed encryption key
         /// (CMEK) if present. Objects that do not use a Cloud KMS encryption key
         /// will be encrypted using the destination bucket's encryption settings.
-        pub const KMS_KEY_PRESERVE: KmsKey = KmsKey::new(2);
+        Preserve,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [KmsKey::value] or
+        /// [KmsKey::name].
+        UnknownValue(kms_key::UnknownValue),
+    }
 
-        /// Creates a new KmsKey instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod kms_key {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl KmsKey {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::DestinationBucketDefault => std::option::Option::Some(1),
+                Self::Preserve => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("KMS_KEY_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("KMS_KEY_DESTINATION_BUCKET_DEFAULT"),
-                2 => std::borrow::Cow::Borrowed("KMS_KEY_PRESERVE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "KMS_KEY_UNSPECIFIED" => std::option::Option::Some(Self::KMS_KEY_UNSPECIFIED),
-                "KMS_KEY_DESTINATION_BUCKET_DEFAULT" => {
-                    std::option::Option::Some(Self::KMS_KEY_DESTINATION_BUCKET_DEFAULT)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("KMS_KEY_UNSPECIFIED"),
+                Self::DestinationBucketDefault => {
+                    std::option::Option::Some("KMS_KEY_DESTINATION_BUCKET_DEFAULT")
                 }
-                "KMS_KEY_PRESERVE" => std::option::Option::Some(Self::KMS_KEY_PRESERVE),
-                _ => std::option::Option::None,
+                Self::Preserve => std::option::Option::Some("KMS_KEY_PRESERVE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for KmsKey {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for KmsKey {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for KmsKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for KmsKey {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::DestinationBucketDefault,
+                2 => Self::Preserve,
+                _ => Self::UnknownValue(kms_key::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for KmsKey {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "KMS_KEY_UNSPECIFIED" => Self::Unspecified,
+                "KMS_KEY_DESTINATION_BUCKET_DEFAULT" => Self::DestinationBucketDefault,
+                "KMS_KEY_PRESERVE" => Self::Preserve,
+                _ => Self::UnknownValue(kms_key::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for KmsKey {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::DestinationBucketDefault => serializer.serialize_i32(1),
+                Self::Preserve => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for KmsKey {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<KmsKey>::new(
+                ".google.storagetransfer.v1.MetadataOptions.KmsKey",
+            ))
         }
     }
 
     /// Options for handling `timeCreated` metadata for Google Cloud Storage
     /// objects.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct TimeCreated(i32);
-
-    impl TimeCreated {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum TimeCreated {
         /// TimeCreated behavior is unspecified.
-        pub const TIME_CREATED_UNSPECIFIED: TimeCreated = TimeCreated::new(0);
-
+        Unspecified,
         /// Do not preserve the `timeCreated` metadata from the source object.
-        pub const TIME_CREATED_SKIP: TimeCreated = TimeCreated::new(1);
-
+        Skip,
         /// Preserves the source object's `timeCreated` or `lastModified` metadata in
         /// the `customTime` field in the destination object.  Note that any value
         /// stored in the source object's `customTime` field will not be propagated
         /// to the destination object.
-        pub const TIME_CREATED_PRESERVE_AS_CUSTOM_TIME: TimeCreated = TimeCreated::new(2);
+        PreserveAsCustomTime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [TimeCreated::value] or
+        /// [TimeCreated::name].
+        UnknownValue(time_created::UnknownValue),
+    }
 
-        /// Creates a new TimeCreated instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod time_created {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl TimeCreated {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Skip => std::option::Option::Some(1),
+                Self::PreserveAsCustomTime => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TIME_CREATED_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TIME_CREATED_SKIP"),
-                2 => std::borrow::Cow::Borrowed("TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TIME_CREATED_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::TIME_CREATED_UNSPECIFIED)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("TIME_CREATED_UNSPECIFIED"),
+                Self::Skip => std::option::Option::Some("TIME_CREATED_SKIP"),
+                Self::PreserveAsCustomTime => {
+                    std::option::Option::Some("TIME_CREATED_PRESERVE_AS_CUSTOM_TIME")
                 }
-                "TIME_CREATED_SKIP" => std::option::Option::Some(Self::TIME_CREATED_SKIP),
-                "TIME_CREATED_PRESERVE_AS_CUSTOM_TIME" => {
-                    std::option::Option::Some(Self::TIME_CREATED_PRESERVE_AS_CUSTOM_TIME)
-                }
-                _ => std::option::Option::None,
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for TimeCreated {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for TimeCreated {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for TimeCreated {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for TimeCreated {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Skip,
+                2 => Self::PreserveAsCustomTime,
+                _ => Self::UnknownValue(time_created::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for TimeCreated {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TIME_CREATED_UNSPECIFIED" => Self::Unspecified,
+                "TIME_CREATED_SKIP" => Self::Skip,
+                "TIME_CREATED_PRESERVE_AS_CUSTOM_TIME" => Self::PreserveAsCustomTime,
+                _ => Self::UnknownValue(time_created::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for TimeCreated {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Skip => serializer.serialize_i32(1),
+                Self::PreserveAsCustomTime => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for TimeCreated {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<TimeCreated>::new(
+                ".google.storagetransfer.v1.MetadataOptions.TimeCreated",
+            ))
         }
     }
 }
@@ -4155,7 +5060,7 @@ pub struct Schedule {
     ///   [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] is returned.
     ///
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     /// [google.storagetransfer.v1.Schedule.schedule_end_date]: crate::model::Schedule::schedule_end_date
     /// [google.storagetransfer.v1.Schedule.schedule_start_date]: crate::model::Schedule::schedule_start_date
     /// [google.storagetransfer.v1.Schedule.start_time_of_day]: crate::model::Schedule::start_time_of_day
@@ -4339,8 +5244,8 @@ pub struct TransferJob {
     /// Invalid job names fail with an
     /// [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] error.
     ///
-    /// [google.rpc.Code.ALREADY_EXISTS]: rpc::model::code::ALREADY_EXISTS
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.ALREADY_EXISTS]: rpc::model::Code::AlreadyExists
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub name: std::string::String,
 
@@ -4391,8 +5296,8 @@ pub struct TransferJob {
     /// operation spawned by the transfer is running, the status change would not
     /// affect the current operation.
     ///
-    /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::status::DISABLED
-    /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::status::ENABLED
+    /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::Status::Disabled
+    /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::Status::Enabled
     pub status: crate::model::transfer_job::Status,
 
     /// Output only. The time that the transfer job was created.
@@ -4563,67 +5468,130 @@ pub mod transfer_job {
     use super::*;
 
     /// The status of the transfer job.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
-
-    impl Status {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
         /// Zero is an illegal value.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
+        Unspecified,
         /// New transfers are performed based on the schedule.
-        pub const ENABLED: Status = Status::new(1);
-
+        Enabled,
         /// New transfers are not scheduled.
-        pub const DISABLED: Status = Status::new(2);
-
+        Disabled,
         /// This is a soft delete state. After a transfer job is set to this
         /// state, the job and all the transfer executions are subject to
         /// garbage collection. Transfer jobs become eligible for garbage collection
         /// 30 days after their status is set to `DELETED`.
-        pub const DELETED: Status = Status::new(3);
+        Deleted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
 
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Status {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Enabled => std::option::Option::Some(1),
+                Self::Disabled => std::option::Option::Some(2),
+                Self::Deleted => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("ENABLED"),
-                2 => std::borrow::Cow::Borrowed("DISABLED"),
-                3 => std::borrow::Cow::Borrowed("DELETED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::Enabled => std::option::Option::Some("ENABLED"),
+                Self::Disabled => std::option::Option::Some("DISABLED"),
+                Self::Deleted => std::option::Option::Some("DELETED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "ENABLED" => std::option::Option::Some(Self::ENABLED),
-                "DISABLED" => std::option::Option::Some(Self::DISABLED),
-                "DELETED" => std::option::Option::Some(Self::DELETED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Enabled,
+                2 => Self::Disabled,
+                3 => Self::Deleted,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "ENABLED" => Self::Enabled,
+                "DISABLED" => Self::Disabled,
+                "DELETED" => Self::Deleted,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Enabled => serializer.serialize_i32(1),
+                Self::Disabled => serializer.serialize_i32(2),
+                Self::Deleted => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.storagetransfer.v1.TransferJob.Status",
+            ))
         }
     }
 }
@@ -5070,7 +6038,7 @@ pub struct NotificationConfig {
     /// Not matching this format results in an
     /// [INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] error.
     ///
-    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::code::INVALID_ARGUMENT
+    /// [google.rpc.Code.INVALID_ARGUMENT]: rpc::model::Code::InvalidArgument
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub pubsub_topic: std::string::String,
 
@@ -5137,140 +6105,262 @@ pub mod notification_config {
     /// Additional event types may be added in the future. Clients should either
     /// safely ignore unrecognized event types or explicitly specify which event
     /// types they are prepared to accept.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EventType(i32);
-
-    impl EventType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EventType {
         /// Illegal value, to avoid allowing a default.
-        pub const EVENT_TYPE_UNSPECIFIED: EventType = EventType::new(0);
-
+        Unspecified,
         /// `TransferOperation` completed with status
         /// [SUCCESS][google.storagetransfer.v1.TransferOperation.Status.SUCCESS].
         ///
-        /// [google.storagetransfer.v1.TransferOperation.Status.SUCCESS]: crate::model::transfer_operation::status::SUCCESS
-        pub const TRANSFER_OPERATION_SUCCESS: EventType = EventType::new(1);
-
+        /// [google.storagetransfer.v1.TransferOperation.Status.SUCCESS]: crate::model::transfer_operation::Status::Success
+        TransferOperationSuccess,
         /// `TransferOperation` completed with status
         /// [FAILED][google.storagetransfer.v1.TransferOperation.Status.FAILED].
         ///
-        /// [google.storagetransfer.v1.TransferOperation.Status.FAILED]: crate::model::transfer_operation::status::FAILED
-        pub const TRANSFER_OPERATION_FAILED: EventType = EventType::new(2);
-
+        /// [google.storagetransfer.v1.TransferOperation.Status.FAILED]: crate::model::transfer_operation::Status::Failed
+        TransferOperationFailed,
         /// `TransferOperation` completed with status
         /// [ABORTED][google.storagetransfer.v1.TransferOperation.Status.ABORTED].
         ///
-        /// [google.storagetransfer.v1.TransferOperation.Status.ABORTED]: crate::model::transfer_operation::status::ABORTED
-        pub const TRANSFER_OPERATION_ABORTED: EventType = EventType::new(3);
+        /// [google.storagetransfer.v1.TransferOperation.Status.ABORTED]: crate::model::transfer_operation::Status::Aborted
+        TransferOperationAborted,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EventType::value] or
+        /// [EventType::name].
+        UnknownValue(event_type::UnknownValue),
+    }
 
-        /// Creates a new EventType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod event_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl EventType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::TransferOperationSuccess => std::option::Option::Some(1),
+                Self::TransferOperationFailed => std::option::Option::Some(2),
+                Self::TransferOperationAborted => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("EVENT_TYPE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("TRANSFER_OPERATION_SUCCESS"),
-                2 => std::borrow::Cow::Borrowed("TRANSFER_OPERATION_FAILED"),
-                3 => std::borrow::Cow::Borrowed("TRANSFER_OPERATION_ABORTED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("EVENT_TYPE_UNSPECIFIED"),
+                Self::TransferOperationSuccess => {
+                    std::option::Option::Some("TRANSFER_OPERATION_SUCCESS")
+                }
+                Self::TransferOperationFailed => {
+                    std::option::Option::Some("TRANSFER_OPERATION_FAILED")
+                }
+                Self::TransferOperationAborted => {
+                    std::option::Option::Some("TRANSFER_OPERATION_ABORTED")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "EVENT_TYPE_UNSPECIFIED" => std::option::Option::Some(Self::EVENT_TYPE_UNSPECIFIED),
-                "TRANSFER_OPERATION_SUCCESS" => {
-                    std::option::Option::Some(Self::TRANSFER_OPERATION_SUCCESS)
-                }
-                "TRANSFER_OPERATION_FAILED" => {
-                    std::option::Option::Some(Self::TRANSFER_OPERATION_FAILED)
-                }
-                "TRANSFER_OPERATION_ABORTED" => {
-                    std::option::Option::Some(Self::TRANSFER_OPERATION_ABORTED)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EventType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EventType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for EventType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EventType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::TransferOperationSuccess,
+                2 => Self::TransferOperationFailed,
+                3 => Self::TransferOperationAborted,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EventType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "EVENT_TYPE_UNSPECIFIED" => Self::Unspecified,
+                "TRANSFER_OPERATION_SUCCESS" => Self::TransferOperationSuccess,
+                "TRANSFER_OPERATION_FAILED" => Self::TransferOperationFailed,
+                "TRANSFER_OPERATION_ABORTED" => Self::TransferOperationAborted,
+                _ => Self::UnknownValue(event_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EventType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::TransferOperationSuccess => serializer.serialize_i32(1),
+                Self::TransferOperationFailed => serializer.serialize_i32(2),
+                Self::TransferOperationAborted => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EventType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EventType>::new(
+                ".google.storagetransfer.v1.NotificationConfig.EventType",
+            ))
         }
     }
 
     /// Enum for specifying the format of a notification message's payload.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct PayloadFormat(i32);
-
-    impl PayloadFormat {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum PayloadFormat {
         /// Illegal value, to avoid allowing a default.
-        pub const PAYLOAD_FORMAT_UNSPECIFIED: PayloadFormat = PayloadFormat::new(0);
-
+        Unspecified,
         /// No payload is included with the notification.
-        pub const NONE: PayloadFormat = PayloadFormat::new(1);
-
+        None,
         /// `TransferOperation` is [formatted as a JSON
         /// response](https://developers.google.com/protocol-buffers/docs/proto3#json),
         /// in application/json.
-        pub const JSON: PayloadFormat = PayloadFormat::new(2);
+        Json,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [PayloadFormat::value] or
+        /// [PayloadFormat::name].
+        UnknownValue(payload_format::UnknownValue),
+    }
 
-        /// Creates a new PayloadFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod payload_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl PayloadFormat {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::None => std::option::Option::Some(1),
+                Self::Json => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("PAYLOAD_FORMAT_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("NONE"),
-                2 => std::borrow::Cow::Borrowed("JSON"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("PAYLOAD_FORMAT_UNSPECIFIED"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::Json => std::option::Option::Some("JSON"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "PAYLOAD_FORMAT_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::PAYLOAD_FORMAT_UNSPECIFIED)
-                }
-                "NONE" => std::option::Option::Some(Self::NONE),
-                "JSON" => std::option::Option::Some(Self::JSON),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for PayloadFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for PayloadFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for PayloadFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for PayloadFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::None,
+                2 => Self::Json,
+                _ => Self::UnknownValue(payload_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for PayloadFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "PAYLOAD_FORMAT_UNSPECIFIED" => Self::Unspecified,
+                "NONE" => Self::None,
+                "JSON" => Self::Json,
+                _ => Self::UnknownValue(payload_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for PayloadFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::None => serializer.serialize_i32(1),
+                Self::Json => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for PayloadFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<PayloadFormat>::new(
+                ".google.storagetransfer.v1.NotificationConfig.PayloadFormat",
+            ))
         }
     }
 }
@@ -5357,128 +6447,247 @@ pub mod logging_config {
     use super::*;
 
     /// Loggable actions.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggableAction(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoggableAction {
+        /// Default value. This value is unused.
+        Unspecified,
+        /// Listing objects in a bucket.
+        Find,
+        /// Deleting objects at the source or the destination.
+        Delete,
+        /// Copying objects to Google Cloud Storage.
+        Copy,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoggableAction::value] or
+        /// [LoggableAction::name].
+        UnknownValue(loggable_action::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod loggable_action {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl LoggableAction {
-        /// Default value. This value is unused.
-        pub const LOGGABLE_ACTION_UNSPECIFIED: LoggableAction = LoggableAction::new(0);
-
-        /// Listing objects in a bucket.
-        pub const FIND: LoggableAction = LoggableAction::new(1);
-
-        /// Deleting objects at the source or the destination.
-        pub const DELETE: LoggableAction = LoggableAction::new(2);
-
-        /// Copying objects to Google Cloud Storage.
-        pub const COPY: LoggableAction = LoggableAction::new(3);
-
-        /// Creates a new LoggableAction instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Find => std::option::Option::Some(1),
+                Self::Delete => std::option::Option::Some(2),
+                Self::Copy => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOGGABLE_ACTION_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("FIND"),
-                2 => std::borrow::Cow::Borrowed("DELETE"),
-                3 => std::borrow::Cow::Borrowed("COPY"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOGGABLE_ACTION_UNSPECIFIED"),
+                Self::Find => std::option::Option::Some("FIND"),
+                Self::Delete => std::option::Option::Some("DELETE"),
+                Self::Copy => std::option::Option::Some("COPY"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOGGABLE_ACTION_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOGGABLE_ACTION_UNSPECIFIED)
-                }
-                "FIND" => std::option::Option::Some(Self::FIND),
-                "DELETE" => std::option::Option::Some(Self::DELETE),
-                "COPY" => std::option::Option::Some(Self::COPY),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoggableAction {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggableAction {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoggableAction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoggableAction {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Find,
+                2 => Self::Delete,
+                3 => Self::Copy,
+                _ => Self::UnknownValue(loggable_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoggableAction {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOGGABLE_ACTION_UNSPECIFIED" => Self::Unspecified,
+                "FIND" => Self::Find,
+                "DELETE" => Self::Delete,
+                "COPY" => Self::Copy,
+                _ => Self::UnknownValue(loggable_action::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoggableAction {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Find => serializer.serialize_i32(1),
+                Self::Delete => serializer.serialize_i32(2),
+                Self::Copy => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoggableAction {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoggableAction>::new(
+                ".google.storagetransfer.v1.LoggingConfig.LoggableAction",
+            ))
         }
     }
 
     /// Loggable action states.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct LoggableActionState(i32);
-
-    impl LoggableActionState {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum LoggableActionState {
         /// Default value. This value is unused.
-        pub const LOGGABLE_ACTION_STATE_UNSPECIFIED: LoggableActionState =
-            LoggableActionState::new(0);
-
+        Unspecified,
         /// `LoggableAction` completed successfully. `SUCCEEDED` actions are
         /// logged as [INFO][google.logging.type.LogSeverity.INFO].
-        pub const SUCCEEDED: LoggableActionState = LoggableActionState::new(1);
-
+        Succeeded,
         /// `LoggableAction` terminated in an error state. `FAILED` actions are
         /// logged as [ERROR][google.logging.type.LogSeverity.ERROR].
-        pub const FAILED: LoggableActionState = LoggableActionState::new(2);
+        Failed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [LoggableActionState::value] or
+        /// [LoggableActionState::name].
+        UnknownValue(loggable_action_state::UnknownValue),
+    }
 
-        /// Creates a new LoggableActionState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod loggable_action_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl LoggableActionState {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::Succeeded => std::option::Option::Some(1),
+                Self::Failed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("LOGGABLE_ACTION_STATE_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("SUCCEEDED"),
-                2 => std::borrow::Cow::Borrowed("FAILED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("LOGGABLE_ACTION_STATE_UNSPECIFIED"),
+                Self::Succeeded => std::option::Option::Some("SUCCEEDED"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LOGGABLE_ACTION_STATE_UNSPECIFIED" => {
-                    std::option::Option::Some(Self::LOGGABLE_ACTION_STATE_UNSPECIFIED)
-                }
-                "SUCCEEDED" => std::option::Option::Some(Self::SUCCEEDED),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for LoggableActionState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for LoggableActionState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for LoggableActionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for LoggableActionState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::Succeeded,
+                2 => Self::Failed,
+                _ => Self::UnknownValue(loggable_action_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for LoggableActionState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LOGGABLE_ACTION_STATE_UNSPECIFIED" => Self::Unspecified,
+                "SUCCEEDED" => Self::Succeeded,
+                "FAILED" => Self::Failed,
+                _ => Self::UnknownValue(loggable_action_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for LoggableActionState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::Succeeded => serializer.serialize_i32(1),
+                Self::Failed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for LoggableActionState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<LoggableActionState>::new(
+                ".google.storagetransfer.v1.LoggingConfig.LoggableActionState",
+            ))
         }
     }
 }
@@ -5657,84 +6866,155 @@ pub mod transfer_operation {
     use super::*;
 
     /// The status of a TransferOperation.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Status(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Status {
+        /// Zero is an illegal value.
+        Unspecified,
+        /// In progress.
+        InProgress,
+        /// Paused.
+        Paused,
+        /// Completed successfully.
+        Success,
+        /// Terminated due to an unrecoverable failure.
+        Failed,
+        /// Aborted by the user.
+        Aborted,
+        /// Temporarily delayed by the system. No user action is required.
+        Queued,
+        /// The operation is suspending and draining the ongoing work to completion.
+        Suspending,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Status::value] or
+        /// [Status::name].
+        UnknownValue(status::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod status {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Status {
-        /// Zero is an illegal value.
-        pub const STATUS_UNSPECIFIED: Status = Status::new(0);
-
-        /// In progress.
-        pub const IN_PROGRESS: Status = Status::new(1);
-
-        /// Paused.
-        pub const PAUSED: Status = Status::new(2);
-
-        /// Completed successfully.
-        pub const SUCCESS: Status = Status::new(3);
-
-        /// Terminated due to an unrecoverable failure.
-        pub const FAILED: Status = Status::new(4);
-
-        /// Aborted by the user.
-        pub const ABORTED: Status = Status::new(5);
-
-        /// Temporarily delayed by the system. No user action is required.
-        pub const QUEUED: Status = Status::new(6);
-
-        /// The operation is suspending and draining the ongoing work to completion.
-        pub const SUSPENDING: Status = Status::new(7);
-
-        /// Creates a new Status instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::InProgress => std::option::Option::Some(1),
+                Self::Paused => std::option::Option::Some(2),
+                Self::Success => std::option::Option::Some(3),
+                Self::Failed => std::option::Option::Some(4),
+                Self::Aborted => std::option::Option::Some(5),
+                Self::Queued => std::option::Option::Some(6),
+                Self::Suspending => std::option::Option::Some(7),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STATUS_UNSPECIFIED"),
-                1 => std::borrow::Cow::Borrowed("IN_PROGRESS"),
-                2 => std::borrow::Cow::Borrowed("PAUSED"),
-                3 => std::borrow::Cow::Borrowed("SUCCESS"),
-                4 => std::borrow::Cow::Borrowed("FAILED"),
-                5 => std::borrow::Cow::Borrowed("ABORTED"),
-                6 => std::borrow::Cow::Borrowed("QUEUED"),
-                7 => std::borrow::Cow::Borrowed("SUSPENDING"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("STATUS_UNSPECIFIED"),
+                Self::InProgress => std::option::Option::Some("IN_PROGRESS"),
+                Self::Paused => std::option::Option::Some("PAUSED"),
+                Self::Success => std::option::Option::Some("SUCCESS"),
+                Self::Failed => std::option::Option::Some("FAILED"),
+                Self::Aborted => std::option::Option::Some("ABORTED"),
+                Self::Queued => std::option::Option::Some("QUEUED"),
+                Self::Suspending => std::option::Option::Some("SUSPENDING"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STATUS_UNSPECIFIED" => std::option::Option::Some(Self::STATUS_UNSPECIFIED),
-                "IN_PROGRESS" => std::option::Option::Some(Self::IN_PROGRESS),
-                "PAUSED" => std::option::Option::Some(Self::PAUSED),
-                "SUCCESS" => std::option::Option::Some(Self::SUCCESS),
-                "FAILED" => std::option::Option::Some(Self::FAILED),
-                "ABORTED" => std::option::Option::Some(Self::ABORTED),
-                "QUEUED" => std::option::Option::Some(Self::QUEUED),
-                "SUSPENDING" => std::option::Option::Some(Self::SUSPENDING),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Status {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Status {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Status {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                1 => Self::InProgress,
+                2 => Self::Paused,
+                3 => Self::Success,
+                4 => Self::Failed,
+                5 => Self::Aborted,
+                6 => Self::Queued,
+                7 => Self::Suspending,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Status {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STATUS_UNSPECIFIED" => Self::Unspecified,
+                "IN_PROGRESS" => Self::InProgress,
+                "PAUSED" => Self::Paused,
+                "SUCCESS" => Self::Success,
+                "FAILED" => Self::Failed,
+                "ABORTED" => Self::Aborted,
+                "QUEUED" => Self::Queued,
+                "SUSPENDING" => Self::Suspending,
+                _ => Self::UnknownValue(status::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Status {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::InProgress => serializer.serialize_i32(1),
+                Self::Paused => serializer.serialize_i32(2),
+                Self::Success => serializer.serialize_i32(3),
+                Self::Failed => serializer.serialize_i32(4),
+                Self::Aborted => serializer.serialize_i32(5),
+                Self::Queued => serializer.serialize_i32(6),
+                Self::Suspending => serializer.serialize_i32(7),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Status {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Status>::new(
+                ".google.storagetransfer.v1.TransferOperation.Status",
+            ))
         }
     }
 }

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -1662,278 +1662,499 @@ impl wkt::message::Message for TimeOfDay {
 /// A `CalendarPeriod` represents the abstract concept of a time period that has
 /// a canonical start. Grammatically, "the start of the current
 /// `CalendarPeriod`." All calendar times begin at midnight UTC.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct CalendarPeriod(i32);
-
-impl CalendarPeriod {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum CalendarPeriod {
     /// Undefined period, raises an error.
-    pub const CALENDAR_PERIOD_UNSPECIFIED: CalendarPeriod = CalendarPeriod::new(0);
-
+    Unspecified,
     /// A day.
-    pub const DAY: CalendarPeriod = CalendarPeriod::new(1);
-
+    Day,
     /// A week. Weeks begin on Monday, following
     /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).
-    pub const WEEK: CalendarPeriod = CalendarPeriod::new(2);
-
+    Week,
     /// A fortnight. The first calendar fortnight of the year begins at the start
     /// of week 1 according to
     /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date).
-    pub const FORTNIGHT: CalendarPeriod = CalendarPeriod::new(3);
-
+    Fortnight,
     /// A month.
-    pub const MONTH: CalendarPeriod = CalendarPeriod::new(4);
-
+    Month,
     /// A quarter. Quarters start on dates 1-Jan, 1-Apr, 1-Jul, and 1-Oct of each
     /// year.
-    pub const QUARTER: CalendarPeriod = CalendarPeriod::new(5);
-
+    Quarter,
     /// A half-year. Half-years start on dates 1-Jan and 1-Jul.
-    pub const HALF: CalendarPeriod = CalendarPeriod::new(6);
-
+    Half,
     /// A year.
-    pub const YEAR: CalendarPeriod = CalendarPeriod::new(7);
+    Year,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [CalendarPeriod::value] or
+    /// [CalendarPeriod::name].
+    UnknownValue(calendar_period::UnknownValue),
+}
 
-    /// Creates a new CalendarPeriod instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod calendar_period {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl CalendarPeriod {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Day => std::option::Option::Some(1),
+            Self::Week => std::option::Option::Some(2),
+            Self::Fortnight => std::option::Option::Some(3),
+            Self::Month => std::option::Option::Some(4),
+            Self::Quarter => std::option::Option::Some(5),
+            Self::Half => std::option::Option::Some(6),
+            Self::Year => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("CALENDAR_PERIOD_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("DAY"),
-            2 => std::borrow::Cow::Borrowed("WEEK"),
-            3 => std::borrow::Cow::Borrowed("FORTNIGHT"),
-            4 => std::borrow::Cow::Borrowed("MONTH"),
-            5 => std::borrow::Cow::Borrowed("QUARTER"),
-            6 => std::borrow::Cow::Borrowed("HALF"),
-            7 => std::borrow::Cow::Borrowed("YEAR"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("CALENDAR_PERIOD_UNSPECIFIED"),
+            Self::Day => std::option::Option::Some("DAY"),
+            Self::Week => std::option::Option::Some("WEEK"),
+            Self::Fortnight => std::option::Option::Some("FORTNIGHT"),
+            Self::Month => std::option::Option::Some("MONTH"),
+            Self::Quarter => std::option::Option::Some("QUARTER"),
+            Self::Half => std::option::Option::Some("HALF"),
+            Self::Year => std::option::Option::Some("YEAR"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "CALENDAR_PERIOD_UNSPECIFIED" => {
-                std::option::Option::Some(Self::CALENDAR_PERIOD_UNSPECIFIED)
-            }
-            "DAY" => std::option::Option::Some(Self::DAY),
-            "WEEK" => std::option::Option::Some(Self::WEEK),
-            "FORTNIGHT" => std::option::Option::Some(Self::FORTNIGHT),
-            "MONTH" => std::option::Option::Some(Self::MONTH),
-            "QUARTER" => std::option::Option::Some(Self::QUARTER),
-            "HALF" => std::option::Option::Some(Self::HALF),
-            "YEAR" => std::option::Option::Some(Self::YEAR),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for CalendarPeriod {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for CalendarPeriod {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for CalendarPeriod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for CalendarPeriod {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Day,
+            2 => Self::Week,
+            3 => Self::Fortnight,
+            4 => Self::Month,
+            5 => Self::Quarter,
+            6 => Self::Half,
+            7 => Self::Year,
+            _ => Self::UnknownValue(calendar_period::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for CalendarPeriod {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "CALENDAR_PERIOD_UNSPECIFIED" => Self::Unspecified,
+            "DAY" => Self::Day,
+            "WEEK" => Self::Week,
+            "FORTNIGHT" => Self::Fortnight,
+            "MONTH" => Self::Month,
+            "QUARTER" => Self::Quarter,
+            "HALF" => Self::Half,
+            "YEAR" => Self::Year,
+            _ => Self::UnknownValue(calendar_period::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for CalendarPeriod {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Day => serializer.serialize_i32(1),
+            Self::Week => serializer.serialize_i32(2),
+            Self::Fortnight => serializer.serialize_i32(3),
+            Self::Month => serializer.serialize_i32(4),
+            Self::Quarter => serializer.serialize_i32(5),
+            Self::Half => serializer.serialize_i32(6),
+            Self::Year => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for CalendarPeriod {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<CalendarPeriod>::new(
+            ".google.type.CalendarPeriod",
+        ))
     }
 }
 
 /// Represents a day of the week.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DayOfWeek(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DayOfWeek {
+    /// The day of the week is unspecified.
+    Unspecified,
+    /// Monday
+    Monday,
+    /// Tuesday
+    Tuesday,
+    /// Wednesday
+    Wednesday,
+    /// Thursday
+    Thursday,
+    /// Friday
+    Friday,
+    /// Saturday
+    Saturday,
+    /// Sunday
+    Sunday,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [DayOfWeek::value] or
+    /// [DayOfWeek::name].
+    UnknownValue(day_of_week::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod day_of_week {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl DayOfWeek {
-    /// The day of the week is unspecified.
-    pub const DAY_OF_WEEK_UNSPECIFIED: DayOfWeek = DayOfWeek::new(0);
-
-    /// Monday
-    pub const MONDAY: DayOfWeek = DayOfWeek::new(1);
-
-    /// Tuesday
-    pub const TUESDAY: DayOfWeek = DayOfWeek::new(2);
-
-    /// Wednesday
-    pub const WEDNESDAY: DayOfWeek = DayOfWeek::new(3);
-
-    /// Thursday
-    pub const THURSDAY: DayOfWeek = DayOfWeek::new(4);
-
-    /// Friday
-    pub const FRIDAY: DayOfWeek = DayOfWeek::new(5);
-
-    /// Saturday
-    pub const SATURDAY: DayOfWeek = DayOfWeek::new(6);
-
-    /// Sunday
-    pub const SUNDAY: DayOfWeek = DayOfWeek::new(7);
-
-    /// Creates a new DayOfWeek instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::Monday => std::option::Option::Some(1),
+            Self::Tuesday => std::option::Option::Some(2),
+            Self::Wednesday => std::option::Option::Some(3),
+            Self::Thursday => std::option::Option::Some(4),
+            Self::Friday => std::option::Option::Some(5),
+            Self::Saturday => std::option::Option::Some(6),
+            Self::Sunday => std::option::Option::Some(7),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("DAY_OF_WEEK_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("MONDAY"),
-            2 => std::borrow::Cow::Borrowed("TUESDAY"),
-            3 => std::borrow::Cow::Borrowed("WEDNESDAY"),
-            4 => std::borrow::Cow::Borrowed("THURSDAY"),
-            5 => std::borrow::Cow::Borrowed("FRIDAY"),
-            6 => std::borrow::Cow::Borrowed("SATURDAY"),
-            7 => std::borrow::Cow::Borrowed("SUNDAY"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("DAY_OF_WEEK_UNSPECIFIED"),
+            Self::Monday => std::option::Option::Some("MONDAY"),
+            Self::Tuesday => std::option::Option::Some("TUESDAY"),
+            Self::Wednesday => std::option::Option::Some("WEDNESDAY"),
+            Self::Thursday => std::option::Option::Some("THURSDAY"),
+            Self::Friday => std::option::Option::Some("FRIDAY"),
+            Self::Saturday => std::option::Option::Some("SATURDAY"),
+            Self::Sunday => std::option::Option::Some("SUNDAY"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "DAY_OF_WEEK_UNSPECIFIED" => std::option::Option::Some(Self::DAY_OF_WEEK_UNSPECIFIED),
-            "MONDAY" => std::option::Option::Some(Self::MONDAY),
-            "TUESDAY" => std::option::Option::Some(Self::TUESDAY),
-            "WEDNESDAY" => std::option::Option::Some(Self::WEDNESDAY),
-            "THURSDAY" => std::option::Option::Some(Self::THURSDAY),
-            "FRIDAY" => std::option::Option::Some(Self::FRIDAY),
-            "SATURDAY" => std::option::Option::Some(Self::SATURDAY),
-            "SUNDAY" => std::option::Option::Some(Self::SUNDAY),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for DayOfWeek {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for DayOfWeek {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for DayOfWeek {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for DayOfWeek {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::Monday,
+            2 => Self::Tuesday,
+            3 => Self::Wednesday,
+            4 => Self::Thursday,
+            5 => Self::Friday,
+            6 => Self::Saturday,
+            7 => Self::Sunday,
+            _ => Self::UnknownValue(day_of_week::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for DayOfWeek {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "DAY_OF_WEEK_UNSPECIFIED" => Self::Unspecified,
+            "MONDAY" => Self::Monday,
+            "TUESDAY" => Self::Tuesday,
+            "WEDNESDAY" => Self::Wednesday,
+            "THURSDAY" => Self::Thursday,
+            "FRIDAY" => Self::Friday,
+            "SATURDAY" => Self::Saturday,
+            "SUNDAY" => Self::Sunday,
+            _ => Self::UnknownValue(day_of_week::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for DayOfWeek {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::Monday => serializer.serialize_i32(1),
+            Self::Tuesday => serializer.serialize_i32(2),
+            Self::Wednesday => serializer.serialize_i32(3),
+            Self::Thursday => serializer.serialize_i32(4),
+            Self::Friday => serializer.serialize_i32(5),
+            Self::Saturday => serializer.serialize_i32(6),
+            Self::Sunday => serializer.serialize_i32(7),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DayOfWeek {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<DayOfWeek>::new(
+            ".google.type.DayOfWeek",
+        ))
     }
 }
 
 /// Represents a month in the Gregorian calendar.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Month(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Month {
+    /// The unspecified month.
+    Unspecified,
+    /// The month of January.
+    January,
+    /// The month of February.
+    February,
+    /// The month of March.
+    March,
+    /// The month of April.
+    April,
+    /// The month of May.
+    May,
+    /// The month of June.
+    June,
+    /// The month of July.
+    July,
+    /// The month of August.
+    August,
+    /// The month of September.
+    September,
+    /// The month of October.
+    October,
+    /// The month of November.
+    November,
+    /// The month of December.
+    December,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Month::value] or
+    /// [Month::name].
+    UnknownValue(month::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod month {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Month {
-    /// The unspecified month.
-    pub const MONTH_UNSPECIFIED: Month = Month::new(0);
-
-    /// The month of January.
-    pub const JANUARY: Month = Month::new(1);
-
-    /// The month of February.
-    pub const FEBRUARY: Month = Month::new(2);
-
-    /// The month of March.
-    pub const MARCH: Month = Month::new(3);
-
-    /// The month of April.
-    pub const APRIL: Month = Month::new(4);
-
-    /// The month of May.
-    pub const MAY: Month = Month::new(5);
-
-    /// The month of June.
-    pub const JUNE: Month = Month::new(6);
-
-    /// The month of July.
-    pub const JULY: Month = Month::new(7);
-
-    /// The month of August.
-    pub const AUGUST: Month = Month::new(8);
-
-    /// The month of September.
-    pub const SEPTEMBER: Month = Month::new(9);
-
-    /// The month of October.
-    pub const OCTOBER: Month = Month::new(10);
-
-    /// The month of November.
-    pub const NOVEMBER: Month = Month::new(11);
-
-    /// The month of December.
-    pub const DECEMBER: Month = Month::new(12);
-
-    /// Creates a new Month instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unspecified => std::option::Option::Some(0),
+            Self::January => std::option::Option::Some(1),
+            Self::February => std::option::Option::Some(2),
+            Self::March => std::option::Option::Some(3),
+            Self::April => std::option::Option::Some(4),
+            Self::May => std::option::Option::Some(5),
+            Self::June => std::option::Option::Some(6),
+            Self::July => std::option::Option::Some(7),
+            Self::August => std::option::Option::Some(8),
+            Self::September => std::option::Option::Some(9),
+            Self::October => std::option::Option::Some(10),
+            Self::November => std::option::Option::Some(11),
+            Self::December => std::option::Option::Some(12),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("MONTH_UNSPECIFIED"),
-            1 => std::borrow::Cow::Borrowed("JANUARY"),
-            2 => std::borrow::Cow::Borrowed("FEBRUARY"),
-            3 => std::borrow::Cow::Borrowed("MARCH"),
-            4 => std::borrow::Cow::Borrowed("APRIL"),
-            5 => std::borrow::Cow::Borrowed("MAY"),
-            6 => std::borrow::Cow::Borrowed("JUNE"),
-            7 => std::borrow::Cow::Borrowed("JULY"),
-            8 => std::borrow::Cow::Borrowed("AUGUST"),
-            9 => std::borrow::Cow::Borrowed("SEPTEMBER"),
-            10 => std::borrow::Cow::Borrowed("OCTOBER"),
-            11 => std::borrow::Cow::Borrowed("NOVEMBER"),
-            12 => std::borrow::Cow::Borrowed("DECEMBER"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unspecified => std::option::Option::Some("MONTH_UNSPECIFIED"),
+            Self::January => std::option::Option::Some("JANUARY"),
+            Self::February => std::option::Option::Some("FEBRUARY"),
+            Self::March => std::option::Option::Some("MARCH"),
+            Self::April => std::option::Option::Some("APRIL"),
+            Self::May => std::option::Option::Some("MAY"),
+            Self::June => std::option::Option::Some("JUNE"),
+            Self::July => std::option::Option::Some("JULY"),
+            Self::August => std::option::Option::Some("AUGUST"),
+            Self::September => std::option::Option::Some("SEPTEMBER"),
+            Self::October => std::option::Option::Some("OCTOBER"),
+            Self::November => std::option::Option::Some("NOVEMBER"),
+            Self::December => std::option::Option::Some("DECEMBER"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "MONTH_UNSPECIFIED" => std::option::Option::Some(Self::MONTH_UNSPECIFIED),
-            "JANUARY" => std::option::Option::Some(Self::JANUARY),
-            "FEBRUARY" => std::option::Option::Some(Self::FEBRUARY),
-            "MARCH" => std::option::Option::Some(Self::MARCH),
-            "APRIL" => std::option::Option::Some(Self::APRIL),
-            "MAY" => std::option::Option::Some(Self::MAY),
-            "JUNE" => std::option::Option::Some(Self::JUNE),
-            "JULY" => std::option::Option::Some(Self::JULY),
-            "AUGUST" => std::option::Option::Some(Self::AUGUST),
-            "SEPTEMBER" => std::option::Option::Some(Self::SEPTEMBER),
-            "OCTOBER" => std::option::Option::Some(Self::OCTOBER),
-            "NOVEMBER" => std::option::Option::Some(Self::NOVEMBER),
-            "DECEMBER" => std::option::Option::Some(Self::DECEMBER),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Month {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Month {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Month {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Month {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unspecified,
+            1 => Self::January,
+            2 => Self::February,
+            3 => Self::March,
+            4 => Self::April,
+            5 => Self::May,
+            6 => Self::June,
+            7 => Self::July,
+            8 => Self::August,
+            9 => Self::September,
+            10 => Self::October,
+            11 => Self::November,
+            12 => Self::December,
+            _ => Self::UnknownValue(month::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Month {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "MONTH_UNSPECIFIED" => Self::Unspecified,
+            "JANUARY" => Self::January,
+            "FEBRUARY" => Self::February,
+            "MARCH" => Self::March,
+            "APRIL" => Self::April,
+            "MAY" => Self::May,
+            "JUNE" => Self::June,
+            "JULY" => Self::July,
+            "AUGUST" => Self::August,
+            "SEPTEMBER" => Self::September,
+            "OCTOBER" => Self::October,
+            "NOVEMBER" => Self::November,
+            "DECEMBER" => Self::December,
+            _ => Self::UnknownValue(month::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Month {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unspecified => serializer.serialize_i32(0),
+            Self::January => serializer.serialize_i32(1),
+            Self::February => serializer.serialize_i32(2),
+            Self::March => serializer.serialize_i32(3),
+            Self::April => serializer.serialize_i32(4),
+            Self::May => serializer.serialize_i32(5),
+            Self::June => serializer.serialize_i32(6),
+            Self::July => serializer.serialize_i32(7),
+            Self::August => serializer.serialize_i32(8),
+            Self::September => serializer.serialize_i32(9),
+            Self::October => serializer.serialize_i32(10),
+            Self::November => serializer.serialize_i32(11),
+            Self::December => serializer.serialize_i32(12),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Month {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Month>::new(
+            ".google.type.Month",
+        ))
     }
 }

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -66,9 +66,9 @@ package = "google-cloud-workflows-executions-v1"
 path    = "../../src/generated/cloud/workflows/executions/v1"
 
 [dev-dependencies]
-anyhow.workspace = true
-mockall          = "0.13"
-serde            = { version = "1", features = ["serde_derive"] }
-serde_with       = { version = "3", features = ["base64"] }
-test-case        = "3"
-tokio            = { version = "1", features = ["full", "macros"] }
+anyhow.workspace    = true
+mockall             = "0.13"
+serde               = { version = "1", features = ["serde_derive"] }
+serde_with          = { version = "3", features = ["base64"] }
+test-case.workspace = true
+tokio               = { version = "1", features = ["full", "macros"] }

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -53,7 +53,7 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
     // The execution list using the `BASIC` view.
     let mut executions = client
         .list_executions(&parent)
-        .set_view(wfe::model::ExecutionView::BASIC)
+        .set_view(wfe::model::ExecutionView::Basic)
         .paginator()
         .await
         .items();
@@ -67,7 +67,7 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
     // The execution list using the `FULL` view.
     let mut executions = client
         .list_executions(&parent)
-        .set_view(wfe::model::ExecutionView::FULL)
+        .set_view(wfe::model::ExecutionView::Full)
         .paginator()
         .await
         .items();

--- a/src/integration-tests/tests/enums.rs
+++ b/src/integration-tests/tests/enums.rs
@@ -19,7 +19,7 @@ mod enums {
     #[test]
     fn test_default_value() {
         let default = secret_version::State::default();
-        assert_eq!(default, secret_version::State::STATE_UNSPECIFIED);
+        assert_eq!(default, secret_version::State::Unspecified);
     }
 
     #[test]
@@ -28,9 +28,24 @@ mod enums {
             "name": "projects/test-only/secrets/my-secret/versions/my-version",
         });
         let secret_version = serde_json::from_value::<SecretVersion>(input).unwrap();
-        assert_eq!(
-            secret_version.state,
-            secret_version::State::STATE_UNSPECIFIED
-        );
+        assert_eq!(secret_version.state, secret_version::State::Unspecified);
+    }
+
+    #[test]
+    fn branch() -> anyhow::Result<()> {
+        use secret_version::State;
+        use serde_json::json;
+        let state = serde_json::from_value::<State>(json!("DISABLED"))?;
+        #[warn(clippy::wildcard_enum_match_arm)]
+        let initial = match state {
+            State::Unspecified => "u",
+            State::Enabled => "e",
+            State::Disabled => "i",
+            State::Destroyed => "d",
+            State::UnknownValue(_) => "unknown value",
+            _ => "",
+        };
+        assert_eq!(initial, "i");
+        Ok(())
     }
 }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -47,9 +47,9 @@ pub enum PollingResult<R, M> {
     /// recover.
     ///
     /// [ServiceError]: gax::error::ServiceError
-    /// [NOT_FOUND]: rpc::model::Code::NOT_FOUND
-    /// [ABORTED]: rpc::model::Code::ABORTED
-    /// [PERMISSION_DENIED]: rpc::model::Code::PERMISSION_DENIED
+    /// [NOT_FOUND]: rpc::model::Code::NotFound
+    /// [ABORTED]: rpc::model::Code::Aborted
+    /// [PERMISSION_DENIED]: rpc::model::Code::PermissionDenied
     PollingError(Error),
 }
 

--- a/src/storage-control/src/generated/convert/iam/convert.rs
+++ b/src/storage-control/src/generated/convert/iam/convert.rs
@@ -183,7 +183,7 @@ impl gaxi::prost::FromProto<iam_v1::model::AuditConfig> for AuditConfig {
 impl gaxi::prost::ToProto<audit_log_config::LogType> for iam_v1::model::audit_log_config::LogType {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("iam_v1::model::audit_log_config::LogType"))
     }
 }
 
@@ -235,7 +235,7 @@ impl gaxi::prost::FromProto<iam_v1::model::PolicyDelta> for PolicyDelta {
 impl gaxi::prost::ToProto<binding_delta::Action> for iam_v1::model::binding_delta::Action {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("iam_v1::model::binding_delta::Action"))
     }
 }
 
@@ -264,7 +264,7 @@ impl gaxi::prost::FromProto<iam_v1::model::BindingDelta> for BindingDelta {
 impl gaxi::prost::ToProto<audit_config_delta::Action> for iam_v1::model::audit_config_delta::Action {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("iam_v1::model::audit_config_delta::Action"))
     }
 }
 

--- a/src/storage-control/src/generated/convert/storage/convert.rs
+++ b/src/storage-control/src/generated/convert/storage/convert.rs
@@ -551,7 +551,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::CommonObjectRequestP
 impl gaxi::prost::ToProto<service_constants::Values> for crate::generated::gapic::model::service_constants::Values {
     type Output = i32;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
-        Ok(self.value())
+        self.value().ok_or(gaxi::prost::ConvertError::EnumNoIntegerValue("crate::generated::gapic::model::service_constants::Values"))
     }
 }
 

--- a/src/storage-control/src/generated/gapic/model.rs
+++ b/src/storage-control/src/generated/gapic/model.rs
@@ -2366,180 +2366,277 @@ pub mod service_constants {
     use super::*;
 
     /// A collection of constant values meaningful to the Storage API.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Values(i32);
-
-    impl Values {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Values {
         /// Unused. Proto3 requires first enum to be 0.
-        pub const VALUES_UNSPECIFIED: Values = Values::new(0);
-
+        Unspecified,
         /// The maximum size chunk that can will be returned in a single
         /// ReadRequest.
         /// 2 MiB.
-        pub const MAX_READ_CHUNK_BYTES: Values = Values::new(2097152);
-
+        MaxReadChunkBytes,
         /// The maximum size chunk that can be sent in a single WriteObjectRequest.
         /// 2 MiB.
-        pub const MAX_WRITE_CHUNK_BYTES: Values = Values::new(2097152);
-
+        MaxWriteChunkBytes,
         /// The maximum size of an object in MB - whether written in a single stream
         /// or composed from multiple other objects.
         /// 5 TiB.
-        pub const MAX_OBJECT_SIZE_MB: Values = Values::new(5242880);
-
+        MaxObjectSizeMb,
         /// The maximum length field name that can be sent in a single
         /// custom metadata field.
         /// 1 KiB.
-        pub const MAX_CUSTOM_METADATA_FIELD_NAME_BYTES: Values = Values::new(1024);
-
+        MaxCustomMetadataFieldNameBytes,
         /// The maximum length field value that can be sent in a single
         /// custom_metadata field.
         /// 4 KiB.
-        pub const MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES: Values = Values::new(4096);
-
+        MaxCustomMetadataFieldValueBytes,
         /// The maximum total bytes that can be populated into all field names and
         /// values of the custom_metadata for one object.
         /// 8 KiB.
-        pub const MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES: Values = Values::new(8192);
-
+        MaxCustomMetadataTotalSizeBytes,
         /// The maximum total bytes that can be populated into all bucket metadata
         /// fields.
         /// 20 KiB.
-        pub const MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES: Values = Values::new(20480);
-
+        MaxBucketMetadataTotalSizeBytes,
         /// The maximum number of NotificationConfigs that can be registered
         /// for a given bucket.
-        pub const MAX_NOTIFICATION_CONFIGS_PER_BUCKET: Values = Values::new(100);
-
+        MaxNotificationConfigsPerBucket,
         /// The maximum number of LifecycleRules that can be registered for a given
         /// bucket.
-        pub const MAX_LIFECYCLE_RULES_PER_BUCKET: Values = Values::new(100);
-
+        MaxLifecycleRulesPerBucket,
         /// The maximum number of custom attributes per NotificationConfigs.
-        pub const MAX_NOTIFICATION_CUSTOM_ATTRIBUTES: Values = Values::new(5);
-
+        MaxNotificationCustomAttributes,
         /// The maximum length of a custom attribute key included in
         /// NotificationConfig.
-        pub const MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH: Values = Values::new(256);
-
+        MaxNotificationCustomAttributeKeyLength,
         /// The maximum length of a custom attribute value included in a
         /// NotificationConfig.
-        pub const MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_VALUE_LENGTH: Values = Values::new(1024);
-
+        MaxNotificationCustomAttributeValueLength,
         /// The maximum number of key/value entries per bucket label.
-        pub const MAX_LABELS_ENTRIES_COUNT: Values = Values::new(64);
-
+        MaxLabelsEntriesCount,
         /// The maximum character length of the key or value in a bucket
         /// label map.
-        pub const MAX_LABELS_KEY_VALUE_LENGTH: Values = Values::new(63);
-
+        MaxLabelsKeyValueLength,
         /// The maximum byte size of the key or value in a bucket label
         /// map.
-        pub const MAX_LABELS_KEY_VALUE_BYTES: Values = Values::new(128);
-
+        MaxLabelsKeyValueBytes,
         /// The maximum number of object IDs that can be included in a
         /// DeleteObjectsRequest.
-        pub const MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST: Values = Values::new(1000);
-
+        MaxObjectIdsPerDeleteObjectsRequest,
         /// The maximum number of days for which a token returned by the
         /// GetListObjectsSplitPoints RPC is valid.
-        pub const SPLIT_TOKEN_MAX_VALID_DAYS: Values = Values::new(14);
+        SplitTokenMaxValidDays,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Values::value] or
+        /// [Values::name].
+        UnknownValue(values::UnknownValue),
+    }
 
-        /// Creates a new Values instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod values {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Values {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unspecified => std::option::Option::Some(0),
+                Self::MaxReadChunkBytes => std::option::Option::Some(2097152),
+                Self::MaxWriteChunkBytes => std::option::Option::Some(2097152),
+                Self::MaxObjectSizeMb => std::option::Option::Some(5242880),
+                Self::MaxCustomMetadataFieldNameBytes => std::option::Option::Some(1024),
+                Self::MaxCustomMetadataFieldValueBytes => std::option::Option::Some(4096),
+                Self::MaxCustomMetadataTotalSizeBytes => std::option::Option::Some(8192),
+                Self::MaxBucketMetadataTotalSizeBytes => std::option::Option::Some(20480),
+                Self::MaxNotificationConfigsPerBucket => std::option::Option::Some(100),
+                Self::MaxLifecycleRulesPerBucket => std::option::Option::Some(100),
+                Self::MaxNotificationCustomAttributes => std::option::Option::Some(5),
+                Self::MaxNotificationCustomAttributeKeyLength => std::option::Option::Some(256),
+                Self::MaxNotificationCustomAttributeValueLength => std::option::Option::Some(1024),
+                Self::MaxLabelsEntriesCount => std::option::Option::Some(64),
+                Self::MaxLabelsKeyValueLength => std::option::Option::Some(63),
+                Self::MaxLabelsKeyValueBytes => std::option::Option::Some(128),
+                Self::MaxObjectIdsPerDeleteObjectsRequest => std::option::Option::Some(1000),
+                Self::SplitTokenMaxValidDays => std::option::Option::Some(14),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("VALUES_UNSPECIFIED"),
-                5 => std::borrow::Cow::Borrowed("MAX_NOTIFICATION_CUSTOM_ATTRIBUTES"),
-                14 => std::borrow::Cow::Borrowed("SPLIT_TOKEN_MAX_VALID_DAYS"),
-                63 => std::borrow::Cow::Borrowed("MAX_LABELS_KEY_VALUE_LENGTH"),
-                64 => std::borrow::Cow::Borrowed("MAX_LABELS_ENTRIES_COUNT"),
-                100 => std::borrow::Cow::Borrowed("MAX_LIFECYCLE_RULES_PER_BUCKET"),
-                128 => std::borrow::Cow::Borrowed("MAX_LABELS_KEY_VALUE_BYTES"),
-                256 => std::borrow::Cow::Borrowed("MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH"),
-                1000 => std::borrow::Cow::Borrowed("MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST"),
-                1024 => std::borrow::Cow::Borrowed("MAX_CUSTOM_METADATA_FIELD_NAME_BYTES"),
-                4096 => std::borrow::Cow::Borrowed("MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES"),
-                8192 => std::borrow::Cow::Borrowed("MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES"),
-                20480 => std::borrow::Cow::Borrowed("MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES"),
-                2097152 => std::borrow::Cow::Borrowed("MAX_READ_CHUNK_BYTES"),
-                5242880 => std::borrow::Cow::Borrowed("MAX_OBJECT_SIZE_MB"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unspecified => std::option::Option::Some("VALUES_UNSPECIFIED"),
+                Self::MaxReadChunkBytes => std::option::Option::Some("MAX_READ_CHUNK_BYTES"),
+                Self::MaxWriteChunkBytes => std::option::Option::Some("MAX_WRITE_CHUNK_BYTES"),
+                Self::MaxObjectSizeMb => std::option::Option::Some("MAX_OBJECT_SIZE_MB"),
+                Self::MaxCustomMetadataFieldNameBytes => {
+                    std::option::Option::Some("MAX_CUSTOM_METADATA_FIELD_NAME_BYTES")
+                }
+                Self::MaxCustomMetadataFieldValueBytes => {
+                    std::option::Option::Some("MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES")
+                }
+                Self::MaxCustomMetadataTotalSizeBytes => {
+                    std::option::Option::Some("MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES")
+                }
+                Self::MaxBucketMetadataTotalSizeBytes => {
+                    std::option::Option::Some("MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES")
+                }
+                Self::MaxNotificationConfigsPerBucket => {
+                    std::option::Option::Some("MAX_NOTIFICATION_CONFIGS_PER_BUCKET")
+                }
+                Self::MaxLifecycleRulesPerBucket => {
+                    std::option::Option::Some("MAX_LIFECYCLE_RULES_PER_BUCKET")
+                }
+                Self::MaxNotificationCustomAttributes => {
+                    std::option::Option::Some("MAX_NOTIFICATION_CUSTOM_ATTRIBUTES")
+                }
+                Self::MaxNotificationCustomAttributeKeyLength => {
+                    std::option::Option::Some("MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH")
+                }
+                Self::MaxNotificationCustomAttributeValueLength => {
+                    std::option::Option::Some("MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_VALUE_LENGTH")
+                }
+                Self::MaxLabelsEntriesCount => {
+                    std::option::Option::Some("MAX_LABELS_ENTRIES_COUNT")
+                }
+                Self::MaxLabelsKeyValueLength => {
+                    std::option::Option::Some("MAX_LABELS_KEY_VALUE_LENGTH")
+                }
+                Self::MaxLabelsKeyValueBytes => {
+                    std::option::Option::Some("MAX_LABELS_KEY_VALUE_BYTES")
+                }
+                Self::MaxObjectIdsPerDeleteObjectsRequest => {
+                    std::option::Option::Some("MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST")
+                }
+                Self::SplitTokenMaxValidDays => {
+                    std::option::Option::Some("SPLIT_TOKEN_MAX_VALID_DAYS")
+                }
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "VALUES_UNSPECIFIED" => std::option::Option::Some(Self::VALUES_UNSPECIFIED),
-                "MAX_READ_CHUNK_BYTES" => std::option::Option::Some(Self::MAX_READ_CHUNK_BYTES),
-                "MAX_WRITE_CHUNK_BYTES" => std::option::Option::Some(Self::MAX_WRITE_CHUNK_BYTES),
-                "MAX_OBJECT_SIZE_MB" => std::option::Option::Some(Self::MAX_OBJECT_SIZE_MB),
-                "MAX_CUSTOM_METADATA_FIELD_NAME_BYTES" => {
-                    std::option::Option::Some(Self::MAX_CUSTOM_METADATA_FIELD_NAME_BYTES)
-                }
-                "MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES" => {
-                    std::option::Option::Some(Self::MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES)
-                }
-                "MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES" => {
-                    std::option::Option::Some(Self::MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES)
-                }
-                "MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES" => {
-                    std::option::Option::Some(Self::MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES)
-                }
-                "MAX_NOTIFICATION_CONFIGS_PER_BUCKET" => {
-                    std::option::Option::Some(Self::MAX_NOTIFICATION_CONFIGS_PER_BUCKET)
-                }
-                "MAX_LIFECYCLE_RULES_PER_BUCKET" => {
-                    std::option::Option::Some(Self::MAX_LIFECYCLE_RULES_PER_BUCKET)
-                }
-                "MAX_NOTIFICATION_CUSTOM_ATTRIBUTES" => {
-                    std::option::Option::Some(Self::MAX_NOTIFICATION_CUSTOM_ATTRIBUTES)
-                }
-                "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH" => {
-                    std::option::Option::Some(Self::MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH)
-                }
-                "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_VALUE_LENGTH" => {
-                    std::option::Option::Some(Self::MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_VALUE_LENGTH)
-                }
-                "MAX_LABELS_ENTRIES_COUNT" => {
-                    std::option::Option::Some(Self::MAX_LABELS_ENTRIES_COUNT)
-                }
-                "MAX_LABELS_KEY_VALUE_LENGTH" => {
-                    std::option::Option::Some(Self::MAX_LABELS_KEY_VALUE_LENGTH)
-                }
-                "MAX_LABELS_KEY_VALUE_BYTES" => {
-                    std::option::Option::Some(Self::MAX_LABELS_KEY_VALUE_BYTES)
-                }
-                "MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST" => {
-                    std::option::Option::Some(Self::MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST)
-                }
-                "SPLIT_TOKEN_MAX_VALID_DAYS" => {
-                    std::option::Option::Some(Self::SPLIT_TOKEN_MAX_VALID_DAYS)
-                }
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Values {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Values {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Values {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Values {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unspecified,
+                5 => Self::MaxNotificationCustomAttributes,
+                14 => Self::SplitTokenMaxValidDays,
+                63 => Self::MaxLabelsKeyValueLength,
+                64 => Self::MaxLabelsEntriesCount,
+                100 => Self::MaxLifecycleRulesPerBucket,
+                128 => Self::MaxLabelsKeyValueBytes,
+                256 => Self::MaxNotificationCustomAttributeKeyLength,
+                1000 => Self::MaxObjectIdsPerDeleteObjectsRequest,
+                1024 => Self::MaxCustomMetadataFieldNameBytes,
+                4096 => Self::MaxCustomMetadataFieldValueBytes,
+                8192 => Self::MaxCustomMetadataTotalSizeBytes,
+                20480 => Self::MaxBucketMetadataTotalSizeBytes,
+                2097152 => Self::MaxReadChunkBytes,
+                5242880 => Self::MaxObjectSizeMb,
+                _ => Self::UnknownValue(values::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Values {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "VALUES_UNSPECIFIED" => Self::Unspecified,
+                "MAX_READ_CHUNK_BYTES" => Self::MaxReadChunkBytes,
+                "MAX_WRITE_CHUNK_BYTES" => Self::MaxWriteChunkBytes,
+                "MAX_OBJECT_SIZE_MB" => Self::MaxObjectSizeMb,
+                "MAX_CUSTOM_METADATA_FIELD_NAME_BYTES" => Self::MaxCustomMetadataFieldNameBytes,
+                "MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES" => Self::MaxCustomMetadataFieldValueBytes,
+                "MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES" => Self::MaxCustomMetadataTotalSizeBytes,
+                "MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES" => Self::MaxBucketMetadataTotalSizeBytes,
+                "MAX_NOTIFICATION_CONFIGS_PER_BUCKET" => Self::MaxNotificationConfigsPerBucket,
+                "MAX_LIFECYCLE_RULES_PER_BUCKET" => Self::MaxLifecycleRulesPerBucket,
+                "MAX_NOTIFICATION_CUSTOM_ATTRIBUTES" => Self::MaxNotificationCustomAttributes,
+                "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH" => {
+                    Self::MaxNotificationCustomAttributeKeyLength
+                }
+                "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_VALUE_LENGTH" => {
+                    Self::MaxNotificationCustomAttributeValueLength
+                }
+                "MAX_LABELS_ENTRIES_COUNT" => Self::MaxLabelsEntriesCount,
+                "MAX_LABELS_KEY_VALUE_LENGTH" => Self::MaxLabelsKeyValueLength,
+                "MAX_LABELS_KEY_VALUE_BYTES" => Self::MaxLabelsKeyValueBytes,
+                "MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST" => {
+                    Self::MaxObjectIdsPerDeleteObjectsRequest
+                }
+                "SPLIT_TOKEN_MAX_VALID_DAYS" => Self::SplitTokenMaxValidDays,
+                _ => Self::UnknownValue(values::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Values {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unspecified => serializer.serialize_i32(0),
+                Self::MaxReadChunkBytes => serializer.serialize_i32(2097152),
+                Self::MaxWriteChunkBytes => serializer.serialize_i32(2097152),
+                Self::MaxObjectSizeMb => serializer.serialize_i32(5242880),
+                Self::MaxCustomMetadataFieldNameBytes => serializer.serialize_i32(1024),
+                Self::MaxCustomMetadataFieldValueBytes => serializer.serialize_i32(4096),
+                Self::MaxCustomMetadataTotalSizeBytes => serializer.serialize_i32(8192),
+                Self::MaxBucketMetadataTotalSizeBytes => serializer.serialize_i32(20480),
+                Self::MaxNotificationConfigsPerBucket => serializer.serialize_i32(100),
+                Self::MaxLifecycleRulesPerBucket => serializer.serialize_i32(100),
+                Self::MaxNotificationCustomAttributes => serializer.serialize_i32(5),
+                Self::MaxNotificationCustomAttributeKeyLength => serializer.serialize_i32(256),
+                Self::MaxNotificationCustomAttributeValueLength => serializer.serialize_i32(1024),
+                Self::MaxLabelsEntriesCount => serializer.serialize_i32(64),
+                Self::MaxLabelsKeyValueLength => serializer.serialize_i32(63),
+                Self::MaxLabelsKeyValueBytes => serializer.serialize_i32(128),
+                Self::MaxObjectIdsPerDeleteObjectsRequest => serializer.serialize_i32(1000),
+                Self::SplitTokenMaxValidDays => serializer.serialize_i32(14),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Values {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Values>::new(
+                ".google.storage.v2.ServiceConstants.Values",
+            ))
         }
     }
 }

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -1048,53 +1048,112 @@ pub mod extension_range_options {
     }
 
     /// The verification state of the extension range.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct VerificationState(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum VerificationState {
+        /// All the extensions of the range must be declared.
+        Declaration,
+        Unverified,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [VerificationState::value] or
+        /// [VerificationState::name].
+        UnknownValue(verification_state::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod verification_state {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl VerificationState {
-        /// All the extensions of the range must be declared.
-        pub const DECLARATION: VerificationState = VerificationState::new(0);
-
-        pub const UNVERIFIED: VerificationState = VerificationState::new(1);
-
-        /// Creates a new VerificationState instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Declaration => std::option::Option::Some(0),
+                Self::Unverified => std::option::Option::Some(1),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("DECLARATION"),
-                1 => std::borrow::Cow::Borrowed("UNVERIFIED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Declaration => std::option::Option::Some("DECLARATION"),
+                Self::Unverified => std::option::Option::Some("UNVERIFIED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "DECLARATION" => std::option::Option::Some(Self::DECLARATION),
-                "UNVERIFIED" => std::option::Option::Some(Self::UNVERIFIED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for VerificationState {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for VerificationState {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for VerificationState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for VerificationState {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Declaration,
+                1 => Self::Unverified,
+                _ => Self::UnknownValue(verification_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for VerificationState {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "DECLARATION" => Self::Declaration,
+                "UNVERIFIED" => Self::Unverified,
+                _ => Self::UnknownValue(verification_state::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for VerificationState {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Declaration => serializer.serialize_i32(0),
+                Self::Unverified => serializer.serialize_i32(1),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for VerificationState {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<VerificationState>::new(
+                ".google.protobuf.ExtensionRangeOptions.VerificationState",
+            ))
         }
     }
 }
@@ -1273,185 +1332,337 @@ pub mod field_descriptor_proto {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Type(i32);
-
-    impl Type {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Type {
         /// 0 is reserved for errors.
         /// Order is weird for historical reasons.
-        pub const TYPE_DOUBLE: Type = Type::new(1);
-
-        pub const TYPE_FLOAT: Type = Type::new(2);
-
+        Double,
+        Float,
         /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
         /// negative values are likely.
-        pub const TYPE_INT64: Type = Type::new(3);
-
-        pub const TYPE_UINT64: Type = Type::new(4);
-
+        Int64,
+        Uint64,
         /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
         /// negative values are likely.
-        pub const TYPE_INT32: Type = Type::new(5);
-
-        pub const TYPE_FIXED64: Type = Type::new(6);
-
-        pub const TYPE_FIXED32: Type = Type::new(7);
-
-        pub const TYPE_BOOL: Type = Type::new(8);
-
-        pub const TYPE_STRING: Type = Type::new(9);
-
+        Int32,
+        Fixed64,
+        Fixed32,
+        Bool,
+        String,
         /// Tag-delimited aggregate.
         /// Group type is deprecated and not supported after google.protobuf. However, Proto3
         /// implementations should still be able to parse the group wire format and
         /// treat group fields as unknown fields.  In Editions, the group wire format
         /// can be enabled via the `message_encoding` feature.
-        pub const TYPE_GROUP: Type = Type::new(10);
-
-        pub const TYPE_MESSAGE: Type = Type::new(11);
-
+        Group,
+        Message,
         /// New in version 2.
-        pub const TYPE_BYTES: Type = Type::new(12);
+        Bytes,
+        Uint32,
+        Enum,
+        Sfixed32,
+        Sfixed64,
+        Sint32,
+        Sint64,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Type::value] or
+        /// [Type::name].
+        UnknownValue(r#type::UnknownValue),
+    }
 
-        pub const TYPE_UINT32: Type = Type::new(13);
+    #[doc(hidden)]
+    pub mod r#type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
-        pub const TYPE_ENUM: Type = Type::new(14);
-
-        pub const TYPE_SFIXED32: Type = Type::new(15);
-
-        pub const TYPE_SFIXED64: Type = Type::new(16);
-
-        pub const TYPE_SINT32: Type = Type::new(17);
-
-        pub const TYPE_SINT64: Type = Type::new(18);
-
-        /// Creates a new Type instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
+    impl Type {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Double => std::option::Option::Some(1),
+                Self::Float => std::option::Option::Some(2),
+                Self::Int64 => std::option::Option::Some(3),
+                Self::Uint64 => std::option::Option::Some(4),
+                Self::Int32 => std::option::Option::Some(5),
+                Self::Fixed64 => std::option::Option::Some(6),
+                Self::Fixed32 => std::option::Option::Some(7),
+                Self::Bool => std::option::Option::Some(8),
+                Self::String => std::option::Option::Some(9),
+                Self::Group => std::option::Option::Some(10),
+                Self::Message => std::option::Option::Some(11),
+                Self::Bytes => std::option::Option::Some(12),
+                Self::Uint32 => std::option::Option::Some(13),
+                Self::Enum => std::option::Option::Some(14),
+                Self::Sfixed32 => std::option::Option::Some(15),
+                Self::Sfixed64 => std::option::Option::Some(16),
+                Self::Sint32 => std::option::Option::Some(17),
+                Self::Sint64 => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                1 => std::borrow::Cow::Borrowed("TYPE_DOUBLE"),
-                2 => std::borrow::Cow::Borrowed("TYPE_FLOAT"),
-                3 => std::borrow::Cow::Borrowed("TYPE_INT64"),
-                4 => std::borrow::Cow::Borrowed("TYPE_UINT64"),
-                5 => std::borrow::Cow::Borrowed("TYPE_INT32"),
-                6 => std::borrow::Cow::Borrowed("TYPE_FIXED64"),
-                7 => std::borrow::Cow::Borrowed("TYPE_FIXED32"),
-                8 => std::borrow::Cow::Borrowed("TYPE_BOOL"),
-                9 => std::borrow::Cow::Borrowed("TYPE_STRING"),
-                10 => std::borrow::Cow::Borrowed("TYPE_GROUP"),
-                11 => std::borrow::Cow::Borrowed("TYPE_MESSAGE"),
-                12 => std::borrow::Cow::Borrowed("TYPE_BYTES"),
-                13 => std::borrow::Cow::Borrowed("TYPE_UINT32"),
-                14 => std::borrow::Cow::Borrowed("TYPE_ENUM"),
-                15 => std::borrow::Cow::Borrowed("TYPE_SFIXED32"),
-                16 => std::borrow::Cow::Borrowed("TYPE_SFIXED64"),
-                17 => std::borrow::Cow::Borrowed("TYPE_SINT32"),
-                18 => std::borrow::Cow::Borrowed("TYPE_SINT64"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Double => std::option::Option::Some("TYPE_DOUBLE"),
+                Self::Float => std::option::Option::Some("TYPE_FLOAT"),
+                Self::Int64 => std::option::Option::Some("TYPE_INT64"),
+                Self::Uint64 => std::option::Option::Some("TYPE_UINT64"),
+                Self::Int32 => std::option::Option::Some("TYPE_INT32"),
+                Self::Fixed64 => std::option::Option::Some("TYPE_FIXED64"),
+                Self::Fixed32 => std::option::Option::Some("TYPE_FIXED32"),
+                Self::Bool => std::option::Option::Some("TYPE_BOOL"),
+                Self::String => std::option::Option::Some("TYPE_STRING"),
+                Self::Group => std::option::Option::Some("TYPE_GROUP"),
+                Self::Message => std::option::Option::Some("TYPE_MESSAGE"),
+                Self::Bytes => std::option::Option::Some("TYPE_BYTES"),
+                Self::Uint32 => std::option::Option::Some("TYPE_UINT32"),
+                Self::Enum => std::option::Option::Some("TYPE_ENUM"),
+                Self::Sfixed32 => std::option::Option::Some("TYPE_SFIXED32"),
+                Self::Sfixed64 => std::option::Option::Some("TYPE_SFIXED64"),
+                Self::Sint32 => std::option::Option::Some("TYPE_SINT32"),
+                Self::Sint64 => std::option::Option::Some("TYPE_SINT64"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_DOUBLE" => std::option::Option::Some(Self::TYPE_DOUBLE),
-                "TYPE_FLOAT" => std::option::Option::Some(Self::TYPE_FLOAT),
-                "TYPE_INT64" => std::option::Option::Some(Self::TYPE_INT64),
-                "TYPE_UINT64" => std::option::Option::Some(Self::TYPE_UINT64),
-                "TYPE_INT32" => std::option::Option::Some(Self::TYPE_INT32),
-                "TYPE_FIXED64" => std::option::Option::Some(Self::TYPE_FIXED64),
-                "TYPE_FIXED32" => std::option::Option::Some(Self::TYPE_FIXED32),
-                "TYPE_BOOL" => std::option::Option::Some(Self::TYPE_BOOL),
-                "TYPE_STRING" => std::option::Option::Some(Self::TYPE_STRING),
-                "TYPE_GROUP" => std::option::Option::Some(Self::TYPE_GROUP),
-                "TYPE_MESSAGE" => std::option::Option::Some(Self::TYPE_MESSAGE),
-                "TYPE_BYTES" => std::option::Option::Some(Self::TYPE_BYTES),
-                "TYPE_UINT32" => std::option::Option::Some(Self::TYPE_UINT32),
-                "TYPE_ENUM" => std::option::Option::Some(Self::TYPE_ENUM),
-                "TYPE_SFIXED32" => std::option::Option::Some(Self::TYPE_SFIXED32),
-                "TYPE_SFIXED64" => std::option::Option::Some(Self::TYPE_SFIXED64),
-                "TYPE_SINT32" => std::option::Option::Some(Self::TYPE_SINT32),
-                "TYPE_SINT64" => std::option::Option::Some(Self::TYPE_SINT64),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Type {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Type {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Label(i32);
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
 
-    impl Label {
+    impl std::convert::From<i32> for Type {
+        fn from(value: i32) -> Self {
+            match value {
+                1 => Self::Double,
+                2 => Self::Float,
+                3 => Self::Int64,
+                4 => Self::Uint64,
+                5 => Self::Int32,
+                6 => Self::Fixed64,
+                7 => Self::Fixed32,
+                8 => Self::Bool,
+                9 => Self::String,
+                10 => Self::Group,
+                11 => Self::Message,
+                12 => Self::Bytes,
+                13 => Self::Uint32,
+                14 => Self::Enum,
+                15 => Self::Sfixed32,
+                16 => Self::Sfixed64,
+                17 => Self::Sint32,
+                18 => Self::Sint64,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Type {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_DOUBLE" => Self::Double,
+                "TYPE_FLOAT" => Self::Float,
+                "TYPE_INT64" => Self::Int64,
+                "TYPE_UINT64" => Self::Uint64,
+                "TYPE_INT32" => Self::Int32,
+                "TYPE_FIXED64" => Self::Fixed64,
+                "TYPE_FIXED32" => Self::Fixed32,
+                "TYPE_BOOL" => Self::Bool,
+                "TYPE_STRING" => Self::String,
+                "TYPE_GROUP" => Self::Group,
+                "TYPE_MESSAGE" => Self::Message,
+                "TYPE_BYTES" => Self::Bytes,
+                "TYPE_UINT32" => Self::Uint32,
+                "TYPE_ENUM" => Self::Enum,
+                "TYPE_SFIXED32" => Self::Sfixed32,
+                "TYPE_SFIXED64" => Self::Sfixed64,
+                "TYPE_SINT32" => Self::Sint32,
+                "TYPE_SINT64" => Self::Sint64,
+                _ => Self::UnknownValue(r#type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Type {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Double => serializer.serialize_i32(1),
+                Self::Float => serializer.serialize_i32(2),
+                Self::Int64 => serializer.serialize_i32(3),
+                Self::Uint64 => serializer.serialize_i32(4),
+                Self::Int32 => serializer.serialize_i32(5),
+                Self::Fixed64 => serializer.serialize_i32(6),
+                Self::Fixed32 => serializer.serialize_i32(7),
+                Self::Bool => serializer.serialize_i32(8),
+                Self::String => serializer.serialize_i32(9),
+                Self::Group => serializer.serialize_i32(10),
+                Self::Message => serializer.serialize_i32(11),
+                Self::Bytes => serializer.serialize_i32(12),
+                Self::Uint32 => serializer.serialize_i32(13),
+                Self::Enum => serializer.serialize_i32(14),
+                Self::Sfixed32 => serializer.serialize_i32(15),
+                Self::Sfixed64 => serializer.serialize_i32(16),
+                Self::Sint32 => serializer.serialize_i32(17),
+                Self::Sint64 => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Type {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Type>::new(
+                ".google.protobuf.FieldDescriptorProto.Type",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Label {
         /// 0 is reserved for errors
-        pub const LABEL_OPTIONAL: Label = Label::new(1);
-
-        pub const LABEL_REPEATED: Label = Label::new(3);
-
+        Optional,
+        Repeated,
         /// The required label is only allowed in google.protobuf.  In proto3 and Editions
         /// it's explicitly prohibited.  In Editions, the `field_presence` feature
         /// can be used to get this behavior.
-        pub const LABEL_REQUIRED: Label = Label::new(2);
+        Required,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Label::value] or
+        /// [Label::name].
+        UnknownValue(label::UnknownValue),
+    }
 
-        /// Creates a new Label instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
+    #[doc(hidden)]
+    pub mod label {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
+    impl Label {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Optional => std::option::Option::Some(1),
+                Self::Repeated => std::option::Option::Some(3),
+                Self::Required => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                1 => std::borrow::Cow::Borrowed("LABEL_OPTIONAL"),
-                2 => std::borrow::Cow::Borrowed("LABEL_REQUIRED"),
-                3 => std::borrow::Cow::Borrowed("LABEL_REPEATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Optional => std::option::Option::Some("LABEL_OPTIONAL"),
+                Self::Repeated => std::option::Option::Some("LABEL_REPEATED"),
+                Self::Required => std::option::Option::Some("LABEL_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "LABEL_OPTIONAL" => std::option::Option::Some(Self::LABEL_OPTIONAL),
-                "LABEL_REPEATED" => std::option::Option::Some(Self::LABEL_REPEATED),
-                "LABEL_REQUIRED" => std::option::Option::Some(Self::LABEL_REQUIRED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Label {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Label {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Label {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Label {
+        fn from(value: i32) -> Self {
+            match value {
+                1 => Self::Optional,
+                2 => Self::Required,
+                3 => Self::Repeated,
+                _ => Self::UnknownValue(label::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Label {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "LABEL_OPTIONAL" => Self::Optional,
+                "LABEL_REPEATED" => Self::Repeated,
+                "LABEL_REQUIRED" => Self::Required,
+                _ => Self::UnknownValue(label::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Label {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Optional => serializer.serialize_i32(1),
+                Self::Repeated => serializer.serialize_i32(3),
+                Self::Required => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Label {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Label>::new(
+                ".google.protobuf.FieldDescriptorProto.Label",
+            ))
         }
     }
 }
@@ -2142,57 +2353,118 @@ pub mod file_options {
     use super::*;
 
     /// Generated classes can be optimized for speed or code size.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptimizeMode(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OptimizeMode {
+        Speed,
+        /// etc.
+        CodeSize,
+        LiteRuntime,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OptimizeMode::value] or
+        /// [OptimizeMode::name].
+        UnknownValue(optimize_mode::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod optimize_mode {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OptimizeMode {
-        pub const SPEED: OptimizeMode = OptimizeMode::new(1);
-
-        /// etc.
-        pub const CODE_SIZE: OptimizeMode = OptimizeMode::new(2);
-
-        pub const LITE_RUNTIME: OptimizeMode = OptimizeMode::new(3);
-
-        /// Creates a new OptimizeMode instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Speed => std::option::Option::Some(1),
+                Self::CodeSize => std::option::Option::Some(2),
+                Self::LiteRuntime => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                1 => std::borrow::Cow::Borrowed("SPEED"),
-                2 => std::borrow::Cow::Borrowed("CODE_SIZE"),
-                3 => std::borrow::Cow::Borrowed("LITE_RUNTIME"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Speed => std::option::Option::Some("SPEED"),
+                Self::CodeSize => std::option::Option::Some("CODE_SIZE"),
+                Self::LiteRuntime => std::option::Option::Some("LITE_RUNTIME"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "SPEED" => std::option::Option::Some(Self::SPEED),
-                "CODE_SIZE" => std::option::Option::Some(Self::CODE_SIZE),
-                "LITE_RUNTIME" => std::option::Option::Some(Self::LITE_RUNTIME),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OptimizeMode {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OptimizeMode {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OptimizeMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OptimizeMode {
+        fn from(value: i32) -> Self {
+            match value {
+                1 => Self::Speed,
+                2 => Self::CodeSize,
+                3 => Self::LiteRuntime,
+                _ => Self::UnknownValue(optimize_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OptimizeMode {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "SPEED" => Self::Speed,
+                "CODE_SIZE" => Self::CodeSize,
+                "LITE_RUNTIME" => Self::LiteRuntime,
+                _ => Self::UnknownValue(optimize_mode::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OptimizeMode {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Speed => serializer.serialize_i32(1),
+                Self::CodeSize => serializer.serialize_i32(2),
+                Self::LiteRuntime => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OptimizeMode {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OptimizeMode>::new(
+                ".google.protobuf.FileOptions.OptimizeMode",
+            ))
         }
     }
 }
@@ -2699,259 +2971,517 @@ pub mod field_options {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct CType(i32);
-
-    impl CType {
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum CType {
         /// Default mode.
-        pub const STRING: CType = CType::new(0);
-
+        String,
         /// The option [ctype=CORD] may be applied to a non-repeated field of type
         /// "bytes". It indicates that in C++, the data should be stored in a Cord
         /// instead of a string.  For very large strings, this may reduce memory
         /// fragmentation. It may also allow better performance when parsing from a
         /// Cord, or when parsing with aliasing enabled, as the parsed Cord may then
         /// alias the original buffer.
-        pub const CORD: CType = CType::new(1);
+        Cord,
+        StringPiece,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [CType::value] or
+        /// [CType::name].
+        UnknownValue(c_type::UnknownValue),
+    }
 
-        pub const STRING_PIECE: CType = CType::new(2);
+    #[doc(hidden)]
+    pub mod c_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
-        /// Creates a new CType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
+    impl CType {
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::String => std::option::Option::Some(0),
+                Self::Cord => std::option::Option::Some(1),
+                Self::StringPiece => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("STRING"),
-                1 => std::borrow::Cow::Borrowed("CORD"),
-                2 => std::borrow::Cow::Borrowed("STRING_PIECE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::String => std::option::Option::Some("STRING"),
+                Self::Cord => std::option::Option::Some("CORD"),
+                Self::StringPiece => std::option::Option::Some("STRING_PIECE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "STRING" => std::option::Option::Some(Self::STRING),
-                "CORD" => std::option::Option::Some(Self::CORD),
-                "STRING_PIECE" => std::option::Option::Some(Self::STRING_PIECE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for CType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for CType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JSType(i32);
+    impl std::fmt::Display for CType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for CType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::String,
+                1 => Self::Cord,
+                2 => Self::StringPiece,
+                _ => Self::UnknownValue(c_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for CType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "STRING" => Self::String,
+                "CORD" => Self::Cord,
+                "STRING_PIECE" => Self::StringPiece,
+                _ => Self::UnknownValue(c_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for CType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::String => serializer.serialize_i32(0),
+                Self::Cord => serializer.serialize_i32(1),
+                Self::StringPiece => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for CType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<CType>::new(
+                ".google.protobuf.FieldOptions.CType",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JSType {
+        /// Use the default type.
+        JsNormal,
+        /// Use JavaScript strings.
+        JsString,
+        /// Use JavaScript numbers.
+        JsNumber,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JSType::value] or
+        /// [JSType::name].
+        UnknownValue(js_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod js_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl JSType {
-        /// Use the default type.
-        pub const JS_NORMAL: JSType = JSType::new(0);
-
-        /// Use JavaScript strings.
-        pub const JS_STRING: JSType = JSType::new(1);
-
-        /// Use JavaScript numbers.
-        pub const JS_NUMBER: JSType = JSType::new(2);
-
-        /// Creates a new JSType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::JsNormal => std::option::Option::Some(0),
+                Self::JsString => std::option::Option::Some(1),
+                Self::JsNumber => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JS_NORMAL"),
-                1 => std::borrow::Cow::Borrowed("JS_STRING"),
-                2 => std::borrow::Cow::Borrowed("JS_NUMBER"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::JsNormal => std::option::Option::Some("JS_NORMAL"),
+                Self::JsString => std::option::Option::Some("JS_STRING"),
+                Self::JsNumber => std::option::Option::Some("JS_NUMBER"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JS_NORMAL" => std::option::Option::Some(Self::JS_NORMAL),
-                "JS_STRING" => std::option::Option::Some(Self::JS_STRING),
-                "JS_NUMBER" => std::option::Option::Some(Self::JS_NUMBER),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JSType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JSType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JSType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JSType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::JsNormal,
+                1 => Self::JsString,
+                2 => Self::JsNumber,
+                _ => Self::UnknownValue(js_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JSType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JS_NORMAL" => Self::JsNormal,
+                "JS_STRING" => Self::JsString,
+                "JS_NUMBER" => Self::JsNumber,
+                _ => Self::UnknownValue(js_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JSType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::JsNormal => serializer.serialize_i32(0),
+                Self::JsString => serializer.serialize_i32(1),
+                Self::JsNumber => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JSType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JSType>::new(
+                ".google.protobuf.FieldOptions.JSType",
+            ))
         }
     }
 
     /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptionRetention(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OptionRetention {
+        RetentionUnknown,
+        RetentionRuntime,
+        RetentionSource,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OptionRetention::value] or
+        /// [OptionRetention::name].
+        UnknownValue(option_retention::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod option_retention {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OptionRetention {
-        pub const RETENTION_UNKNOWN: OptionRetention = OptionRetention::new(0);
-
-        pub const RETENTION_RUNTIME: OptionRetention = OptionRetention::new(1);
-
-        pub const RETENTION_SOURCE: OptionRetention = OptionRetention::new(2);
-
-        /// Creates a new OptionRetention instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::RetentionUnknown => std::option::Option::Some(0),
+                Self::RetentionRuntime => std::option::Option::Some(1),
+                Self::RetentionSource => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("RETENTION_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("RETENTION_RUNTIME"),
-                2 => std::borrow::Cow::Borrowed("RETENTION_SOURCE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::RetentionUnknown => std::option::Option::Some("RETENTION_UNKNOWN"),
+                Self::RetentionRuntime => std::option::Option::Some("RETENTION_RUNTIME"),
+                Self::RetentionSource => std::option::Option::Some("RETENTION_SOURCE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "RETENTION_UNKNOWN" => std::option::Option::Some(Self::RETENTION_UNKNOWN),
-                "RETENTION_RUNTIME" => std::option::Option::Some(Self::RETENTION_RUNTIME),
-                "RETENTION_SOURCE" => std::option::Option::Some(Self::RETENTION_SOURCE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for OptionRetention {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OptionRetention {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OptionRetention {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OptionRetention {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::RetentionUnknown,
+                1 => Self::RetentionRuntime,
+                2 => Self::RetentionSource,
+                _ => Self::UnknownValue(option_retention::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OptionRetention {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "RETENTION_UNKNOWN" => Self::RetentionUnknown,
+                "RETENTION_RUNTIME" => Self::RetentionRuntime,
+                "RETENTION_SOURCE" => Self::RetentionSource,
+                _ => Self::UnknownValue(option_retention::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OptionRetention {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::RetentionUnknown => serializer.serialize_i32(0),
+                Self::RetentionRuntime => serializer.serialize_i32(1),
+                Self::RetentionSource => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OptionRetention {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OptionRetention>::new(
+                ".google.protobuf.FieldOptions.OptionRetention",
+            ))
         }
     }
 
     /// This indicates the types of entities that the field may apply to when used
     /// as an option. If it is unset, then the field may be freely used as an
     /// option on any kind of entity.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct OptionTargetType(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum OptionTargetType {
+        TargetTypeUnknown,
+        TargetTypeFile,
+        TargetTypeExtensionRange,
+        TargetTypeMessage,
+        TargetTypeField,
+        TargetTypeOneof,
+        TargetTypeEnum,
+        TargetTypeEnumEntry,
+        TargetTypeService,
+        TargetTypeMethod,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [OptionTargetType::value] or
+        /// [OptionTargetType::name].
+        UnknownValue(option_target_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod option_target_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl OptionTargetType {
-        pub const TARGET_TYPE_UNKNOWN: OptionTargetType = OptionTargetType::new(0);
-
-        pub const TARGET_TYPE_FILE: OptionTargetType = OptionTargetType::new(1);
-
-        pub const TARGET_TYPE_EXTENSION_RANGE: OptionTargetType = OptionTargetType::new(2);
-
-        pub const TARGET_TYPE_MESSAGE: OptionTargetType = OptionTargetType::new(3);
-
-        pub const TARGET_TYPE_FIELD: OptionTargetType = OptionTargetType::new(4);
-
-        pub const TARGET_TYPE_ONEOF: OptionTargetType = OptionTargetType::new(5);
-
-        pub const TARGET_TYPE_ENUM: OptionTargetType = OptionTargetType::new(6);
-
-        pub const TARGET_TYPE_ENUM_ENTRY: OptionTargetType = OptionTargetType::new(7);
-
-        pub const TARGET_TYPE_SERVICE: OptionTargetType = OptionTargetType::new(8);
-
-        pub const TARGET_TYPE_METHOD: OptionTargetType = OptionTargetType::new(9);
-
-        /// Creates a new OptionTargetType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::TargetTypeUnknown => std::option::Option::Some(0),
+                Self::TargetTypeFile => std::option::Option::Some(1),
+                Self::TargetTypeExtensionRange => std::option::Option::Some(2),
+                Self::TargetTypeMessage => std::option::Option::Some(3),
+                Self::TargetTypeField => std::option::Option::Some(4),
+                Self::TargetTypeOneof => std::option::Option::Some(5),
+                Self::TargetTypeEnum => std::option::Option::Some(6),
+                Self::TargetTypeEnumEntry => std::option::Option::Some(7),
+                Self::TargetTypeService => std::option::Option::Some(8),
+                Self::TargetTypeMethod => std::option::Option::Some(9),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TARGET_TYPE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("TARGET_TYPE_FILE"),
-                2 => std::borrow::Cow::Borrowed("TARGET_TYPE_EXTENSION_RANGE"),
-                3 => std::borrow::Cow::Borrowed("TARGET_TYPE_MESSAGE"),
-                4 => std::borrow::Cow::Borrowed("TARGET_TYPE_FIELD"),
-                5 => std::borrow::Cow::Borrowed("TARGET_TYPE_ONEOF"),
-                6 => std::borrow::Cow::Borrowed("TARGET_TYPE_ENUM"),
-                7 => std::borrow::Cow::Borrowed("TARGET_TYPE_ENUM_ENTRY"),
-                8 => std::borrow::Cow::Borrowed("TARGET_TYPE_SERVICE"),
-                9 => std::borrow::Cow::Borrowed("TARGET_TYPE_METHOD"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
-            }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TARGET_TYPE_UNKNOWN" => std::option::Option::Some(Self::TARGET_TYPE_UNKNOWN),
-                "TARGET_TYPE_FILE" => std::option::Option::Some(Self::TARGET_TYPE_FILE),
-                "TARGET_TYPE_EXTENSION_RANGE" => {
-                    std::option::Option::Some(Self::TARGET_TYPE_EXTENSION_RANGE)
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::TargetTypeUnknown => std::option::Option::Some("TARGET_TYPE_UNKNOWN"),
+                Self::TargetTypeFile => std::option::Option::Some("TARGET_TYPE_FILE"),
+                Self::TargetTypeExtensionRange => {
+                    std::option::Option::Some("TARGET_TYPE_EXTENSION_RANGE")
                 }
-                "TARGET_TYPE_MESSAGE" => std::option::Option::Some(Self::TARGET_TYPE_MESSAGE),
-                "TARGET_TYPE_FIELD" => std::option::Option::Some(Self::TARGET_TYPE_FIELD),
-                "TARGET_TYPE_ONEOF" => std::option::Option::Some(Self::TARGET_TYPE_ONEOF),
-                "TARGET_TYPE_ENUM" => std::option::Option::Some(Self::TARGET_TYPE_ENUM),
-                "TARGET_TYPE_ENUM_ENTRY" => std::option::Option::Some(Self::TARGET_TYPE_ENUM_ENTRY),
-                "TARGET_TYPE_SERVICE" => std::option::Option::Some(Self::TARGET_TYPE_SERVICE),
-                "TARGET_TYPE_METHOD" => std::option::Option::Some(Self::TARGET_TYPE_METHOD),
-                _ => std::option::Option::None,
+                Self::TargetTypeMessage => std::option::Option::Some("TARGET_TYPE_MESSAGE"),
+                Self::TargetTypeField => std::option::Option::Some("TARGET_TYPE_FIELD"),
+                Self::TargetTypeOneof => std::option::Option::Some("TARGET_TYPE_ONEOF"),
+                Self::TargetTypeEnum => std::option::Option::Some("TARGET_TYPE_ENUM"),
+                Self::TargetTypeEnumEntry => std::option::Option::Some("TARGET_TYPE_ENUM_ENTRY"),
+                Self::TargetTypeService => std::option::Option::Some("TARGET_TYPE_SERVICE"),
+                Self::TargetTypeMethod => std::option::Option::Some("TARGET_TYPE_METHOD"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-    }
-
-    impl std::convert::From<i32> for OptionTargetType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for OptionTargetType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for OptionTargetType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for OptionTargetType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::TargetTypeUnknown,
+                1 => Self::TargetTypeFile,
+                2 => Self::TargetTypeExtensionRange,
+                3 => Self::TargetTypeMessage,
+                4 => Self::TargetTypeField,
+                5 => Self::TargetTypeOneof,
+                6 => Self::TargetTypeEnum,
+                7 => Self::TargetTypeEnumEntry,
+                8 => Self::TargetTypeService,
+                9 => Self::TargetTypeMethod,
+                _ => Self::UnknownValue(option_target_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for OptionTargetType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TARGET_TYPE_UNKNOWN" => Self::TargetTypeUnknown,
+                "TARGET_TYPE_FILE" => Self::TargetTypeFile,
+                "TARGET_TYPE_EXTENSION_RANGE" => Self::TargetTypeExtensionRange,
+                "TARGET_TYPE_MESSAGE" => Self::TargetTypeMessage,
+                "TARGET_TYPE_FIELD" => Self::TargetTypeField,
+                "TARGET_TYPE_ONEOF" => Self::TargetTypeOneof,
+                "TARGET_TYPE_ENUM" => Self::TargetTypeEnum,
+                "TARGET_TYPE_ENUM_ENTRY" => Self::TargetTypeEnumEntry,
+                "TARGET_TYPE_SERVICE" => Self::TargetTypeService,
+                "TARGET_TYPE_METHOD" => Self::TargetTypeMethod,
+                _ => Self::UnknownValue(option_target_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for OptionTargetType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::TargetTypeUnknown => serializer.serialize_i32(0),
+                Self::TargetTypeFile => serializer.serialize_i32(1),
+                Self::TargetTypeExtensionRange => serializer.serialize_i32(2),
+                Self::TargetTypeMessage => serializer.serialize_i32(3),
+                Self::TargetTypeField => serializer.serialize_i32(4),
+                Self::TargetTypeOneof => serializer.serialize_i32(5),
+                Self::TargetTypeEnum => serializer.serialize_i32(6),
+                Self::TargetTypeEnumEntry => serializer.serialize_i32(7),
+                Self::TargetTypeService => serializer.serialize_i32(8),
+                Self::TargetTypeMethod => serializer.serialize_i32(9),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for OptionTargetType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<OptionTargetType>::new(
+                ".google.protobuf.FieldOptions.OptionTargetType",
+            ))
         }
     }
 }
@@ -3328,56 +3858,117 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct IdempotencyLevel(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum IdempotencyLevel {
+        IdempotencyUnknown,
+        NoSideEffects,
+        Idempotent,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [IdempotencyLevel::value] or
+        /// [IdempotencyLevel::name].
+        UnknownValue(idempotency_level::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod idempotency_level {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl IdempotencyLevel {
-        pub const IDEMPOTENCY_UNKNOWN: IdempotencyLevel = IdempotencyLevel::new(0);
-
-        pub const NO_SIDE_EFFECTS: IdempotencyLevel = IdempotencyLevel::new(1);
-
-        pub const IDEMPOTENT: IdempotencyLevel = IdempotencyLevel::new(2);
-
-        /// Creates a new IdempotencyLevel instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::IdempotencyUnknown => std::option::Option::Some(0),
+                Self::NoSideEffects => std::option::Option::Some(1),
+                Self::Idempotent => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("IDEMPOTENCY_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("NO_SIDE_EFFECTS"),
-                2 => std::borrow::Cow::Borrowed("IDEMPOTENT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::IdempotencyUnknown => std::option::Option::Some("IDEMPOTENCY_UNKNOWN"),
+                Self::NoSideEffects => std::option::Option::Some("NO_SIDE_EFFECTS"),
+                Self::Idempotent => std::option::Option::Some("IDEMPOTENT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "IDEMPOTENCY_UNKNOWN" => std::option::Option::Some(Self::IDEMPOTENCY_UNKNOWN),
-                "NO_SIDE_EFFECTS" => std::option::Option::Some(Self::NO_SIDE_EFFECTS),
-                "IDEMPOTENT" => std::option::Option::Some(Self::IDEMPOTENT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for IdempotencyLevel {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for IdempotencyLevel {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for IdempotencyLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for IdempotencyLevel {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::IdempotencyUnknown,
+                1 => Self::NoSideEffects,
+                2 => Self::Idempotent,
+                _ => Self::UnknownValue(idempotency_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for IdempotencyLevel {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "IDEMPOTENCY_UNKNOWN" => Self::IdempotencyUnknown,
+                "NO_SIDE_EFFECTS" => Self::NoSideEffects,
+                "IDEMPOTENT" => Self::Idempotent,
+                _ => Self::UnknownValue(idempotency_level::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for IdempotencyLevel {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::IdempotencyUnknown => serializer.serialize_i32(0),
+                Self::NoSideEffects => serializer.serialize_i32(1),
+                Self::Idempotent => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for IdempotencyLevel {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<IdempotencyLevel>::new(
+                ".google.protobuf.MethodOptions.IdempotencyLevel",
+            ))
         }
     }
 }
@@ -3635,332 +4226,693 @@ pub mod feature_set {
     #[allow(unused_imports)]
     use super::*;
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct FieldPresence(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum FieldPresence {
+        Unknown,
+        Explicit,
+        Implicit,
+        LegacyRequired,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [FieldPresence::value] or
+        /// [FieldPresence::name].
+        UnknownValue(field_presence::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod field_presence {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl FieldPresence {
-        pub const FIELD_PRESENCE_UNKNOWN: FieldPresence = FieldPresence::new(0);
-
-        pub const EXPLICIT: FieldPresence = FieldPresence::new(1);
-
-        pub const IMPLICIT: FieldPresence = FieldPresence::new(2);
-
-        pub const LEGACY_REQUIRED: FieldPresence = FieldPresence::new(3);
-
-        /// Creates a new FieldPresence instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Explicit => std::option::Option::Some(1),
+                Self::Implicit => std::option::Option::Some(2),
+                Self::LegacyRequired => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("FIELD_PRESENCE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("EXPLICIT"),
-                2 => std::borrow::Cow::Borrowed("IMPLICIT"),
-                3 => std::borrow::Cow::Borrowed("LEGACY_REQUIRED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("FIELD_PRESENCE_UNKNOWN"),
+                Self::Explicit => std::option::Option::Some("EXPLICIT"),
+                Self::Implicit => std::option::Option::Some("IMPLICIT"),
+                Self::LegacyRequired => std::option::Option::Some("LEGACY_REQUIRED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "FIELD_PRESENCE_UNKNOWN" => std::option::Option::Some(Self::FIELD_PRESENCE_UNKNOWN),
-                "EXPLICIT" => std::option::Option::Some(Self::EXPLICIT),
-                "IMPLICIT" => std::option::Option::Some(Self::IMPLICIT),
-                "LEGACY_REQUIRED" => std::option::Option::Some(Self::LEGACY_REQUIRED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for FieldPresence {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for FieldPresence {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct EnumType(i32);
+    impl std::fmt::Display for FieldPresence {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for FieldPresence {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Explicit,
+                2 => Self::Implicit,
+                3 => Self::LegacyRequired,
+                _ => Self::UnknownValue(field_presence::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for FieldPresence {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "FIELD_PRESENCE_UNKNOWN" => Self::Unknown,
+                "EXPLICIT" => Self::Explicit,
+                "IMPLICIT" => Self::Implicit,
+                "LEGACY_REQUIRED" => Self::LegacyRequired,
+                _ => Self::UnknownValue(field_presence::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for FieldPresence {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Explicit => serializer.serialize_i32(1),
+                Self::Implicit => serializer.serialize_i32(2),
+                Self::LegacyRequired => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for FieldPresence {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<FieldPresence>::new(
+                ".google.protobuf.FeatureSet.FieldPresence",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum EnumType {
+        Unknown,
+        Open,
+        Closed,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [EnumType::value] or
+        /// [EnumType::name].
+        UnknownValue(enum_type::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod enum_type {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl EnumType {
-        pub const ENUM_TYPE_UNKNOWN: EnumType = EnumType::new(0);
-
-        pub const OPEN: EnumType = EnumType::new(1);
-
-        pub const CLOSED: EnumType = EnumType::new(2);
-
-        /// Creates a new EnumType instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Open => std::option::Option::Some(1),
+                Self::Closed => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("ENUM_TYPE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("OPEN"),
-                2 => std::borrow::Cow::Borrowed("CLOSED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("ENUM_TYPE_UNKNOWN"),
+                Self::Open => std::option::Option::Some("OPEN"),
+                Self::Closed => std::option::Option::Some("CLOSED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "ENUM_TYPE_UNKNOWN" => std::option::Option::Some(Self::ENUM_TYPE_UNKNOWN),
-                "OPEN" => std::option::Option::Some(Self::OPEN),
-                "CLOSED" => std::option::Option::Some(Self::CLOSED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for EnumType {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for EnumType {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct RepeatedFieldEncoding(i32);
+    impl std::fmt::Display for EnumType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for EnumType {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Open,
+                2 => Self::Closed,
+                _ => Self::UnknownValue(enum_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for EnumType {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "ENUM_TYPE_UNKNOWN" => Self::Unknown,
+                "OPEN" => Self::Open,
+                "CLOSED" => Self::Closed,
+                _ => Self::UnknownValue(enum_type::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for EnumType {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Open => serializer.serialize_i32(1),
+                Self::Closed => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for EnumType {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<EnumType>::new(
+                ".google.protobuf.FeatureSet.EnumType",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum RepeatedFieldEncoding {
+        Unknown,
+        Packed,
+        Expanded,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [RepeatedFieldEncoding::value] or
+        /// [RepeatedFieldEncoding::name].
+        UnknownValue(repeated_field_encoding::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod repeated_field_encoding {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl RepeatedFieldEncoding {
-        pub const REPEATED_FIELD_ENCODING_UNKNOWN: RepeatedFieldEncoding =
-            RepeatedFieldEncoding::new(0);
-
-        pub const PACKED: RepeatedFieldEncoding = RepeatedFieldEncoding::new(1);
-
-        pub const EXPANDED: RepeatedFieldEncoding = RepeatedFieldEncoding::new(2);
-
-        /// Creates a new RepeatedFieldEncoding instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Packed => std::option::Option::Some(1),
+                Self::Expanded => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("REPEATED_FIELD_ENCODING_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("PACKED"),
-                2 => std::borrow::Cow::Borrowed("EXPANDED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("REPEATED_FIELD_ENCODING_UNKNOWN"),
+                Self::Packed => std::option::Option::Some("PACKED"),
+                Self::Expanded => std::option::Option::Some("EXPANDED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "REPEATED_FIELD_ENCODING_UNKNOWN" => {
-                    std::option::Option::Some(Self::REPEATED_FIELD_ENCODING_UNKNOWN)
-                }
-                "PACKED" => std::option::Option::Some(Self::PACKED),
-                "EXPANDED" => std::option::Option::Some(Self::EXPANDED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for RepeatedFieldEncoding {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for RepeatedFieldEncoding {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Utf8Validation(i32);
+    impl std::fmt::Display for RepeatedFieldEncoding {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for RepeatedFieldEncoding {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Packed,
+                2 => Self::Expanded,
+                _ => Self::UnknownValue(repeated_field_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for RepeatedFieldEncoding {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "REPEATED_FIELD_ENCODING_UNKNOWN" => Self::Unknown,
+                "PACKED" => Self::Packed,
+                "EXPANDED" => Self::Expanded,
+                _ => Self::UnknownValue(repeated_field_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for RepeatedFieldEncoding {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Packed => serializer.serialize_i32(1),
+                Self::Expanded => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for RepeatedFieldEncoding {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<RepeatedFieldEncoding>::new(
+                ".google.protobuf.FeatureSet.RepeatedFieldEncoding",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Utf8Validation {
+        Unknown,
+        Verify,
+        None,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Utf8Validation::value] or
+        /// [Utf8Validation::name].
+        UnknownValue(utf_8_validation::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod utf_8_validation {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Utf8Validation {
-        pub const UTF8_VALIDATION_UNKNOWN: Utf8Validation = Utf8Validation::new(0);
-
-        pub const VERIFY: Utf8Validation = Utf8Validation::new(2);
-
-        pub const NONE: Utf8Validation = Utf8Validation::new(3);
-
-        /// Creates a new Utf8Validation instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Verify => std::option::Option::Some(2),
+                Self::None => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("UTF8_VALIDATION_UNKNOWN"),
-                2 => std::borrow::Cow::Borrowed("VERIFY"),
-                3 => std::borrow::Cow::Borrowed("NONE"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("UTF8_VALIDATION_UNKNOWN"),
+                Self::Verify => std::option::Option::Some("VERIFY"),
+                Self::None => std::option::Option::Some("NONE"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "UTF8_VALIDATION_UNKNOWN" => {
-                    std::option::Option::Some(Self::UTF8_VALIDATION_UNKNOWN)
-                }
-                "VERIFY" => std::option::Option::Some(Self::VERIFY),
-                "NONE" => std::option::Option::Some(Self::NONE),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Utf8Validation {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Utf8Validation {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct MessageEncoding(i32);
+    impl std::fmt::Display for Utf8Validation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Utf8Validation {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                2 => Self::Verify,
+                3 => Self::None,
+                _ => Self::UnknownValue(utf_8_validation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Utf8Validation {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "UTF8_VALIDATION_UNKNOWN" => Self::Unknown,
+                "VERIFY" => Self::Verify,
+                "NONE" => Self::None,
+                _ => Self::UnknownValue(utf_8_validation::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Utf8Validation {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Verify => serializer.serialize_i32(2),
+                Self::None => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Utf8Validation {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Utf8Validation>::new(
+                ".google.protobuf.FeatureSet.Utf8Validation",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum MessageEncoding {
+        Unknown,
+        LengthPrefixed,
+        Delimited,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [MessageEncoding::value] or
+        /// [MessageEncoding::name].
+        UnknownValue(message_encoding::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod message_encoding {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl MessageEncoding {
-        pub const MESSAGE_ENCODING_UNKNOWN: MessageEncoding = MessageEncoding::new(0);
-
-        pub const LENGTH_PREFIXED: MessageEncoding = MessageEncoding::new(1);
-
-        pub const DELIMITED: MessageEncoding = MessageEncoding::new(2);
-
-        /// Creates a new MessageEncoding instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::LengthPrefixed => std::option::Option::Some(1),
+                Self::Delimited => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("MESSAGE_ENCODING_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("LENGTH_PREFIXED"),
-                2 => std::borrow::Cow::Borrowed("DELIMITED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("MESSAGE_ENCODING_UNKNOWN"),
+                Self::LengthPrefixed => std::option::Option::Some("LENGTH_PREFIXED"),
+                Self::Delimited => std::option::Option::Some("DELIMITED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "MESSAGE_ENCODING_UNKNOWN" => {
-                    std::option::Option::Some(Self::MESSAGE_ENCODING_UNKNOWN)
-                }
-                "LENGTH_PREFIXED" => std::option::Option::Some(Self::LENGTH_PREFIXED),
-                "DELIMITED" => std::option::Option::Some(Self::DELIMITED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for MessageEncoding {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for MessageEncoding {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct JsonFormat(i32);
+    impl std::fmt::Display for MessageEncoding {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for MessageEncoding {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::LengthPrefixed,
+                2 => Self::Delimited,
+                _ => Self::UnknownValue(message_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for MessageEncoding {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "MESSAGE_ENCODING_UNKNOWN" => Self::Unknown,
+                "LENGTH_PREFIXED" => Self::LengthPrefixed,
+                "DELIMITED" => Self::Delimited,
+                _ => Self::UnknownValue(message_encoding::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for MessageEncoding {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::LengthPrefixed => serializer.serialize_i32(1),
+                Self::Delimited => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for MessageEncoding {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<MessageEncoding>::new(
+                ".google.protobuf.FeatureSet.MessageEncoding",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum JsonFormat {
+        Unknown,
+        Allow,
+        LegacyBestEffort,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [JsonFormat::value] or
+        /// [JsonFormat::name].
+        UnknownValue(json_format::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod json_format {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl JsonFormat {
-        pub const JSON_FORMAT_UNKNOWN: JsonFormat = JsonFormat::new(0);
-
-        pub const ALLOW: JsonFormat = JsonFormat::new(1);
-
-        pub const LEGACY_BEST_EFFORT: JsonFormat = JsonFormat::new(2);
-
-        /// Creates a new JsonFormat instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Allow => std::option::Option::Some(1),
+                Self::LegacyBestEffort => std::option::Option::Some(2),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("JSON_FORMAT_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("ALLOW"),
-                2 => std::borrow::Cow::Borrowed("LEGACY_BEST_EFFORT"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("JSON_FORMAT_UNKNOWN"),
+                Self::Allow => std::option::Option::Some("ALLOW"),
+                Self::LegacyBestEffort => std::option::Option::Some("LEGACY_BEST_EFFORT"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "JSON_FORMAT_UNKNOWN" => std::option::Option::Some(Self::JSON_FORMAT_UNKNOWN),
-                "ALLOW" => std::option::Option::Some(Self::ALLOW),
-                "LEGACY_BEST_EFFORT" => std::option::Option::Some(Self::LEGACY_BEST_EFFORT),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for JsonFormat {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for JsonFormat {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for JsonFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for JsonFormat {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Allow,
+                2 => Self::LegacyBestEffort,
+                _ => Self::UnknownValue(json_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for JsonFormat {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "JSON_FORMAT_UNKNOWN" => Self::Unknown,
+                "ALLOW" => Self::Allow,
+                "LEGACY_BEST_EFFORT" => Self::LegacyBestEffort,
+                _ => Self::UnknownValue(json_format::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for JsonFormat {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Allow => serializer.serialize_i32(1),
+                Self::LegacyBestEffort => serializer.serialize_i32(2),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for JsonFormat {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<JsonFormat>::new(
+                ".google.protobuf.FeatureSet.JsonFormat",
+            ))
         }
     }
 }
@@ -4476,59 +5428,123 @@ pub mod generated_code_info {
 
         /// Represents the identified object's effect on the element in the original
         /// .proto file.
-        #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-        pub struct Semantic(i32);
+        #[derive(Clone, Debug, PartialEq)]
+        #[non_exhaustive]
+        pub enum Semantic {
+            /// There is no effect or the effect is indescribable.
+            None,
+            /// The element is set or otherwise mutated.
+            Set,
+            /// An alias to the element is returned.
+            Alias,
+            /// If set, the enum was initialized with an unknown value.
+            ///
+            /// Applications can examine the value using [Semantic::value] or
+            /// [Semantic::name].
+            UnknownValue(semantic::UnknownValue),
+        }
+
+        #[doc(hidden)]
+        pub mod semantic {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, Debug, PartialEq)]
+            pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+        }
 
         impl Semantic {
-            /// There is no effect or the effect is indescribable.
-            pub const NONE: Semantic = Semantic::new(0);
-
-            /// The element is set or otherwise mutated.
-            pub const SET: Semantic = Semantic::new(1);
-
-            /// An alias to the element is returned.
-            pub const ALIAS: Semantic = Semantic::new(2);
-
-            /// Creates a new Semantic instance.
-            pub(crate) const fn new(value: i32) -> Self {
-                Self(value)
-            }
-
             /// Gets the enum value.
-            pub fn value(&self) -> i32 {
-                self.0
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the string representation of enums.
+            pub fn value(&self) -> std::option::Option<i32> {
+                match self {
+                    Self::None => std::option::Option::Some(0),
+                    Self::Set => std::option::Option::Some(1),
+                    Self::Alias => std::option::Option::Some(2),
+                    Self::UnknownValue(u) => u.0.value(),
+                }
             }
 
             /// Gets the enum value as a string.
-            pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-                match self.0 {
-                    0 => std::borrow::Cow::Borrowed("NONE"),
-                    1 => std::borrow::Cow::Borrowed("SET"),
-                    2 => std::borrow::Cow::Borrowed("ALIAS"),
-                    _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+            ///
+            /// Returns `None` if the enum contains an unknown value deserialized from
+            /// the integer representation of enums.
+            pub fn name(&self) -> std::option::Option<&str> {
+                match self {
+                    Self::None => std::option::Option::Some("NONE"),
+                    Self::Set => std::option::Option::Some("SET"),
+                    Self::Alias => std::option::Option::Some("ALIAS"),
+                    Self::UnknownValue(u) => u.0.name(),
                 }
-            }
-
-            /// Creates an enum value from the value name.
-            pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-                match name {
-                    "NONE" => std::option::Option::Some(Self::NONE),
-                    "SET" => std::option::Option::Some(Self::SET),
-                    "ALIAS" => std::option::Option::Some(Self::ALIAS),
-                    _ => std::option::Option::None,
-                }
-            }
-        }
-
-        impl std::convert::From<i32> for Semantic {
-            fn from(value: i32) -> Self {
-                Self::new(value)
             }
         }
 
         impl std::default::Default for Semantic {
             fn default() -> Self {
-                Self::new(0)
+                use std::convert::From;
+                Self::from(0)
+            }
+        }
+
+        impl std::fmt::Display for Semantic {
+            fn fmt(
+                &self,
+                f: &mut std::fmt::Formatter<'_>,
+            ) -> std::result::Result<(), std::fmt::Error> {
+                wkt::internal::display_enum(f, self.name(), self.value())
+            }
+        }
+
+        impl std::convert::From<i32> for Semantic {
+            fn from(value: i32) -> Self {
+                match value {
+                    0 => Self::None,
+                    1 => Self::Set,
+                    2 => Self::Alias,
+                    _ => Self::UnknownValue(semantic::UnknownValue(
+                        wkt::internal::UnknownEnumValue::Integer(value),
+                    )),
+                }
+            }
+        }
+
+        impl std::convert::From<&str> for Semantic {
+            fn from(value: &str) -> Self {
+                use std::string::ToString;
+                match value {
+                    "NONE" => Self::None,
+                    "SET" => Self::Set,
+                    "ALIAS" => Self::Alias,
+                    _ => Self::UnknownValue(semantic::UnknownValue(
+                        wkt::internal::UnknownEnumValue::String(value.to_string()),
+                    )),
+                }
+            }
+        }
+
+        impl serde::ser::Serialize for Semantic {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    Self::None => serializer.serialize_i32(0),
+                    Self::Set => serializer.serialize_i32(1),
+                    Self::Alias => serializer.serialize_i32(2),
+                    Self::UnknownValue(u) => u.0.serialize(serializer),
+                }
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for Semantic {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(wkt::internal::EnumVisitor::<Semantic>::new(
+                    ".google.protobuf.GeneratedCodeInfo.Annotation.Semantic",
+                ))
             }
         }
     }
@@ -4813,201 +5829,357 @@ pub mod field {
     use super::*;
 
     /// Basic field types.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Kind(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Kind {
+        /// Field type unknown.
+        TypeUnknown,
+        /// Field type double.
+        TypeDouble,
+        /// Field type float.
+        TypeFloat,
+        /// Field type int64.
+        TypeInt64,
+        /// Field type uint64.
+        TypeUint64,
+        /// Field type int32.
+        TypeInt32,
+        /// Field type fixed64.
+        TypeFixed64,
+        /// Field type fixed32.
+        TypeFixed32,
+        /// Field type bool.
+        TypeBool,
+        /// Field type string.
+        TypeString,
+        /// Field type group. Proto2 syntax only, and deprecated.
+        TypeGroup,
+        /// Field type message.
+        TypeMessage,
+        /// Field type bytes.
+        TypeBytes,
+        /// Field type uint32.
+        TypeUint32,
+        /// Field type enum.
+        TypeEnum,
+        /// Field type sfixed32.
+        TypeSfixed32,
+        /// Field type sfixed64.
+        TypeSfixed64,
+        /// Field type sint32.
+        TypeSint32,
+        /// Field type sint64.
+        TypeSint64,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Kind::value] or
+        /// [Kind::name].
+        UnknownValue(kind::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod kind {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Kind {
-        /// Field type unknown.
-        pub const TYPE_UNKNOWN: Kind = Kind::new(0);
-
-        /// Field type double.
-        pub const TYPE_DOUBLE: Kind = Kind::new(1);
-
-        /// Field type float.
-        pub const TYPE_FLOAT: Kind = Kind::new(2);
-
-        /// Field type int64.
-        pub const TYPE_INT64: Kind = Kind::new(3);
-
-        /// Field type uint64.
-        pub const TYPE_UINT64: Kind = Kind::new(4);
-
-        /// Field type int32.
-        pub const TYPE_INT32: Kind = Kind::new(5);
-
-        /// Field type fixed64.
-        pub const TYPE_FIXED64: Kind = Kind::new(6);
-
-        /// Field type fixed32.
-        pub const TYPE_FIXED32: Kind = Kind::new(7);
-
-        /// Field type bool.
-        pub const TYPE_BOOL: Kind = Kind::new(8);
-
-        /// Field type string.
-        pub const TYPE_STRING: Kind = Kind::new(9);
-
-        /// Field type group. Proto2 syntax only, and deprecated.
-        pub const TYPE_GROUP: Kind = Kind::new(10);
-
-        /// Field type message.
-        pub const TYPE_MESSAGE: Kind = Kind::new(11);
-
-        /// Field type bytes.
-        pub const TYPE_BYTES: Kind = Kind::new(12);
-
-        /// Field type uint32.
-        pub const TYPE_UINT32: Kind = Kind::new(13);
-
-        /// Field type enum.
-        pub const TYPE_ENUM: Kind = Kind::new(14);
-
-        /// Field type sfixed32.
-        pub const TYPE_SFIXED32: Kind = Kind::new(15);
-
-        /// Field type sfixed64.
-        pub const TYPE_SFIXED64: Kind = Kind::new(16);
-
-        /// Field type sint32.
-        pub const TYPE_SINT32: Kind = Kind::new(17);
-
-        /// Field type sint64.
-        pub const TYPE_SINT64: Kind = Kind::new(18);
-
-        /// Creates a new Kind instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::TypeUnknown => std::option::Option::Some(0),
+                Self::TypeDouble => std::option::Option::Some(1),
+                Self::TypeFloat => std::option::Option::Some(2),
+                Self::TypeInt64 => std::option::Option::Some(3),
+                Self::TypeUint64 => std::option::Option::Some(4),
+                Self::TypeInt32 => std::option::Option::Some(5),
+                Self::TypeFixed64 => std::option::Option::Some(6),
+                Self::TypeFixed32 => std::option::Option::Some(7),
+                Self::TypeBool => std::option::Option::Some(8),
+                Self::TypeString => std::option::Option::Some(9),
+                Self::TypeGroup => std::option::Option::Some(10),
+                Self::TypeMessage => std::option::Option::Some(11),
+                Self::TypeBytes => std::option::Option::Some(12),
+                Self::TypeUint32 => std::option::Option::Some(13),
+                Self::TypeEnum => std::option::Option::Some(14),
+                Self::TypeSfixed32 => std::option::Option::Some(15),
+                Self::TypeSfixed64 => std::option::Option::Some(16),
+                Self::TypeSint32 => std::option::Option::Some(17),
+                Self::TypeSint64 => std::option::Option::Some(18),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("TYPE_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("TYPE_DOUBLE"),
-                2 => std::borrow::Cow::Borrowed("TYPE_FLOAT"),
-                3 => std::borrow::Cow::Borrowed("TYPE_INT64"),
-                4 => std::borrow::Cow::Borrowed("TYPE_UINT64"),
-                5 => std::borrow::Cow::Borrowed("TYPE_INT32"),
-                6 => std::borrow::Cow::Borrowed("TYPE_FIXED64"),
-                7 => std::borrow::Cow::Borrowed("TYPE_FIXED32"),
-                8 => std::borrow::Cow::Borrowed("TYPE_BOOL"),
-                9 => std::borrow::Cow::Borrowed("TYPE_STRING"),
-                10 => std::borrow::Cow::Borrowed("TYPE_GROUP"),
-                11 => std::borrow::Cow::Borrowed("TYPE_MESSAGE"),
-                12 => std::borrow::Cow::Borrowed("TYPE_BYTES"),
-                13 => std::borrow::Cow::Borrowed("TYPE_UINT32"),
-                14 => std::borrow::Cow::Borrowed("TYPE_ENUM"),
-                15 => std::borrow::Cow::Borrowed("TYPE_SFIXED32"),
-                16 => std::borrow::Cow::Borrowed("TYPE_SFIXED64"),
-                17 => std::borrow::Cow::Borrowed("TYPE_SINT32"),
-                18 => std::borrow::Cow::Borrowed("TYPE_SINT64"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::TypeUnknown => std::option::Option::Some("TYPE_UNKNOWN"),
+                Self::TypeDouble => std::option::Option::Some("TYPE_DOUBLE"),
+                Self::TypeFloat => std::option::Option::Some("TYPE_FLOAT"),
+                Self::TypeInt64 => std::option::Option::Some("TYPE_INT64"),
+                Self::TypeUint64 => std::option::Option::Some("TYPE_UINT64"),
+                Self::TypeInt32 => std::option::Option::Some("TYPE_INT32"),
+                Self::TypeFixed64 => std::option::Option::Some("TYPE_FIXED64"),
+                Self::TypeFixed32 => std::option::Option::Some("TYPE_FIXED32"),
+                Self::TypeBool => std::option::Option::Some("TYPE_BOOL"),
+                Self::TypeString => std::option::Option::Some("TYPE_STRING"),
+                Self::TypeGroup => std::option::Option::Some("TYPE_GROUP"),
+                Self::TypeMessage => std::option::Option::Some("TYPE_MESSAGE"),
+                Self::TypeBytes => std::option::Option::Some("TYPE_BYTES"),
+                Self::TypeUint32 => std::option::Option::Some("TYPE_UINT32"),
+                Self::TypeEnum => std::option::Option::Some("TYPE_ENUM"),
+                Self::TypeSfixed32 => std::option::Option::Some("TYPE_SFIXED32"),
+                Self::TypeSfixed64 => std::option::Option::Some("TYPE_SFIXED64"),
+                Self::TypeSint32 => std::option::Option::Some("TYPE_SINT32"),
+                Self::TypeSint64 => std::option::Option::Some("TYPE_SINT64"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "TYPE_UNKNOWN" => std::option::Option::Some(Self::TYPE_UNKNOWN),
-                "TYPE_DOUBLE" => std::option::Option::Some(Self::TYPE_DOUBLE),
-                "TYPE_FLOAT" => std::option::Option::Some(Self::TYPE_FLOAT),
-                "TYPE_INT64" => std::option::Option::Some(Self::TYPE_INT64),
-                "TYPE_UINT64" => std::option::Option::Some(Self::TYPE_UINT64),
-                "TYPE_INT32" => std::option::Option::Some(Self::TYPE_INT32),
-                "TYPE_FIXED64" => std::option::Option::Some(Self::TYPE_FIXED64),
-                "TYPE_FIXED32" => std::option::Option::Some(Self::TYPE_FIXED32),
-                "TYPE_BOOL" => std::option::Option::Some(Self::TYPE_BOOL),
-                "TYPE_STRING" => std::option::Option::Some(Self::TYPE_STRING),
-                "TYPE_GROUP" => std::option::Option::Some(Self::TYPE_GROUP),
-                "TYPE_MESSAGE" => std::option::Option::Some(Self::TYPE_MESSAGE),
-                "TYPE_BYTES" => std::option::Option::Some(Self::TYPE_BYTES),
-                "TYPE_UINT32" => std::option::Option::Some(Self::TYPE_UINT32),
-                "TYPE_ENUM" => std::option::Option::Some(Self::TYPE_ENUM),
-                "TYPE_SFIXED32" => std::option::Option::Some(Self::TYPE_SFIXED32),
-                "TYPE_SFIXED64" => std::option::Option::Some(Self::TYPE_SFIXED64),
-                "TYPE_SINT32" => std::option::Option::Some(Self::TYPE_SINT32),
-                "TYPE_SINT64" => std::option::Option::Some(Self::TYPE_SINT64),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Kind {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Kind {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Kind {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Kind {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::TypeUnknown,
+                1 => Self::TypeDouble,
+                2 => Self::TypeFloat,
+                3 => Self::TypeInt64,
+                4 => Self::TypeUint64,
+                5 => Self::TypeInt32,
+                6 => Self::TypeFixed64,
+                7 => Self::TypeFixed32,
+                8 => Self::TypeBool,
+                9 => Self::TypeString,
+                10 => Self::TypeGroup,
+                11 => Self::TypeMessage,
+                12 => Self::TypeBytes,
+                13 => Self::TypeUint32,
+                14 => Self::TypeEnum,
+                15 => Self::TypeSfixed32,
+                16 => Self::TypeSfixed64,
+                17 => Self::TypeSint32,
+                18 => Self::TypeSint64,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Kind {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "TYPE_UNKNOWN" => Self::TypeUnknown,
+                "TYPE_DOUBLE" => Self::TypeDouble,
+                "TYPE_FLOAT" => Self::TypeFloat,
+                "TYPE_INT64" => Self::TypeInt64,
+                "TYPE_UINT64" => Self::TypeUint64,
+                "TYPE_INT32" => Self::TypeInt32,
+                "TYPE_FIXED64" => Self::TypeFixed64,
+                "TYPE_FIXED32" => Self::TypeFixed32,
+                "TYPE_BOOL" => Self::TypeBool,
+                "TYPE_STRING" => Self::TypeString,
+                "TYPE_GROUP" => Self::TypeGroup,
+                "TYPE_MESSAGE" => Self::TypeMessage,
+                "TYPE_BYTES" => Self::TypeBytes,
+                "TYPE_UINT32" => Self::TypeUint32,
+                "TYPE_ENUM" => Self::TypeEnum,
+                "TYPE_SFIXED32" => Self::TypeSfixed32,
+                "TYPE_SFIXED64" => Self::TypeSfixed64,
+                "TYPE_SINT32" => Self::TypeSint32,
+                "TYPE_SINT64" => Self::TypeSint64,
+                _ => Self::UnknownValue(kind::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Kind {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::TypeUnknown => serializer.serialize_i32(0),
+                Self::TypeDouble => serializer.serialize_i32(1),
+                Self::TypeFloat => serializer.serialize_i32(2),
+                Self::TypeInt64 => serializer.serialize_i32(3),
+                Self::TypeUint64 => serializer.serialize_i32(4),
+                Self::TypeInt32 => serializer.serialize_i32(5),
+                Self::TypeFixed64 => serializer.serialize_i32(6),
+                Self::TypeFixed32 => serializer.serialize_i32(7),
+                Self::TypeBool => serializer.serialize_i32(8),
+                Self::TypeString => serializer.serialize_i32(9),
+                Self::TypeGroup => serializer.serialize_i32(10),
+                Self::TypeMessage => serializer.serialize_i32(11),
+                Self::TypeBytes => serializer.serialize_i32(12),
+                Self::TypeUint32 => serializer.serialize_i32(13),
+                Self::TypeEnum => serializer.serialize_i32(14),
+                Self::TypeSfixed32 => serializer.serialize_i32(15),
+                Self::TypeSfixed64 => serializer.serialize_i32(16),
+                Self::TypeSint32 => serializer.serialize_i32(17),
+                Self::TypeSint64 => serializer.serialize_i32(18),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Kind {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Kind>::new(
+                ".google.protobuf.Field.Kind",
+            ))
         }
     }
 
     /// Whether a field is optional, required, or repeated.
-    #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-    pub struct Cardinality(i32);
+    #[derive(Clone, Debug, PartialEq)]
+    #[non_exhaustive]
+    pub enum Cardinality {
+        /// For fields with unknown cardinality.
+        Unknown,
+        /// For optional fields.
+        Optional,
+        /// For required fields. Proto2 syntax only.
+        Required,
+        /// For repeated fields.
+        Repeated,
+        /// If set, the enum was initialized with an unknown value.
+        ///
+        /// Applications can examine the value using [Cardinality::value] or
+        /// [Cardinality::name].
+        UnknownValue(cardinality::UnknownValue),
+    }
+
+    #[doc(hidden)]
+    pub mod cardinality {
+        #[allow(unused_imports)]
+        use super::*;
+        #[derive(Clone, Debug, PartialEq)]
+        pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+    }
 
     impl Cardinality {
-        /// For fields with unknown cardinality.
-        pub const CARDINALITY_UNKNOWN: Cardinality = Cardinality::new(0);
-
-        /// For optional fields.
-        pub const CARDINALITY_OPTIONAL: Cardinality = Cardinality::new(1);
-
-        /// For required fields. Proto2 syntax only.
-        pub const CARDINALITY_REQUIRED: Cardinality = Cardinality::new(2);
-
-        /// For repeated fields.
-        pub const CARDINALITY_REPEATED: Cardinality = Cardinality::new(3);
-
-        /// Creates a new Cardinality instance.
-        pub(crate) const fn new(value: i32) -> Self {
-            Self(value)
-        }
-
         /// Gets the enum value.
-        pub fn value(&self) -> i32 {
-            self.0
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the string representation of enums.
+        pub fn value(&self) -> std::option::Option<i32> {
+            match self {
+                Self::Unknown => std::option::Option::Some(0),
+                Self::Optional => std::option::Option::Some(1),
+                Self::Required => std::option::Option::Some(2),
+                Self::Repeated => std::option::Option::Some(3),
+                Self::UnknownValue(u) => u.0.value(),
+            }
         }
 
         /// Gets the enum value as a string.
-        pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-            match self.0 {
-                0 => std::borrow::Cow::Borrowed("CARDINALITY_UNKNOWN"),
-                1 => std::borrow::Cow::Borrowed("CARDINALITY_OPTIONAL"),
-                2 => std::borrow::Cow::Borrowed("CARDINALITY_REQUIRED"),
-                3 => std::borrow::Cow::Borrowed("CARDINALITY_REPEATED"),
-                _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+        ///
+        /// Returns `None` if the enum contains an unknown value deserialized from
+        /// the integer representation of enums.
+        pub fn name(&self) -> std::option::Option<&str> {
+            match self {
+                Self::Unknown => std::option::Option::Some("CARDINALITY_UNKNOWN"),
+                Self::Optional => std::option::Option::Some("CARDINALITY_OPTIONAL"),
+                Self::Required => std::option::Option::Some("CARDINALITY_REQUIRED"),
+                Self::Repeated => std::option::Option::Some("CARDINALITY_REPEATED"),
+                Self::UnknownValue(u) => u.0.name(),
             }
-        }
-
-        /// Creates an enum value from the value name.
-        pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-            match name {
-                "CARDINALITY_UNKNOWN" => std::option::Option::Some(Self::CARDINALITY_UNKNOWN),
-                "CARDINALITY_OPTIONAL" => std::option::Option::Some(Self::CARDINALITY_OPTIONAL),
-                "CARDINALITY_REQUIRED" => std::option::Option::Some(Self::CARDINALITY_REQUIRED),
-                "CARDINALITY_REPEATED" => std::option::Option::Some(Self::CARDINALITY_REPEATED),
-                _ => std::option::Option::None,
-            }
-        }
-    }
-
-    impl std::convert::From<i32> for Cardinality {
-        fn from(value: i32) -> Self {
-            Self::new(value)
         }
     }
 
     impl std::default::Default for Cardinality {
         fn default() -> Self {
-            Self::new(0)
+            use std::convert::From;
+            Self::from(0)
+        }
+    }
+
+    impl std::fmt::Display for Cardinality {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+            wkt::internal::display_enum(f, self.name(), self.value())
+        }
+    }
+
+    impl std::convert::From<i32> for Cardinality {
+        fn from(value: i32) -> Self {
+            match value {
+                0 => Self::Unknown,
+                1 => Self::Optional,
+                2 => Self::Required,
+                3 => Self::Repeated,
+                _ => Self::UnknownValue(cardinality::UnknownValue(
+                    wkt::internal::UnknownEnumValue::Integer(value),
+                )),
+            }
+        }
+    }
+
+    impl std::convert::From<&str> for Cardinality {
+        fn from(value: &str) -> Self {
+            use std::string::ToString;
+            match value {
+                "CARDINALITY_UNKNOWN" => Self::Unknown,
+                "CARDINALITY_OPTIONAL" => Self::Optional,
+                "CARDINALITY_REQUIRED" => Self::Required,
+                "CARDINALITY_REPEATED" => Self::Repeated,
+                _ => Self::UnknownValue(cardinality::UnknownValue(
+                    wkt::internal::UnknownEnumValue::String(value.to_string()),
+                )),
+            }
+        }
+    }
+
+    impl serde::ser::Serialize for Cardinality {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match self {
+                Self::Unknown => serializer.serialize_i32(0),
+                Self::Optional => serializer.serialize_i32(1),
+                Self::Required => serializer.serialize_i32(2),
+                Self::Repeated => serializer.serialize_i32(3),
+                Self::UnknownValue(u) => u.0.serialize(serializer),
+            }
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Cardinality {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_any(wkt::internal::EnumVisitor::<Cardinality>::new(
+                ".google.protobuf.Field.Cardinality",
+            ))
         }
     }
 }
@@ -5216,163 +6388,303 @@ impl wkt::message::Message for Option {
 }
 
 /// The full set of known editions.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Edition(i32);
-
-impl Edition {
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Edition {
     /// A placeholder for an unknown edition value.
-    pub const EDITION_UNKNOWN: Edition = Edition::new(0);
-
+    Unknown,
     /// A placeholder edition for specifying default behaviors *before* a feature
     /// was first introduced.  This is effectively an "infinite past".
-    pub const EDITION_LEGACY: Edition = Edition::new(900);
-
+    Legacy,
     /// Legacy syntax "editions".  These pre-date editions, but behave much like
     /// distinct editions.  These can't be used to specify the edition of proto
     /// files, but feature definitions must supply proto2/proto3 defaults for
     /// backwards compatibility.
-    pub const EDITION_PROTO2: Edition = Edition::new(998);
-
-    pub const EDITION_PROTO3: Edition = Edition::new(999);
-
+    Proto2,
+    Proto3,
     /// Editions that have been released.  The specific values are arbitrary and
     /// should not be depended on, but they will always be time-ordered for easy
     /// comparison.
-    pub const EDITION_2023: Edition = Edition::new(1000);
-
-    pub const EDITION_2024: Edition = Edition::new(1001);
-
+    _2023,
+    _2024,
     /// Placeholder editions for testing feature resolution.  These should not be
     /// used or relied on outside of tests.
-    pub const EDITION_1_TEST_ONLY: Edition = Edition::new(1);
-
-    pub const EDITION_2_TEST_ONLY: Edition = Edition::new(2);
-
-    pub const EDITION_99997_TEST_ONLY: Edition = Edition::new(99997);
-
-    pub const EDITION_99998_TEST_ONLY: Edition = Edition::new(99998);
-
-    pub const EDITION_99999_TEST_ONLY: Edition = Edition::new(99999);
-
+    _1TestOnly,
+    _2TestOnly,
+    _99997TestOnly,
+    _99998TestOnly,
+    _99999TestOnly,
     /// Placeholder for specifying unbounded edition support.  This should only
     /// ever be used by plugins that can expect to never require any changes to
     /// support a new edition.
-    pub const EDITION_MAX: Edition = Edition::new(2147483647);
+    Max,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Edition::value] or
+    /// [Edition::name].
+    UnknownValue(edition::UnknownValue),
+}
 
-    /// Creates a new Edition instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
+#[doc(hidden)]
+pub mod edition {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
+impl Edition {
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Unknown => std::option::Option::Some(0),
+            Self::Legacy => std::option::Option::Some(900),
+            Self::Proto2 => std::option::Option::Some(998),
+            Self::Proto3 => std::option::Option::Some(999),
+            Self::_2023 => std::option::Option::Some(1000),
+            Self::_2024 => std::option::Option::Some(1001),
+            Self::_1TestOnly => std::option::Option::Some(1),
+            Self::_2TestOnly => std::option::Option::Some(2),
+            Self::_99997TestOnly => std::option::Option::Some(99997),
+            Self::_99998TestOnly => std::option::Option::Some(99998),
+            Self::_99999TestOnly => std::option::Option::Some(99999),
+            Self::Max => std::option::Option::Some(2147483647),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("EDITION_UNKNOWN"),
-            1 => std::borrow::Cow::Borrowed("EDITION_1_TEST_ONLY"),
-            2 => std::borrow::Cow::Borrowed("EDITION_2_TEST_ONLY"),
-            900 => std::borrow::Cow::Borrowed("EDITION_LEGACY"),
-            998 => std::borrow::Cow::Borrowed("EDITION_PROTO2"),
-            999 => std::borrow::Cow::Borrowed("EDITION_PROTO3"),
-            1000 => std::borrow::Cow::Borrowed("EDITION_2023"),
-            1001 => std::borrow::Cow::Borrowed("EDITION_2024"),
-            99997 => std::borrow::Cow::Borrowed("EDITION_99997_TEST_ONLY"),
-            99998 => std::borrow::Cow::Borrowed("EDITION_99998_TEST_ONLY"),
-            99999 => std::borrow::Cow::Borrowed("EDITION_99999_TEST_ONLY"),
-            2147483647 => std::borrow::Cow::Borrowed("EDITION_MAX"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Unknown => std::option::Option::Some("EDITION_UNKNOWN"),
+            Self::Legacy => std::option::Option::Some("EDITION_LEGACY"),
+            Self::Proto2 => std::option::Option::Some("EDITION_PROTO2"),
+            Self::Proto3 => std::option::Option::Some("EDITION_PROTO3"),
+            Self::_2023 => std::option::Option::Some("EDITION_2023"),
+            Self::_2024 => std::option::Option::Some("EDITION_2024"),
+            Self::_1TestOnly => std::option::Option::Some("EDITION_1_TEST_ONLY"),
+            Self::_2TestOnly => std::option::Option::Some("EDITION_2_TEST_ONLY"),
+            Self::_99997TestOnly => std::option::Option::Some("EDITION_99997_TEST_ONLY"),
+            Self::_99998TestOnly => std::option::Option::Some("EDITION_99998_TEST_ONLY"),
+            Self::_99999TestOnly => std::option::Option::Some("EDITION_99999_TEST_ONLY"),
+            Self::Max => std::option::Option::Some("EDITION_MAX"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "EDITION_UNKNOWN" => std::option::Option::Some(Self::EDITION_UNKNOWN),
-            "EDITION_LEGACY" => std::option::Option::Some(Self::EDITION_LEGACY),
-            "EDITION_PROTO2" => std::option::Option::Some(Self::EDITION_PROTO2),
-            "EDITION_PROTO3" => std::option::Option::Some(Self::EDITION_PROTO3),
-            "EDITION_2023" => std::option::Option::Some(Self::EDITION_2023),
-            "EDITION_2024" => std::option::Option::Some(Self::EDITION_2024),
-            "EDITION_1_TEST_ONLY" => std::option::Option::Some(Self::EDITION_1_TEST_ONLY),
-            "EDITION_2_TEST_ONLY" => std::option::Option::Some(Self::EDITION_2_TEST_ONLY),
-            "EDITION_99997_TEST_ONLY" => std::option::Option::Some(Self::EDITION_99997_TEST_ONLY),
-            "EDITION_99998_TEST_ONLY" => std::option::Option::Some(Self::EDITION_99998_TEST_ONLY),
-            "EDITION_99999_TEST_ONLY" => std::option::Option::Some(Self::EDITION_99999_TEST_ONLY),
-            "EDITION_MAX" => std::option::Option::Some(Self::EDITION_MAX),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Edition {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Edition {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Edition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Edition {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Unknown,
+            1 => Self::_1TestOnly,
+            2 => Self::_2TestOnly,
+            900 => Self::Legacy,
+            998 => Self::Proto2,
+            999 => Self::Proto3,
+            1000 => Self::_2023,
+            1001 => Self::_2024,
+            99997 => Self::_99997TestOnly,
+            99998 => Self::_99998TestOnly,
+            99999 => Self::_99999TestOnly,
+            2147483647 => Self::Max,
+            _ => Self::UnknownValue(edition::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Edition {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "EDITION_UNKNOWN" => Self::Unknown,
+            "EDITION_LEGACY" => Self::Legacy,
+            "EDITION_PROTO2" => Self::Proto2,
+            "EDITION_PROTO3" => Self::Proto3,
+            "EDITION_2023" => Self::_2023,
+            "EDITION_2024" => Self::_2024,
+            "EDITION_1_TEST_ONLY" => Self::_1TestOnly,
+            "EDITION_2_TEST_ONLY" => Self::_2TestOnly,
+            "EDITION_99997_TEST_ONLY" => Self::_99997TestOnly,
+            "EDITION_99998_TEST_ONLY" => Self::_99998TestOnly,
+            "EDITION_99999_TEST_ONLY" => Self::_99999TestOnly,
+            "EDITION_MAX" => Self::Max,
+            _ => Self::UnknownValue(edition::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Edition {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Unknown => serializer.serialize_i32(0),
+            Self::Legacy => serializer.serialize_i32(900),
+            Self::Proto2 => serializer.serialize_i32(998),
+            Self::Proto3 => serializer.serialize_i32(999),
+            Self::_2023 => serializer.serialize_i32(1000),
+            Self::_2024 => serializer.serialize_i32(1001),
+            Self::_1TestOnly => serializer.serialize_i32(1),
+            Self::_2TestOnly => serializer.serialize_i32(2),
+            Self::_99997TestOnly => serializer.serialize_i32(99997),
+            Self::_99998TestOnly => serializer.serialize_i32(99998),
+            Self::_99999TestOnly => serializer.serialize_i32(99999),
+            Self::Max => serializer.serialize_i32(2147483647),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Edition {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Edition>::new(
+            ".google.protobuf.Edition",
+        ))
     }
 }
 
 /// The syntax in which a protocol buffer element is defined.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Syntax(i32);
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum Syntax {
+    /// Syntax `proto2`.
+    Proto2,
+    /// Syntax `proto3`.
+    Proto3,
+    /// Syntax `editions`.
+    Editions,
+    /// If set, the enum was initialized with an unknown value.
+    ///
+    /// Applications can examine the value using [Syntax::value] or
+    /// [Syntax::name].
+    UnknownValue(syntax::UnknownValue),
+}
+
+#[doc(hidden)]
+pub mod syntax {
+    #[allow(unused_imports)]
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct UnknownValue(pub(crate) wkt::internal::UnknownEnumValue);
+}
 
 impl Syntax {
-    /// Syntax `proto2`.
-    pub const SYNTAX_PROTO2: Syntax = Syntax::new(0);
-
-    /// Syntax `proto3`.
-    pub const SYNTAX_PROTO3: Syntax = Syntax::new(1);
-
-    /// Syntax `editions`.
-    pub const SYNTAX_EDITIONS: Syntax = Syntax::new(2);
-
-    /// Creates a new Syntax instance.
-    pub(crate) const fn new(value: i32) -> Self {
-        Self(value)
-    }
-
     /// Gets the enum value.
-    pub fn value(&self) -> i32 {
-        self.0
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the string representation of enums.
+    pub fn value(&self) -> std::option::Option<i32> {
+        match self {
+            Self::Proto2 => std::option::Option::Some(0),
+            Self::Proto3 => std::option::Option::Some(1),
+            Self::Editions => std::option::Option::Some(2),
+            Self::UnknownValue(u) => u.0.value(),
+        }
     }
 
     /// Gets the enum value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        match self.0 {
-            0 => std::borrow::Cow::Borrowed("SYNTAX_PROTO2"),
-            1 => std::borrow::Cow::Borrowed("SYNTAX_PROTO3"),
-            2 => std::borrow::Cow::Borrowed("SYNTAX_EDITIONS"),
-            _ => std::borrow::Cow::Owned(std::format!("UNKNOWN-VALUE:{}", self.0)),
+    ///
+    /// Returns `None` if the enum contains an unknown value deserialized from
+    /// the integer representation of enums.
+    pub fn name(&self) -> std::option::Option<&str> {
+        match self {
+            Self::Proto2 => std::option::Option::Some("SYNTAX_PROTO2"),
+            Self::Proto3 => std::option::Option::Some("SYNTAX_PROTO3"),
+            Self::Editions => std::option::Option::Some("SYNTAX_EDITIONS"),
+            Self::UnknownValue(u) => u.0.name(),
         }
-    }
-
-    /// Creates an enum value from the value name.
-    pub fn from_str_name(name: &str) -> std::option::Option<Self> {
-        match name {
-            "SYNTAX_PROTO2" => std::option::Option::Some(Self::SYNTAX_PROTO2),
-            "SYNTAX_PROTO3" => std::option::Option::Some(Self::SYNTAX_PROTO3),
-            "SYNTAX_EDITIONS" => std::option::Option::Some(Self::SYNTAX_EDITIONS),
-            _ => std::option::Option::None,
-        }
-    }
-}
-
-impl std::convert::From<i32> for Syntax {
-    fn from(value: i32) -> Self {
-        Self::new(value)
     }
 }
 
 impl std::default::Default for Syntax {
     fn default() -> Self {
-        Self::new(0)
+        use std::convert::From;
+        Self::from(0)
+    }
+}
+
+impl std::fmt::Display for Syntax {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        wkt::internal::display_enum(f, self.name(), self.value())
+    }
+}
+
+impl std::convert::From<i32> for Syntax {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Proto2,
+            1 => Self::Proto3,
+            2 => Self::Editions,
+            _ => Self::UnknownValue(syntax::UnknownValue(
+                wkt::internal::UnknownEnumValue::Integer(value),
+            )),
+        }
+    }
+}
+
+impl std::convert::From<&str> for Syntax {
+    fn from(value: &str) -> Self {
+        use std::string::ToString;
+        match value {
+            "SYNTAX_PROTO2" => Self::Proto2,
+            "SYNTAX_PROTO3" => Self::Proto3,
+            "SYNTAX_EDITIONS" => Self::Editions,
+            _ => Self::UnknownValue(syntax::UnknownValue(
+                wkt::internal::UnknownEnumValue::String(value.to_string()),
+            )),
+        }
+    }
+}
+
+impl serde::ser::Serialize for Syntax {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Proto2 => serializer.serialize_i32(0),
+            Self::Proto3 => serializer.serialize_i32(1),
+            Self::Editions => serializer.serialize_i32(2),
+            Self::UnknownValue(u) => u.0.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Syntax {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(wkt::internal::EnumVisitor::<Syntax>::new(
+            ".google.protobuf.Syntax",
+        ))
     }
 }

--- a/src/wkt/src/internal/enums.rs
+++ b/src/wkt/src/internal/enums.rs
@@ -120,6 +120,7 @@ pub fn display_enum(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::field_descriptor_proto::Label;
     use serde_json::json;
     use test_case::test_case;
 
@@ -216,7 +217,7 @@ mod test {
     impl std::fmt::Display for TestDisplay {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let tmp = self.name.clone();
-            display_enum(f, tmp.as_deref(), self.value)
+            super::display_enum(f, tmp.as_deref(), self.value)
         }
     }
 
@@ -227,5 +228,25 @@ mod test {
         let input = TestDisplay { name, value };
         let got = format!("{input}");
         assert_eq!(got.as_str(), want);
+    }
+
+    #[test_case(json!("LABEL_OPTIONAL"), Label::Optional)]
+    #[test_case(json!(1), Label::Optional)]
+    #[test_case(json!("UNKNOWN_VALUE"), Label::from("UNKNOWN_VALUE"))]
+    #[test_case(json!(42), Label::from(42))]
+    fn deserialize(input: serde_json::Value, want: Label) -> anyhow::Result<()> {
+        let got = serde_json::from_value::<Label>(input)?;
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    #[test_case(Label::Optional, "LABEL_OPTIONAL")]
+    #[test_case(Label::from(1), "LABEL_OPTIONAL")]
+    #[test_case(Label::from("LABEL_OPTIONAL"), "LABEL_OPTIONAL")]
+    #[test_case(Label::from("UNKNOWN_VALUE"), "UNKNOWN_VALUE")]
+    #[test_case(Label::from(42), "42")]
+    fn display_enum(input: Label, want: &str) {
+        let got = format!("{input}");
+        assert_eq!(got, want);
     }
 }

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -77,23 +77,30 @@ impl crate::message::Message for ListValue {
 /// useful to make it behave as if it was.
 impl NullValue {
     /// Gets the value.
-    pub fn value(&self) -> i32 {
-        0
+    pub fn value(&self) -> Option<i32> {
+        Some(0)
     }
 
     /// Gets the value as a string.
-    pub fn as_str_name(&self) -> std::borrow::Cow<'static, str> {
-        "NULL_VALUE".into()
-    }
-
-    /// Creates a value from the value name
-    pub fn from_str_name(_name: &str) -> Option<Self> {
-        Some(Self)
+    pub fn name(&self) -> Option<&str> {
+        Some("NULL_VALUE")
     }
 }
 
 impl From<i32> for NullValue {
     fn from(_value: i32) -> Self {
+        Self
+    }
+}
+
+impl From<&str> for NullValue {
+    fn from(_value: &str) -> Self {
+        Self
+    }
+}
+
+impl From<String> for NullValue {
+    fn from(_value: String) -> Self {
         Self
     }
 }
@@ -154,9 +161,10 @@ mod any_tests {
     #[test]
     fn test_null_value_interface() {
         let input = NullValue;
-        assert_eq!(input.value(), NullValue.value());
-        assert_eq!(input.as_str_name().as_ref(), "NULL_VALUE");
-        assert_eq!(NullValue::from_str_name("NULL_VALUE"), Some(NullValue));
+        assert_eq!(input.value(), Some(0));
+        assert_eq!(input.name(), Some("NULL_VALUE"));
+        assert_eq!(NullValue::from("NULL_VALUE"), NullValue);
+        assert_eq!(NullValue::from("NULL_VALUE".to_string()), NullValue);
         assert_eq!(NullValue::from(0), NullValue);
     }
 

--- a/src/wkt/tests/enums.rs
+++ b/src/wkt/tests/enums.rs
@@ -13,26 +13,22 @@
 // limitations under the License.
 
 #[cfg(test)]
-mod generated {
+mod test {
     use google_cloud_wkt::Syntax;
-
-    #[test]
-    fn string_to_constant() {
-        let got = Syntax::from_str_name("SYNTAX_PROTO2");
-        assert_eq!(Some(google_cloud_wkt::Syntax::SYNTAX_PROTO2), got)
-    }
-}
-
-#[cfg(test)]
-mod desired_protobuf {
     use google_cloud_wkt::file_options::OptimizeMode;
     use serde_json::json;
     use test_case::test_case;
     type TestResult = Result<(), Box<dyn std::error::Error>>;
 
-    #[test_case(OptimizeMode::SPEED, 1)]
-    #[test_case(OptimizeMode::CODE_SIZE, 2)]
-    #[test_case(OptimizeMode::LITE_RUNTIME, 3)]
+    #[test]
+    fn string_to_constant() {
+        let got = Syntax::from("SYNTAX_PROTO2");
+        assert_eq!(Syntax::Proto2, got)
+    }
+
+    #[test_case(OptimizeMode::Speed, 1)]
+    #[test_case(OptimizeMode::CodeSize, 2)]
+    #[test_case(OptimizeMode::LiteRuntime, 3)]
     #[test_case(OptimizeMode::from(42), 42)]
     fn serialize(input: OptimizeMode, want: i32) -> TestResult {
         let got = serde_json::to_value(input)?;
@@ -41,9 +37,9 @@ mod desired_protobuf {
         Ok(())
     }
 
-    #[test_case(1, OptimizeMode::SPEED)]
-    #[test_case(2, OptimizeMode::CODE_SIZE)]
-    #[test_case(3, OptimizeMode::LITE_RUNTIME)]
+    #[test_case(1, OptimizeMode::Speed)]
+    #[test_case(2, OptimizeMode::CodeSize)]
+    #[test_case(3, OptimizeMode::LiteRuntime)]
     #[test_case(42, OptimizeMode::from(42))]
     fn deserialize(input: i32, want: OptimizeMode) -> TestResult {
         let value = json!(input);
@@ -52,35 +48,58 @@ mod desired_protobuf {
         Ok(())
     }
 
-    #[test_case(OptimizeMode::SPEED, 1)]
-    #[test_case(OptimizeMode::CODE_SIZE, 2)]
-    #[test_case(OptimizeMode::LITE_RUNTIME, 3)]
+    #[test_case(OptimizeMode::Speed, 1)]
+    #[test_case(OptimizeMode::CodeSize, 2)]
+    #[test_case(OptimizeMode::LiteRuntime, 3)]
     #[test_case(OptimizeMode::from(42), 42)]
     fn value(input: OptimizeMode, want: i32) {
         let got = input.value();
+        assert_eq!(got, Some(want));
+    }
+
+    #[test_case(OptimizeMode::Speed, "SPEED")]
+    #[test_case(OptimizeMode::CodeSize, "CODE_SIZE")]
+    #[test_case(OptimizeMode::LiteRuntime, "LITE_RUNTIME")]
+    fn to_string(input: OptimizeMode, want: &str) {
+        let got = input.name();
+        assert_eq!(got, Some(want));
+    }
+
+    #[test_case("SPEED", OptimizeMode::Speed)]
+    #[test_case("CODE_SIZE", OptimizeMode::CodeSize)]
+    #[test_case("LITE_RUNTIME", OptimizeMode::LiteRuntime)]
+    fn from_string(input: &str, want: OptimizeMode) {
+        let got = OptimizeMode::from(input);
         assert_eq!(got, want);
     }
 
-    #[test_case(OptimizeMode::SPEED, "SPEED")]
-    #[test_case(OptimizeMode::CODE_SIZE, "CODE_SIZE")]
-    #[test_case(OptimizeMode::LITE_RUNTIME, "LITE_RUNTIME")]
-    #[test_case(OptimizeMode::from(42), "UNKNOWN-VALUE:42")]
-    fn to_string(input: OptimizeMode, want: &str) {
-        let got = input.as_str_name();
-        assert_eq!(got.as_ref(), want);
+    #[test]
+    fn unknown_i32() -> TestResult {
+        let input = OptimizeMode::from(32);
+        let got = input.value();
+        assert_eq!(got, Some(32));
+        let got = input.name();
+        assert_eq!(got, None);
+        let got = serde_json::to_value(&input)?;
+        assert_eq!(got, json!(32));
+        Ok(())
     }
 
-    #[test_case("SPEED", OptimizeMode::SPEED)]
-    #[test_case("CODE_SIZE", OptimizeMode::CODE_SIZE)]
-    #[test_case("LITE_RUNTIME", OptimizeMode::LITE_RUNTIME)]
-    fn from_string(input: &str, want: OptimizeMode) {
-        let got = OptimizeMode::from_str_name(input);
-        assert_eq!(got, Some(want));
+    #[test]
+    fn unknown_str() -> TestResult {
+        let input = OptimizeMode::from("HEAVY_RUNTIME_HA_HA");
+        let got = input.value();
+        assert_eq!(got, None);
+        let got = input.name();
+        assert_eq!(got, Some("HEAVY_RUNTIME_HA_HA"));
+        let got = serde_json::to_value(&input)?;
+        assert_eq!(got, json!("HEAVY_RUNTIME_HA_HA"));
+        Ok(())
     }
 
     #[test]
     fn default() {
         let got = OptimizeMode::default();
-        assert_eq!(got.value(), 0);
+        assert_eq!(got.value(), Some(0));
     }
 }


### PR DESCRIPTION
With this change, the generator emits Rust enumerations for Protobuf
enumerations. Because Google Cloud uses open enumerations, the generated
enumerations can accept unknown values, as strings or integers and are
marked as `#[non_exhaustive]`.

Both unknown integers and unknown strings can roundtrip via JSON. Only
unknown integers can roundtrip the Protobuf wire format (currently
implemented with Prost-generated types).

The user guide gets a new section showing how these work and with some
recommendations to use them in `match` expressions.

Fixes #1904 